### PR TITLE
fix: pass fresh-fork browser Sprint gate

### DIFF
--- a/.super-coder/api/sprint_routes.py
+++ b/.super-coder/api/sprint_routes.py
@@ -1527,6 +1527,21 @@ def _arm_sprint(
                 ),
             )
             sprint_lifecycle.transition(con, sprint_doc_id, "active")
+            directive_id = con.execute(
+                "INSERT INTO directives "
+                "(issuer_shell_id,issuer_flavor,kind,payload,target,"
+                " sprint_doc_id,unit_id) "
+                "VALUES (NULL,'system','sprint-armed','{}','conductor',?,NULL)",
+                (sprint_doc_id,),
+            ).lastrowid
+            sprint_conversations.enqueue_conductor_directive(
+                con,
+                sprint_doc_id=sprint_doc_id,
+                directive_id=directive_id,
+                source_kind="sprint-armed",
+                evidence={"armed_by_shell_id": actor.shell_id},
+                idempotency_key=f"sprint-arm-release:{sprint_doc_id}",
+            )
             con.execute(
                 "INSERT INTO sentinel_events "
                 "(event_kind,shell_id,sprint_doc_id,evidence) "

--- a/.super-coder/assets/skills/sprint_cond/SKILL.md
+++ b/.super-coder/assets/skills/sprint_cond/SKILL.md
@@ -25,6 +25,7 @@ board directly. The stored sprint row is the only owner/state/route authority.
 | planner | answer/hold/re-task/re-scope | apply only the named mechanical consequence | issuer is the stored owner |
 | planner | kickoff | boot named assigned worker or conformance reviewer using the stored role route | no payload-selected model |
 | planner | close | require terminal board + clean integrated conformance; `active → closing → closed`; freeze doc in the same transaction | state and document agree |
+| system | sprint-armed | release every dependency-ready unit through its assigned developer route | every initially ready developer starts |
 | system | pr-green/pr-red/pr-merged | apply recorded PR transition and assigned-role wake | no discretionary interpretation |
 | system | stall/dead-shell | block when legal; boot originating Planner with evidence | Planner decides |
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3746,6 +3746,7 @@ board directly. The stored sprint row is the only owner/state/route authority.
 | planner | answer/hold/re-task/re-scope | apply only the named mechanical consequence | issuer is the stored owner |
 | planner | kickoff | boot named assigned worker or conformance reviewer using the stored role route | no payload-selected model |
 | planner | close | require terminal board + clean integrated conformance; `active → closing → closed`; freeze doc in the same transaction | state and document agree |
+| system | sprint-armed | release every dependency-ready unit through its assigned developer route | every initially ready developer starts |
 | system | pr-green/pr-red/pr-merged | apply recorded PR transition and assigned-role wake | no discretionary interpretation |
 | system | stall/dead-shell | block when legal; boot originating Planner with evidence | Planner decides |
 

--- a/.super-coder/migrations/0140_sprint_arm_release.sql
+++ b/.super-coder/migrations/0140_sprint_arm_release.sql
@@ -1,0 +1,19 @@
+-- An armed Sprint must give its persistent Conductor committed work to
+-- consume.  The initial release is a system transition so board activation
+-- remains atomic and the Conductor uses the same assignment/outbox path as
+-- every later dependency release.
+INSERT OR IGNORE INTO directive_kinds (issuer_flavor,kind)
+VALUES ('system','sprint-armed');
+
+-- Existing forks have already applied the generated 0001 baseline. Carry the
+-- corresponding authoritative sprint_cond asset edit forward without
+-- duplicating it when a fresh rebuild applies both 0001 and this delta.
+UPDATE skills
+SET content=replace(
+  content,
+  '| system | pr-green/pr-red/pr-merged | apply recorded PR transition and assigned-role wake | no discretionary interpretation |',
+  '| system | sprint-armed | release every dependency-ready unit through its assigned developer route | every initially ready developer starts |
+| system | pr-green/pr-red/pr-merged | apply recorded PR transition and assigned-role wake | no discretionary interpretation |'
+)
+WHERE name='sprint_cond'
+  AND content NOT LIKE '%| system | sprint-armed |%';

--- a/.super-coder/migrations/0141_rebuild_completed_sprint_cancellations.sql
+++ b/.super-coder/migrations/0141_rebuild_completed_sprint_cancellations.sql
@@ -1,0 +1,39 @@
+-- A completed cancellation is serialized after its Sprint has already made
+-- the terminal `aborted` transition.  The original insert guard admitted only
+-- live Sprint states, so a valid snapshot could not be reconstructed.
+DROP TRIGGER IF EXISTS trg_sprint_cancellation_links_insert;
+CREATE TRIGGER trg_sprint_cancellation_links_insert
+BEFORE INSERT ON sprint_cancellations
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM sprints sp
+  JOIN directives d
+    ON d.directive_id=NEW.source_directive_id
+  JOIN conversations c
+    ON c.conversation_id=NEW.planner_conversation_id
+  JOIN sprint_conversation_bindings b
+    ON b.conversation_id=c.conversation_id
+  WHERE sp.sprint_doc_id=NEW.sprint_doc_id
+    AND (
+      (NEW.state='requested' AND sp.state IN ('declared','active'))
+      OR
+      (NEW.state='completed' AND sp.state='aborted')
+    )
+    AND d.sprint_doc_id=NEW.sprint_doc_id
+    AND d.issuer_flavor='system'
+    AND d.kind='cancel'
+    AND d.target='planner'
+    AND d.status='executed'
+    AND c.mode='sprint'
+    AND c.sprint_doc_id=NEW.sprint_doc_id
+    AND b.sprint_doc_id=NEW.sprint_doc_id
+    AND b.role='planner'
+    AND b.lifecycle='one_shot'
+    AND b.source_directive_id=NEW.source_directive_id
+)
+BEGIN
+  SELECT RAISE(
+    ABORT,
+    'Sprint cancellation links must name its executed cancel directive and Planner conversation'
+  );
+END;

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -517,15 +517,22 @@ def _spawn(
             f"{prepared['error']}"
         )
     role = _assignment_role(slot, unit)
