### PR TITLE
fix: make OpenCode turns interruptible

### DIFF
--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -40,6 +40,7 @@ ENGINE = Path(__file__).resolve().parents[2]
 SERVER_ENDPOINT = "http://127.0.0.1:4096"
 SERVER_LOG = ENGINE / "logs" / "opencode-server.log"
 SHELL_RUNTIME_DIR = ENGINE / "run" / "opencode-shells"
+TURN_TIMEOUT_SECONDS = 5400.0
 _SERVER_LOCK = threading.RLock()
 _SERVER_PROCESS: subprocess.Popen | None = None
 _SERVER_PASSWORD: str | None = None
@@ -243,7 +244,7 @@ class OpenCodeAdapter(ConversationAdapter):
             self.transport = UrlHttpTransport(
                 endpoint,
                 password=password if password is not None else ensure_server(),
-                timeout=600.0,
+                timeout=TURN_TIMEOUT_SECONDS,
             )
 
     def probe(self) -> ProbeResult:
@@ -412,12 +413,23 @@ class OpenCodeAdapter(ConversationAdapter):
             run_ref=run_ref,
             worktree=worktree,
             metadata={
+                "context": context,
                 "event_stream": event_stream,
+                "message": message,
+                "dispatch_pending": True,
+                "interrupt_lock": threading.Lock(),
                 "resumed": resumed,
             },
         )
-        self._prompt(session_ref, context, message)
         return turn
+
+    @staticmethod
+    def _interrupt_lock(turn: NativeTurn):
+        lock = turn.metadata.get("interrupt_lock")
+        if lock is None:
+            lock = threading.Lock()
+            turn.metadata["interrupt_lock"] = lock
+        return lock
 
     def start(self, context: ConversationContext, message: str) -> NativeTurn:
         worktree = context.checked_worktree()
@@ -647,6 +659,31 @@ class OpenCodeAdapter(ConversationAdapter):
             },
             "session.create-or-resume",
         )
+        context = turn.metadata.pop("context", None)
+        message = turn.metadata.pop("message", None)
+        if not isinstance(context, ConversationContext) or not isinstance(
+            message, str
+        ):
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                "OpenCode turn has no pending synchronous message dispatch",
+            )
+        interrupted_before_dispatch = False
+        with self._interrupt_lock(turn):
+            if turn.metadata.get("interrupt_requested"):
+                turn.metadata["dispatch_pending"] = False
+                turn.metadata["terminal"] = "run.interrupted"
+                interrupted_before_dispatch = True
+            else:
+                turn.metadata["dispatch_pending"] = False
+        if interrupted_before_dispatch:
+            yield NormalizedEvent(
+                "run.interrupted",
+                {"status": "cancelled"},
+                "operator.interrupt",
+            )
+            return
+        self._prompt(turn.session_ref, context, message)
         observed_activity = False
         for raw in native_stream:
             event_session = self._session_of(raw)
@@ -659,6 +696,14 @@ class OpenCodeAdapter(ConversationAdapter):
                 # the new message complete without ever generating a reply.
                 if event.type == "run.completed" and not observed_activity:
                     continue
