### PR TITLE
test: freeze browser diff review fixtures

### DIFF
--- a/tests/fixtures/review/github_prs.json
+++ b/tests/fixtures/review/github_prs.json
@@ -1,0 +1,102 @@
+{
+  "pull_requests": [
+    {
+      "number": 821,
+      "headRefName": "feature/open",
+      "baseRefName": "main",
+      "headRefOid": "1111111111111111111111111111111111111111",
+      "state": "OPEN",
+      "mergedAt": null,
+      "mergeCommit": null,
+      "title": "Open review fixture",
+      "url": "https://example.test/pulls/821",
+      "reviewDecision": "",
+      "statusCheckRollup": [
+        {
+          "name": "tests",
+          "status": "COMPLETED",
+          "conclusion": "SUCCESS"
+        }
+      ]
+    },
+    {
+      "number": 822,
+      "headRefName": "feature/failing",
+      "baseRefName": "main",
+      "headRefOid": "2222222222222222222222222222222222222222",
+      "state": "OPEN",
+      "mergedAt": null,
+      "mergeCommit": null,
+      "title": "Failing-check fixture",
+      "url": "https://example.test/pulls/822",
+      "reviewDecision": "CHANGES_REQUESTED",
+      "statusCheckRollup": [
+        {
+          "name": "tests",
+          "status": "COMPLETED",
+          "conclusion": "FAILURE"
+        }
+      ]
+    },
+    {
+      "number": 823,
+      "headRefName": "feature/squash",
+      "baseRefName": "main",
+      "headRefOid": "3333333333333333333333333333333333333333",
+      "state": "MERGED",
+      "mergedAt": "2026-07-30T12:00:00Z",
+      "mergeCommit": {
+        "oid": "4444444444444444444444444444444444444444"
+      },
+      "title": "Squash-merged fixture",
+      "url": "https://example.test/pulls/823",
+      "reviewDecision": "APPROVED",
+      "statusCheckRollup": []
+    },
+    {
+      "number": 826,
+      "headRefName": "feature/closed",
+      "baseRefName": "main",
+      "headRefOid": "8888888888888888888888888888888888888888",
+      "state": "CLOSED",
+      "mergedAt": null,
+      "mergeCommit": null,
+      "title": "Closed-without-merge fixture",
+      "url": "https://example.test/pulls/826",
+      "reviewDecision": "",
+      "statusCheckRollup": []
+    },
+    {
+      "number": 824,
+      "headRefName": "feature/reused",
+      "baseRefName": "main",
+      "headRefOid": "5555555555555555555555555555555555555555",
+      "state": "MERGED",
+      "mergedAt": "2026-07-30T13:00:00Z",
+      "mergeCommit": {
+        "oid": "6666666666666666666666666666666666666666"
+      },
+      "title": "First reused-branch fixture",
+      "url": "https://example.test/pulls/824",
+      "reviewDecision": "APPROVED",
+      "statusCheckRollup": []
+    },
+    {
+      "number": 825,
+      "headRefName": "feature/reused",
+      "baseRefName": "main",
+      "headRefOid": "7777777777777777777777777777777777777777",
+      "state": "OPEN",
+      "mergedAt": null,
+      "mergeCommit": null,
+      "title": "Second reused-branch fixture",
+      "url": "https://example.test/pulls/825",
+      "reviewDecision": "",
+      "statusCheckRollup": []
+    }
+  ],
+  "patches": {
+    "821": "diff --git a/open.txt b/open.txt\nnew file mode 100644\n--- /dev/null\n+++ b/open.txt\n@@ -0,0 +1 @@\n+open\n",
+    "823": "diff --git a/squash.txt b/squash.txt\nnew file mode 100644\n--- /dev/null\n+++ b/squash.txt\n@@ -0,0 +1 @@\n+squash\n"
+  }
+}

