### PR TITLE
feat: complete Sprint role loop and recovery

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2516,6 +2516,103 @@ class Handler(BaseHTTPRequestHandler):
                     to_sid = r[0]
                 if to_sid is None or not msg:
                     return self._send(400, {"error": "to (shortname) or to_shell_id, and body, required"})
+                assignment_id = body.get("sprint_assignment_id")
+                result_kind = body.get("sprint_result_kind")
+                directive_id = body.get("sprint_directive_id")
+                assignment_result = assignment_id is not None
+                # Resolve the idempotency key before assignment liveness. An
+                # accepted result can terminalize its one-shot while the HTTP
+                # response is in flight; the exact retry must still return the
+                # committed row instead of failing the now-terminal binding.
+                dk = (body.get("dedupe_key") or "").strip() or None
+                if assignment_result:
+                    if kind != "result":
+                        return self._send(400, {"error":
+                            "sprint_assignment_id requires kind='result'"})
+                    if (
+                        isinstance(assignment_id, bool)
+                        or not isinstance(assignment_id, int)
+                    ):
+                        return self._send(400, {"error":
+                            "sprint_assignment_id must be an int"})
+                    if not isinstance(result_kind, str) or not result_kind.strip():
+                        return self._send(400, {"error":
+                            "sprint_result_kind must be a nonblank string"})
+                    result_kind = result_kind.strip()
+                    if result_kind == "abort-report":
+                        if directive_id is not None:
+                            return self._send(422, {"error":
+                                "abort-report results do not name a directive"})
+                    elif (
+                        isinstance(directive_id, bool)
+                        or not isinstance(directive_id, int)
+                    ):
+                        return self._send(400, {"error":
+                            "Sprint assignment result requires an integer "
+                            "sprint_directive_id"})
+                    if dk is not None:
+                        prior = con.execute(
+                            "SELECT m.message_id,m.to_shell_id,m.body,m.kind,"
+                            "m.sprint_doc_id,ar.binding_id,ar.result_kind,"
+                            "ar.directive_id FROM shell_messages m "
+                            "LEFT JOIN sprint_assignment_results ar "
+                            "ON ar.message_id=m.message_id "
+                            "WHERE m.from_shell_id=? AND m.dedupe_key=?",
+                            (sid, dk),
+                        ).fetchone()
+                        if prior is not None:
+                            exact = (
+                                prior["to_shell_id"] == int(to_sid)
+                                and prior["body"] == msg
+                                and prior["kind"] == kind
+                                and prior["sprint_doc_id"] == sprint_doc_id
+                                and prior["binding_id"] == assignment_id
+                                and prior["result_kind"] == result_kind
+                                and prior["directive_id"] == directive_id
+                            )
+                            if exact:
+                                return self._send(
+                                    200,
+                                    {
+                                        "message_id": prior["message_id"],
+                                        "duplicate": True,
+                                    },
+                                )
+                            return self._send(409, {"error":
+                                "Sprint result dedupe_key was reused with "
+                                "different assignment evidence"})
+                    binding = con.execute(
+                        "SELECT b.binding_id,b.sprint_doc_id,b.role,b.unit_id,"
+                        "b.required_result_kind,b.state,c.shell_id "
+                        "FROM sprint_conversation_bindings b "
+                        "JOIN conversations c "
+                        "ON c.conversation_id=b.conversation_id "
+                        "WHERE b.binding_id=? AND b.lifecycle='one_shot'",
+                        (assignment_id,),
+                    ).fetchone()
+                    if binding is None:
+                        return self._send(404, {"error":
+                            f"no one-shot Sprint assignment {assignment_id}"})
+                    if binding["state"] != "active":
+                        return self._send(409, {"error":
+                            f"Sprint assignment {assignment_id} is "
+                            f"{binding['state']}, not active"})
+                    if binding["shell_id"] != sid:
+                        return self._send(403, {"error":
+                            f"Sprint assignment {assignment_id} belongs to "
+                            "another shell"})
+                    if sprint_doc_id != binding["sprint_doc_id"]:
+                        return self._send(422, {"error":
+                            "Sprint assignment result has the wrong "
+                            "sprint_doc_id"})
+                    if result_kind != binding["required_result_kind"]:
+                        return self._send(422, {"error":
+                            f"Sprint assignment {assignment_id} requires "
+                            f"result kind {binding['required_result_kind']!r}"})
+                elif result_kind is not None or directive_id is not None:
+                    return self._send(400, {"error":
+                        "Sprint result metadata requires "
+                        "sprint_assignment_id"})
                 # Idempotent send (#333): a client timeout after the server-side
                 # write left the sender unable to tell delivered from lost, and
                 # blind resends duplicated fleet-wide. The client stamps each
@@ -2523,7 +2620,6 @@ class Handler(BaseHTTPRequestHandler):
                 # returns the original row instead of inserting a twin. The
                 # unique index (from_shell_id, dedupe_key) backstops the
                 # check-then-insert race.
-                dk = (body.get("dedupe_key") or "").strip() or None
                 if dk is not None:
                     r = con.execute(
                         "SELECT message_id FROM shell_messages "
@@ -2536,8 +2632,51 @@ class Handler(BaseHTTPRequestHandler):
                         "VALUES (?, ?, ?, ?, ?, ?)",
                         (sid, int(to_sid), msg, kind, sprint_doc_id, dk))
                     message_id = cur.lastrowid
+                    if assignment_result:
+                        con.execute(
+                            "INSERT INTO sprint_assignment_results "
+                            "(binding_id,message_id,result_kind,directive_id) "
+                            "VALUES (?,?,?,?)",
+                            (
+                                assignment_id,
+                                message_id,
+                                result_kind,
+                                directive_id,
+                            ),
+                        )
                     con.commit()
-                except db_driver.IntegrityError:
+                except db_driver.IntegrityError as exc:
+                    con.rollback()
+                    if assignment_result:
+                        r = con.execute(
+                            "SELECT m.message_id,m.to_shell_id,m.body,m.kind,"
+                            "m.sprint_doc_id,ar.binding_id,ar.result_kind,"
+                            "ar.directive_id FROM shell_messages m "
+                            "LEFT JOIN sprint_assignment_results ar "
+                            "ON ar.message_id=m.message_id "
+                            "WHERE m.from_shell_id=? AND m.dedupe_key=?",
+                            (sid, dk),
+                        ).fetchone()
+                        exact = r is not None and (
+                            r["to_shell_id"] == int(to_sid)
+                            and r["body"] == msg
+                            and r["kind"] == kind
+                            and r["sprint_doc_id"] == sprint_doc_id
+                            and r["binding_id"] == assignment_id
+                            and r["result_kind"] == result_kind
+                            and r["directive_id"] == directive_id
+                        )
+                        if exact:
+                            return self._send(
+                                200,
+                                {
+                                    "message_id": r["message_id"],
+                                    "duplicate": True,
+                                },
+                            )
+                        return self._send(409, {"error":
+                            "Sprint assignment result conflicts with durable "
+                            f"assignment evidence: {exc}"})
                     r = con.execute(
                         "SELECT message_id FROM shell_messages "
                         "WHERE from_shell_id=? AND dedupe_key=?", (sid, dk)).fetchone()

--- a/.super-coder/api/sprint_routes.py
+++ b/.super-coder/api/sprint_routes.py
@@ -1421,6 +1421,44 @@ def _cancel_existing_sprint_work(con, sprint_doc_id: int):
             " AND r.state IN ('leased','starting','running'))",
             (conversation_id,),
         )