-    prompt = json.dumps(
-        {
-            "directive_id": row["directive_id"],
-            "issuer": row["issuer_flavor"],
-            "kind": row["kind"],
-            "payload": payload,
-        },
-        sort_keys=True,
-    )
+    packet = {
+        "directive_id": row["directive_id"],
+        "issuer": row["issuer_flavor"],
+        "kind": row["kind"],
+        "payload": payload,
+    }
+    if role == "planner" and row["kind"] == "unit-report":
+        packet["instruction"] = (
+            "All declared units are terminal. This is a conformance handoff, "
+            "not a question: do not emit answer. Read the governing spec, "
+            "board, and unit evidence; resolve the integrated main SHA; emit "
+            "one kickoff directive to an assigned reviewer with "
+            "mode=conformance and the complete requirement scope; then return "
+            "the required planner-directive result."
+        )
+    prompt = json.dumps(packet, sort_keys=True)
     creation_key = (
         f"sprint:{row['sprint_doc_id']}:assignment:{row['directive_id']}:"
         f"{role}:{shell['shortname']}"

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -167,6 +167,12 @@ TRANSITIONS = (
     ),
     (
         "system",
+        "sprint-armed",
+        "release every dependency-ready unit",
+        "every initially ready developer starts from committed board state",
+    ),
+    (
+        "system",
         "pr-green",
         "boot assigned reviewer",
         "reviewer receives the green-head evidence",
@@ -1100,7 +1106,18 @@ def _execute(
         return assignments
 
     unit = _unit(con, row) if row["unit_id"] is not None else None
-    if kind == "pr-green":
+    if kind == "sprint-armed":
+        if unit is not None:
+            raise DirectiveRefused("sprint-armed must not name a unit")
+        _release_ready_units(
+            con,
+            assignments,
+            row,
+            payload,
+            actor_shell_id,
+            prepared_routes,
+        )
+    elif kind == "pr-green":
         if unit is None:
             raise DirectiveRefused("pr-green requires unit_id")
         if unit["state"] != "in_review":

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -522,6 +522,13 @@ def _spawn(
         "issuer": row["issuer_flavor"],
         "kind": row["kind"],
         "payload": payload,
+        "completion_contract": (
+            f"Complete this one-shot {role} assignment by emitting exactly "
+            "one appropriate directive, then immediately send exactly one "
+            f"correlated {_required_result_kind(role)} result to the injected "
+            "SC_SPRINT_RESULT_TARGET before exit. Final assistant prose does "
+            "not satisfy the typed result."
+        ),
     }
     if role == "planner" and row["kind"] == "unit-report":
         packet["instruction"] = (

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -1000,6 +1000,15 @@ def _execute(
                     raise DirectiveRefused(
                         "unitless reviewer kickoff requires mode=conformance"
                     )
+                if con.execute(
+                    "SELECT 1 FROM sprint_conversation_bindings "
+                    "WHERE sprint_doc_id=? AND role='conformance' "
+                    "AND state<>'terminal' LIMIT 1",
+                    (sprint_id,),
+                ).fetchone() is not None:
+                    raise DirectiveRefused(
+                        "Sprint already has a nonterminal conformance assignment"
+                    )
                 _spawn(
                     con,
                     assignments,

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -530,7 +530,22 @@ def _spawn(
             "not satisfy the typed result."
         ),
     }
-    if role == "planner" and row["kind"] == "unit-report":
+    if role == "developer" and unit["state"] in ("pending", "blocked", "working"):
+        packet["instruction"] = (
+            "This is a first-pass or retry execution assignment. Perform the "
+            "bounded unit verification, then emit ready-for-review as the one "
+            "workflow directive with exact head/check evidence. Do not emit "
+            "unit-report as the workflow directive: unit-report is the "
+            "separate typed result required by completion_contract."
+        )
+    elif role == "developer":
+        packet["instruction"] = (
+            "This is the post-review completion assignment. Follow the "
+            "sprint_dev terminal reporting contract for the reviewed unit, "
+            "then send the separate typed unit-report result required by "
+            "completion_contract."
+        )
+    elif role == "planner" and row["kind"] == "unit-report":
         packet["instruction"] = (
             "All declared units are terminal. This is a conformance handoff, "
             "not a question: do not emit answer. Read the governing spec, "

--- a/.super-coder/scripts/conductor_runtime.py
+++ b/.super-coder/scripts/conductor_runtime.py
@@ -550,8 +550,9 @@ def _spawn(
             "All declared units are terminal. This is a conformance handoff, "
             "not a question: do not emit answer. Read the governing spec, "
             "board, and unit evidence; resolve the integrated main SHA; emit "
-            "one kickoff directive to an assigned reviewer with "
-            "mode=conformance and the complete requirement scope; then return "
+            "one unitless kickoff directive to an assigned reviewer with "
+            "mode=conformance and the complete requirement scope. Omit "
+            "--unit even when the triggering unit is injected; then return "
             "the required planner-directive result."
         )
     prompt = json.dumps(packet, sort_keys=True)
@@ -991,7 +992,11 @@ def _execute(
                     unit=unit,
                 )
             elif target["flavor"] == "reviewer":
-                if unit is None and payload.get("mode") != "conformance":
+                if unit is not None:
+                    raise DirectiveRefused(
+                        "reviewer kickoff must be unitless conformance"
+                    )
+                if payload.get("mode") != "conformance":
                     raise DirectiveRefused(
                         "unitless reviewer kickoff requires mode=conformance"
                     )

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import atexit
+import hashlib
+import json
 import os
 import secrets
+import shlex
 import shutil
 import subprocess
 import threading
@@ -36,6 +39,7 @@ from .base import (
 ENGINE = Path(__file__).resolve().parents[2]
 SERVER_ENDPOINT = "http://127.0.0.1:4096"
 SERVER_LOG = ENGINE / "logs" / "opencode-server.log"
+SHELL_RUNTIME_DIR = ENGINE / "run" / "opencode-shells"
 _SERVER_LOCK = threading.RLock()
 _SERVER_PROCESS: subprocess.Popen | None = None
 _SERVER_PASSWORD: str | None = None
@@ -229,8 +233,10 @@ class OpenCodeAdapter(ConversationAdapter):
         password: str | None = None,
         transport: HttpTransport | None = None,
         manifest: Mapping[str, Any] | None = None,
+        shell_runtime_dir: Path = SHELL_RUNTIME_DIR,
     ) -> None:
         super().__init__(manifest or load_manifest(self.harness))
+        self.shell_runtime_dir = shell_runtime_dir
         if transport is not None:
             self.transport = transport
         else:
@@ -296,6 +302,65 @@ class OpenCodeAdapter(ConversationAdapter):
             }
         ]
 
+    def _prepare_shell_environment(
+        self,
+        context: ConversationContext,
+    ) -> Path:
+        """Bind OpenCode shell tools to this conversation's launch identity.
+
+        ``opencode serve`` is one long-lived process, so every shell tool it
+        starts otherwise inherits the server's environment rather than the
+        target shell's canonical ``LaunchPlan.env``. A server started from an
+        already-wired shell could therefore route ``sc mem`` to that unrelated
+        install and identity.
+
+        OpenCode's project config supports an exact shell executable. Point it
+        at an owner-only runtime wrapper which restores the canonical SC_*
+        contract and PATH before delegating to bash. The project config stores
+        only the wrapper path; the API key remains under the gitignored engine
+        runtime directory.
+        """
+        worktree = context.checked_worktree()
+        identity = hashlib.sha256(str(worktree).encode()).hexdigest()[:20]
+        self.shell_runtime_dir.mkdir(parents=True, exist_ok=True)
+        wrapper = self.shell_runtime_dir / f"{identity}.sh"
+        exported = {
+            key: str(value)
+            for key, value in context.env.items()
+            if key == "PATH" or key.startswith("SC_")
+        }
+        lines = ["#!/bin/sh"]
+        lines.extend(
+            f"export {key}={shlex.quote(value)}"
+            for key, value in sorted(exported.items())
+        )
+        lines.append('exec /bin/bash "$@"')
+        temporary = wrapper.with_name(
+            f".{wrapper.name}.{secrets.token_hex(6)}.tmp"
+        )
+        temporary.write_text("\n".join(lines) + "\n")
+        temporary.chmod(0o700)
+        os.replace(temporary, wrapper)
+
+        config_path = worktree / "opencode.json"
+        try:
+            config = json.loads(config_path.read_text())
+        except FileNotFoundError:
+            config = {}
+        except (OSError, json.JSONDecodeError) as exc:
+            raise AdapterError(
+                "HARNESS_CONFIG_INVALID",
+                f"cannot prepare OpenCode shell config: {exc}",
+            ) from exc
+        if not isinstance(config, dict):
+            raise AdapterError(
+                "HARNESS_CONFIG_INVALID",
+                "OpenCode project config must be a JSON object",
+            )
+        config["shell"] = str(wrapper)
+        config_path.write_text(json.dumps(config, indent=2) + "\n")
+        return wrapper
+
     def _prompt(
         self,
         session_ref: str,
@@ -357,6 +422,7 @@ class OpenCodeAdapter(ConversationAdapter):
     def start(self, context: ConversationContext, message: str) -> NativeTurn:
         worktree = context.checked_worktree()
         message = ensure_nonempty_message(message)
+        self._prepare_shell_environment(context)
         body: dict[str, Any] = {}
         if context.title:
             body["title"] = context.title
@@ -390,6 +456,7 @@ class OpenCodeAdapter(ConversationAdapter):
         message: str,
     ) -> NativeTurn:
         message = ensure_nonempty_message(message)
+        self._prepare_shell_environment(context)
         inspected = self.inspect(session_ref, context)
         if not inspected.exists:
             raise AdapterError(

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -819,7 +819,7 @@ def main(argv: list[str]) -> int:
     # Record harness + installed marker in instance.json ---------------------
     cfg = ports_mod.resolve(persist=False)
     cfg["harness"] = harness
-    cfg["installed_at"] = date.today().isoformat()
+    cfg["installed_at"] = datetime.now(timezone.utc).date().isoformat()
     cfg["conductor"] = {
         "enabled": True,
         "shell": "CON1",

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -690,6 +690,17 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         self.assertEqual(report["status"], "executed")
         self.assertEqual(len(report["assignments"]), 1)
         self.assertEqual(report["assignments"][0]["slot"], "PLN1")
+        planner_prompt = self.con.execute(
+            "SELECT body FROM conversation_messages "
+            "WHERE conversation_id=? ORDER BY message_id LIMIT 1",
+            (report["assignments"][0]["conversation_id"],),
+        ).fetchone()
+        packet = json.loads(planner_prompt["body"])
+        self.assertIn(
+            "This is a conformance handoff, not a question",
+            packet["instruction"],
+        )
+        self.assertIn("do not emit answer", packet["instruction"])
 
     def test_report_only_requires_explicit_null_contract_and_evidence(self):
         cases = (

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -618,6 +618,17 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
                             "immediately send exactly one correlated",
                             packet["completion_contract"],
                         )
+                        if kind == "sprint-armed":
+                            self.assertIn(
+                                "emit ready-for-review as the one workflow "
+                                "directive",
+                                packet["instruction"],
+                            )
+                            self.assertIn(
+                                "Do not emit unit-report as the workflow "
+                                "directive",
+                                packet["instruction"],
+                            )
                     row = con.execute(
                         "SELECT status,refusal_reason FROM directives "
                         "WHERE directive_id=?",
@@ -1112,6 +1123,14 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         )
         self.assertEqual(len(result["assignments"]), 1)
         self.assertEqual(result["assignments"][0]["slot"], "DEV1")
+        prompt = self.con.execute(
+            "SELECT body FROM conversation_messages WHERE conversation_id=?",
+            (result["assignments"][0]["conversation_id"],),
+        ).fetchone()[0]
+        self.assertIn(
+            "emit ready-for-review as the one workflow directive",
+            json.loads(prompt)["instruction"],
+        )
 
     def test_unit_report_boots_planner_only_after_all_units_terminal(self):
         self.set_unit("working")

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -603,6 +603,21 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
                             ).fetchone()[0],
                             1,
                         )
+                        message = con.execute(
+                            "SELECT body FROM conversation_messages "
+                            "WHERE conversation_id=? "
+                            "ORDER BY message_id LIMIT 1",
+                            (assignment["conversation_id"],),
+                        ).fetchone()
+                        packet = json.loads(message["body"])
+                        self.assertIn(
+                            "emitting exactly one appropriate directive",
+                            packet["completion_contract"],
+                        )
+                        self.assertIn(
+                            "immediately send exactly one correlated",
+                            packet["completion_contract"],
+                        )
                     row = con.execute(
                         "SELECT status,refusal_reason FROM directives "
                         "WHERE directive_id=?",

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -1148,6 +1148,48 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         self.assertEqual(len(terminal["assignments"]), 1)
         self.assertEqual(terminal["assignments"][0]["slot"], "PLN1")
 
+    def test_conformance_kickoff_is_unitless_and_typed_conformance(self):
+        self.set_unit("working")
+        self.set_unit("in_review")
+        self.set_unit("merged")
+        linked = self.emit(
+            "planner",
+            "kickoff",
+            {
+                "to": "REV1",
+                "mode": "conformance",
+                "main_sha": "abc",
+                "scope": "all requirements",
+                "ratified_deviations": [],
+            },
+        )
+        self.con.commit()
+        refused = runtime.act(self.con, linked, 1)
+        self.assertEqual(refused["status"], "refused")
+        self.assertIn("must be unitless", refused["reason"])
+
+        unitless = self.emit(
+            "planner",
+            "kickoff",
+            {
+                "to": "REV1",
+                "mode": "conformance",
+                "main_sha": "abc",
+                "scope": "all requirements",
+                "ratified_deviations": [],
+            },
+            unit=False,
+        )
+        self.con.commit()
+        result = runtime.act(self.con, unitless, 1)
+        self.assertEqual(result["status"], "executed")
+        binding = self.con.execute(
+            "SELECT role,required_result_kind FROM "
+            "sprint_conversation_bindings WHERE conversation_id=?",
+            (result["assignments"][0]["conversation_id"],),
+        ).fetchone()
+        self.assertEqual(tuple(binding), ("conformance", "conformance-verdict"))
+
 
 class ConductorSyntheticSprintTests(RuntimeFixture):
     def act_one(self, issuer, kind, payload, *, unit=True):

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -462,6 +462,13 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         ),
         (
             "system",
+            "sprint-armed",
+            "pending",
+            {},
+            False,
+        ),
+        (
+            "system",
             "pr-green",
             "in_review",
             {"head_sha": "abc", "transition": "checks:SUCCESS"},

--- a/tests/test_conductor_runtime.py
+++ b/tests/test_conductor_runtime.py
@@ -1190,6 +1190,26 @@ class ConductorDirectiveMatrixTests(RuntimeFixture):
         ).fetchone()
         self.assertEqual(tuple(binding), ("conformance", "conformance-verdict"))
 
+        duplicate = self.emit(
+            "planner",
+            "kickoff",
+            {
+                "to": "REV1",
+                "mode": "conformance",
+                "main_sha": "abc",
+                "scope": "all requirements",
+                "ratified_deviations": [],
+            },
+            unit=False,
+        )
+        self.con.commit()
+        refused_duplicate = runtime.act(self.con, duplicate, 1)
+        self.assertEqual(refused_duplicate["status"], "refused")
+        self.assertIn(
+            "already has a nonterminal conformance assignment",
+            refused_duplicate["reason"],
+        )
+
 
 class ConductorSyntheticSprintTests(RuntimeFixture):
     def act_one(self, issuer, kind, payload, *, unit=True):

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import signal
+import subprocess
 import sys
 import tempfile
 import threading
@@ -661,7 +663,13 @@ class ConversationAdapterTest(unittest.TestCase):
     def build(self, harness: str):
         if harness == "opencode":
             native = FakeOpenCode()
-            return OpenCodeAdapter(transport=native), native
+            return (
+                OpenCodeAdapter(
+                    transport=native,
+                    shell_runtime_dir=self.root / "opencode-shells",
+                ),
+                native,
+            )
         if harness == "claude":
             native = FakeClaudeRunner()
             return (
@@ -872,6 +880,63 @@ class ConversationAdapterTest(unittest.TestCase):
         recovered = adapter.reconcile(fresh, self.context)
         self.assertEqual(recovered.outcome, "unknown")
         self.assertFalse(recovered.proven)
+
+    def test_opencode_shell_tools_use_the_conversation_launch_identity(
+        self,
+    ) -> None:
+        native = FakeOpenCode()
+        adapter = OpenCodeAdapter(
+            transport=native,
+            shell_runtime_dir=self.root / "runtime-shells",
+        )
+        config = self.root / "opencode.json"
+        config.write_text('{"permission":{"*":"allow"}}\n')
+        context = ConversationContext(
+            worktree=self.root,
+            provider="openai",
+            model="gpt-test",
+            env={
+                "PATH": os.environ["PATH"],
+                "SC_API_BASE": "http://127.0.0.1:9911",
+                "SC_API_TOKEN": "reviewer-token",
+                "SC_ROOT": "/target/fork",
+                "SC_SHELL_FLAVOR": "reviewer",
+                "UNRELATED_SECRET": "must-not-persist",
+            },
+        )
+
+        adapter.start(context, "review")
+
+        configured = json.loads(config.read_text())
+        self.assertEqual(configured["permission"], {"*": "allow"})
+        wrapper = Path(configured["shell"])
+        self.assertEqual(wrapper.stat().st_mode & 0o777, 0o700)
+        self.assertNotIn("reviewer-token", config.read_text())
+        self.assertNotIn("UNRELATED_SECRET", wrapper.read_text())
+        result = subprocess.run(
+            [
+                str(wrapper),
+                "-lc",
+                "printf '%s\\n%s\\n%s' \"$SC_API_BASE\" \"$SC_API_TOKEN\" \"$SC_SHELL_FLAVOR\"",
+            ],
+            env={
+                **os.environ,
+                "SC_API_BASE": "http://127.0.0.1:8837",
+                "SC_API_TOKEN": "wrong-parent-token",
+                "SC_SHELL_FLAVOR": "dev",
+            },
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertEqual(
+            result.stdout.splitlines(),
+            [
+                "http://127.0.0.1:9911",
+                "reviewer-token",
+                "reviewer",
+            ],
+        )
 
     def test_opencode_strips_the_selected_provider_prefix_from_model_id(
         self,

--- a/tests/test_install_fresh_fork.py
+++ b/tests/test_install_fresh_fork.py
@@ -1,0 +1,98 @@
+"""Fresh-fork installer completion regression coverage."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class FreshForkInstallTest(unittest.TestCase):
+    def test_noninteractive_install_reaches_durable_completion_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw) / "host-project"
+            repo.mkdir()
+            shutil.copytree(
+                ROOT / ".super-coder",
+                repo / ".super-coder",
+                ignore=shutil.ignore_patterns(
+                    "shell_db.db*",
+                    "instance.json",
+                    "run",
+                    "logs",
+                    "__pycache__",
+                ),
+            )
+            shutil.copy2(ROOT / "sc", repo / "sc")
+            (repo / "README.md").write_text("# disposable host project\n")
+
+            subprocess.run(
+                ["git", "init", "-b", "main"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Fresh Fork Test"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "fresh-fork@noreply.local"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "add", ".super-coder", "sc", "README.md"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "test fixture"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(repo / ".super-coder" / "scripts" / "install.py"),
+                    "--skip-harness-install",
+                    "--username",
+                    "Gate",
+                ],
+                cwd=repo,
+                env={**os.environ, "NO_COLOR": "1"},
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            config = json.loads(
+                (repo / ".super-coder" / "instance.json").read_text()
+            )
+            self.assertRegex(
+                config["installed_at"],
+                re.compile(r"^\d{4}-\d{2}-\d{2}$"),
+            )
+            self.assertIn("Installed ✓", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_sprint_declarations.py
+++ b/tests/test_sprint_declarations.py
@@ -582,7 +582,36 @@ class SprintDeclarationContractTest(unittest.TestCase):
                 "SELECT COUNT(*) FROM conversation_outbox "
                 "WHERE state='pending'"
             ).fetchone()[0],
-            1,
+            2,
+        )
+        release = self.con.execute(
+            "SELECT directive_id,issuer_shell_id,issuer_flavor,kind,target,"
+            "sprint_doc_id,unit_id,status FROM directives "
+            "WHERE sprint_doc_id=? AND kind='sprint-armed'",
+            (sprint_id,),
+        ).fetchone()
+        self.assertIsNotNone(release)
+        self.assertEqual(
+            tuple(release)[1:],
+            (
+                None,
+                "system",
+                "sprint-armed",
+                "conductor",
+                sprint_id,
+                None,
+                "pending",
+            ),
+        )
+        queued = list(self.con.execute(
+            "SELECT body FROM conversation_messages "
+            "WHERE conversation_id=? ORDER BY message_id",
+            (armed["conductor"]["conversation_id"],),
+        ))
+        self.assertEqual(len(queued), 2)
+        self.assertIn(
+            f'"directive_id":{release["directive_id"]}',
+            queued[1]["body"],
         )
 
         with mock.patch.object(
@@ -606,6 +635,54 @@ class SprintDeclarationContractTest(unittest.TestCase):
             ).fetchone()[0],
             1,
         )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM directives "
+                "WHERE sprint_doc_id=? AND kind='sprint-armed'",
+                (sprint_id,),
+            ).fetchone()[0],
+            1,
+        )
+
+    def test_arm_release_enqueue_failure_rolls_back_every_activation_row(self):
+        sprint = self.staged_sprint(key="arm-release-failure")
+        sprint_id = sprint["sprint_doc_id"]
+
+        with mock.patch.object(
+            sprint_routes.sprint_conversations,
+            "enqueue_conductor_directive",
+            side_effect=sqlite3.OperationalError("injected release enqueue failure"),
+        ):
+            with self.assertRaisesRegex(
+                sqlite3.OperationalError,
+                "injected release enqueue failure",
+            ):
+                self.call(
+                    "PATCH",
+                    f"/api/sprints/{sprint_id}",
+                    {"state": "active"},
+                    key="arm-release-failure",
+                )
+
+        self.assertEqual(
+            self.con.execute(
+                "SELECT state FROM sprints WHERE sprint_doc_id=?",
+                (sprint_id,),
+            ).fetchone()[0],
+            "declared",
+        )
+        for table in (
+            "conversations",
+            "sprint_conversation_bindings",
+            "directives",
+            "conversation_messages",
+            "conversation_outbox",
+        ):
+            self.assertEqual(
+                self.con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0],
+                0,
+                f"{table} escaped a failed arm transaction",
+            )
 
     def test_parallel_arm_retry_creates_exactly_one_conductor(self):
         sprint = self.staged_sprint(key="parallel-arm")
@@ -759,6 +836,31 @@ class SprintDeclarationContractTest(unittest.TestCase):
                 (sprint_id,),
             ).fetchone()[0],
             1,
+        )
+
+        restored = self.con.execute(
+            "SELECT * FROM sprint_cancellations WHERE sprint_doc_id=?",
+            (sprint_id,),
+        ).fetchone()
+        self.con.execute(
+            "DROP TRIGGER trg_sprint_cancellation_delete"
+        )
+        self.con.execute(
+            "DELETE FROM sprint_cancellations WHERE sprint_doc_id=?",
+            (sprint_id,),
+        )
+        columns = tuple(restored.keys())
+        self.con.execute(
+            f"INSERT INTO sprint_cancellations ({','.join(columns)}) "
+            f"VALUES ({','.join('?' for _ in columns)})",
+            tuple(restored),
+        )
+        self.assertEqual(
+            self.con.execute(
+                "SELECT state FROM sprint_cancellations WHERE sprint_doc_id=?",
+                (sprint_id,),
+            ).fetchone()[0],
+            "completed",
         )
 
     def test_cancel_records_interrupt_for_a_run_that_crossed_dispatch(self):


### PR DESCRIPTION
## Summary

- make a clean fresh-fork install complete and bind OpenCode tool shells to each conversation’s canonical SC identity
- atomically enqueue a system `sprint-armed` transition so the persistent Conductor releases initially ready units
- make completed cancellations rebuildable and keep the generated Conductor skill seed aligned with its authoritative asset
- make one-shot directive/result handshakes explicit, disambiguate Developer workflow directives, require unitless conformance, and serialize conformance assignments

## Task 137 release evidence

- clean disposable fork installed and pinned to the candidate engine
- normal browser Planner and Reviewer OpenCode/Luna conversations created and QAQC-reviewed real specs with isolated shell identities
- browser Cancel terminalized the board and returned the same originating Planner for a durable typed abort report, with zero post-cancel Conductor relay and zero legacy `sc run CON1` launch records
- real one-unit Sprint closed through Developer, Reviewer, integrated conformance, and the originating Planner
- real two-unit Sprint held U2 pending until U1 merged, then released DEV2 and closed both units
- persistent Conductor used one native session across 12 runs (11 exact resumes); 12 non-Conductor bindings used 12 distinct conversations and native sessions; all bindings terminal

## Verification

- `./sc test` — 1,641 passed
- focused Sprint/install/adapter/rebuild suites — 76 passed plus 32 subtests at the widest focused gate
- fresh-fork migration/rebuild — 141 migrations
- `./sc render-check`
- `./sc verify </dev/null>`

Internal task: #137.