--- a/tests/fixtures/review/projection_contract.json
+++ b/tests/fixtures/review/projection_contract.json
@@ -1,0 +1,158 @@
+{
+  "contract_version": 1,
+  "target_kinds": {
+    "workspace": {
+      "stable_identity": [
+        "conversation_id",
+        "observed_worktree"
+      ]
+    },
+    "local_branch": {
+      "stable_identity": [
+        "target_id",
+        "branch_name",
+        "first_head_sha"
+      ]
+    },
+    "pull_request": {
+      "stable_identity": [
+        "repository",
+        "pr_number"
+      ]
+    }
+  },
+  "lifecycle_statuses": {
+    "local_branch": "LOCAL BRANCH",
+    "pushed": "PUSHED",
+    "pr_open": "PR OPEN",
+    "checks_failed": "CHECKS FAILED",
+    "pr_merged": "PR MERGED",
+    "pr_closed": "PR CLOSED",
+    "remote_unknown": "REMOTE UNKNOWN"
+  },
+  "comparison_scopes": {
+    "review": {
+      "question": "What does this branch or PR introduce?",
+      "local_source": "merge-base-to-selected-head-or-worktree",
+      "remote_source": "canonical-pr-patch"
+    },
+    "local": {
+      "question": "What is present locally but absent from the selected PR or head?",
+      "local_source": "selected-head-to-index-and-worktree"
+    },
+    "commits": {
+      "question": "Which commits belong to this change set?",
+      "local_source": "merge-base-to-selected-head"
+    }
+  },
+  "freshness_states": [
+    "fresh",
+    "cached",
+    "unavailable"
+  ],
+  "freshness_fields": {
+    "local": [
+      "observed_at",
+      "base_sha",
+      "head_sha",
+      "fingerprint"
+    ],
+    "remote": [
+      "state",
+      "refreshed_at"
+    ]
+  },
+  "error_codes": [
+    "REVIEW_TARGET_NOT_FOUND",
+    "REVIEW_TARGET_UNAVAILABLE",
+    "REVIEW_WORKTREE_MISSING",
+    "REVIEW_NOT_A_GIT_REPOSITORY",
+    "REVIEW_REF_MISSING",
+    "REVIEW_REMOTE_UNAVAILABLE",
+    "REVIEW_PATH_INVALID",
+    "REVIEW_DIFF_TOO_LARGE",
+    "REVIEW_TARGET_CHANGED"
+  ],
+  "scenario_expectations": {
+    "clean": {
+      "selected_kind": "workspace",
+      "lifecycle": null,
+      "empty_reason": "clean_workspace"
+    },
+    "dirty": {
+      "selected_kind": "workspace",
+      "lifecycle": "local_branch",
+      "facts": [
+        "dirty_files"
+      ]
+    },
+    "local": {
+      "selected_kind": "local_branch",
+      "lifecycle": "local_branch"
+    },
+    "pushed": {
+      "selected_kind": "local_branch",
+      "lifecycle": "pushed"
+    },
+    "open": {
+      "selected_kind": "pull_request",
+      "lifecycle": "pr_open",
+      "remote_freshness": "fresh"
+    },
+    "checks_failed": {
+      "selected_kind": "pull_request",
+      "lifecycle": "checks_failed",
+      "remote_freshness": "fresh"
+    },
+    "closed": {
+      "selected_kind": "pull_request",
+      "lifecycle": "pr_closed",
+      "remote_freshness": "fresh"
+    },
+    "squash_merged": {
+      "selected_kind": "pull_request",
+      "lifecycle": "pr_merged",
+      "remote_overrides_ancestry": true
+    },
+    "retained_behind": {
+      "selected_kind": "pull_request",
+      "lifecycle": "pr_merged",
+      "facts": [
+        "cleanup_pending",
+        "local_base_not_refreshed"
+      ]
+    },
+    "pruned": {
+      "selected_kind": "pull_request",
+      "lifecycle": "pr_merged",
+      "facts": [
+        "branch_pruned"
+      ]
+    },
+    "branch_reuse": {
+      "selected_kind": "pull_request",
+      "target_count": 2,
+      "identity_field": "pr_number"
+    },
+    "offline_cached": {
+      "selected_kind": "pull_request",
+      "lifecycle": "pr_open",
+      "remote_freshness": "cached"
+    },
+    "offline_uncached": {
+      "selected_kind": "local_branch",
+      "lifecycle": "remote_unknown",
+      "remote_freshness": "unavailable"
+    }
+  },
+  "file_states": [
+    "added",
+    "modified",
+    "deleted",
+    "renamed",
+    "untracked",
+    "conflict",
+    "binary",
+    "oversized"
+  ]
+}