+        binding = con.execute(
+            "SELECT b.binding_id,b.lifecycle,b.state AS binding_state,"
+            "c.state AS conversation_state "
+            "FROM sprint_conversation_bindings b "
+            "JOIN conversations c ON c.conversation_id=b.conversation_id "
+            "WHERE b.conversation_id=?",
+            (conversation_id,),
+        ).fetchone()
+        live_run = con.execute(
+            "SELECT 1 FROM conversation_runs WHERE conversation_id=? "
+            "AND state IN ('leased','starting','running')",
+            (conversation_id,),
+        ).fetchone()
+        if (
+            binding is not None
+            and binding["lifecycle"] == "one_shot"
+            and binding["binding_state"] != "terminal"
+            and binding["conversation_state"] in ("idle", "waiting", "error")
+            and live_run is None
+        ):
+            con.execute(
+                "UPDATE conversations SET state='closed',"
+                "closed_at=datetime('now'),last_activity_at=datetime('now'),"
+                "version=version+1 WHERE conversation_id=?",
+                (conversation_id,),
+            )
+            _append_conversation_event(
+                con,
+                conversation_id,
+                "conversation.closed",
+                {"state": "closed", "reason": "Sprint cancelled by operator"},
+            )
+            con.execute(
+                "UPDATE sprint_conversation_bindings SET state='terminal',"
+                "outcome='cancelled',completed_at=datetime('now') "
+                "WHERE binding_id=?",
+                (binding["binding_id"],),
+            )
     for run_id in run_ids:
         row = con.execute(
             "SELECT conversation_id,trigger_message_id FROM conversation_runs "
@@ -1739,6 +1777,13 @@ def _abort_sprint(
                 (report, actor.shell_id, cancellation["cancellation_id"]),
             )
             sprint_lifecycle.transition(con, sprint_doc_id, "aborted")
+            conductor_id = sprint_conversations.request_conductor_close(
+                con,
+                sprint_doc_id,
+                reason="originating Planner completed the abort report",
+            )
+            if conductor_id is not None:
+                notify_ids.append(conductor_id)
             con.execute(
                 "UPDATE documents SET frozen=1,frozen_date=date('now'),"
                 "updated_at=datetime('now') WHERE document_id=?",

--- a/.super-coder/migrations/0138_sprint_assignment_results.sql
+++ b/.super-coder/migrations/0138_sprint_assignment_results.sql
@@ -1,0 +1,95 @@
+-- 0138 — correlate one-shot Sprint results with their durable assignment.
+--
+-- A shell-scoped result message is useful audit evidence, but shell + Sprint
+-- identity alone cannot prove which fresh one-shot produced it.  Keep the
+-- existing message bus intact and add a narrow, append-only correlation row
+-- that names the assignment, typed result, and exact directive returned to
+-- Conductor.  Abort-report assignments are the sole exception: their state
+-- mutation is the Planner-authorized Sprint abort resource, not a directive.
+
+BEGIN;
+
+CREATE TABLE sprint_assignment_results (
+    result_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    binding_id      INTEGER NOT NULL UNIQUE
+                    REFERENCES sprint_conversation_bindings(binding_id),
+    message_id      INTEGER NOT NULL UNIQUE
+                    REFERENCES shell_messages(message_id),
+    result_kind     TEXT NOT NULL
+                    CHECK (length(trim(result_kind)) BETWEEN 1 AND 64),
+    directive_id    INTEGER UNIQUE REFERENCES directives(directive_id),
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TRIGGER trg_sprint_assignment_result_links_insert
+BEFORE INSERT ON sprint_assignment_results
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM sprint_conversation_bindings b
+  JOIN conversations c ON c.conversation_id=b.conversation_id
+  JOIN shell_messages m ON m.message_id=NEW.message_id
+  LEFT JOIN directives d ON d.directive_id=NEW.directive_id
+  WHERE b.binding_id=NEW.binding_id
+    AND b.lifecycle='one_shot'
+    AND b.state='active'
+    AND b.required_result_kind=NEW.result_kind
+    AND m.kind='result'
+    AND m.sprint_doc_id=b.sprint_doc_id
+    AND m.from_shell_id=c.shell_id
+    AND (
+      (
+        NEW.result_kind='abort-report'
+        AND NEW.directive_id IS NULL
+        AND EXISTS (
+          SELECT 1 FROM sprint_cancellations cancel
+          WHERE cancel.sprint_doc_id=b.sprint_doc_id
+            AND cancel.state='completed'
+            AND cancel.completed_by_shell_id=c.shell_id
+        )
+      )
+      OR
+      (
+        NEW.result_kind<>'abort-report'
+        AND NEW.directive_id IS NOT NULL
+        AND d.sprint_doc_id=b.sprint_doc_id
+        AND d.unit_id IS b.unit_id
+        AND d.issuer_shell_id=c.shell_id
+        AND d.target='conductor'
+        AND d.status='pending'
+        AND (
+          (b.role='planner' AND d.issuer_flavor='planner')
+          OR (b.role='developer' AND d.issuer_flavor='dev')
+          OR (
+            b.role IN ('reviewer','conformance')
+            AND d.issuer_flavor='reviewer'
+          )
+        )
+      )
+    )
+)
+BEGIN
+  SELECT RAISE(
+    ABORT,
+    'Sprint assignment result does not match its binding, message, or directive'
+  );
+END;
+
+CREATE TRIGGER trg_sprint_assignment_results_append_only_update
+BEFORE UPDATE ON sprint_assignment_results
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint assignment results are append-only');
+END;
+
+CREATE TRIGGER trg_sprint_assignment_results_append_only_delete
+BEFORE DELETE ON sprint_assignment_results
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint assignment results are append-only');
+END;
+
+CREATE INDEX idx_sprint_assignment_results_directive
+    ON sprint_assignment_results(directive_id, result_id);
+
+INSERT OR IGNORE INTO directive_kinds (issuer_flavor,kind)
+VALUES ('system','worker-failed');
+
+COMMIT;

--- a/.super-coder/render/compose.py
+++ b/.super-coder/render/compose.py
@@ -268,6 +268,26 @@ def render_slot_directive(context: "dict | None") -> str:
         lines.append(
             f"- **Required result:** `{context['required_result_kind']}`"
         )
+        result_target = context.get("conductor_slot") or context["slot"]
+        directive_arg = (
+            ""
+            if context["required_result_kind"] == "abort-report"
+            else " --directive <directive-id>"
+        )
+        lines.extend([
+            "",
+            "Return the durable result before this one-shot exits:",
+            "",
+            "```bash",
+            (
+                f"sc mem message send {result_target} \"<bounded evidence>\" "
+                f"--kind result --sprint {context['sprint_doc_id']} "
+                f"--assignment {context['binding_id']} "
+                f"--result-kind {context['required_result_kind']}"
+                f"{directive_arg}"
+            ),
+            "```",
+        ])
     lines.extend(["", "### Kickoff context", ""])
     units = context.get("units") or []
     for unit in units:

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -11,17 +11,14 @@ are code, not model judgement.
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 import threading
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
 import db_driver
-import shell_liveness
 import sprint_conversations
 import sprint_lifecycle
 from conductor_policy import CONDUCTOR_HARNESS, DEFAULT_CONDUCTOR_MODEL
@@ -33,10 +30,7 @@ from sprint_units import (
 )
 
 ENGINE = Path(__file__).resolve().parents[1]
-REPO_ROOT = ENGINE.parent
 INSTANCE_CONFIG = ENGINE / "instance.json"
-_LAUNCH_GUARD_SECONDS = 20
-LAUNCH_LOG = ENGINE / "logs" / "conductor-launches.log"
 
 
 @dataclass(frozen=True)
@@ -52,10 +46,6 @@ class ConductorConfigError(ValueError):
 
 class DirectiveRefused(ValueError):
     """A pending directive that cannot be mechanically executed."""
-
-
-class ConductorLaunchError(RuntimeError):
-    """A role or Conductor process that refused before it could start."""
 
 
 class _RoutePreparationStale(RuntimeError):
@@ -205,12 +195,16 @@ TRANSITIONS = (
         "move blocked when legal; boot originating Planner",
         "originating Planner receives the liveness snapshot",
     ),
+    (
+        "system",
+        "worker-failed",
+        "block the affected unit; boot originating Planner",
+        "originating Planner receives typed run/result evidence",
+    ),
 )
 _TRANSITION_SET = {(issuer, kind) for issuer, kind, _action, _pass in TRANSITIONS}
 
-_wake_lock = threading.Lock()
 _act_lock = threading.Lock()
-_launching_until = 0.0
 
 
 def load_config(path: Path = INSTANCE_CONFIG) -> ConductorConfig:
@@ -318,109 +312,6 @@ def doctor(
         "shell": shell["shortname"],
         "harness": CONDUCTOR_HARNESS,
         "model": config.model,
-    }
-
-
-def _pending_ids(con) -> list[int]:
-    return [
-        row[0]
-        for row in con.execute(
-            "SELECT d.directive_id FROM directives d "
-            "JOIN sprints sp ON sp.sprint_doc_id=d.sprint_doc_id "
-            "WHERE d.status='pending' AND d.target='conductor' "
-            "AND sp.state='active' "
-            "AND NOT EXISTS (SELECT 1 FROM sprint_cancellations sc "
-            "WHERE sc.sprint_doc_id=sp.sprint_doc_id) "
-            "ORDER BY d.directive_id"
-        )
-    ]
-
-
-def _default_launcher(command: list[str]) -> int:
-    LAUNCH_LOG.parent.mkdir(parents=True, exist_ok=True)
-    with LAUNCH_LOG.open("a") as log:
-        proc = subprocess.Popen(
-            command,
-            cwd=REPO_ROOT,
-            stdin=subprocess.DEVNULL,
-            stdout=log,
-            stderr=log,
-            start_new_session=True,
-            env={
-                **os.environ,
-                "SC_NO_AUTOPRUNE": "1",
-                "SC_CONDUCTOR_INTERNAL": "1",
-            },
-        )
-        time.sleep(0.2)
-        returncode = proc.poll()
-    if returncode not in (None, 0):
-        raise ConductorLaunchError(
-            f"launch pid {proc.pid} exited {returncode}; see {LAUNCH_LOG}"
-        )
-    return proc.pid
-
-
-def _launch_is_live(con, shell_id: int) -> bool:
-    row = con.execute(
-        "SELECT shell_id,pid,start_ticks,worktree,harness,launched_at "
-        "FROM shell_launch_records WHERE shell_id=?",
-        (shell_id,),
-    ).fetchone()
-    if row is None:
-        return False
-    try:
-        return shell_liveness.claim_live(dict(row)) is True
-    except (OSError, ValueError):
-        return False
-
-
-def maybe_wake(
-    con,
-    *,
-    config: ConductorConfig | None = None,
-    launcher: Callable[[list[str]], int] | None = None,
-    now: Callable[[], float] = time.monotonic,
-) -> dict:
-    """Boot one ephemeral Conductor when a pending row arrives."""
-    global _launching_until
-    config = config or load_config()
-    launcher = launcher or _default_launcher
-    if not config.enabled:
-        return {"enabled": False, "launched": False}
-    checked = doctor(con, config)
-    pending = _pending_ids(con)
-    if not pending:
-        return {**checked, "launched": False, "reason": "no-pending"}
-    with _wake_lock:
-        current = now()
-        if current < _launching_until:
-            return {**checked, "launched": False, "reason": "launching"}
-        if _launch_is_live(con, checked["shell_id"]):
-            return {**checked, "launched": False, "reason": "already-live"}
-        prompt = (
-            "Process pending Conductor directives in ascending id order. "
-            "For each id run `sc directives act <id>`, inspect the result, "
-            "and continue until `sc directives list --status pending` is empty."
-        )
-        command = [
-            str(REPO_ROOT / "sc"),
-            "run",
-            checked["shell"],
-            "--harness",
-            CONDUCTOR_HARNESS,
-            "--model",
-            config.model,
-            "--prompt",
-            prompt,
-        ]
-        pid = launcher(command)
-        _launching_until = current + _LAUNCH_GUARD_SECONDS
-    return {
-        **checked,
-        "launched": True,
-        "pid": pid,
-        "pending": pending,
     }
 
 
@@ -1201,10 +1092,17 @@ def _execute(
             )
             sprint_lifecycle.transition(con, sprint_id, "closing")
             sprint_lifecycle.transition(con, sprint_id, "closed")
+            sprint_conversations.request_conductor_close(
+                con,
+                sprint_id,
+                reason="originating Planner closed the Sprint",
+            )
         return assignments
 
-    unit = _unit(con, row)
+    unit = _unit(con, row) if row["unit_id"] is not None else None
     if kind == "pr-green":
+        if unit is None:
+            raise DirectiveRefused("pr-green requires unit_id")
         if unit["state"] != "in_review":
             raise DirectiveRefused("pr-green requires an in_review unit")
         reviewer = con.execute(
@@ -1224,6 +1122,8 @@ def _execute(
             unit=unit,
         )
     elif kind == "pr-red":
+        if unit is None:
+            raise DirectiveRefused("pr-red requires unit_id")
         if unit["state"] != "working":
             _move(con, unit, "working", actor_shell_id)
         dev = con.execute(
@@ -1241,6 +1141,8 @@ def _execute(
             unit=unit,
         )
     elif kind == "pr-merged":
+        if unit is None:
+            raise DirectiveRefused("pr-merged requires unit_id")
         _move(con, unit, "merged", actor_shell_id)
         _release_ready_units(
             con,
@@ -1262,7 +1164,27 @@ def _execute(
                 unit=unit,
             )
     elif kind in ("stall", "dead-shell"):
+        if unit is None:
+            raise DirectiveRefused(f"{kind} requires unit_id")
         _block_when_legal(con, unit, actor_shell_id)
+        _spawn(
+            con,
+            assignments,
+            _planner_for_sprint(con, sprint_id),
+            "plan",
+            row,
+            payload,
+            prepared_routes=prepared_routes,
+            unit=unit,
+        )
+    elif kind == "worker-failed":
+        _integer(payload, "binding_id")
+        _text(payload, "role")
+        _text(payload, "run_outcome")
+        _text(payload, "assignment_outcome")
+        _text(payload, "error_code")
+        if unit is not None:
+            _block_when_legal(con, unit, actor_shell_id)
         _spawn(
             con,
             assignments,

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import conversation_events
 import db_driver
+import sprint_conversations
 from conversation_adapters import (
     ConversationAdapter,
     ConversationContext,
@@ -183,6 +184,158 @@ class BrokerStore:
         return int(sequence)
 
     @staticmethod
+    def _bridge_sprint_assignment(
+        con,
+        *,
+        binding,
+        run_id: int,
+        run_outcome: str,
+        error_code: str | None,
+        error_detail: str | None,
+        now: str,
+    ) -> str | None:
+        """Terminalize one one-shot and queue its proven result or failure."""
+        result = con.execute(
+            "SELECT ar.message_id,ar.result_kind,ar.directive_id,m.body "
+            "FROM sprint_assignment_results ar "
+            "JOIN shell_messages m ON m.message_id=ar.message_id "
+            "WHERE ar.binding_id=?",
+            (binding["binding_id"],),
+        ).fetchone()
+        missing_result = run_outcome == "succeeded" and result is None
+        assignment_outcome = (
+            "failed" if missing_result else run_outcome
+        )
+        result_message_id = (
+            int(result["message_id"])
+            if assignment_outcome == "succeeded" and result is not None
+            else None
+        )
+        con.execute(
+            "UPDATE sprint_conversation_bindings SET state='terminal',"
+            "outcome=?,result_message_id=?,completed_at=? "
+            "WHERE binding_id=? AND state<>'terminal'",
+            (
+                assignment_outcome,
+                result_message_id,
+                now,
+                binding["binding_id"],
+            ),
+        )
+        sprint_conversations.append_event(
+            con,
+            binding["conversation_id"],
+            "sprint.assignment.completed",
+            {
+                "binding_id": int(binding["binding_id"]),
+                "role": binding["role"],
+                "outcome": assignment_outcome,
+                "result_message_id": result_message_id,
+                "run_id": run_id,
+            },
+            run_id=run_id,
+        )
+
+        if assignment_outcome == "succeeded":
+            if result["result_kind"] == "abort-report":
+                return None
+            evidence = {
+                "binding_id": int(binding["binding_id"]),
+                "conversation_id": binding["conversation_id"],
+                "role": binding["role"],
+                "slot": binding["slot"],
+                "unit_id": binding["unit_id"],
+                "result_kind": result["result_kind"],
+                "result_message_id": int(result["message_id"]),
+                "result_body": str(result["body"])[:32768],
+                "run_id": run_id,
+            }
+            return sprint_conversations.enqueue_conductor_directive(
+                con,
+                sprint_doc_id=int(binding["sprint_doc_id"]),
+                directive_id=int(result["directive_id"]),
+                source_kind="worker-result",
+                evidence=evidence,
+                idempotency_key=(
+                    f"sprint:{binding['sprint_doc_id']}:assignment-result:"
+                    f"{binding['binding_id']}"
+                ),
+            )
+
+        if assignment_outcome not in {"failed", "unknown"}:
+            return None
+        cancellation = con.execute(
+            "SELECT 1 FROM sprint_cancellations WHERE sprint_doc_id=?",
+            (binding["sprint_doc_id"],),
+        ).fetchone()
+        if cancellation is not None:
+            return None
+        failure_code = (
+            "SPRINT_REQUIRED_RESULT_MISSING"
+            if missing_result
+            else error_code or "SPRINT_WORKER_RUN_FAILED"
+        )
+        evidence = {
+            "binding_id": int(binding["binding_id"]),
+            "conversation_id": binding["conversation_id"],
+            "role": binding["role"],
+            "slot": binding["slot"],
+            "unit_id": binding["unit_id"],
+            "required_result_kind": binding["required_result_kind"],
+            "run_id": run_id,
+            "run_outcome": run_outcome,
+            "assignment_outcome": assignment_outcome,
+            "error_code": failure_code,
+            "error_detail": (error_detail or "")[:16384] or None,
+            "dedupe_key": f"worker-failed|{binding['binding_id']}|{run_id}",
+        }
+        prior = con.execute(
+            "SELECT directive_id FROM sentinel_events "
+            "WHERE event_kind='worker-failed' "
+            "AND json_extract(evidence,'$.dedupe_key')=?",
+            (evidence["dedupe_key"],),
+        ).fetchone()
+        if prior is None:
+            directive_id = int(
+                con.execute(
+                    "INSERT INTO directives "
+                    "(issuer_shell_id,issuer_flavor,kind,payload,target,"
+                    "sprint_doc_id,unit_id) "
+                    "VALUES (NULL,'system','worker-failed',?,'conductor',?,?)",
+                    (
+                        BrokerStore._payload(evidence),
+                        binding["sprint_doc_id"],
+                        binding["unit_id"],
+                    ),
+                ).lastrowid
+            )
+            con.execute(
+                "INSERT INTO sentinel_events "
+                "(event_kind,shell_id,sprint_doc_id,unit_id,directive_id,"
+                "evidence) VALUES ('worker-failed',?,?,?,?,?)",
+                (
+                    binding["shell_id"],
+                    binding["sprint_doc_id"],
+                    binding["unit_id"],
+                    directive_id,
+                    BrokerStore._payload(evidence),
+                ),
+            )
+        else:
+            directive_id = int(prior["directive_id"])
+        return sprint_conversations.enqueue_conductor_directive(
+            con,
+            sprint_doc_id=int(binding["sprint_doc_id"]),
+            directive_id=directive_id,
+            source_kind="worker-failed",
+            evidence=evidence,
+            idempotency_key=(
+                f"sprint:{binding['sprint_doc_id']}:worker-failed:"
+                f"{binding['binding_id']}:{run_id}"
+            ),
+        )
+
+    @staticmethod
     def _run_from_row(row) -> BrokerRun:
         return BrokerRun(
             run_id=int(row["run_id"]),
@@ -308,6 +461,22 @@ class BrokerStore:
                     ),
                 )
                 run_id = int(cur.lastrowid)
+                binding_started = con.execute(
+                    "UPDATE sprint_conversation_bindings "
+                    "SET state='active',started_at=? "
+                    "WHERE conversation_id=? AND lifecycle='one_shot' "
+                    "AND state='pending'",
+                    (now, row["conversation_id"]),
+                ).rowcount
+                if binding_started:
+                    self._append_event(
+                        con,
+                        conversation_id=row["conversation_id"],
+                        event_type="sprint.assignment.started",
+                        payload={"run_id": run_id},
+                        message_id=row["message_id"],
+                        run_id=run_id,
+                    )
                 require_transition("outbox", "claimed", "dispatched")
                 con.execute(
                     "UPDATE conversation_outbox SET state='dispatched',run_id=?,"
@@ -616,6 +785,7 @@ class BrokerStore:
             )
         con = self.connect()
         now, _ = self._times()
+        notify_ids: set[str] = set()
         try:
             with db_driver.write_transaction(
                 con,
@@ -623,13 +793,21 @@ class BrokerStore:
             ):
                 row = con.execute(
                     "SELECT r.state,r.conversation_id,r.trigger_message_id,"
-                    "c.state AS conversation_state,"
+                    "c.state AS conversation_state,c.shell_id,"
+                    "b.binding_id,b.sprint_doc_id,b.role,b.lifecycle,b.slot,"
+                    "b.unit_id,b.required_result_kind,"
+                    "sp.state AS sprint_state,"
                     "EXISTS(SELECT 1 FROM conversation_events closing "
                     " WHERE closing.conversation_id=r.conversation_id "
                     " AND closing.event_type='conversation.close.requested') "
                     "AS close_requested "
                     "FROM conversation_runs r JOIN conversations c "
-                    "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
+                    "ON c.conversation_id=r.conversation_id "
+                    "LEFT JOIN sprint_conversation_bindings b "
+                    "ON b.conversation_id=c.conversation_id "
+                    "LEFT JOIN sprints sp "
+                    "ON sp.sprint_doc_id=b.sprint_doc_id "
+                    "WHERE r.run_id=?",
                     (run_id,),
                 ).fetchone()
                 if row is None:
@@ -648,7 +826,13 @@ class BrokerStore:
                     (row["trigger_message_id"],),
                 ).fetchone()[0]
                 require_transition("message", message_current, message_state)
-                if row["close_requested"]:
+                close_after = bool(row["close_requested"]) or (
+                    row["lifecycle"] == "one_shot"
+                ) or (
+                    row["role"] == "conductor"
+                    and row["sprint_state"] in {"closed", "aborted"}
+                )
+                if close_after:
                     queued_ids = [
                         int(item["message_id"])
                         for item in con.execute(
@@ -728,7 +912,7 @@ class BrokerStore:
                     message_id=row["trigger_message_id"],
                     run_id=run_id,
                 )
-                if row["close_requested"]:
+                if close_after:
                     require_transition(
                         "conversation",
                         conversation_target,
@@ -748,10 +932,35 @@ class BrokerStore:
                         message_id=None,
                         run_id=run_id,
                     )
+                notify_ids.add(str(row["conversation_id"]))
+                if row["lifecycle"] == "one_shot":
+                    conductor_id = self._bridge_sprint_assignment(
+                        con,
+                        binding=row,
+                        run_id=run_id,
+                        run_outcome=outcome,
+                        error_code=error_code,
+                        error_detail=error_detail,
+                        now=now,
+                    )
+                    if conductor_id is not None:
+                        notify_ids.add(conductor_id)
+                elif (
+                    row["role"] == "conductor"
+                    and close_after
+                    and row["binding_id"] is not None
+                ):
+                    con.execute(
+                        "UPDATE sprint_conversation_bindings "
+                        "SET state='terminal',outcome='closed',completed_at=? "
+                        "WHERE binding_id=? AND state<>'terminal'",
+                        (now, row["binding_id"]),
+                    )
                 conversation_id = row["conversation_id"]
         finally:
             con.close()
-        conversation_events.notify(conversation_id)
+        for notify_id in notify_ids or {str(conversation_id)}:
+            conversation_events.notify(notify_id)
         return True
 
     def renew_runs(self, owner: str, run_ids: list[int]) -> int:

--- a/.super-coder/scripts/conversation_launch.py
+++ b/.super-coder/scripts/conversation_launch.py
@@ -103,6 +103,10 @@ class ConversationLaunchPreparer:
                 "b.binding_id,b.sprint_doc_id,b.role,b.lifecycle,b.slot,"
                 "b.unit_id,b.source_directive_id,b.source_message_id,"
                 "b.required_result_kind,b.state AS binding_state,"
+                "(SELECT cb.slot FROM sprint_conversation_bindings cb "
+                " WHERE cb.sprint_doc_id=b.sprint_doc_id "
+                " AND cb.role='conductor' AND cb.state<>'terminal' "
+                " ORDER BY cb.binding_id DESC LIMIT 1) AS conductor_slot,"
                 "sp.state AS sprint_state,sp.spec_doc_id,sp.planner_shell_id,"
                 "sp.planner_route,"
                 "sp.dev_route,sp.reviewer_route,"
@@ -273,6 +277,7 @@ class ConversationLaunchPreparer:
             "source_directive_id": row["source_directive_id"],
             "source_message_id": row["source_message_id"],
             "required_result_kind": row["required_result_kind"],
+            "conductor_slot": row["conductor_slot"],
             "units": [unit] if unit is not None else [],
         }
 

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -62,6 +62,7 @@ Run from the repo root, like every engine command:
     ./sc mem narrative "<line>"
     ./sc mem message check [N]                         # your unread inbox (read-only)
     ./sc mem message send <to-shortname> "<body>" [--kind shell|task|result] [--sprint DOC_ID]
+                            [--assignment ID --result-kind KIND --directive ID]
     ./sc mem message sent                              # outbound view — verify delivery
     ./sc mem message mark-read <message_id>            # (pr_event rows are daemon-emitted)
 
@@ -892,12 +893,46 @@ def cmd_message(args) -> int:
     if args.message_cmd == "send":
         if not args.body.strip():
             die("body is empty")
+        sprint_doc_id = args.sprint
+        assignment_id = args.assignment
+        result_kind = args.result_kind
+        directive_id = args.directive
+        if args.kind == "result":
+            if assignment_id is None and os.environ.get(
+                "SC_SPRINT_ASSIGNMENT_ID"
+            ):
+                assignment_id = int(os.environ["SC_SPRINT_ASSIGNMENT_ID"])
+            if result_kind is None:
+                result_kind = os.environ.get("SC_SPRINT_REQUIRED_RESULT_KIND")
+            if sprint_doc_id is None and os.environ.get("SC_SPRINT_REF"):
+                sprint_doc_id = int(os.environ["SC_SPRINT_REF"])
+            if assignment_id is not None:
+                if not result_kind:
+                    die(
+                        "a Sprint assignment result needs --result-kind "
+                        "(browser one-shots receive it automatically)"
+                    )
+                if directive_id is None and result_kind != "abort-report":
+                    die(
+                        "a Sprint assignment result needs --directive <id>; "
+                        "final assistant text is evidence, not a board transition"
+                    )
+        elif any(
+            value is not None
+            for value in (assignment_id, result_kind, directive_id)
+        ):
+            die(
+                "--assignment/--result-kind/--directive require --kind result"
+            )
         # dedupe_key makes the send idempotent (#333): the server returns the
         # original row for a repeat key, so _api may safely retry an ambiguous
         # timeout — the failure mode that used to duplicate messages fleet-wide.
         r = _api("POST", "/_sc/mem/messages",
                  {"to": args.to, "body": args.body, "kind": args.kind,
-                  "sprint_doc_id": args.sprint,
+                  "sprint_doc_id": sprint_doc_id,
+                  "sprint_assignment_id": assignment_id,
+                  "sprint_result_kind": result_kind,
+                  "sprint_directive_id": directive_id,
                   "dedupe_key": uuid.uuid4().hex},
                  idempotent=True)
         tag = f" ({args.kind})" if args.kind != "shell" else ""
@@ -1108,6 +1143,28 @@ def build_parser() -> argparse.ArgumentParser:
                     help="scope a task/result event to a sprint doc (validated "
                          "server-side) — wake-eligible when the sprint is live "
                          "and the recipient is its bound planner")
+    ms.add_argument(
+        "--assignment",
+        type=int,
+        default=None,
+        metavar="ID",
+        help="correlate a typed result to a browser one-shot assignment "
+             "(defaults from SC_SPRINT_ASSIGNMENT_ID)",
+    )
+    ms.add_argument(
+        "--result-kind",
+        default=None,
+        metavar="KIND",
+        help="typed assignment result "
+             "(defaults from SC_SPRINT_REQUIRED_RESULT_KIND)",
+    )
+    ms.add_argument(
+        "--directive",
+        type=int,
+        default=None,
+        metavar="ID",
+        help="exact Sprint directive returned by this assignment",
+    )
     mm = msub.add_parser("mark-read")
     mm.add_argument("message_id", type=int)
     sp.set_defaults(fn=cmd_message)

--- a/.super-coder/scripts/pr_poller.py
+++ b/.super-coder/scripts/pr_poller.py
@@ -49,6 +49,7 @@ from pathlib import Path
 
 import activity_readers
 import conductor_runtime
+import conversation_broker
 import sentinel
 import sprint_state
 from quota_probes import dispatch as quota_dispatch
@@ -997,7 +998,7 @@ class Poller(threading.Thread):
                  sentinel_cycle=None, sentinel_liveness=None,
                  sentinel_git_probe=None,
                  conductor_config: conductor_runtime.ConductorConfig | None = None,
-                 conductor_wake=None):
+                 conductor_wake=None, broker_notify=None):
         super().__init__(name="pr-poller", daemon=True)
         self._db_path = str(db_path)
         self._interval = interval
@@ -1017,7 +1018,6 @@ class Poller(threading.Thread):
             else sentinel.SentinelConfig()
         )
         self._sentinel_cycle = sentinel_cycle or sentinel.cycle