+                if event.type == "run.completed":
+                    with self._interrupt_lock(turn):
+                        if turn.metadata.get("interrupt_acknowledged"):
+                            event = NormalizedEvent(
+                                "run.interrupted",
+                                {"status": "cancelled"},
+                                event.native_type,
+                            )
                 if event.type in {
                     "run.started",
                     "assistant.delta",
@@ -675,12 +720,18 @@ class OpenCodeAdapter(ConversationAdapter):
                     return
 
     def interrupt(self, turn: NativeTurn) -> InterruptResult:
-        result = self.transport.request(
-            "POST",
-            f"/session/{turn.session_ref}/abort",
-            query=self._query(turn.worktree),
-        )
-        return InterruptResult(bool(result))
+        with self._interrupt_lock(turn):
+            turn.metadata["interrupt_requested"] = True
+            result = self.transport.request(
+                "POST",
+                f"/session/{turn.session_ref}/abort",
+                query=self._query(turn.worktree),
+            )
+            acknowledged = bool(result) or bool(
+                turn.metadata.get("dispatch_pending")
+            )
+            turn.metadata["interrupt_acknowledged"] = acknowledged
+        return InterruptResult(acknowledged)
 
     def inspect(
         self,

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -843,6 +843,11 @@ class ConversationAdapterTest(unittest.TestCase):
             [("/event", {"directory": str(self.root)})],
             "the SSE subscription must open before prompt dispatch",
         )
+        self.assertFalse(
+            any(request[1].endswith("/message") for request in native.requests),
+            "message dispatch must wait until NativeTurn can be persisted",
+        )
+        events = list(adapter.stream(turn))
         prompt = next(
             request
             for request in native.requests
@@ -858,7 +863,6 @@ class ConversationAdapterTest(unittest.TestCase):
             prompt[3]["model"],
             {"providerID": "openrouter", "modelID": "test-model"},
         )
-        events = list(adapter.stream(turn))
         self.assertNotIn("wrong", repr(events))
         self.assertIn("permission.requested", [event.type for event in events])
         self.assertEqual(
@@ -947,12 +951,13 @@ class ConversationAdapterTest(unittest.TestCase):
             provider="openai",
             model="openai/gpt-5.6-terra-fast",
         )
-        adapter.start(context, "hello")
+        turn = adapter.start(context, "hello")
         create = next(
             request
             for request in native.requests
             if request[:2] == ("POST", "/session")
         )
+        list(adapter.stream(turn))
         prompt = next(
             request
             for request in native.requests
@@ -965,6 +970,30 @@ class ConversationAdapterTest(unittest.TestCase):
         self.assertEqual(
             prompt[3]["model"],
             {"providerID": "openai", "modelID": "gpt-5.6-terra-fast"},
+        )
+
+    def test_opencode_default_transport_uses_decided_turn_ceiling(
+        self,
+    ) -> None:
+        with mock.patch(
+            "conversation_adapters.opencode.ensure_server",
+            return_value="test-password",
+        ):
+            adapter = OpenCodeAdapter(endpoint="http://127.0.0.1:1")
+        self.assertEqual(adapter.transport.timeout, 5400.0)
+
+    def test_opencode_stop_before_dispatch_never_sends_the_prompt(
+        self,
+    ) -> None:
+        adapter, native = self.build("opencode")
+        turn = adapter.start(self.context, "must not dispatch")
+        self.assertTrue(adapter.interrupt(turn).acknowledged)
+
+        events = list(adapter.stream(turn))
+
+        self.assertEqual(events[-1].type, "run.interrupted")
+        self.assertFalse(
+            any(request[1].endswith("/message") for request in native.requests)
         )
 
     def test_claude_uses_exact_start_and_resume_flags_and_sigint(

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -26,6 +26,7 @@ from conversation_adapters import (  # noqa: E402
     KimiAdapter,
     NativeTurn,
     NormalizedEvent,
+    OpenCodeAdapter,
     ReconcileResult,
 )
 from conversation_broker import (  # noqa: E402
@@ -120,6 +121,80 @@ class FakeAdapter:
 
     def close(self) -> None:
         self.closed += 1
+
+
+class BlockingOpenCodeTransport:
+    """Hold synchronous message delivery until the broker calls abort."""
+
+    def __init__(self) -> None:
+        self.session_ref = "ses_interruptible"
+        self.message_started = threading.Event()
+        self.aborted = threading.Event()
+        self.requests: list[tuple[str, str]] = []
+        self.message_count = 0
+        self.stream_count = 0
+
+    def request(self, method: str, path: str, *, query=None, body=None):
+        self.requests.append((method, path))
+        if method == "POST" and path == "/session":
+            return {"id": self.session_ref}
+        if method == "POST" and path.endswith("/message"):
+            self.message_count += 1
+            self.message_started.set()
+            if self.message_count == 1 and not self.aborted.wait(2):
+                raise AssertionError("OpenCode message remained uninterruptible")
+            return {"id": f"message-{self.message_count}"}
+        if method == "POST" and path.endswith("/abort"):
+            self.aborted.set()
+            # Let the blocked message response and native idle race ahead of
+            # the abort acknowledgement. The adapter must wait for this
+            # result before choosing completed versus interrupted.
+            time.sleep(0.05)
+            return True
+        if method == "GET" and path == f"/session/{self.session_ref}":
+            return {"id": self.session_ref}
+        if method == "GET" and path == "/session/status":
+            return {
+                self.session_ref: {
+                    "type": "idle" if self.aborted.is_set() else "busy"
+                }
+            }
+        raise AssertionError(f"unexpected OpenCode request: {method} {path}")
+
+    def stream(self, path: str, *, query=None):
+        self.stream_count += 1
+        stream_number = self.stream_count
+
+        def events():
+            yield {
+                "type": "session.status",
+                "properties": {
+                    "sessionID": self.session_ref,
+                    "status": {"type": "busy"},
+                },
+            }
+            if stream_number == 1:
+                if not self.aborted.wait(2):
+                    raise AssertionError("OpenCode event stream saw no abort")
+                yield {
+                    "type": "session.idle",
+                    "properties": {"sessionID": self.session_ref},
+                }
+                return
+            yield {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": self.session_ref,
+                    "field": "text",
+                    "delta": f"resumed-{stream_number}",
+                },
+            }
+            yield {
+                "type": "session.idle",
+                "properties": {"sessionID": self.session_ref},
+            }
+
+        return events()
 
 
 class ConversationBrokerCase(unittest.TestCase):
@@ -963,6 +1038,105 @@ class ServiceContractTest(ConversationBrokerCase):
             events.index("run.interrupt.requested"),
             events.index("run.interrupted"),
         )
+
+    def test_opencode_blocking_message_is_interruptible_after_identity(
+        self,
+    ) -> None:
+        transport = BlockingOpenCodeTransport()
+        adapter = OpenCodeAdapter(
+            transport=transport,
+            shell_runtime_dir=self.root / "opencode-shells",
+        )
+        broker = self.start_broker(
+            lambda harness: adapter if harness == "opencode" else None
+        )
+        conversation_id = self.add_conversation(harness="opencode")
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+        self.assertTrue(
+            transport.message_started.wait(1),
+            "OpenCode synchronous message dispatch never started",
+        )
+
+        con = self.connect()
+        run = con.execute(
+            "SELECT run_id,state,harness_session_after,runner_ref "
+            "FROM conversation_runs WHERE trigger_message_id=?",
+            (message_id,),
+        ).fetchone()
+        con.close()
+        self.assertIsNotNone(run)
+        self.assertEqual(run["state"], "running")
+        self.assertEqual(
+            run["harness_session_after"],
+            transport.session_ref,
+        )
+        self.assertTrue(run["runner_ref"])
+
+        second_message_id = self.add_message(conversation_id)
+        third_message_id = self.add_message(conversation_id)
+        self.assertTrue(broker.interrupt(int(run["run_id"])))
+        self.wait_run_state(int(run["run_id"]), "cancelled")
+        self.assertTrue(transport.aborted.is_set())
+        self.assertIn(
+            ("POST", f"/session/{transport.session_ref}/abort"),
+            transport.requests,
+        )
+
+        con = self.connect()
+        events = [
+            row[0]
+            for row in con.execute(
+                "SELECT event_type FROM conversation_events "
+                "WHERE run_id=? ORDER BY sequence",
+                (run["run_id"],),
+            )
+        ]
+        con.close()
+        self.assertLess(
+            events.index("run.interrupt.requested"),
+            events.index("run.interrupted"),
+        )
+
+        deadline = time.monotonic() + 3
+        resumed_runs = []
+        while time.monotonic() < deadline:
+            con = self.connect()
+            resumed_runs = con.execute(
+                "SELECT trigger_message_id,state,harness_session_before,"
+                "harness_session_after FROM conversation_runs "
+                "WHERE conversation_id=? ORDER BY run_id",
+                (conversation_id,),
+            ).fetchall()
+            con.close()
+            if (
+                len(resumed_runs) == 3
+                and resumed_runs[-1]["state"] == "succeeded"
+            ):
+                break
+            time.sleep(0.01)
+        self.assertEqual(
+            [row["trigger_message_id"] for row in resumed_runs],
+            [message_id, second_message_id, third_message_id],
+        )
+        self.assertEqual(
+            [row["state"] for row in resumed_runs],
+            ["cancelled", "succeeded", "succeeded"],
+        )
+        self.assertEqual(
+            [
+                (
+                    row["harness_session_before"],
+                    row["harness_session_after"],
+                )
+                for row in resumed_runs[1:]
+            ],
+            [
+                (transport.session_ref, transport.session_ref),
+                (transport.session_ref, transport.session_ref),
+            ],
+        )
+        self.assertEqual(transport.message_count, 3)
 
     def test_starting_crash_without_exact_identity_becomes_unknown(self) -> None:
         _conversation, _message, run_id = self.add_live_run(state="starting")

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -156,7 +156,7 @@ class OpenCodeServerTest(unittest.TestCase):
         transport.assert_called_once_with(
             opencode.SERVER_ENDPOINT,
             password="managed-secret",
-            timeout=600.0,
+            timeout=opencode.TURN_TIMEOUT_SECONDS,
         )
 
 


### PR DESCRIPTION
## Summary

- apply Decision #21 with a named 5400-second OpenCode transport safety ceiling
- return and persist the native turn before synchronous message dispatch so manual Stop can reach `/abort` while `/message` is blocked
- preserve pre-opened SSE, exact-session resume, ordered stacked follow-ups, and the rule that ordinary messages never interrupt
- translate post-abort native idle/completion into cancellation only after abort acknowledgement
- prevent a Stop received before dispatch from sending the prompt

## Verification

- `./sc test -q` — 1647 passed, 786 subtests passed
- focused adapter/broker/server regressions — green
- live OpenCode 1.18.9 API/broker smoke — blocked turn cancelled; next turn resumed the exact session and returned `SC_STOP_RESUMED`
- targeted Ruff — green (ignoring pre-existing EXE001/RUF100/UP018 whole-file debt)
- `git diff --check` — green
- `./sc verify` — green
- `./sc render-check` — known local active-mirror drift only in `skills_sc/README.md` and `skills_sc/sprint_onboarding.md`; hermetic source rebuild passed and this branch changes no render sources (tracked by #809)

## Release evidence

Engine review flags #33 and #36 were closed in the shared memory DB after regression and live proof passed.