--- a/tests/review_fixtures.py
+++ b/tests/review_fixtures.py
@@ -1,0 +1,189 @@
+"""Reusable Git and mocked-GitHub fixtures for browser Diff review tests."""
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "review"
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "Review Fixture",
+    "GIT_AUTHOR_EMAIL": "review-fixture@example.test",
+    "GIT_COMMITTER_NAME": "Review Fixture",
+    "GIT_COMMITTER_EMAIL": "review-fixture@example.test",
+}
+
+
+class GitFixtureError(AssertionError):
+    """A fixture-building Git command failed unexpectedly."""
+
+
+class RemoteUnavailable(RuntimeError):
+    """The mocked GitHub reader is deliberately offline."""
+
+
+class ReviewRepository:
+    """A disposable repository with a bare origin and deterministic identity."""
+
+    def __init__(self) -> None:
+        self._temporary = tempfile.TemporaryDirectory(prefix="sc-review-")
+        self.root = Path(self._temporary.name)
+        self.repo = self.root / "repo"
+        self.origin = self.root / "origin.git"
+        self.repo.mkdir()
+        self.git("init", "-b", "main")
+        self.git("config", "user.name", "Review Fixture")
+        self.git("config", "user.email", "review-fixture@example.test")
+        self.git("init", "--bare", str(self.origin))
+        self.git("remote", "add", "origin", str(self.origin))
+        self.write("base.txt", "base\n")
+        self.commit("base")
+        self.git("push", "-u", "origin", "main")
+
+    def cleanup(self) -> None:
+        self._temporary.cleanup()
+
+    def git_result(
+        self,
+        *args: str,
+        check: bool = True,
+        text: bool = True,
+    ) -> subprocess.CompletedProcess:
+        result = subprocess.run(
+            ["git", "-C", str(self.repo), *args],
+            capture_output=True,
+            text=text,
+            env=GIT_ENV,
+            timeout=10,
+            check=False,
+        )
+        if check and result.returncode != 0:
+            stderr = result.stderr if text else result.stderr.decode()
+            raise GitFixtureError(
+                f"git {' '.join(args)} failed ({result.returncode}): {stderr}"
+            )
+        return result
+
+    def git(self, *args: str) -> str:
+        return self.git_result(*args).stdout.strip()
+
+    def write(self, relative: str, body: str | bytes) -> Path:
+        path = self.repo / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(body, bytes):
+            path.write_bytes(body)
+        else:
+            path.write_text(body)
+        return path
+
+    def commit(self, message: str) -> str:
+        self.git("add", "-A")
+        self.git("commit", "-m", message)
+        return self.git("rev-parse", "HEAD")
+
+    def branch(self, name: str, start: str = "main") -> None:
+        self.git("checkout", "-b", name, start)
+
+    def checkout(self, name: str) -> None:
+        self.git("checkout", name)
+
+    def changed_paths(self, *diff_args: str) -> set[str]:
+        return set(
+            filter(
+                None,
+                self.git("diff", "--name-only", *diff_args).splitlines(),
+            )
+        )
+
+    def build_three_dot_case(self) -> dict[str, str]:
+        base_sha = self.git("rev-parse", "main")
+        self.branch("feature/three-dot")
+        self.write("topic.txt", "topic\n")
+        topic_sha = self.commit("topic change")
+        self.checkout("main")
+        self.write("unrelated-base.txt", "base advanced\n")
+        advanced_base_sha = self.commit("unrelated base advancement")
+        return {
+            "base_sha": base_sha,
+            "topic_sha": topic_sha,
+            "advanced_base_sha": advanced_base_sha,
+        }
+
+    def build_squash_merge_case(self) -> dict[str, str]:
+        self.branch("feature/squash")
+        self.write("squash.txt", "squash\n")
+        topic_sha = self.commit("squash topic")
+        self.checkout("main")
+        self.git("merge", "--squash", "feature/squash")
+        squash_sha = self.commit("squash merged topic")
+        self.write("post-merge-base.txt", "later\n")
+        latest_base_sha = self.commit("advance main after squash")
+        return {
+            "topic_sha": topic_sha,
+            "merge_sha": squash_sha,
+            "latest_base_sha": latest_base_sha,
+        }
+
+    def build_file_state_case(self) -> None:
+        self.write("modified.txt", "before\n")
+        self.write("renamed-before.txt", "rename me\n")
+        self.write("deleted.txt", "delete me\n")
+        self.write("conflict.txt", "base\n")
+        self.commit("file-state base")
+        self.branch("feature/files")
+        self.write("modified.txt", "after\n")
+        self.git("mv", "renamed-before.txt", "renamed-after.txt")
+        (self.repo / "deleted.txt").unlink()
+        self.write("added.txt", "added\n")
+        self.git("add", "added.txt")
+        self.write("untracked.txt", "untracked\n")
+        self.write("binary.dat", b"\x00\x01\x02review\xff")
+        self.git("add", "binary.dat")
+        self.write("oversized.txt", "x" * (1024 * 1024 + 1))
+
+    def build_conflict_case(self) -> None:
+        self.write("conflict.txt", "base\n")
+        self.commit("conflict base")
+        self.branch("feature/conflict")
+        self.write("conflict.txt", "topic\n")
+        self.commit("topic conflict")
+        self.checkout("main")
+        self.write("conflict.txt", "main\n")
+        self.commit("main conflict")
+        result = self.git_result("merge", "feature/conflict", check=False)
+        if result.returncode == 0:
+            raise GitFixtureError("fixture merge unexpectedly had no conflict")
+
+
+class MockGitHub:
+    """Deterministic PR metadata/patch reader with an explicit offline mode."""
+
+    def __init__(self, *, available: bool = True) -> None:
+        self.available = available
+        self._data = json.loads((FIXTURES / "github_prs.json").read_text())
+
+    def _require_available(self) -> None:
+        if not self.available:
+            raise RemoteUnavailable("mock GitHub is unavailable")
+
+    def list_prs(self) -> list[dict]:
+        self._require_available()
+        return copy.deepcopy(self._data["pull_requests"])
+
+    def pr(self, number: int) -> dict:
+        self._require_available()
+        for item in self._data["pull_requests"]:
+            if item["number"] == number:
+                return copy.deepcopy(item)
+        raise KeyError(number)
+
+    def patch(self, number: int) -> str:
+        self._require_available()
+        try:
+            return self._data["patches"][str(number)]
+        except KeyError as exc:
+            raise KeyError(number) from exc