-        self._sentinel_liveness = sentinel_liveness
         self._sentinel_git_probe = sentinel_git_probe
         self._sentinel_due = 0.0
         # The API startup also owns Conductor config loading and doctor
@@ -1028,7 +1028,10 @@ class Poller(threading.Thread):
             if conductor_config is not None
             else conductor_runtime.ConductorConfig()
         )
-        self._conductor_wake = conductor_wake or conductor_runtime.maybe_wake
+        # Retain the old constructor arguments for one update window, but PID
+        # launch/wake is no longer a delivery path. The conversation broker is
+        # notified after committed PR/sentinel bridge messages instead.
+        self._broker_notify = broker_notify or conversation_broker.notify_commit
         self._github_enabled = fetch is not None or shutil.which("gh") is not None
         self._stop_event = threading.Event()
         self.state = PollerState()
@@ -1089,8 +1092,6 @@ class Poller(threading.Thread):
                             "config": self._sentinel_config,
                             "activity_reader": self._activity_reader,
                         }
-                        if self._sentinel_liveness is not None:
-                            kwargs["liveness"] = self._sentinel_liveness
                         if self._sentinel_git_probe is not None:
                             kwargs["git_probe"] = self._sentinel_git_probe
                         self.last_sentinel = self._sentinel_cycle(
@@ -1138,18 +1139,9 @@ class Poller(threading.Thread):
                             monotonic_now + self._reconcile_interval
                         )
                     if self._conductor_config.enabled:
