### PR TITLE
feat: persist conversation Git targets

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(SCRIPTS))
 
 import conversation_broker
 import conversation_events
+import conversation_git_targets
 import db_driver
 import run as run_mod
 from conversation_adapters import ADAPTER_TYPES
@@ -772,6 +773,10 @@ def _create_conversation(con, operator: dict, headers, body: dict):
     for closed_id in auto_closed:
         conversation_events.notify(closed_id)
     conversation_events.notify(conversation_id)
+    conversation_git_targets.safely_observe_and_persist(
+        DB_PATH,
+        conversation_id,
+    )
     row = _require_conversation(con, conversation_id, operator["user_id"])
     return _json(
         201,

--- a/.super-coder/migrations/0142_conversation_git_targets.sql
+++ b/.super-coder/migrations/0142_conversation_git_targets.sql
@@ -1,0 +1,148 @@
+-- 0142 — durable Git/PR review identities for browser conversations.
+--
+-- Local observations are deliberately small: the read-only review service
+-- added by later Feature #26 steps enriches these rows with PR evidence and
+-- bounded patch artifacts.  PR number becomes immutable once associated so a
+-- reused branch name can never repurpose an older review target.
+
+BEGIN;
+
+CREATE TABLE conversation_git_targets (
+    target_id              TEXT PRIMARY KEY
+                           DEFAULT ('gt_' || lower(hex(randomblob(16))))
+                           CHECK (
+                             length(target_id)=35
+                             AND substr(target_id,1,3)='gt_'
+                             AND substr(target_id,4)
+                                 NOT GLOB '*[^0-9a-f]*'
+                           ),
+    conversation_id        TEXT NOT NULL
+                           REFERENCES conversations(conversation_id),
+    branch_name            TEXT NOT NULL
+                           CHECK (
+                             length(trim(branch_name)) BETWEEN 1 AND 1024
+                           ),
+    base_ref               TEXT
+                           CHECK (
+                             base_ref IS NULL
+                             OR length(trim(base_ref)) BETWEEN 1 AND 1024
+                           ),
+    first_head_sha         TEXT NOT NULL
+                           CHECK (
+                             length(first_head_sha) IN (40,64)
+                             AND first_head_sha NOT GLOB '*[^0-9a-f]*'
+                           ),
+    latest_head_sha        TEXT NOT NULL
+                           CHECK (
+                             length(latest_head_sha) IN (40,64)
+                             AND latest_head_sha NOT GLOB '*[^0-9a-f]*'
+                           ),
+    pr_number              INTEGER CHECK (pr_number IS NULL OR pr_number > 0),
+    pr_head_sha            TEXT
+                           CHECK (
+                             pr_head_sha IS NULL
+                             OR (
+                               length(pr_head_sha) IN (40,64)
+                               AND pr_head_sha NOT GLOB '*[^0-9a-f]*'
+                             )
+                           ),
+    pr_state               TEXT
+                           CHECK (
+                             pr_state IS NULL
+                             OR pr_state IN ('OPEN','MERGED','CLOSED')
+                           ),
+    merge_sha              TEXT
+                           CHECK (
+                             merge_sha IS NULL
+                             OR (
+                               length(merge_sha) IN (40,64)
+                               AND merge_sha NOT GLOB '*[^0-9a-f]*'
+                             )
+                           ),
+    merged_at              TEXT,
+    pr_url                 TEXT
+                           CHECK (
+                             pr_url IS NULL OR length(pr_url) <= 2048
+                           ),
+    pr_title               TEXT
+                           CHECK (
+                             pr_title IS NULL OR length(pr_title) <= 500
+                           ),
+    first_seen_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    last_seen_at           TEXT NOT NULL DEFAULT (datetime('now')),
+    remote_refreshed_at    TEXT,
+    patch_artifact         TEXT
+                           CHECK (
+                             patch_artifact IS NULL
+                             OR (
+                               length(patch_artifact) BETWEEN 1 AND 2048
+                               AND substr(patch_artifact,1,1) <> '/'
+                             )
+                           ),
+    patch_sha256           TEXT
+                           CHECK (
+                             patch_sha256 IS NULL
+                             OR (
+                               length(patch_sha256)=64
+                               AND patch_sha256 NOT GLOB '*[^0-9a-f]*'
+                             )
+                           ),
+    CHECK (last_seen_at >= first_seen_at),
+    CHECK (
+      pr_number IS NOT NULL
+      OR (
+        pr_head_sha IS NULL
+        AND pr_state IS NULL
+        AND merge_sha IS NULL
+        AND merged_at IS NULL
+        AND pr_url IS NULL
+        AND pr_title IS NULL
+        AND remote_refreshed_at IS NULL
+        AND patch_artifact IS NULL
+        AND patch_sha256 IS NULL
+      )
+    ),
+    CHECK (
+      (patch_artifact IS NULL AND patch_sha256 IS NULL)
+      OR
+      (patch_artifact IS NOT NULL AND patch_sha256 IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX idx_conversation_git_targets_pr
+    ON conversation_git_targets(conversation_id, pr_number)
+    WHERE pr_number IS NOT NULL;
+CREATE UNIQUE INDEX idx_conversation_git_targets_local
+    ON conversation_git_targets(
+      conversation_id, branch_name, first_head_sha
+    )
+    WHERE pr_number IS NULL;
+CREATE INDEX idx_conversation_git_targets_recent
+    ON conversation_git_targets(
+      conversation_id, last_seen_at DESC, target_id
+    );
+CREATE INDEX idx_conversation_git_targets_head
+    ON conversation_git_targets(
+      conversation_id, branch_name, latest_head_sha
+    );
+CREATE INDEX idx_conversation_git_targets_pr_lookup
+    ON conversation_git_targets(pr_number)
+    WHERE pr_number IS NOT NULL;
+
+CREATE TRIGGER trg_conversation_git_targets_identity_immutable
+BEFORE UPDATE OF
+    target_id, conversation_id, branch_name, first_head_sha, first_seen_at
+ON conversation_git_targets
+BEGIN
+  SELECT RAISE(ABORT, 'conversation Git target identity is immutable');
+END;
+
+CREATE TRIGGER trg_conversation_git_targets_pr_immutable
+BEFORE UPDATE OF pr_number ON conversation_git_targets
+WHEN OLD.pr_number IS NOT NULL
+  AND NEW.pr_number IS NOT OLD.pr_number
+BEGIN
+  SELECT RAISE(ABORT, 'conversation Git target PR identity is immutable');
+END;
+
+COMMIT;

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 import conversation_events
+import conversation_git_targets
 import db_driver
 import sprint_conversations
 from conversation_adapters import (
@@ -961,6 +962,10 @@ class BrokerStore:
             con.close()
         for notify_id in notify_ids or {str(conversation_id)}:
             conversation_events.notify(notify_id)
+        conversation_git_targets.safely_observe_and_persist(
+            self.db_path,
+            str(conversation_id),
+        )
         return True
 
     def renew_runs(self, owner: str, run_ids: list[int]) -> int:

--- a/.super-coder/scripts/conversation_git_targets.py
+++ b/.super-coder/scripts/conversation_git_targets.py
@@ -1,0 +1,258 @@
+"""Failure-tolerant local Git observations for conversation review targets.
+
+Git and filesystem reads finish before the short persistence transaction
+begins.  This module records only durable local identity; the full read-only
+review projection and GitHub enrichment belong to the Feature #26 review
+service.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import db_driver
+
+_LOG = logging.getLogger("super_coder.conversation_git_targets")
+GIT_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class LocalGitObservation:
+    branch_name: str
+    base_ref: str | None
+    head_sha: str
+    observed_at: str
+
+
+def _stamp(now: datetime | None = None) -> str:
+    value = now or datetime.now(timezone.utc)
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _git_environment() -> dict[str, str]:
+    return {
+        **os.environ,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+
+
+def _run_git(
+    worktree: Path,
+    args: Sequence[str],
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+) -> str | None:
+    result = runner(
+        ["git", "-C", str(worktree), *args],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=GIT_TIMEOUT_SECONDS,
+        check=False,
+        env=_git_environment(),
+    )
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _base_ref(
+    worktree: Path,
+    *,
+    runner: Callable[..., Any],
+) -> str | None:
+    remote_head = _run_git(
+        worktree,
+        ("symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"),
+        runner=runner,
+    )
+    if remote_head:
+        return remote_head
+    for candidate in ("origin/main", "main", "origin/master", "master"):
+        if _run_git(
+            worktree,
+            ("rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"),
+            runner=runner,
+        ):
+            return candidate
+    return None
+
+
+def observe_local_git(
+    worktree: str | Path,
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+    now: datetime | None = None,
+) -> LocalGitObservation:
+    resolved = Path(worktree).resolve(strict=True)
+    if not resolved.is_dir():
+        raise NotADirectoryError(str(resolved))
+    branch = _run_git(
+        resolved,
+        ("symbolic-ref", "--quiet", "--short", "HEAD"),
+        runner=runner,
+    )
+    head = _run_git(
+        resolved,
+        ("rev-parse", "--verify", "--quiet", "HEAD^{commit}"),
+        runner=runner,
+    )
+    if branch is None or head is None:
+        raise RuntimeError("conversation worktree has no observable branch head")
+    return LocalGitObservation(
+        branch_name=branch,
+        base_ref=_base_ref(resolved, runner=runner),
+        head_sha=head.lower(),
+        observed_at=_stamp(now),
+    )
+
+
+def persist_local_observation(
+    db_path: str | Path,
+    conversation_id: str,
+    expected_worktree: str,
+    observation: LocalGitObservation,
+    *,
+    connect: Callable[[str | Path], Any] = db_driver.connect,
+) -> str | None:
+    """Persist one already-read observation in a database-only transaction."""
+    con = connect(db_path)
+    try:
+        with db_driver.write_transaction(
+            con,
+            "conversation.git_target.observe",
+        ):
+            current = con.execute(
+                "SELECT mode,worktree FROM conversations "
+                "WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()
+            if (
+                current is None
+                or current["mode"] != "normal"
+                or current["worktree"] != expected_worktree
+            ):
+                return None
+            target = con.execute(
+                "SELECT target_id FROM conversation_git_targets "
+                "WHERE conversation_id=? AND branch_name=? "
+                "AND pr_number IS NULL "
+                "ORDER BY last_seen_at DESC,target_id DESC LIMIT 1",
+                (conversation_id, observation.branch_name),
+            ).fetchone()
+            if target is None:
+                con.execute(
+                    "INSERT INTO conversation_git_targets "
+                    "(conversation_id,branch_name,base_ref,first_head_sha,"
+                    "latest_head_sha,first_seen_at,last_seen_at) "
+                    "VALUES (?,?,?,?,?,?,?)",
+                    (
+                        conversation_id,
+                        observation.branch_name,
+                        observation.base_ref,
+                        observation.head_sha,
+                        observation.head_sha,
+                        observation.observed_at,
+                        observation.observed_at,
+                    ),
+                )
+                target = con.execute(
+                    "SELECT target_id FROM conversation_git_targets "
+                    "WHERE conversation_id=? AND branch_name=? "
+                    "AND first_head_sha=? AND pr_number IS NULL",
+                    (
+                        conversation_id,
+                        observation.branch_name,
+                        observation.head_sha,
+                    ),
+                ).fetchone()
+            else:
+                con.execute(
+                    "UPDATE conversation_git_targets "
+                    "SET base_ref=?,latest_head_sha=?,last_seen_at=? "
+                    "WHERE target_id=?",
+                    (
+                        observation.base_ref,
+                        observation.head_sha,
+                        observation.observed_at,
+                        target["target_id"],
+                    ),
+                )
+            return str(target["target_id"])
+    finally:
+        con.close()
+
+
+def observe_and_persist(
+    db_path: str | Path,
+    conversation_id: str,
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+    connect: Callable[[str | Path], Any] = db_driver.connect,
+    now: datetime | None = None,
+) -> bool:
+    """Observe and persist one normal conversation.
+
+    Lifecycle callers use ``safely_observe_and_persist`` so observation cannot
+    affect their already-committed result.
+    """
+    con = connect(db_path)
+    try:
+        row = con.execute(
+            "SELECT mode,worktree FROM conversations "
+            "WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()
+        if row is None or row["mode"] != "normal":
+            return False
+        worktree = str(row["worktree"])
+    finally:
+        con.close()
+
+    observation = observe_local_git(worktree, runner=runner, now=now)
+    return (
+        persist_local_observation(
+            db_path,
+            conversation_id,
+            worktree,
+            observation,
+            connect=connect,
+        )
+        is not None
+    )
+
+
+def safely_observe_and_persist(
+    db_path: str | Path,
+    conversation_id: str,
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+    connect: Callable[[str | Path], Any] = db_driver.connect,
+    now: datetime | None = None,
+) -> bool:
+    """Best-effort lifecycle hook; never changes its caller's outcome."""
+    try:
+        return observe_and_persist(
+            db_path,
+            conversation_id,
+            runner=runner,
+            connect=connect,
+            now=now,
+        )
+    except Exception as exc:  # noqa: BLE001 - observation is non-authoritative
+        _LOG.warning(
+            "conversation Git observation skipped conversation=%s: %s",
+            conversation_id,
+            exc,
+        )
+        return False

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -107,6 +107,7 @@ PER_INSTANCE_TABLES = [
     # pending outbox work must all survive update/rebuild. Parents precede
     # children so a snapshot stays readable and foreign-key-valid when loaded.
     "conversations",
+    "conversation_git_targets",
     "sprint_conversation_bindings",
     "sprint_cancellations",
     "conversation_messages",

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -139,6 +139,42 @@ class ConversationApiCase(unittest.TestCase):
         self.assertEqual(status, 201, obj)
         return obj
 
+    def test_creation_observation_is_post_commit_and_cannot_fail_create(self):
+        def observer(db_path, conversation_id):
+            probe = sqlite3.connect(db_path, timeout=0.1)
+            try:
+                probe.execute("BEGIN IMMEDIATE")
+                probe.rollback()
+            finally:
+                probe.close()
+            raise RuntimeError("Git unavailable")
+
+        with mock.patch.object(
+            conversation_routes.conversation_git_targets,
+            "observe_and_persist",
+            side_effect=observer,
+        ) as observe:
+            created = self.create()
+
+        observe.assert_called_once_with(
+            self.db_path,
+            created["conversation_id"],
+            runner=mock.ANY,
+            connect=mock.ANY,
+            now=None,
+        )
+        con = self.connect()
+        try:
+            self.assertEqual(
+                con.execute(
+                    "SELECT state FROM conversations WHERE conversation_id=?",
+                    (created["conversation_id"],),
+                ).fetchone()[0],
+                "idle",
+            )
+        finally:
+            con.close()
+
     def test_create_prepares_never_booted_worktree_on_first_turn(self):
         worktree = self.root / ".sc-worktrees" / "dev"
         worktree.rmdir()

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -14,6 +14,7 @@ import unittest
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
@@ -538,6 +539,71 @@ class StoreContractTest(ConversationBrokerCase):
         con.close()
         self.assertEqual(first_state, "completed")
         self.assertEqual(sequences, [1, 2])
+
+    def test_terminal_observation_is_post_commit_and_cannot_fail_run(self) -> None:
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        store = BrokerStore(self.db_path)
+        run = store.claim_next("broker")
+        store.mark_starting(run.run_id, "broker")
+        store.mark_native_started(
+            run.run_id,
+            "broker",
+            NativeTurn(
+                "codex",
+                "native-session",
+                "native-run-observation",
+                self.worktree,
+            ),
+        )
+
+        def observer(db_path, observed_conversation_id):
+            probe = sqlite3.connect(db_path, timeout=0.1)
+            try:
+                probe.execute("BEGIN IMMEDIATE")
+                probe.rollback()
+            finally:
+                probe.close()
+            raise RuntimeError("Git unavailable")
+
+        with mock.patch(
+            "conversation_broker.conversation_git_targets.observe_and_persist",
+            side_effect=observer,
+        ) as observe:
+            self.assertTrue(
+                store.finish_run(
+                    run.run_id,
+                    "succeeded",
+                    event_type="run.completed",
+                )
+            )
+
+        observe.assert_called_once_with(
+            str(self.db_path),
+            conversation_id,
+            runner=mock.ANY,
+            connect=mock.ANY,
+            now=None,
+        )
+        con = self.connect()
+        try:
+            self.assertEqual(
+                con.execute(
+                    "SELECT state FROM conversation_runs WHERE run_id=?",
+                    (run.run_id,),
+                ).fetchone()[0],
+                "succeeded",
+            )
+            self.assertEqual(
+                con.execute(
+                    "SELECT state FROM conversations "
+                    "WHERE conversation_id=?",
+                    (conversation_id,),
+                ).fetchone()[0],
+                "idle",
+            )
+        finally:
+            con.close()
 
     def test_one_shot_result_closes_and_returns_exact_directive_to_conductor(
         self,

--- a/tests/test_conversation_git_targets.py
+++ b/tests/test_conversation_git_targets.py
@@ -1,0 +1,239 @@
+"""Feature #26 durable conversation Git-target observations."""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+TESTS = ROOT / "tests"
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(TESTS))
+
+import conversation_git_targets  # noqa: E402
+import snapshot  # noqa: E402
+from review_fixtures import ReviewRepository  # noqa: E402
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+class ConversationGitTargetsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = ReviewRepository()
+        self.addCleanup(self.fixture.cleanup)
+        self.db_path = self.fixture.root / "shell.db"
+        con = sqlite3.connect(self.db_path)
+        apply_schema(con)
+        con.execute(
+            "INSERT INTO users (user_id,username) VALUES (1,'operator')"
+        )
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (1,'Dev','dev','dev','prompt',1)"
+        )
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,owner_user_id,harness,worktree,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES ('cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',1,'normal',1,"
+            "'codex',?,'create','hash')",
+            (str(self.fixture.repo),),
+        )
+        con.commit()
+        con.close()
+        self.conversation_id = "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    def connect(self) -> sqlite3.Connection:
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        con.execute("PRAGMA foreign_keys=ON")
+        return con
+
+    def rows(self):
+        con = self.connect()
+        try:
+            return con.execute(
+                "SELECT * FROM conversation_git_targets "
+                "ORDER BY first_seen_at,target_id"
+            ).fetchall()
+        finally:
+            con.close()
+
+    def test_observation_is_idempotent_and_updates_bounded_head_history(
+        self,
+    ) -> None:
+        first_head = self.fixture.git("rev-parse", "HEAD")
+        first_time = datetime(2026, 7, 30, 19, 0, tzinfo=timezone.utc)
+        self.assertTrue(
+            conversation_git_targets.observe_and_persist(
+                self.db_path,
+                self.conversation_id,
+                now=first_time,
+            )
+        )
+
+        self.fixture.write("second.txt", "second\n")
+        latest_head = self.fixture.commit("second")
+        second_time = datetime(2026, 7, 30, 19, 1, tzinfo=timezone.utc)
+        self.assertTrue(
+            conversation_git_targets.observe_and_persist(
+                self.db_path,
+                self.conversation_id,
+                now=second_time,
+            )
+        )
+
+        rows = self.rows()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["branch_name"], "main")
+        self.assertEqual(rows[0]["base_ref"], "origin/main")
+        self.assertEqual(rows[0]["first_head_sha"], first_head)
+        self.assertEqual(rows[0]["latest_head_sha"], latest_head)
+        self.assertEqual(rows[0]["first_seen_at"], "2026-07-30 19:00:00")
+        self.assertEqual(rows[0]["last_seen_at"], "2026-07-30 19:01:00")
+
+    def test_pr_association_never_gets_repurposed_by_later_local_work(
+        self,
+    ) -> None:
+        self.assertTrue(
+            conversation_git_targets.observe_and_persist(
+                self.db_path,
+                self.conversation_id,
+            )
+        )
+        con = self.connect()
+        con.execute(
+            "UPDATE conversation_git_targets SET pr_number=821,"
+            "pr_head_sha=latest_head_sha,pr_state='OPEN',"
+            "remote_refreshed_at=datetime('now')"
+        )
+        con.commit()
+        con.close()
+
+        self.fixture.write("reuse.txt", "new delivery\n")
+        reused_head = self.fixture.commit("reuse branch")
+        self.assertTrue(
+            conversation_git_targets.observe_and_persist(
+                self.db_path,
+                self.conversation_id,
+            )
+        )
+
+        rows = self.rows()
+        self.assertEqual(len(rows), 2)
+        pr_target = next(row for row in rows if row["pr_number"] == 821)
+        local_target = next(row for row in rows if row["pr_number"] is None)
+        self.assertNotEqual(pr_target["target_id"], local_target["target_id"])
+        self.assertEqual(local_target["first_head_sha"], reused_head)
+
+    def test_git_reads_happen_before_the_write_transaction(self) -> None:
+        def unlocked_runner(*args, **kwargs):
+            con = sqlite3.connect(self.db_path, timeout=0.1)
+            try:
+                con.execute("BEGIN IMMEDIATE")
+                con.rollback()
+            finally:
+                con.close()
+            command = args[0]
+            self.assertEqual(command[:3], ["git", "-C", str(self.fixture.repo)])
+            return self.fixture.git_result(*command[3:], check=False)
+
+        self.assertTrue(
+            conversation_git_targets.observe_and_persist(
+                self.db_path,
+                self.conversation_id,
+                runner=unlocked_runner,
+            )
+        )
+
+    def test_every_git_failure_is_non_blocking_and_writes_nothing(self) -> None:
+        def timeout(*_args, **_kwargs):
+            raise subprocess.TimeoutExpired(["git"], 2)
+
+        self.assertFalse(
+            conversation_git_targets.safely_observe_and_persist(
+                self.db_path,
+                self.conversation_id,
+                runner=timeout,
+            )
+        )
+        self.assertEqual(self.rows(), [])
+        con = self.connect()
+        try:
+            self.assertEqual(
+                con.execute(
+                    "SELECT state FROM conversations WHERE conversation_id=?",
+                    (self.conversation_id,),
+                ).fetchone()[0],
+                "idle",
+            )
+        finally:
+            con.close()
+
+    def test_snapshot_round_trip_retains_targets_after_branch_cleanup(
+        self,
+    ) -> None:
+        self.assertTrue(
+            conversation_git_targets.observe_and_persist(
+                self.db_path,
+                self.conversation_id,
+            )
+        )
+        con = self.connect()
+        try:
+            con.execute(
+                "UPDATE conversation_git_targets SET pr_number=821,"
+                "pr_head_sha=latest_head_sha,pr_state='MERGED',"
+                "merge_sha=?,merged_at='2026-07-30 19:30:00',"
+                "remote_refreshed_at='2026-07-30 19:31:00'",
+                ("f" * 40,),
+            )
+            con.commit()
+            statements = snapshot.dump_table(
+                con,
+                "conversation_git_targets",
+            )
+        finally:
+            con.close()
+
+        target = sqlite3.connect(":memory:")
+        target.row_factory = sqlite3.Row
+        apply_schema(target)
+        target.execute(
+            "INSERT INTO users (user_id,username) VALUES (1,'operator')"
+        )
+        target.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (1,'Dev','dev','dev','prompt',1)"
+        )
+        target.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,owner_user_id,harness,worktree,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES ('cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',1,'normal',1,"
+            "'codex','/missing/after-cleanup','create','hash')"
+        )
+        target.executescript(
+            "\n".join(["BEGIN;", *statements, "COMMIT;"])
+        )
+        retained = target.execute(
+            "SELECT pr_number,pr_state,merge_sha "
+            "FROM conversation_git_targets"
+        ).fetchone()
+        self.assertEqual(tuple(retained), (821, "MERGED", "f" * 40))
+        self.assertEqual(target.execute(
+            "PRAGMA foreign_key_check"
+        ).fetchall(), [])
+        target.close()

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -18,6 +18,7 @@ ENGINE = ROOT / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
 MIGRATIONS = ENGINE / "migrations"
 FOUNDATION = MIGRATIONS / "0132_conversation_foundation.sql"
+GIT_TARGETS = MIGRATIONS / "0142_conversation_git_targets.sql"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import conversation_state  # noqa: E402
@@ -358,6 +359,91 @@ class MigrationAndShapeTest(ConversationDbCase):
                     "UPDATE conversations SET starred=2 "
                     "WHERE creation_idempotency_key='legacy'"
                 )
+
+    def test_git_target_migration_upgrades_existing_conversations(self) -> None:
+        with closing(sqlite3.connect(":memory:")) as con:
+            apply_schema(
+                con,
+                through="0141_rebuild_completed_sprint_cancellations.sql",
+            )
+            con.execute(
+                "INSERT INTO users (user_id,username) VALUES (9,'legacy')"
+            )
+            con.execute(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (9,'Legacy','legacy','dev','prompt',9)"
+            )
+            con.execute(
+                "INSERT INTO conversations "
+                "(conversation_id,shell_id,mode,owner_user_id,harness,worktree,"
+                "creation_idempotency_key,creation_request_hash) "
+                "VALUES ('cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',9,'normal',9,"
+                "'codex','/tmp/legacy','legacy','hash')"
+            )
+
+            con.executescript(GIT_TARGETS.read_text())
+
+            indexes = {
+                row[1]
+                for row in con.execute(
+                    "PRAGMA index_list('conversation_git_targets')"
+                )
+            }
+            self.assertTrue(
+                {
+                    "idx_conversation_git_targets_pr",
+                    "idx_conversation_git_targets_local",
+                    "idx_conversation_git_targets_recent",
+                    "idx_conversation_git_targets_head",
+                    "idx_conversation_git_targets_pr_lookup",
+                }.issubset(indexes)
+            )
+            first = "1" * 40
+            target_id = con.execute(
+                "INSERT INTO conversation_git_targets "
+                "(conversation_id,branch_name,base_ref,first_head_sha,"
+                "latest_head_sha) VALUES "
+                "('cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','feature/reused',"
+                "'origin/main',?,?) RETURNING target_id",
+                (first, first),
+            ).fetchone()[0]
+            con.execute(
+                "UPDATE conversation_git_targets SET latest_head_sha=? "
+                "WHERE target_id=?",
+                ("2" * 40, target_id),
+            )
+            con.execute(
+                "UPDATE conversation_git_targets SET pr_number=821,"
+                "pr_head_sha=?,pr_state='OPEN',"
+                "remote_refreshed_at=datetime('now') WHERE target_id=?",
+                ("2" * 40, target_id),
+            )
+            with self.assertRaisesRegex(
+                sqlite3.IntegrityError,
+                "PR identity is immutable",
+            ):
+                con.execute(
+                    "UPDATE conversation_git_targets SET pr_number=822 "
+                    "WHERE target_id=?",
+                    (target_id,),
+                )
+            second = "3" * 40
+            con.execute(
+                "INSERT INTO conversation_git_targets "
+                "(conversation_id,branch_name,base_ref,first_head_sha,"
+                "latest_head_sha,pr_number) VALUES "
+                "('cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','feature/reused',"
+                "'origin/main',?,?,822)",
+                (second, second),
+            )
+            self.assertEqual(
+                con.execute(
+                    "SELECT COUNT(*) FROM conversation_git_targets "
+                    "WHERE branch_name='feature/reused'"
+                ).fetchone()[0],
+                2,
+            )
 
     def test_binding_migration_preserves_reserved_sprint_conversation(
         self,
@@ -1278,6 +1364,7 @@ class SprintBindingConcurrencyTest(unittest.TestCase):
 class SnapshotPolicyTest(ConversationDbCase):
     TABLES = (
         "conversations",
+        "conversation_git_targets",
         "sprint_conversation_bindings",
         "sprint_cancellations",
         "conversation_messages",


### PR DESCRIPTION
## Summary
- add additive `conversation_git_targets` schema, conditional identities, indexes, immutability guards, and snapshot ordering
- record cheap local branch/head observations after normal-chat creation and every terminal run commit
- keep all Git reads outside write transactions and make every observation failure non-authoritative
- cover migration upgrades, retained PR identity, snapshot recovery, branch reuse, idempotent head updates, and lifecycle failure isolation

## Verification
- `86 passed, 146 subtests` focused conversation suite
- `1671 passed, 787 subtests` full Python suite
- targeted Ruff security/style checks passed for the new observer and tests
- `./sc verify` passed, including rebuild through migration 0142 and render-only boot
- `git diff --check` passed

## Known unrelated local gate
- `./sc render-check` applies all 142 migrations hermetically, then reports the pre-existing ignored local mirror drift in `skills_sc/README.md` and `skills_sc/sprint_onboarding.md`; tracked as #809 and unchanged by this PR.