--- a/tests/test_review_contract_fixtures.py
+++ b/tests/test_review_contract_fixtures.py
@@ -1,0 +1,338 @@
+"""Contract and fixture gates for Feature #26 browser Diff review."""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(TESTS))
+
+from review_fixtures import (
+    FIXTURES,
+    MockGitHub,
+    RemoteUnavailable,
+    ReviewRepository,
+)
+
+
+class ProjectionContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = json.loads(
+            (FIXTURES / "projection_contract.json").read_text()
+        )
+
+    def test_target_lifecycle_freshness_and_error_vocabularies_are_frozen(
+        self,
+    ) -> None:
+        self.assertEqual(self.contract["contract_version"], 1)
+        self.assertEqual(
+            set(self.contract["target_kinds"]),
+            {"workspace", "local_branch", "pull_request"},
+        )
+        self.assertEqual(
+            set(self.contract["lifecycle_statuses"]),
+            {
+                "local_branch",
+                "pushed",
+                "pr_open",
+                "checks_failed",
+                "pr_merged",
+                "pr_closed",
+                "remote_unknown",
+            },
+        )
+        self.assertEqual(
+            set(self.contract["freshness_states"]),
+            {"fresh", "cached", "unavailable"},
+        )
+        self.assertEqual(
+            set(self.contract["error_codes"]),
+            {
+                "REVIEW_TARGET_NOT_FOUND",
+                "REVIEW_TARGET_UNAVAILABLE",
+                "REVIEW_WORKTREE_MISSING",
+                "REVIEW_NOT_A_GIT_REPOSITORY",
+                "REVIEW_REF_MISSING",
+                "REVIEW_REMOTE_UNAVAILABLE",
+                "REVIEW_PATH_INVALID",
+                "REVIEW_DIFF_TOO_LARGE",
+                "REVIEW_TARGET_CHANGED",
+            },
+        )
+
+    def test_every_required_lifecycle_scenario_has_an_expectation(self) -> None:
+        self.assertEqual(
+            set(self.contract["scenario_expectations"]),
+            {
+                "clean",
+                "dirty",
+                "local",
+                "pushed",
+                "open",
+                "checks_failed",
+                "closed",
+                "squash_merged",
+                "retained_behind",
+                "pruned",
+                "branch_reuse",
+                "offline_cached",
+                "offline_uncached",
+            },
+        )
+        self.assertTrue(
+            self.contract["scenario_expectations"]["squash_merged"]
+            ["remote_overrides_ancestry"]
+        )
+        self.assertEqual(
+            self.contract["scenario_expectations"]["branch_reuse"]
+            ["identity_field"],
+            "pr_number",
+        )
+
+    def test_comparison_and_file_state_contracts_are_complete(self) -> None:
+        self.assertEqual(
+            set(self.contract["comparison_scopes"]),
+            {"review", "local", "commits"},
+        )
+        self.assertEqual(
+            set(self.contract["file_states"]),
+            {
+                "added",
+                "modified",
+                "deleted",
+                "renamed",
+                "untracked",
+                "conflict",
+                "binary",
+                "oversized",
+            },
+        )
+
+
+class GitComparisonFixtureTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = ReviewRepository()
+        self.addCleanup(self.fixture.cleanup)
+
+    def test_three_dot_review_excludes_unrelated_base_advancement(self) -> None:
+        self.fixture.build_three_dot_case()
+
+        three_dot = self.fixture.changed_paths(
+            "main...feature/three-dot"
+        )
+        direct_tips = self.fixture.changed_paths(
+            "main..feature/three-dot"
+        )
+
+        self.assertEqual(three_dot, {"topic.txt"})
+        self.assertEqual(
+            direct_tips,
+            {"topic.txt", "unrelated-base.txt"},
+            "two-tip comparison demonstrates the unrelated-base failure mode",
+        )
+
+    def test_clean_local_and_pushed_branch_states_are_distinct(self) -> None:
+        self.assertEqual(self.fixture.git("status", "--porcelain=v2"), "")
+        self.fixture.branch("feature/pushed")
+        self.fixture.write("pushed.txt", "pushed\n")
+        self.fixture.commit("local topic")
+
+        absent = self.fixture.git_result(
+            "show-ref",
+            "--verify",
+            "refs/remotes/origin/feature/pushed",
+            check=False,
+        )
+        self.assertNotEqual(absent.returncode, 0)
+
+        self.fixture.git("push", "-u", "origin", "feature/pushed")
+        self.assertEqual(
+            self.fixture.git(
+                "rev-parse",
+                "feature/pushed",
+            ),
+            self.fixture.git(
+                "rev-parse",
+                "refs/remotes/origin/feature/pushed",
+            ),
+        )
+
+    def test_squash_merge_remote_verdict_overrides_misleading_ancestry(
+        self,
+    ) -> None:
+        topology = self.fixture.build_squash_merge_case()
+        ancestry = self.fixture.git_result(
+            "merge-base",
+            "--is-ancestor",
+            topology["topic_sha"],
+            "main",
+            check=False,
+        )
+        behind, ahead = self.fixture.git(
+            "rev-list",
+            "--left-right",
+            "--count",
+            "main...feature/squash",
+        ).split()
+        remote = MockGitHub().pr(823)
+
+        self.assertNotEqual(
+            ancestry.returncode,
+            0,
+            "squash merge must not manufacture topic ancestry",
+        )
+        self.assertGreater(int(behind), 0)
+        self.assertGreater(int(ahead), 0)
+        self.assertEqual(remote["state"], "MERGED")
+        self.assertEqual(
+            remote["headRefName"],
+            "feature/squash",
+            "PR identity survives the misleading retained branch",
+        )
+
+    def test_merged_branch_can_be_checked_out_behind_a_stale_local_base(
+        self,
+    ) -> None:
+        topology = self.fixture.build_squash_merge_case()
+        local_base_has_merge = self.fixture.git_result(
+            "merge-base",
+            "--is-ancestor",
+            topology["merge_sha"],
+            "origin/main",
+            check=False,
+        )
+        self.fixture.checkout("feature/squash")
+        behind, ahead = self.fixture.git(
+            "rev-list",
+            "--left-right",
+            "--count",
+            "main...HEAD",
+        ).split()
+
+        self.assertNotEqual(local_base_has_merge.returncode, 0)
+        self.assertEqual(
+            self.fixture.git("branch", "--show-current"),
+            "feature/squash",
+        )
+        self.assertGreater(int(behind), 0)
+        self.assertGreater(int(ahead), 0)
+        self.assertEqual(MockGitHub().pr(823)["state"], "MERGED")
+
+    def test_pr_target_survives_local_branch_pruning(self) -> None:
+        self.fixture.build_squash_merge_case()
+        self.fixture.git("branch", "-D", "feature/squash")
+        local_branch = self.fixture.git_result(
+            "show-ref",
+            "--verify",
+            "refs/heads/feature/squash",
+            check=False,
+        )
+
+        self.assertNotEqual(local_branch.returncode, 0)
+        self.assertEqual(MockGitHub().pr(823)["number"], 823)
+
+    def test_dirty_rename_binary_and_oversized_states_are_real_git_fixtures(
+        self,
+    ) -> None:
+        self.fixture.build_file_state_case()
+        status = self.fixture.git_result(
+            "status",
+            "--porcelain=v2",
+            "-z",
+            "--branch",
+            text=False,
+        ).stdout
+        numstat = self.fixture.git("diff", "HEAD", "--numstat")
+
+        self.assertIn(b"modified.txt", status)
+        self.assertIn(b"renamed-before.txt", status)
+        self.assertIn(b"renamed-after.txt", status)
+        self.assertIn(b"deleted.txt", status)
+        self.assertIn(b"added.txt", status)
+        self.assertIn(b"untracked.txt", status)
+        self.assertIn(b"binary.dat", status)
+        self.assertIn(b"oversized.txt", status)
+        self.assertIn("-\t-\tbinary.dat", numstat)
+        self.assertGreater(
+            (self.fixture.repo / "oversized.txt").stat().st_size,
+            1024 * 1024,
+        )
+
+    def test_conflict_state_is_a_real_unmerged_index(self) -> None:
+        self.fixture.build_conflict_case()
+        status = self.fixture.git_result(
+            "status",
+            "--porcelain=v2",
+            "-z",
+            text=False,
+        ).stdout
+
+        self.assertIn(b"u UU ", status)
+        self.assertIn(b"conflict.txt", status)
+
+
+class MockGitHubFixtureTest(unittest.TestCase):
+    def test_open_and_failing_check_rollups_are_explicit(self) -> None:
+        github = MockGitHub()
+        open_pr = github.pr(821)
+        failing_pr = github.pr(822)
+        closed_pr = github.pr(826)
+
+        self.assertEqual(open_pr["state"], "OPEN")
+        self.assertEqual(
+            open_pr["statusCheckRollup"][0]["conclusion"],
+            "SUCCESS",
+        )
+        self.assertEqual(failing_pr["state"], "OPEN")
+        self.assertEqual(
+            failing_pr["statusCheckRollup"][0]["conclusion"],
+            "FAILURE",
+        )
+        self.assertEqual(closed_pr["state"], "CLOSED")
+        self.assertIsNone(closed_pr["mergedAt"])
+
+    def test_reused_branch_keeps_distinct_pr_identities(self) -> None:
+        prs = [
+            item
+            for item in MockGitHub().list_prs()
+            if item["headRefName"] == "feature/reused"
+        ]
+
+        self.assertEqual([item["number"] for item in prs], [824, 825])
+        self.assertEqual(
+            {item["headRefOid"] for item in prs},
+            {
+                "5555555555555555555555555555555555555555",
+                "7777777777777777777777777777777777777777",
+            },
+        )
+        self.assertEqual(
+            {item["state"] for item in prs},
+            {"MERGED", "OPEN"},
+        )
+
+    def test_offline_fixture_fails_explicitly_without_losing_cached_contract(
+        self,
+    ) -> None:
+        cached = MockGitHub().pr(821)
+        offline = MockGitHub(available=False)
+
+        with self.assertRaises(RemoteUnavailable):
+            offline.list_prs()
+        self.assertEqual(cached["number"], 821)
+        self.assertEqual(cached["state"], "OPEN")
+
+    def test_canonical_patch_reads_are_by_exact_pr_number(self) -> None:
+        github = MockGitHub()
+
+        self.assertIn("open.txt", github.patch(821))
+        self.assertIn("squash.txt", github.patch(823))
+        with self.assertRaises(KeyError):
+            github.patch(825)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- freeze Feature #26 v1 target, lifecycle, comparison, freshness, file-state, and typed-error projections
- add reusable temporary Git repositories and mocked exact-PR metadata/patch readers
- cover clean, dirty, local, pushed, open, failed-check, closed, squash-merged, retained-behind, pruned, branch-reuse, offline, rename, conflict, binary, and oversized states
- prove three-dot review excludes unrelated base advancement
- prove authoritative merged PR state survives squash ancestry, stale local refs, and branch pruning

This is task #149 only: contract and fixture foundations, with no schema, service, API, UI, Git, GitHub, or conversation mutation path.

## Verification

- `./sc test tests/test_review_contract_fixtures.py -q` — 14 passed
- `./sc test tests/test_git_prune.py tests/test_review_contract_fixtures.py -q` — 22 passed
- `./sc test -q` — 1661 passed, 786 subtests passed
- targeted Ruff — green
- `git diff --check` — green
- `./sc verify` — green
- `./sc render-check` — known local active-mirror drift only in `skills_sc/README.md` and `skills_sc/sprint_onboarding.md`; hermetic source rebuild passed and this branch changes no render sources (tracked by #809)

## Architecture

Honors Decision #31 and spec #40: Diff is a coequal read-only mode, PR number is durable review identity, local Git is an overlay, and remote PR state overrides misleading squash ancestry.