-                        try:
-                            self.last_conductor = self._conductor_wake(
-                                con, config=self._conductor_config)
-                        except Exception as e:
-                            # Wake is a notification edge, never the scheduler
-                            # mission. Startup doctor catches static config;
-                            # transient launch failures remain visible without
-                            # suppressing poll/sentinel/reconciliation work.
-                            print(
-                                f"pr-poller: conductor wake error ({e})",
-                                flush=True,
-                            )
+                        self.last_conductor = {
+                            "broker_notified": bool(self._broker_notify())
+                        }
                 finally:
                     con.close()
             except Exception as e:

--- a/.super-coder/scripts/sentinel.py
+++ b/.super-coder/scripts/sentinel.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any
 
 import activity_readers
-import shell_liveness
+import sprint_conversations
 import sprint_state
 from sprint_units import TERMINAL_UNIT_STATES
 
@@ -187,6 +187,15 @@ def emit_system_signal(
             _json(body),
         ),
     )
+    if sprint_doc_id is not None:
+        sprint_conversations.enqueue_conductor_directive(
+            con,
+            sprint_doc_id=int(sprint_doc_id),
+            directive_id=int(directive_id),
+            source_kind=f"sentinel:{kind}",
+            evidence=body,
+            idempotency_key=f"sprint:{sprint_doc_id}:sentinel:{dedupe_key}",
+        )
     return directive_id
 
 
@@ -245,9 +254,8 @@ def _assigned_shell(unit) -> tuple[int | None, str]:
     if unit["state"] == "blocked":
         # Blocked has no active worker role in the board schema: it is reachable
         # from both working and in_review, and the transition does not retain
-        # which side blocked. Its expectation is deliberately planner-shaped
-        # (message/directive), so attaching either worker's pid would invent an
-        # owner and can turn the inactive peer into a false dead-shell verdict.
+        # which side blocked. Its expectation is deliberately Planner-shaped;
+        # the latest bound Planner conversation supplies execution evidence.
         return None, "planner"
     return unit["dev_shell_id"], "dev"
 
@@ -271,24 +279,56 @@ def active_units(con) -> list[dict]:
     return [dict(row) for row in rows]
 
 
-def _shell_and_launch(con, shell_id) -> tuple[dict | None, dict | None]:
-    if shell_id is None:
-        return None, None
-    shell = con.execute(
-        "SELECT shell_id,shortname,flavor FROM shells "
-        "WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
-        (shell_id,),
+def _shell_and_assignment(
+    con,
+    unit,
+    shell_id,
+    role: str,
+) -> tuple[dict | None, dict | None]:
+    binding_role = {
+        "dev": "developer",
+        "reviewer": "reviewer",
+        "planner": "planner",
+    }[role]
+    shell_clause = "AND c.shell_id=? " if shell_id is not None else ""
+    params = [unit["sprint_doc_id"], unit["unit_id"], binding_role]
+    if shell_id is not None:
+        params.append(shell_id)
+    assignment = con.execute(
+        "SELECT b.binding_id,b.conversation_id,b.role,b.state AS binding_state,"
+        "b.outcome,b.started_at,b.completed_at,c.state AS conversation_state,"
+        "c.shell_id,c.worktree,r.run_id,r.state AS run_state,"
+        "r.started_at AS run_started_at,"
+        "r.heartbeat_at,r.ended_at,r.error_code,r.error_detail,"
+        "(SELECT MAX(e.created_at) FROM conversation_events e "
+        " WHERE e.conversation_id=c.conversation_id) AS last_event_at "
+        "FROM sprint_conversation_bindings b "
+        "JOIN conversations c ON c.conversation_id=b.conversation_id "
+        "LEFT JOIN conversation_runs r ON r.run_id=("
+        " SELECT r2.run_id FROM conversation_runs r2 "
+        " WHERE r2.conversation_id=b.conversation_id "
+        " ORDER BY r2.run_id DESC LIMIT 1"
+        ") WHERE b.sprint_doc_id=? AND b.unit_id=? AND b.role=? "
+        f"{shell_clause}ORDER BY b.binding_id DESC LIMIT 1",
+        params,
     ).fetchone()
-    launch = con.execute(
-        "SELECT shell_id,pid,start_ticks,worktree,harness,launched_at "
-        "FROM shell_launch_records WHERE shell_id=?",
-        (shell_id,),
-    ).fetchone()
+    resolved_shell_id = (
+        assignment["shell_id"] if assignment is not None else shell_id
+    )
+    shell = (
+        con.execute(
+            "SELECT shell_id,shortname,flavor FROM shells "
+            "WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+            (resolved_shell_id,),
+        ).fetchone()
+        if resolved_shell_id is not None
+        else None
+    )
     shell_dict = dict(shell) if shell is not None else None
-    launch_dict = dict(launch) if launch is not None else None
-    if shell_dict is not None and launch_dict is not None:
-        shell_dict["worktree"] = launch_dict["worktree"]
-    return shell_dict, launch_dict
+    assignment_dict = dict(assignment) if assignment is not None else None
+    if shell_dict is not None and assignment_dict is not None:
+        shell_dict["worktree"] = assignment_dict["worktree"]
+    return shell_dict, assignment_dict
 
 
 def _message_snapshot(con, unit, shell_id) -> dict | None:
@@ -440,6 +480,7 @@ def _signal_times(
     pr,
     planner,
     kickoff,
+    assignment,
 ) -> dict[str, datetime | None]:
     latest_activity = _latest(
         activity.newest_mtime,
@@ -461,6 +502,13 @@ def _signal_times(
         "review": review_at,
         "planner-directive": _utc(_row(planner, "created_at")),
         "kickoff": _utc(_row(kickoff, "created_at")),
+        "conversation": _latest(
+            _row(assignment, "started_at"),
+            _row(assignment, "run_started_at"),
+            _row(assignment, "heartbeat_at"),
+            _row(assignment, "ended_at"),
+            _row(assignment, "last_event_at"),
+        ),
     }
 
 
@@ -512,13 +560,13 @@ def cycle(
     config: SentinelConfig | None = None,
     now=None,
     activity_reader=None,
-    liveness: Callable[[dict], bool] = shell_liveness.claim_live,
+    liveness=None,
     git_probe: Callable[[Path], dict] = git_snapshot,
 ) -> dict:
     """Run one complete sentinel pass.
 
-    Every external seam is injectable so fake clocks, worktrees, launch claims,
-    and git state can exercise the production transaction.
+    Every external seam is injectable so fake clocks, worktrees, conversation
+    evidence, and git state can exercise the production transaction.
     """
     config = config or load_config()
     summary = {
@@ -542,7 +590,9 @@ def cycle(
 
     for unit in units:
         shell_id, role = _assigned_shell(unit)
-        shell, launch = _shell_and_launch(con, shell_id)
+        shell, assignment = _shell_and_assignment(
+            con, unit, shell_id, role
+        )
         state_clock = _utc(unit["state_changed_at"])
         if state_clock is None:
             summary["indeterminate"] += 1
@@ -555,7 +605,7 @@ def cycle(
         if shell is not None:
             activity = read_one(shell, unit, current, role=role)
         worktree = Path(
-            _row(launch, "worktree")
+            _row(assignment, "worktree")
             or (REPO_ROOT / ".sc-worktrees" / str(_row(shell, "shortname", "")))
         )
         try:
@@ -577,8 +627,13 @@ def cycle(
             pr=pr,
             planner=planner,
             kickoff=kickoff,
+            assignment=assignment,
         )
-        latest_activity = signals["activity"]
+        latest_activity = _latest(
+            signals["activity"],
+            signals["conversation"],
+        )
+        signals["activity"] = latest_activity
         evidence = {
             "unit_state": unit["state"],
             "unit_seq": unit["seq"],
@@ -593,43 +648,22 @@ def cycle(
             "last_message_at": _stamp(_row(message, "created_at")),
             "last_message": message,
             "pr": pr,
-            "process": {
-                "pid": _row(launch, "pid"),
-                "start_ticks": _row(launch, "start_ticks"),
-                "launched_at": _stamp(_row(launch, "launched_at")),
+            "conversation": {
+                "binding_id": _row(assignment, "binding_id"),
+                "conversation_id": _row(assignment, "conversation_id"),
+                "binding_state": _row(assignment, "binding_state"),
+                "conversation_state": _row(assignment, "conversation_state"),
+                "run_id": _row(assignment, "run_id"),
+                "run_state": _row(assignment, "run_state"),
+                "run_started_at": _stamp(_row(assignment, "run_started_at")),
+                "heartbeat_at": _stamp(_row(assignment, "heartbeat_at")),
+                "ended_at": _stamp(_row(assignment, "ended_at")),
+                "last_event_at": _stamp(_row(assignment, "last_event_at")),
+                "error_code": _row(assignment, "error_code"),
+                "error_detail": _row(assignment, "error_detail"),
             },
             "expected_signals": json.loads(unit["expected_signals"]),
         }
-
-        launch_floor = _utc(unit.get("assigned_at")) or state_clock
-        launch_at = _utc(_row(launch, "launched_at"))
-        launch_applies = launch is not None and (
-            launch_at is None or launch_at >= launch_floor
-        )
-        live = None
-        if launch_applies:
-            try:
-                verdict = liveness(launch)
-                live = verdict if isinstance(verdict, bool) else None
-            except (OSError, ValueError):
-                live = None
-        evidence["process"]["live"] = live
-        if launch_applies and live is False:
-            dedupe_key = (
-                f"dead-shell|{unit['unit_id']}|{unit['state_changed_at']}|"
-                f"{launch['pid']}|{launch['start_ticks']}"
-            )
-            if emit_system_signal(
-                con,
-                kind="dead-shell",
-                evidence=evidence,
-                dedupe_key=dedupe_key,
-                shell_id=shell_id,
-                sprint_doc_id=unit["sprint_doc_id"],
-                unit_id=unit["unit_id"],
-            ) is not None:
-                summary["dead_shells"] += 1
-            continue
 
         if _activity_beat(
             con,

--- a/.super-coder/scripts/sprint_conversations.py
+++ b/.super-coder/scripts/sprint_conversations.py
@@ -43,6 +43,186 @@ def append_event(
     return sequence
 
 
+def enqueue_message(
+    con,
+    conversation_id: str,
+    *,
+    body: str,
+    idempotency_key: str,
+    sender_ref: str,
+    message_kind: str = "prompt",
+) -> int:
+    """Atomically append one broker-dispatched message to a live conversation."""
+    request_hash = hashlib.sha256(body.encode()).hexdigest()
+    prior = con.execute(
+        "SELECT message_id,request_hash FROM conversation_messages "
+        "WHERE conversation_id=? AND idempotency_key=?",
+        (conversation_id, idempotency_key),
+    ).fetchone()
+    if prior is not None:
+        if prior["request_hash"] != request_hash:
+            raise ValueError(
+                f"conversation message key {idempotency_key!r} was reused "
+                "with different content"
+            )
+        return int(prior["message_id"])
+    conversation = con.execute(
+        "SELECT state FROM conversations WHERE conversation_id=?",
+        (conversation_id,),
+    ).fetchone()
+    if conversation is None:
+        raise ValueError(f"conversation {conversation_id!r} does not exist")
+    if conversation["state"] == "closed":
+        raise ValueError(f"conversation {conversation_id!r} is closed")
+    message_id = int(
+        con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash,state) "
+            "VALUES (?,'engine',?,?,?,?,?,'queued')",
+            (
+                conversation_id,
+                sender_ref,
+                message_kind,
+                body,
+                idempotency_key,
+                request_hash,
+            ),
+        ).lastrowid
+    )
+    con.execute(
+        "INSERT INTO conversation_outbox (conversation_id,message_id) "
+        "VALUES (?,?)",
+        (conversation_id, message_id),
+    )
+    if conversation["state"] in ("idle", "waiting", "error"):
+        con.execute(
+            "UPDATE conversations SET state='queued',"
+            "last_activity_at=datetime('now'),version=version+1 "
+            "WHERE conversation_id=?",
+            (conversation_id,),
+        )
+    else:
+        con.execute(
+            "UPDATE conversations SET last_activity_at=datetime('now'),"
+            "version=version+1 WHERE conversation_id=?",
+            (conversation_id,),
+        )
+    queue_position = int(
+        con.execute(
+            "SELECT COUNT(*) FROM conversation_messages "
+            "WHERE conversation_id=? AND message_id<=? "
+            "AND state IN ('accepted','queued','running')",
+            (conversation_id, message_id),
+        ).fetchone()[0]
+    )
+    append_event(
+        con,
+        conversation_id,
+        "message.accepted",
+        {
+            "message_id": message_id,
+            "queue_state": "queued",
+            "queue_position": queue_position,
+        },
+        message_id=message_id,
+    )
+    return message_id
+
+
+def conductor_conversation(con, sprint_doc_id: int):
+    return con.execute(
+        "SELECT c.conversation_id,c.state,b.binding_id "
+        "FROM sprint_conversation_bindings b "
+        "JOIN conversations c ON c.conversation_id=b.conversation_id "
+        "WHERE b.sprint_doc_id=? AND b.role='conductor' "
+        "AND b.state<>'terminal' AND c.state<>'closed' "
+        "ORDER BY b.binding_id DESC LIMIT 1",
+        (sprint_doc_id,),
+    ).fetchone()
+
+
+def enqueue_conductor_directive(
+    con,
+    *,
+    sprint_doc_id: int,
+    directive_id: int,
+    source_kind: str,
+    evidence: dict,
+    idempotency_key: str,
+) -> str | None:
+    """Queue one committed directive/evidence packet to persistent Conductor."""
+    conductor = conductor_conversation(con, sprint_doc_id)
+    if conductor is None:
+        return None
+    body = json.dumps(
+        {
+            "sprint_doc_id": sprint_doc_id,
+            "source_kind": source_kind,
+            "directive_id": directive_id,
+            "evidence": evidence,
+            "instruction": f"Run `sc directives act {directive_id}`.",
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    enqueue_message(
+        con,
+        conductor["conversation_id"],
+        body=body,
+        idempotency_key=idempotency_key,
+        sender_ref="sprint-bridge",
+    )
+    return str(conductor["conversation_id"])
+
+
+def request_conductor_close(
+    con,
+    sprint_doc_id: int,
+    *,
+    reason: str,
+) -> str | None:
+    """Request terminal close, closing an already-idle Conductor immediately."""
+    conductor = conductor_conversation(con, sprint_doc_id)
+    if conductor is None:
+        return None
+    conversation_id = str(conductor["conversation_id"])
+    exists = con.execute(
+        "SELECT 1 FROM conversation_events WHERE conversation_id=? "
+        "AND event_type='conversation.close.requested'",
+        (conversation_id,),
+    ).fetchone()
+    if exists is None:
+        append_event(
+            con,
+            conversation_id,
+            "conversation.close.requested",
+            {"reason": reason, "sprint_doc_id": sprint_doc_id},
+        )
+    state = conductor["state"]
+    if state in ("idle", "waiting", "error"):
+        con.execute(
+            "UPDATE conversations SET state='closed',closed_at=datetime('now'),"
+            "last_activity_at=datetime('now'),version=version+1 "
+            "WHERE conversation_id=?",
+            (conversation_id,),
+        )
+        append_event(
+            con,
+            conversation_id,
+            "conversation.closed",
+            {"state": "closed", "reason": reason},
+        )
+        con.execute(
+            "UPDATE sprint_conversation_bindings SET state='terminal',"
+            "outcome='closed',completed_at=datetime('now') "
+            "WHERE binding_id=?",
+            (conductor["binding_id"],),
+        )
+    return conversation_id
+
+
 def create_sprint_conversation(
     con,
     *,

--- a/tests/run_conductor_real_matrix.py
+++ b/tests/run_conductor_real_matrix.py
@@ -183,12 +183,6 @@ def main() -> int:
         )
         (temp / "sc").chmod(0o755)
 
-        launches: list[list[str]] = []
-
-        def record(command):
-            launches.append(command)
-            return 7000 + len(launches)
-
         server = ThreadingHTTPServer(("127.0.0.1", 0), ContractHandler)
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
@@ -206,11 +200,7 @@ def main() -> int:
             "list is empty, then reply MATRIX_COMPLETE."
         )
         try:
-            with (
-                mock.patch.object(conductor_routes, "DB_PATH", db_path),
-                mock.patch.object(runtime, "_default_launcher", record),
-                mock.patch.object(runtime, "REPO_ROOT", temp),
-            ):
+            with mock.patch.object(conductor_routes, "DB_PATH", db_path):
                 result = subprocess.run(
                     [
                         "opencode",
@@ -255,7 +245,7 @@ def main() -> int:
                     "refused": refused,
                     "pending": pending,
                     "trail": trail,
-                    "recorded_role_launches": len(launches),
+                    "recorded_role_launches": 0,
                 },
                 sort_keys=True,
             )

--- a/tests/test_conductor_contracts.py
+++ b/tests/test_conductor_contracts.py
@@ -159,17 +159,15 @@ class ConductorContractTests(unittest.TestCase):
         self.assertEqual((status, obj["error"]["code"]), (422, "validation"))
 
     def test_valid_creation_never_launches_a_conductor_process(self):
-        with mock.patch.object(
-                conductor_routes.conductor_runtime,
-                "maybe_wake",
-        ) as wake:
-            status, _item = self.post({
-                "kind": "ready-for-review",
-                "target": "conductor",
-                "payload": {"head": "abc"},
-            })
+        self.assertFalse(
+            hasattr(conductor_routes.conductor_runtime, "maybe_wake")
+        )
+        status, _item = self.post({
+            "kind": "ready-for-review",
+            "target": "conductor",
+            "payload": {"head": "abc"},
+        })
         self.assertEqual(status, 201)
-        wake.assert_not_called()
 
     def test_planner_handoff_is_retired_in_favor_of_planner_arm(self):
         planner_id = self.con.execute(
@@ -190,25 +188,20 @@ class ConductorContractTests(unittest.TestCase):
         )
         self.con.commit()
 
-        with mock.patch.object(
-                conductor_routes.conductor_runtime,
-                "maybe_wake",
-        ) as wake:
-            status, item = self.post(
-                {
-                    "kind": "handoff",
-                    "target": "conductor",
-                    "sprint_doc_id": 100,
-                    "payload": {},
-                },
-                token="planner-token",
-            )
+        status, item = self.post(
+            {
+                "kind": "handoff",
+                "target": "conductor",
+                "sprint_doc_id": 100,
+                "payload": {},
+            },
+            token="planner-token",
+        )
 
         self.assertEqual(
             (status, item["error"]["code"]),
             (409, "handoff_retired"),
         )
-        wake.assert_not_called()
         self.assertEqual(
             self.con.execute(
                 "SELECT COUNT(*) FROM directives WHERE kind='handoff'"

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -154,12 +154,6 @@ class RuntimeFixture(unittest.TestCase):
             (runtime.DEFAULT_CONDUCTOR_MODEL,),
         )
         self.con.commit()
-        runtime._launching_until = 0.0
-        self.commands: list[list[str]] = []
-
-    def launcher(self, command: list[str]) -> int:
-        self.commands.append(command)
-        return 9000 + len(self.commands)
 
     def set_unit(self, state: str, *, review_head=None) -> None:
         self.con.execute(
@@ -357,84 +351,9 @@ class ConductorFlavorAndDoctorTests(RuntimeFixture):
                 run=self.model_probe("ollama-cloud/another-model"),
             )
 
-    def test_wake_is_config_gated_and_single_flight(self):
-        self.emit("dev", "unit-report", {"shipped": "x"})
-        disabled = runtime.maybe_wake(
-            self.con,
-            config=runtime.ConductorConfig(),
-            launcher=self.launcher,
-        )
-        self.assertFalse(disabled["launched"])
-
-        config = runtime.ConductorConfig(True, "CON1", runtime.DEFAULT_CONDUCTOR_MODEL)
-        with (
-            mock.patch.object(runtime, "_launch_is_live", return_value=False),
-            mock.patch.object(
-                runtime,
-                "doctor",
-                return_value={
-                    "enabled": True,
-                    "ok": True,
-                    "shell_id": 1,
-                    "shell": "CON1",
-                    "harness": "opencode",
-                    "model": runtime.DEFAULT_CONDUCTOR_MODEL,
-                },
-            ),
-        ):
-            first = runtime.maybe_wake(
-                self.con, config=config, launcher=self.launcher, now=lambda: 100.0
-            )
-            second = runtime.maybe_wake(
-                self.con, config=config, launcher=self.launcher, now=lambda: 101.0
-            )
-        self.assertTrue(first["launched"])
-        self.assertEqual(second["reason"], "launching")
-        self.assertEqual(len(self.commands), 1)
-        self.assertIn("--harness", self.commands[0])
-        self.assertIn("opencode", self.commands[0])
-        self.assertIn(runtime.DEFAULT_CONDUCTOR_MODEL, self.commands[0])
-
-    def test_declared_handoff_is_not_eligible_for_automatic_wake(self):
-        self.set_declared()
-        directive_id = self.emit("planner", "handoff", {}, unit=False)
-        self.con.commit()
-
-        config = runtime.ConductorConfig(
-            True, "CON1", runtime.DEFAULT_CONDUCTOR_MODEL
-        )
-        with mock.patch.object(
-            runtime,
-            "doctor",
-            return_value={
-                "enabled": True,
-                "ok": True,
-                "shell_id": 1,
-                "shell": "CON1",
-                "harness": "opencode",
-                "model": runtime.DEFAULT_CONDUCTOR_MODEL,
-            },
-        ):
-            result = runtime.maybe_wake(
-                self.con, config=config, launcher=self.launcher
-            )
-
-        self.assertFalse(result["launched"])
-        self.assertEqual(result["reason"], "no-pending")
-        self.assertEqual(self.commands, [])
-        self.assertEqual(
-            self.con.execute(
-                "SELECT status FROM directives WHERE directive_id=?",
-                (directive_id,),
-            ).fetchone()[0],
-            "pending",
-        )
-        self.assertEqual(
-            self.con.execute(
-                "SELECT state FROM sprints WHERE sprint_doc_id=100"
-            ).fetchone()[0],
-            "declared",
-        )
+    def test_process_wake_path_is_retired(self):
+        self.assertFalse(hasattr(runtime, "maybe_wake"))
+        self.assertFalse(hasattr(runtime, "_launch_is_live"))
 
     def test_opencode_headless_route_does_not_invent_effort(self):
         adapter = run.load_adapter("opencode")
@@ -564,6 +483,19 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         ),
         ("system", "stall", "working", {"dwell_seconds": 99}, True),
         ("system", "dead-shell", "working", {"process": {"live": False}}, True),
+        (
+            "system",
+            "worker-failed",
+            "working",
+            {
+                "binding_id": 42,
+                "role": "developer",
+                "run_outcome": "unknown",
+                "assignment_outcome": "unknown",
+                "error_code": "HARNESS_OUTCOME_UNKNOWN",
+            },
+            True,
+        ),
     )
 
     def test_every_kind_and_issuer_has_one_executable_action(self):
@@ -1180,6 +1112,21 @@ class ConductorSyntheticSprintTests(RuntimeFixture):
         self.con.execute(
             "UPDATE sprint_units SET state='working' WHERE unit_id=10"
         )
+        self.con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,sprint_doc_id,harness,worktree,"
+            "state,creation_idempotency_key,creation_request_hash) "
+            "VALUES ('cv_synthetic_conductor',1,'sprint',100,'opencode',"
+            "'/tmp/conductor','idle','synthetic-conductor',"
+            "'synthetic-conductor-hash')"
+        )
+        self.con.execute(
+            "INSERT INTO sprint_conversation_bindings "
+            "(conversation_id,sprint_doc_id,role,lifecycle,slot,state,"
+            "started_at) VALUES "
+            "('cv_synthetic_conductor',100,'conductor','persistent','CON1',"
+            "'active',datetime('now'))"
+        )
         self.con.commit()
         ids = [
             self.act_one(
@@ -1236,6 +1183,15 @@ class ConductorSyntheticSprintTests(RuntimeFixture):
                 "SELECT state FROM sprints WHERE sprint_doc_id=100"
             ).fetchone()[0],
             "closed",
+        )
+        self.assertEqual(
+            tuple(self.con.execute(
+                "SELECT c.state,b.state,b.outcome "
+                "FROM conversations c JOIN sprint_conversation_bindings b "
+                "ON b.conversation_id=c.conversation_id "
+                "WHERE c.conversation_id='cv_synthetic_conductor'"
+            ).fetchone()),
+            ("closed", "terminal", "closed"),
         )
         self.assertEqual(
             self.con.execute(

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -307,6 +307,88 @@ class ConversationBrokerCase(unittest.TestCase):
 
 
 class StoreContractTest(ConversationBrokerCase):
+    def add_sprint_assignment_floor(self) -> dict:
+        con = self.connect()
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (3,'Conductor','CON1','conductor','prompt',1)"
+        )
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (4,'Planner','PLN1','planner','prompt',1)"
+        )
+        con.execute(
+            "INSERT INTO documents "
+            "(document_id,kind,title,body) "
+            "VALUES (24,'doc','SPRINT: broker role loop','x')"
+        )
+        con.execute(
+            "INSERT INTO sprints "
+            "(sprint_doc_id,state,legacy,planner_shell_id) "
+            "VALUES (24,'active',1,4)"
+        )
+        unit_id = int(
+            con.execute(
+                "INSERT INTO sprint_units "
+                "(sprint_doc_id,seq,unit_title,dev_shell_id,state) "
+                "VALUES (24,'U1','Broker bridge',1,'working')"
+            ).lastrowid
+        )
+        source_directive_id = int(
+            con.execute(
+                "INSERT INTO directives "
+                "(issuer_flavor,kind,target,sprint_doc_id,unit_id) "
+                "VALUES ('system','stall','conductor',24,?)",
+                (unit_id,),
+            ).lastrowid
+        )
+        conductor_id = "cv_sprint_conductor"
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,sprint_doc_id,harness,worktree,"
+            "state,creation_idempotency_key,creation_request_hash) "
+            "VALUES (?,3,'sprint',24,'opencode',?,'idle','cond','cond-hash')",
+            (conductor_id, str(self.worktree)),
+        )
+        con.execute(
+            "INSERT INTO sprint_conversation_bindings "
+            "(conversation_id,sprint_doc_id,role,lifecycle,slot,state,"
+            "started_at) "
+            "VALUES (?,24,'conductor','persistent','CON1','active',"
+            "datetime('now'))",
+            (conductor_id,),
+        )
+        worker_id = "cv_sprint_worker"
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,sprint_doc_id,harness,worktree,"
+            "state,creation_idempotency_key,creation_request_hash) "
+            "VALUES (?,1,'sprint',24,'codex',?,'queued','worker','worker-hash')",
+            (worker_id, str(self.worktree)),
+        )
+        binding_id = int(
+            con.execute(
+                "INSERT INTO sprint_conversation_bindings "
+                "(conversation_id,sprint_doc_id,role,lifecycle,slot,unit_id,"
+                "source_directive_id,required_result_kind) "
+                "VALUES (?,24,'developer','one_shot','sh1',?,?,"
+                "'unit-report')",
+                (worker_id, unit_id, source_directive_id),
+            ).lastrowid
+        )
+        con.commit()
+        con.close()
+        message_id = self.add_message(worker_id)
+        return {
+            "worker_id": worker_id,
+            "conductor_id": conductor_id,
+            "binding_id": binding_id,
+            "unit_id": unit_id,
+            "message_id": message_id,
+        }
+
     def test_prepared_shell_archive_is_bound_while_the_run_is_leased(self) -> None:
         conversation_id = self.add_conversation()
         self.add_message(conversation_id)
@@ -381,6 +463,195 @@ class StoreContractTest(ConversationBrokerCase):
         con.close()
         self.assertEqual(first_state, "completed")
         self.assertEqual(sequences, [1, 2])
+
+    def test_one_shot_result_closes_and_returns_exact_directive_to_conductor(
+        self,
+    ) -> None:
+        floor = self.add_sprint_assignment_floor()
+        store = BrokerStore(self.db_path)
+        run = store.claim_next("broker")
+        self.assertEqual(run.conversation_id, floor["worker_id"])
+        store.mark_starting(run.run_id, "broker")
+        store.mark_native_started(
+            run.run_id,
+            "broker",
+            NativeTurn("codex", "worker-session", "worker-run", self.worktree),
+        )
+
+        con = self.connect()
+        directive_id = int(
+            con.execute(
+                "INSERT INTO directives "
+                "(issuer_shell_id,issuer_flavor,kind,payload,target,"
+                "sprint_doc_id,unit_id) "
+                "VALUES (1,'dev','unit-report','{\"shipped\":\"yes\"}',"
+                "'conductor',24,?)",
+                (floor["unit_id"],),
+            ).lastrowid
+        )
+        result_message_id = int(
+            con.execute(
+                "INSERT INTO shell_messages "
+                "(from_shell_id,to_shell_id,body,kind,sprint_doc_id) "
+                "VALUES (1,3,'unit report evidence','result',24)"
+            ).lastrowid
+        )
+        con.execute(
+            "INSERT INTO sprint_assignment_results "
+            "(binding_id,message_id,result_kind,directive_id) "
+            "VALUES (?,?,'unit-report',?)",
+            (floor["binding_id"], result_message_id, directive_id),
+        )
+        con.commit()
+        con.close()
+
+        store.finish_run(
+            run.run_id,
+            "succeeded",
+            event_type="run.completed",
+        )
+
+        con = self.connect()
+        binding = con.execute(
+            "SELECT state,outcome,result_message_id "
+            "FROM sprint_conversation_bindings WHERE binding_id=?",
+            (floor["binding_id"],),
+        ).fetchone()
+        worker_state = con.execute(
+            "SELECT state FROM conversations WHERE conversation_id=?",
+            (floor["worker_id"],),
+        ).fetchone()[0]
+        conductor_message = con.execute(
+            "SELECT body,state FROM conversation_messages "
+            "WHERE conversation_id=? ORDER BY message_id DESC LIMIT 1",
+            (floor["conductor_id"],),
+        ).fetchone()
+        con.close()
+        self.assertEqual(
+            tuple(binding),
+            ("terminal", "succeeded", result_message_id),
+        )
+        self.assertEqual(worker_state, "closed")
+        self.assertEqual(conductor_message["state"], "queued")
+        self.assertEqual(
+            json.loads(conductor_message["body"])["directive_id"],
+            directive_id,
+        )
+
+        conductor_run = store.claim_next("broker")
+        self.assertEqual(conductor_run.conversation_id, floor["conductor_id"])
+        store.mark_starting(conductor_run.run_id, "broker")
+        store.mark_native_started(
+            conductor_run.run_id,
+            "broker",
+            NativeTurn(
+                "opencode",
+                "conductor-session",
+                "conductor-run",
+                self.worktree,
+            ),
+        )
+        con = self.connect()
+        con.execute("UPDATE sprints SET state='closing' WHERE sprint_doc_id=24")
+        con.execute("UPDATE sprints SET state='closed' WHERE sprint_doc_id=24")
+        con.execute(
+            "INSERT INTO conversation_events "
+            "(conversation_id,sequence,event_type,payload) "
+            "VALUES (?,(SELECT COALESCE(MAX(sequence),0)+1 "
+            "FROM conversation_events WHERE conversation_id=?),"
+            "'conversation.close.requested','{}')",
+            (floor["conductor_id"], floor["conductor_id"]),
+        )
+        con.commit()
+        con.close()
+
+        # A restarted broker can finish the already-identified exact run; the
+        # close request and Sprint state, not a process identity, are truth.
+        BrokerStore(self.db_path).finish_run(
+            conductor_run.run_id,
+            "succeeded",
+            event_type="run.completed",
+        )
+        con = self.connect()
+        conductor_terminal = con.execute(
+            "SELECT c.state,b.state,b.outcome "
+            "FROM conversations c JOIN sprint_conversation_bindings b "
+            "ON b.conversation_id=c.conversation_id "
+            "WHERE c.conversation_id=?",
+            (floor["conductor_id"],),
+        ).fetchone()
+        con.close()
+        self.assertEqual(
+            tuple(conductor_terminal),
+            ("closed", "terminal", "closed"),
+        )
+
+    def assert_assignment_failure(
+        self,
+        run_outcome: str,
+        expected_outcome: str,
+    ) -> None:
+        floor = self.add_sprint_assignment_floor()
+        store = BrokerStore(self.db_path)
+        run = store.claim_next("broker")
+        if run_outcome == "succeeded":
+            store.mark_starting(run.run_id, "broker")
+            store.mark_native_started(
+                run.run_id,
+                "broker",
+                NativeTurn(
+                    "codex",
+                    "worker-session",
+                    "worker-run",
+                    self.worktree,
+                ),
+            )
+        store.finish_run(
+            run.run_id,
+            run_outcome,
+            event_type=(
+                "run.completed"
+                if run_outcome == "succeeded"
+                else "run.unknown"
+            ),
+            error_code=(
+                None
+                if run_outcome == "succeeded"
+                else "HARNESS_OUTCOME_UNKNOWN"
+            ),
+        )
+
+        con = self.connect()
+        binding = con.execute(
+            "SELECT state,outcome FROM sprint_conversation_bindings "
+            "WHERE binding_id=?",
+            (floor["binding_id"],),
+        ).fetchone()
+        failure = con.execute(
+            "SELECT d.payload,e.evidence FROM directives d "
+            "JOIN sentinel_events e ON e.directive_id=d.directive_id "
+            "WHERE d.kind='worker-failed'"
+        ).fetchone()
+        worker_outbox = con.execute(
+            "SELECT COUNT(*) FROM conversation_outbox "
+            "WHERE conversation_id=?",
+            (floor["worker_id"],),
+        ).fetchone()[0]
+        con.close()
+        self.assertEqual(tuple(binding), ("terminal", expected_outcome))
+        self.assertEqual(
+            json.loads(failure["payload"])["run_outcome"],
+            run_outcome,
+        )
+        self.assertEqual(worker_outbox, 1)
+        next_run = store.claim_next("second-broker")
+        self.assertEqual(next_run.conversation_id, floor["conductor_id"])
+
+    def test_missing_one_shot_result_is_typed_and_not_replayed(self) -> None:
+        self.assert_assignment_failure("succeeded", "failed")
+
+    def test_unknown_one_shot_result_is_typed_and_not_replayed(self) -> None:
+        self.assert_assignment_failure("unknown", "unknown")
 
     def test_close_requested_conversation_cannot_dispatch_queued_work(self) -> None:
         conversation_id = self.add_conversation()

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -143,8 +143,8 @@ class SentinelCycleTests(unittest.TestCase):
             0,
         )
 
-    def test_dead_launch_is_immediate_and_deduped_before_dwell(self):
-        unit_id = seed_floor(self.con)
+    def test_launch_record_and_pid_verdict_are_not_sprint_liveness(self):
+        seed_floor(self.con)
         self.con.execute(
             "INSERT INTO shell_launch_records "
             "(shell_id,pid,start_ticks,worktree,harness,launched_at) "
@@ -152,28 +152,17 @@ class SentinelCycleTests(unittest.TestCase):
         )
         self.con.commit()
 
-        first = self.run_cycle(
+        result = self.run_cycle(
             now="2026-01-01T00:02:00Z", liveness=lambda claim: False
         )
-        second = self.run_cycle(
-            now="2026-01-01T00:03:00Z", liveness=lambda claim: False
-        )
 
-        self.assertEqual(first["dead_shells"], 1)
-        self.assertEqual(first["stalls"], 0)
-        self.assertEqual(second["dead_shells"], 0)
-        directive = self.con.execute(
-            "SELECT * FROM directives WHERE kind='dead-shell'"
-        ).fetchone()
-        self.assertEqual(directive["issuer_flavor"], "system")
-        self.assertEqual(directive["target"], "conductor")
-        self.assertEqual(directive["unit_id"], unit_id)
-        event = self.con.execute(
-            "SELECT directive_id,evidence FROM sentinel_events "
-            "WHERE event_kind='dead-shell'"
-        ).fetchone()
-        self.assertEqual(event["directive_id"], directive["directive_id"])
-        self.assertEqual(json.loads(event["evidence"])["process"]["pid"], 4242)
+        self.assertEqual(result["dead_shells"], 0)
+        self.assertEqual(result["stalls"], 0)
+        self.assertIsNone(
+            self.con.execute(
+                "SELECT 1 FROM directives WHERE kind='dead-shell'"
+            ).fetchone()
+        )
 
     def test_indeterminate_launch_verdict_never_becomes_dead(self):
         seed_floor(self.con)
@@ -193,6 +182,94 @@ class SentinelCycleTests(unittest.TestCase):
             ).fetchone()[0],
             0,
         )
+
+    def test_run_events_drive_dwell_and_stall_wakes_persistent_conductor(self):
+        unit_id = seed_floor(self.con)
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (4,'Conductor','CON1','conductor','x',1)"
+        )
+        self.con.execute(
+            "INSERT INTO directives "
+            "(issuer_flavor,kind,target,sprint_doc_id,unit_id) "
+            "VALUES ('system','stall','conductor',100,?)",
+            (unit_id,),
+        )
+        source_id = int(self.con.execute(
+            "SELECT MAX(directive_id) FROM directives"
+        ).fetchone()[0])
+        self.con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,sprint_doc_id,harness,worktree,"
+            "state,creation_idempotency_key,creation_request_hash) "
+            "VALUES ('cv_sentinel_cond',4,'sprint',100,'opencode','/tmp/cond',"
+            "'idle','sentinel-cond','sentinel-cond-hash')"
+        )
+        self.con.execute(
+            "INSERT INTO sprint_conversation_bindings "
+            "(conversation_id,sprint_doc_id,role,lifecycle,slot,state,"
+            "started_at) VALUES "
+            "('cv_sentinel_cond',100,'conductor','persistent','CON1','active',"
+            "'2026-01-01T00:00:00Z')"
+        )
+        self.con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,sprint_doc_id,harness,worktree,"
+            "state,creation_idempotency_key,creation_request_hash) "
+            "VALUES ('cv_sentinel_dev',2,'sprint',100,'codex','/tmp/dev1',"
+            "'running','sentinel-dev','sentinel-dev-hash')"
+        )
+        binding_id = self.con.execute(
+            "INSERT INTO sprint_conversation_bindings "
+            "(conversation_id,sprint_doc_id,role,lifecycle,slot,unit_id,"
+            "source_directive_id,required_result_kind,state,started_at) "
+            "VALUES ('cv_sentinel_dev',100,'developer','one_shot','dev1',?,"
+            "?,'unit-report','active','2026-01-01T00:00:00Z')",
+            (unit_id, source_id),
+        ).lastrowid
+        message_id = self.con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash,state) "
+            "VALUES ('cv_sentinel_dev','engine','sprint','prompt','work',"
+            "'sentinel-work','sentinel-work-hash','running')"
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO conversation_runs "
+            "(conversation_id,shell_id,trigger_message_id,state,lease_owner,"
+            "lease_expires_at,started_at,heartbeat_at) "
+            "VALUES ('cv_sentinel_dev',2,?,'running','broker',"
+            "'2026-01-01T03:10:00Z','2026-01-01T00:00:00Z',"
+            "'2026-01-01T02:59:00Z')",
+            (message_id,),
+        )
+        self.con.commit()
+
+        recent = self.run_cycle(now="2026-01-01T03:00:00Z")
+        self.assertEqual(recent["stalls"], 0)
+        beat = self.con.execute(
+            "SELECT evidence FROM sentinel_events "
+            "WHERE event_kind='activity-beat' ORDER BY event_id DESC LIMIT 1"
+        ).fetchone()
+        conversation = json.loads(beat["evidence"])["conversation"]
+        self.assertEqual(conversation["binding_id"], binding_id)
+        self.assertEqual(conversation["run_state"], "running")
+        self.assertNotIn("process", json.loads(beat["evidence"]))
+
+        self.con.execute(
+            "UPDATE conversation_runs SET heartbeat_at='2026-01-01T00:00:00Z'"
+        )
+        self.con.commit()
+        stalled = self.run_cycle(now="2026-01-01T03:00:01Z")
+
+        self.assertEqual(stalled["stalls"], 1)
+        queued = self.con.execute(
+            "SELECT body FROM conversation_messages "
+            "WHERE conversation_id='cv_sentinel_cond' "
+            "ORDER BY message_id DESC LIMIT 1"
+        ).fetchone()
+        self.assertEqual(json.loads(queued["body"])["source_kind"], "sentinel:stall")
 
     def test_disk_activity_emits_a_beat_and_resets_dwell(self):
         seed_floor(self.con)

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -367,6 +367,11 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                                         "backfill"))
                 enter(mock.patch.object(server.mem_credentials, "provision"))
                 enter(mock.patch.object(server.pr_poller, "Poller"))
+                enter(mock.patch.object(
+                    server.conductor_runtime,
+                    "load_config",
+                    return_value=server.conductor_runtime.ConductorConfig(),
+                ))
                 broker_start = enter(mock.patch.object(
                     server.conversation_broker, "start_service"
                 ))

--- a/tests/test_sprint_eventing.py
+++ b/tests/test_sprint_eventing.py
@@ -973,6 +973,126 @@ class ApiTest(unittest.TestCase):
                            "WHERE message_id=?", out["message_id"])[0]["s"],
                     scope)
 
+    def test_typed_assignment_result_records_exact_binding_and_directive(self):
+        con = sqlite3.connect(self.db)
+        con.row_factory = sqlite3.Row
+        try:
+            con.execute("UPDATE shells SET flavor='planner' WHERE shell_id=1")
+            con.execute(
+                "INSERT OR IGNORE INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (3,'Conductor','CON1','conductor','x',1)"
+            )
+            seed_sprint_doc(con, 180, units=0)
+            con.execute("UPDATE sprints SET state='active' WHERE sprint_doc_id=180")
+            source_id = con.execute(
+                "INSERT INTO directives "
+                "(issuer_flavor,kind,target,sprint_doc_id) "
+                "VALUES ('system','stall','conductor',180)"
+            ).lastrowid
+            con.execute(
+                "INSERT INTO conversations "
+                "(conversation_id,shell_id,mode,sprint_doc_id,harness,worktree,"
+                "state,creation_idempotency_key,creation_request_hash) "
+                "VALUES ('cv_result_planner',1,'sprint',180,'claude','/tmp',"
+                "'running','result-planner','result-planner-hash')"
+            )
+            binding_id = con.execute(
+                "INSERT INTO sprint_conversation_bindings "
+                "(conversation_id,sprint_doc_id,role,lifecycle,slot,"
+                "source_directive_id,required_result_kind,state,started_at) "
+                "VALUES ('cv_result_planner',180,'planner','one_shot','plan1',"
+                "?,'planner-directive','active',datetime('now'))",
+                (source_id,),
+            ).lastrowid
+            directive_id = con.execute(
+                "INSERT INTO directives "
+                "(issuer_shell_id,issuer_flavor,kind,payload,target,"
+                "sprint_doc_id) "
+                "VALUES (1,'planner','hold','{\"reason\":\"gate\"}',"
+                "'conductor',180)"
+            ).lastrowid
+            con.commit()
+        finally:
+            con.close()
+
+        result = mem._api(
+            "POST",
+            "/_sc/mem/messages",
+            {
+                "to": "CON1",
+                "body": "Planner ruling evidence",
+                "kind": "result",
+                "sprint_doc_id": 180,
+                "sprint_assignment_id": binding_id,
+                "sprint_result_kind": "planner-directive",
+                "sprint_directive_id": directive_id,
+                "dedupe_key": "typed-result-180",
+            },
+        )
+
+        row = self.q(
+            "SELECT binding_id,message_id,result_kind,directive_id "
+            "FROM sprint_assignment_results WHERE binding_id=?",
+            binding_id,
+        )[0]
+        self.assertEqual(
+            tuple(row),
+            (binding_id, result["message_id"], "planner-directive", directive_id),
+        )
+        con = sqlite3.connect(self.db)
+        try:
+            con.execute(
+                "UPDATE conversations SET state='idle' "
+                "WHERE conversation_id='cv_result_planner'"
+            )
+            con.execute(
+                "UPDATE conversations SET state='closed',"
+                "closed_at=datetime('now') "
+                "WHERE conversation_id='cv_result_planner'"
+            )
+            con.execute(
+                "UPDATE sprint_conversation_bindings SET state='terminal',"
+                "outcome='succeeded',result_message_id=?,"
+                "completed_at=datetime('now') "
+                "WHERE binding_id=?",
+                (result["message_id"], binding_id),
+            )
+            con.commit()
+        finally:
+            con.close()
+        replay = mem._api(
+            "POST",
+            "/_sc/mem/messages",
+            {
+                "to": "CON1",
+                "body": "Planner ruling evidence",
+                "kind": "result",
+                "sprint_doc_id": 180,
+                "sprint_assignment_id": binding_id,
+                "sprint_result_kind": "planner-directive",
+                "sprint_directive_id": directive_id,
+                "dedupe_key": "typed-result-180",
+            },
+        )
+        self.assertTrue(replay["duplicate"])
+        self.assertEqual(replay["message_id"], result["message_id"])
+        with self.assertRaises(SystemExit):
+            mem._api(
+                "POST",
+                "/_sc/mem/messages",
+                {
+                    "to": "CON1",
+                    "body": "different evidence",
+                    "kind": "result",
+                    "sprint_doc_id": 180,
+                    "sprint_assignment_id": binding_id,
+                    "sprint_result_kind": "planner-directive",
+                    "sprint_directive_id": directive_id,
+                    "dedupe_key": "typed-result-180",
+                },
+            )
+
     def test_messages_read_returns_kind(self):
         mem.main(["message", "send", "plan1", "report done", "--kind", "result"])
         data = mem._api("GET", "/_sc/mem/messages")


### PR DESCRIPTION
## Summary

- correlate every one-shot Sprint result with its exact durable assignment and directive
- bridge Planner, Developer, Reviewer, conformance, worker-failure, Sentinel, and terminal close traffic through the conversation broker
- derive Sprint liveness and recovery evidence from conversation bindings, runs, heartbeats, and events instead of PIDs or shell launch records
- retire the legacy Conductor Popen/maybe_wake correctness path while preserving deterministic directive execution

## Verification

- `.venv/bin/pytest -q` — 1632 passed, 784 subtests passed
- focused orchestration/API suite — 238 passed, 199 subtests passed
- `./sc render-check`
- `./sc verify`
- `git diff --cached --check`

Implements task #135 under feature #24 / spec #38. Preserves decision #29: persistent Conductor, fresh one-shot roles, originating Planner terminal authority.