### PR TITLE
feat: expose conversation review API

### DIFF
--- a/.super-coder/api/review_routes.py
+++ b/.super-coder/api/review_routes.py
@@ -1,0 +1,1087 @@
+"""Authenticated, read-only Git and pull-request review resources.
+
+The browser operator selects only durable conversation/target identities.  The
+server resolves every worktree and Git ref from owned database rows, performs
+bounded external reads outside transactions, then revalidates the target
+snapshot before returning it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+import sqlite3
+import time
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import conversation_git_targets
+import conversation_routes
+import db_driver
+import git_review
+from github_pull_requests import (
+    GitHubPullRequestReader,
+    GitHubReadError,
+    PullRequest,
+    lifecycle_status,
+)
+
+DB_PATH = conversation_routes.DB_PATH
+REMOTE_TTL_SECONDS = 30.0
+REMOTE_CACHE_LIMIT = 256
+MAX_PAGE_SIZE = 200
+READER_FACTORY = GitHubPullRequestReader
+CACHE_FACTORY = git_review.MergedPatchCache
+
+_CONVERSATION_TARGETS = re.compile(
+    r"^/api/conversations/(cv_[0-9a-f]{32})/review-targets$"
+)
+_TARGET_RESOURCE = re.compile(
+    r"^/api/review-targets/(gt_[0-9a-f]{32})/(files|diff|commits)$"
+)
+_REMOTE_ATTEMPTS: dict[str, float] = {}
+_REMOTE_RESULTS: dict[
+    str,
+    tuple[dict[int, PullRequest], str, str | None],
+] = {}
+_FILE_STATUSES = frozenset(
+    ("added", "modified", "deleted", "renamed", "untracked", "conflict")
+)
+
+ApiError = conversation_routes.ApiError
+
+
+def _db():
+    return db_driver.connect(str(DB_PATH))
+
+
+def _query(raw: str, allowed: set[str]) -> dict[str, str]:
+    try:
+        parsed = parse_qs(
+            raw,
+            keep_blank_values=True,
+            max_num_fields=20,
+        )
+    except ValueError as exc:
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            "query contains too many parameters",
+        ) from exc
+    unknown = sorted(set(parsed) - allowed)
+    repeated = sorted(key for key, values in parsed.items() if len(values) != 1)
+    if unknown or repeated:
+        fields = sorted(set(unknown + repeated))
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            "unknown or repeated query parameter(s): " + ", ".join(fields),
+            {"fields": fields},
+        )
+    return {key: values[0] for key, values in parsed.items()}
+
+
+def _limit(query: dict[str, str]) -> int:
+    raw = query.get("limit", "100")
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ApiError(422, "VALIDATION_ERROR", "limit must be an integer") from exc
+    if value < 1 or value > MAX_PAGE_SIZE:
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            f"limit must be between 1 and {MAX_PAGE_SIZE}",
+        )
+    return value
+
+
+def _cursor_encode(value: dict[str, Any]) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+
+def _cursor_decode(raw: str, kind: str) -> dict[str, Any]:
+    try:
+        payload = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4))
+        value = json.loads(payload)
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise ApiError(422, "VALIDATION_ERROR", "cursor is invalid") from exc
+    if (
+        not isinstance(value, dict)
+        or value.get("v") != 1
+        or value.get("kind") != kind
+        or not isinstance(value.get("offset"), int)
+        or value["offset"] < 0
+        or not isinstance(value.get("fingerprint"), str)
+    ):
+        raise ApiError(422, "VALIDATION_ERROR", "cursor is invalid")
+    return value
+
+
+def _etag_response(headers, etag_value: str, body: dict[str, Any]):
+    if headers.get("If-None-Match") == etag_value:
+        return (
+            304,
+            [("Cache-Control", "no-store"), ("ETag", etag_value)],
+            b"",
+        )
+    return conversation_routes._json(200, body, [("ETag", etag_value)])
+
+
+def _conversation(con, conversation_id: str, owner_user_id: int):
+    row = con.execute(
+        "SELECT conversation_id,worktree FROM conversations "
+        "WHERE conversation_id=? AND mode='normal' AND owner_user_id=?",
+        (conversation_id, owner_user_id),
+    ).fetchone()
+    if row is None:
+        raise ApiError(404, "CONVERSATION_NOT_FOUND", "conversation does not exist")
+    return row
+
+
+def _target_select() -> str:
+    return (
+        "SELECT t.*,c.worktree FROM conversation_git_targets t "
+        "JOIN conversations c ON c.conversation_id=t.conversation_id "
+        "WHERE t.target_id=? AND c.mode='normal' AND c.owner_user_id=?"
+    )
+
+
+def _target(con, target_id: str, owner_user_id: int) -> dict[str, Any]:
+    row = con.execute(_target_select(), (target_id, owner_user_id)).fetchone()
+    if row is None:
+        raise ApiError(
+            404,
+            "REVIEW_TARGET_NOT_FOUND",
+            "review target does not exist",
+        )
+    return dict(row)
+
+
+def _targets(con, conversation_id: str) -> list[dict[str, Any]]:
+    return [
+        dict(row)
+        for row in con.execute(
+            "SELECT * FROM conversation_git_targets WHERE conversation_id=? "
+            "ORDER BY last_seen_at DESC,target_id",
+            (conversation_id,),
+        ).fetchall()
+    ]
+
+
+def _snapshot(row: dict[str, Any]) -> str:
+    return git_review.fingerprint(
+        {
+            key: row.get(key)
+            for key in (
+                "target_id",
+                "conversation_id",
+                "worktree",
+                "base_ref",
+                "latest_head_sha",
+                "pr_number",
+                "pr_head_sha",
+                "pr_state",
+                "merge_sha",
+                "patch_artifact",
+                "patch_sha256",
+            )
+        }
+    )
+
+
+def _revalidate(target_id: str, owner_user_id: int, expected: str) -> None:
+    con = _db()
+    try:
+        row = _target(con, target_id, owner_user_id)
+    finally:
+        con.close()
+    if _snapshot(row) != expected:
+        raise ApiError(
+            409,
+            "REVIEW_TARGET_CHANGED",
+            "review target changed while it was being read",
+        )
+
+
+def _cached_pull_request(row: dict[str, Any]) -> PullRequest | None:
+    if row.get("pr_number") is None or row.get("pr_state") is None:
+        return None
+    return PullRequest(
+        number=int(row["pr_number"]),
+        head_ref=row["branch_name"],
+        base_ref=row.get("base_ref"),
+        head_sha=row.get("pr_head_sha"),
+        state=row["pr_state"],
+        merged_at=row.get("merged_at"),
+        merge_sha=row.get("merge_sha"),
+        title=row.get("pr_title"),
+        url=row.get("pr_url"),
+        review_decision=None,
+        checks=None,
+        checks_failed=False,
+    )
+
+
+def _stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _associate_source(
+    local_rows: list[dict[str, Any]],
+    pull_request: PullRequest,
+    worktree: str,
+) -> dict[str, Any] | None:
+    branch_rows = [
+        row for row in local_rows if row["branch_name"] == pull_request.head_ref
+    ]
+    if not branch_rows:
+        return None
+    exact = [
+        row
+        for row in branch_rows
+        if pull_request.head_sha
+        in {row["first_head_sha"], row["latest_head_sha"]}
+    ]
+    if exact:
+        return max(
+            exact,
+            key=lambda row: (row["last_seen_at"], row["target_id"]),
+        )
+    if pull_request.head_sha is None:
+        return None
+    compatible = []
+    for row in branch_rows:
+        try:
+            if git_review.commit_is_ancestor(
+                worktree,
+                row["first_head_sha"],
+                pull_request.head_sha,
+            ) or git_review.commit_is_ancestor(
+                worktree,
+                pull_request.head_sha,
+                row["latest_head_sha"],
+            ):
+                compatible.append(row)
+        except git_review.ReviewError:
+            continue
+    if not compatible:
+        return None
+    return max(
+        compatible,
+        key=lambda row: (row["last_seen_at"], row["target_id"]),
+    )
+
+
+def _persist_remote(
+    conversation_id: str,
+    worktree: str,
+    owner_user_id: int,
+    pull_requests: list[PullRequest],
+) -> None:
+    con = _db()
+    try:
+        current = con.execute(
+            "SELECT worktree FROM conversations WHERE conversation_id=? "
+            "AND mode='normal' AND owner_user_id=?",
+            (conversation_id, owner_user_id),
+        ).fetchone()
+        if current is None or current["worktree"] != worktree:
+            raise ApiError(
+                409,
+                "REVIEW_TARGET_CHANGED",
+                "conversation review source changed during refresh",
+            )
+        observed_rows = _targets(con, conversation_id)
+    finally:
+        con.close()
+    observed_existing = {
+        int(row["pr_number"]): row
+        for row in observed_rows
+        if row["pr_number"] is not None
+    }
+    observed_local = [
+        row for row in observed_rows if row["pr_number"] is None
+    ]
+    sources = {
+        pull_request.number: (
+            _associate_source(observed_local, pull_request, worktree)
+            or observed_existing.get(pull_request.number)
+        )
+        for pull_request in pull_requests
+    }
+
+    con = _db()
+    try:
+        with db_driver.write_transaction(con, "conversation.review_targets.refresh"):
+            current = con.execute(
+                "SELECT worktree FROM conversations WHERE conversation_id=? "
+                "AND mode='normal' AND owner_user_id=?",
+                (conversation_id, owner_user_id),
+            ).fetchone()
+            if current is None or current["worktree"] != worktree:
+                raise ApiError(
+                    409,
+                    "REVIEW_TARGET_CHANGED",
+                    "conversation review source changed during refresh",
+                )
+            rows = _targets(con, conversation_id)
+            existing = {
+                int(row["pr_number"]): row
+                for row in rows
+                if row["pr_number"] is not None
+            }
+            now = _stamp()
+            for pull_request in pull_requests:
+                row = existing.get(pull_request.number)
+                source = sources[pull_request.number] or row
+                if source is None:
+                    continue
+                if source["pr_number"] is None:
+                    current_source = next(
+                        (
+                            item
+                            for item in rows
+                            if item["target_id"] == source["target_id"]
+                            and item["pr_number"] is None
+                            and item["branch_name"] == source["branch_name"]
+                            and item["first_head_sha"] == source["first_head_sha"]
+                            and item["latest_head_sha"] == source["latest_head_sha"]
+                        ),
+                        None,
+                    )
+                    if current_source is None:
+                        if row is not None:
+                            source = row
+                        else:
+                            raise ApiError(
+                                409,
+                                "REVIEW_TARGET_CHANGED",
+                                "local review identity changed during refresh",
+                            )
+                    else:
+                        source = current_source
+                if row is None:
+                    con.execute(
+                        "INSERT INTO conversation_git_targets "
+                        "(conversation_id,branch_name,base_ref,first_head_sha,"
+                        "latest_head_sha,pr_number,pr_head_sha,pr_state,merge_sha,"
+                        "merged_at,pr_url,pr_title,first_seen_at,last_seen_at,"
+                        "remote_refreshed_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                        (
+                            conversation_id,
+                            pull_request.head_ref,
+                            pull_request.base_ref or source["base_ref"],
+                            source["first_head_sha"],
+                            source["latest_head_sha"],
+                            pull_request.number,
+                            pull_request.head_sha,
+                            pull_request.state,
+                            pull_request.merge_sha,
+                            pull_request.merged_at,
+                            pull_request.url,
+                            pull_request.title,
+                            source["first_seen_at"],
+                            now,
+                            now,
+                        ),
+                    )
+                else:
+                    con.execute(
+                        "UPDATE conversation_git_targets SET base_ref=?,"
+                        "latest_head_sha=?,pr_head_sha=?,pr_state=?,merge_sha=?,"
+                        "merged_at=?,pr_url=?,pr_title=?,last_seen_at=?,"
+                        "remote_refreshed_at=? "
+                        "WHERE target_id=?",
+                        (
+                            pull_request.base_ref or row["base_ref"],
+                            source["latest_head_sha"],
+                            pull_request.head_sha,
+                            pull_request.state,
+                            pull_request.merge_sha,
+                            pull_request.merged_at,
+                            pull_request.url,
+                            pull_request.title,
+                            now,
+                            now,
+                            row["target_id"],
+                        ),
+                    )
+    finally:
+        con.close()
+
+
+def _refresh_remote(
+    conversation_id: str,
+    worktree: str,
+    owner_user_id: int,
+    *,
+    force: bool,
+) -> tuple[dict[int, PullRequest], str, str | None]:
+    now = time.monotonic()
+    last = _REMOTE_ATTEMPTS.get(conversation_id)
+    if not force and last is not None and now - last < REMOTE_TTL_SECONDS:
+        return _REMOTE_RESULTS.get(conversation_id, ({}, "cached", None))
+    try:
+        pull_requests = READER_FACTORY(worktree).list()
+    except GitHubReadError as exc:
+        result = ({}, "unavailable", str(exc)[:240])
+        _remember_remote(conversation_id, now, result)
+        return result
+    _persist_remote(conversation_id, worktree, owner_user_id, pull_requests)
+    result = ({item.number: item for item in pull_requests}, "fresh", None)
+    _remember_remote(conversation_id, now, result)
+    return result
+
+
+def _remember_remote(
+    conversation_id: str,
+    observed_at: float,
+    result: tuple[dict[int, PullRequest], str, str | None],
+) -> None:
+    _REMOTE_ATTEMPTS[conversation_id] = observed_at
+    _REMOTE_RESULTS[conversation_id] = result
+    while len(_REMOTE_ATTEMPTS) > REMOTE_CACHE_LIMIT:
+        oldest = min(_REMOTE_ATTEMPTS, key=_REMOTE_ATTEMPTS.__getitem__)
+        _REMOTE_ATTEMPTS.pop(oldest, None)
+        _REMOTE_RESULTS.pop(oldest, None)
+
+
+def _target_summary(
+    row: dict[str, Any],
+    workspace: git_review.WorkspaceProjection,
+    fresh_remote: dict[int, PullRequest],
+) -> dict[str, Any]:
+    pr_number = row["pr_number"]
+    current = (
+        row["branch_name"] == workspace.branch
+        and row["latest_head_sha"] == workspace.head_sha
+    )
+    pull_request = (
+        fresh_remote.get(int(pr_number))
+        if pr_number is not None
+        else None
+    ) or _cached_pull_request(row)
+    if pull_request is not None:
+        lifecycle = lifecycle_status(pull_request)
+        freshness = (
+            "fresh"
+            if int(pr_number) in fresh_remote
+            else "cached"
+        )
+        kind = "pull_request"
+    else:
+        lifecycle = "pushed" if current and workspace.pushed else "local"
+        freshness = "not_applicable"
+        kind = "workspace" if current else "local_branch"
+    core: dict[str, Any] = {
+        "target_id": row["target_id"],
+        "kind": kind,
+        "branch": row["branch_name"],
+        "head_sha": (
+            pull_request.head_sha
+            if pull_request is not None
+            else row["latest_head_sha"]
+        ),
+        "pr_number": pr_number,
+        "lifecycle": lifecycle,
+        "local_fingerprint": workspace.fingerprint if current else None,
+        "remote_freshness": freshness,
+    }
+    summary = {
+        **core,
+        "base_ref": row["base_ref"],
+        "title": pull_request.title if pull_request is not None else None,
+        "url": pull_request.url if pull_request is not None else None,
+        "freshness": {
+            "local": "fresh" if current else "stored",
+            "remote": freshness,
+        },
+        "facts": {
+            "checked_out": current,
+            "dirty": bool(workspace.files) if current else False,
+            "pushed": workspace.pushed if current else None,
+            "ahead": workspace.ahead if current else None,
+            "behind": workspace.behind if current else None,
+            "cleanup_pending": lifecycle == "pr_merged" and current,
+        },
+    }
+    digest = git_review.fingerprint(summary)
+    return {
+        **summary,
+        "fingerprint": digest,
+        "etag": git_review.etag(digest),
+    }
+
+
+def _selected_target(items: list[dict[str, Any]]) -> str | None:
+    priority = {
+        "pr_open": 0,
+        "checks_failed": 0,
+        "workspace": 1,
+        "pushed": 2,
+        "local": 3,
+        "pr_merged": 4,
+        "pr_closed": 5,
+    }
+    if not items:
+        return None
+    return min(
+        enumerate(items),
+        key=lambda pair: (
+            priority.get(
+                pair[1]["kind"]
+                if pair[1]["kind"] == "workspace"
+                else pair[1]["lifecycle"],
+                10,
+            ),
+            pair[0],
+        ),
+    )[1]["target_id"]
+
+
+def _list_targets(
+    conversation_id: str,
+    owner_user_id: int,
+    query: dict[str, str],
+    headers,
+):
+    refresh = query.get("refresh")
+    if refresh not in {None, "remote"}:
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            "refresh must be remote when provided",
+        )
+    con = _db()
+    try:
+        conversation = _conversation(con, conversation_id, owner_user_id)
+        worktree = str(conversation["worktree"])
+    finally:
+        con.close()
+
+    conversation_git_targets.safely_observe_and_persist(
+        DB_PATH,
+        conversation_id,
+    )
+    workspace = git_review.collect_workspace(worktree)
+    fresh_remote, remote_freshness, remote_error = _refresh_remote(
+        conversation_id,
+        worktree,
+        owner_user_id,
+        force=refresh == "remote",
+    )
+    con = _db()
+    try:
+        current = _conversation(con, conversation_id, owner_user_id)
+        if str(current["worktree"]) != worktree:
+            raise ApiError(
+                409,
+                "REVIEW_TARGET_CHANGED",
+                "conversation review source changed while it was being read",
+            )
+        rows = _targets(con, conversation_id)
+    finally:
+        con.close()
+    items = [
+        _target_summary(row, workspace, fresh_remote)
+        for row in rows
+    ]
+    items.sort(
+        key=lambda item: (
+            not item["facts"]["checked_out"],
+            item["kind"] != "pull_request",
+            -(item["pr_number"] or 0),
+            item["target_id"],
+        )
+    )
+    body = {
+        "conversation_id": conversation_id,
+        "items": items,
+        "selected_target_id": _selected_target(items),
+        "freshness": {
+            "local": "fresh",
+            "remote": remote_freshness,
+            "remote_error": remote_error,
+        },
+        "git_fingerprint": workspace.fingerprint,
+    }
+    response_etag = git_review.etag(git_review.fingerprint(body))
+    return _etag_response(headers, response_etag, body)
+
+
+def _pull_request_for_target(
+    row: dict[str, Any],
+) -> tuple[PullRequest, str]:
+    cached = _cached_pull_request(row)
+    if cached is None:
+        raise ApiError(
+            409,
+            "REVIEW_TARGET_UNAVAILABLE",
+            "pull-request target has no cached identity",
+        )
+    try:
+        return READER_FACTORY(row["worktree"]).get(cached.number), "fresh"
+    except GitHubReadError:
+        return cached, "cached"
+
+
+def _persist_artifact(
+    row: dict[str, Any],
+    owner_user_id: int,
+    artifact: git_review.CacheArtifact,
+) -> None:
+    expected = _snapshot(row)
+    con = _db()
+    try:
+        with db_driver.write_transaction(con, "conversation.review_patch.cache"):
+            current = _target(con, row["target_id"], owner_user_id)
+            if _snapshot(current) != expected:
+                raise ApiError(
+                    409,
+                    "REVIEW_TARGET_CHANGED",
+                    "review target changed while its patch was cached",
+                )
+            con.execute(
+                "UPDATE conversation_git_targets SET patch_artifact=?,"
+                "patch_sha256=? WHERE target_id=?",
+                (
+                    artifact.relative_path,
+                    artifact.sha256,
+                    row["target_id"],
+                ),
+            )
+    finally:
+        con.close()
+
+
+def _canonical_projection(
+    row: dict[str, Any],
+    owner_user_id: int,
+) -> tuple[git_review.CanonicalPatchSet, str]:
+    pull_request, freshness = _pull_request_for_target(row)
+    artifact = (
+        git_review.CacheArtifact(row["patch_artifact"], row["patch_sha256"])
+        if row["patch_artifact"] is not None
+        else None
+    )
+    try:
+        read = git_review.read_canonical_pr_patch(
+            READER_FACTORY(row["worktree"]),
+            pull_request,
+            repository=row["worktree"],
+            cache=CACHE_FACTORY(),
+            cached_artifact=artifact,
+        )
+    except GitHubReadError as exc:
+        raise ApiError(
+            503,
+            "REVIEW_REMOTE_UNAVAILABLE",
+            "canonical pull-request patch is unavailable",
+        ) from exc
+    if read.artifact is not None and read.artifact != artifact:
+        _persist_artifact(row, owner_user_id, read.artifact)
+        row["patch_artifact"] = read.artifact.relative_path
+        row["patch_sha256"] = read.artifact.sha256
+    return git_review.parse_canonical_patch(read.patch), read.freshness or freshness
+
+
+def _file_projection(
+    row: dict[str, Any],
+    owner_user_id: int,
+    scope: str,
+):
+    if scope == "local":
+        selected = row["pr_head_sha"] or row["latest_head_sha"]
+        return git_review.local_only_files(row["worktree"], selected), "local"
+    if row["pr_number"] is not None:
+        return _canonical_projection(row, owner_user_id)
+    if not row["base_ref"]:
+        raise ApiError(409, "REVIEW_REF_MISSING", "review target has no base ref")
+    current = git_review.collect_workspace(row["worktree"])
+    include_worktree = (
+        row["branch_name"] == current.branch
+        and row["latest_head_sha"] == current.head_sha
+    )
+    return (
+        git_review.review_files(
+            row["worktree"],
+            row["base_ref"],
+            head_ref=row["latest_head_sha"],
+            include_worktree=include_worktree,
+        ),
+        "local",
+    )
+
+
+def _filters(query: dict[str, str]) -> tuple[tuple[str, ...], str | None]:
+    raw_status = query.get("status")
+    statuses = tuple(filter(None, (raw_status or "").split(",")))
+    if any(status not in _FILE_STATUSES for status in statuses):
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            "status contains an unsupported value",
+        )
+    path = query.get("path")
+    if path is not None:
+        path = git_review.validate_review_path(path)
+    return statuses, path
+
+
+def _files(
+    row: dict[str, Any],
+    owner_user_id: int,
+    query: dict[str, str],
+    headers,
+):
+    scope = query.get("scope", "review")
+    if scope not in {"review", "local"}:
+        raise ApiError(422, "VALIDATION_ERROR", "scope must be review or local")
+    limit = _limit(query)
+    statuses, path_filter = _filters(query)
+    projection, freshness = _file_projection(row, owner_user_id, scope)
+    expected = _snapshot(row)
+    files = [
+        item
+        for item in projection.files
+        if (not statuses or item.status in statuses)
+        and (path_filter is None or item.path.startswith(path_filter))
+    ]
+    filter_fingerprint = git_review.fingerprint(
+        {
+            "target_id": row["target_id"],
+            "projection": projection.fingerprint,
+            "statuses": statuses,
+            "path": path_filter,
+            "scope": scope,
+        }
+    )
+    offset = 0
+    if "cursor" in query:
+        cursor = _cursor_decode(query["cursor"], "review_files")
+        if cursor["fingerprint"] != filter_fingerprint:
+            raise ApiError(
+                409,
+                "REVIEW_TARGET_CHANGED",
+                "file projection changed after the cursor was issued",
+            )
+        offset = cursor["offset"]
+        if offset > len(files):
+            raise ApiError(422, "VALIDATION_ERROR", "cursor is invalid")
+    page = files[offset : offset + limit]
+    next_offset = offset + len(page)
+    next_cursor = (
+        _cursor_encode(
+            {
+                "v": 1,
+                "kind": "review_files",
+                "offset": next_offset,
+                "fingerprint": filter_fingerprint,
+            }
+        )
+        if next_offset < len(files)
+        else None
+    )
+    _revalidate(row["target_id"], owner_user_id, expected)
+    body = {
+        "target_id": row["target_id"],
+        "scope": scope,
+        "items": [
+            {
+                "file_id": "rf_" + git_review.fingerprint(
+                    {
+                        "target_id": row["target_id"],
+                        "path": item.path,
+                        "old_path": item.old_path,
+                    }
+                )[:32],
+                **asdict(item),
+            }
+            for item in page
+        ],
+        "files_truncated": projection.files_truncated,
+        "fingerprint": filter_fingerprint,
+        "freshness": freshness,
+        "next_cursor": next_cursor,
+    }
+    response_etag = git_review.etag(
+        git_review.fingerprint(
+            {
+                "projection": filter_fingerprint,
+                "offset": offset,
+                "limit": limit,
+                "items": [item.path for item in page],
+            }
+        )
+    )
+    return _etag_response(headers, response_etag, body)
+
+
+def _diff(
+    row: dict[str, Any],
+    owner_user_id: int,
+    query: dict[str, str],
+    headers,
+):
+    scope = query.get("scope")
+    if scope not in {"review", "local"}:
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            "scope is required and must be review or local",
+        )
+    path = git_review.validate_review_path(query.get("path", ""))
+    projection, freshness = _file_projection(row, owner_user_id, scope)
+    expected = _snapshot(row)
+    selected = next((item for item in projection.files if item.path == path), None)
+    if selected is None:
+        raise ApiError(
+            422,
+            "REVIEW_PATH_INVALID",
+            "path is not part of the current review projection",
+        )
+    if row["pr_number"] is not None and scope == "review":
+        canonical = projection
+        text = canonical.file_patches.get(path)
+        patch = git_review.PatchProjection(
+            text=text,
+            sha256=(
+                hashlib.sha256(text.encode("utf-8")).hexdigest()
+                if text is not None
+                else None
+            ),
+            truncated=canonical.patch_truncated,
+            binary=selected.binary,
+            unavailable_reason="binary" if selected.binary else None,
+            etag=git_review.etag(git_review.fingerprint(text)),
+        )
+    else:
+        old_ref = (
+            projection.merge_base_sha
+            if scope == "review"
+            else projection.base_sha
+        )
+        if old_ref is None:
+            raise ApiError(409, "REVIEW_REF_MISSING", "review base is unavailable")
+        current = git_review.collect_workspace(row["worktree"])
+        include_worktree = (
+            row["branch_name"] == current.branch
+            and (
+                scope == "local"
+                or row["latest_head_sha"] == current.head_sha
+            )
+        )
+        patch = git_review.read_file_patch(
+            row["worktree"],
+            old_ref,
+            path,
+            new_ref=None if include_worktree else projection.head_sha,
+        )
+    if row["pr_number"] is None or scope == "local":
+        current_projection, _ = _file_projection(row, owner_user_id, scope)
+        if current_projection.fingerprint != projection.fingerprint:
+            raise ApiError(
+                409,
+                "REVIEW_TARGET_CHANGED",
+                "review files changed while the patch was being read",
+            )
+    _revalidate(row["target_id"], owner_user_id, expected)
+    body = {
+        "target_id": row["target_id"],
+        "scope": scope,
+        "path": path,
+        "patch": patch.text,
+        "sha256": patch.sha256,
+        "truncated": patch.truncated,
+        "binary": patch.binary,
+        "unavailable_reason": patch.unavailable_reason,
+        "freshness": freshness,
+        "fingerprint": projection.fingerprint,
+    }
+    response_etag = git_review.etag(
+        git_review.fingerprint(
+            {
+                "target_id": row["target_id"],
+                "scope": scope,
+                "path": path,
+                "projection": projection.fingerprint,
+                "patch": patch.sha256,
+                "truncated": patch.truncated,
+                "binary": patch.binary,
+            }
+        )
+    )
+    return _etag_response(headers, response_etag, body)
+
+
+def _commits(
+    row: dict[str, Any],
+    owner_user_id: int,
+    query: dict[str, str],
+    headers,
+):
+    limit = _limit(query)
+    if not row["base_ref"]:
+        raise ApiError(409, "REVIEW_REF_MISSING", "review target has no base ref")
+    expected = _snapshot(row)
+    head_ref = row["pr_head_sha"] or row["latest_head_sha"]
+    projection = git_review.review_commits(
+        row["worktree"],
+        row["base_ref"],
+        head_ref=head_ref,
+    )
+    cursor_fingerprint = git_review.fingerprint(
+        {
+            "target_id": row["target_id"],
+            "projection": projection.fingerprint,
+        }
+    )
+    offset = 0
+    if "cursor" in query:
+        cursor = _cursor_decode(query["cursor"], "review_commits")
+        if cursor["fingerprint"] != cursor_fingerprint:
+            raise ApiError(
+                409,
+                "REVIEW_TARGET_CHANGED",
+                "commit projection changed after the cursor was issued",
+            )
+        offset = cursor["offset"]
+        if offset > len(projection.commits):
+            raise ApiError(422, "VALIDATION_ERROR", "cursor is invalid")
+    page = projection.commits[offset : offset + limit]
+    next_offset = offset + len(page)
+    next_cursor = (
+        _cursor_encode(
+            {
+                "v": 1,
+                "kind": "review_commits",
+                "offset": next_offset,
+                "fingerprint": cursor_fingerprint,
+            }
+        )
+        if next_offset < len(projection.commits)
+        else None
+    )
+    _revalidate(row["target_id"], owner_user_id, expected)
+    body = {
+        "target_id": row["target_id"],
+        "items": [asdict(item) for item in page],
+        "commits_truncated": projection.commits_truncated,
+        "fingerprint": projection.fingerprint,
+        "next_cursor": next_cursor,
+    }
+    response_etag = git_review.etag(
+        git_review.fingerprint(
+            {
+                "projection": projection.fingerprint,
+                "offset": offset,
+                "limit": limit,
+                "items": [item.sha for item in page],
+            }
+        )
+    )
+    return _etag_response(headers, response_etag, body)
+
+
+_REVIEW_ERROR_STATUS = {
+    "REVIEW_TARGET_NOT_FOUND": 404,
+    "REVIEW_WORKTREE_MISSING": 409,
+    "REVIEW_NOT_A_GIT_REPOSITORY": 409,
+    "REVIEW_REF_MISSING": 409,
+    "REVIEW_REMOTE_UNAVAILABLE": 503,
+    "REVIEW_PATH_INVALID": 422,
+    "REVIEW_DIFF_TOO_LARGE": 413,
+    "REVIEW_TARGET_CHANGED": 409,
+    "REVIEW_TARGET_UNAVAILABLE": 503,
+}
+
+
+def handle(method: str, path: str, headers_raw: str, raw_body: bytes):
+    """Dispatch one authenticated review GET request."""
+    headers = conversation_routes._parse_headers(headers_raw)
+    if not conversation_routes._host_ok(headers):
+        return conversation_routes._err(403, "HOST_FORBIDDEN", "Host is not allowed")
+    parsed = urlparse(path)
+    conversation_match = _CONVERSATION_TARGETS.fullmatch(parsed.path)
+    target_match = _TARGET_RESOURCE.fullmatch(parsed.path)
+    if conversation_match is None and target_match is None:
+        return conversation_routes._err(404, "NOT_FOUND", "route does not exist")
+    if method != "GET":
+        return conversation_routes._err(
+            405,
+            "METHOD_NOT_ALLOWED",
+            "review resources are read-only",
+            headers=[("Allow", "GET")],
+        )
+    if not conversation_routes._mutation_site_ok(headers):
+        return conversation_routes._err(
+            403,
+            "NOT_SAME_ORIGIN",
+            "cross-site review request rejected",
+        )
+    try:
+        con = _db()
+        try:
+            operator = conversation_routes._operator(con, headers)
+            if conversation_match is not None:
+                _conversation(
+                    con,
+                    conversation_match.group(1),
+                    operator["user_id"],
+                )
+            else:
+                row = _target(con, target_match.group(1), operator["user_id"])
+        finally:
+            con.close()
+        if conversation_match is not None:
+            query = _query(parsed.query, {"refresh"})
+            return _list_targets(
+                conversation_match.group(1),
+                operator["user_id"],
+                query,
+                headers,
+            )
+        resource = target_match.group(2)
+        if resource == "files":
+            query = _query(
+                parsed.query,
+                {"scope", "cursor", "limit", "status", "path"},
+            )
+            return _files(row, operator["user_id"], query, headers)
+        if resource == "diff":
+            query = _query(parsed.query, {"scope", "path"})
+            return _diff(row, operator["user_id"], query, headers)
+        query = _query(parsed.query, {"cursor", "limit"})
+        return _commits(row, operator["user_id"], query, headers)
+    except ApiError as exc:
+        return conversation_routes._api_error(exc)
+    except git_review.ReviewError as exc:
+        return conversation_routes._err(
+            _REVIEW_ERROR_STATUS.get(exc.code, 503),
+            exc.code,
+            str(exc),
+        )
+    except sqlite3.OperationalError as exc:
+        if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+            return conversation_routes._err(
+                503,
+                "DATABASE_BUSY",
+                "database is busy; retry the request",
+            )
+        return conversation_routes._err(
+            500,
+            "INTERNAL_ERROR",
+            "review request failed",
+        )
+    except Exception:  # noqa: BLE001 - request isolation returns a safe envelope
+        return conversation_routes._err(
+            500,
+            "INTERNAL_ERROR",
+            "review request failed",
+        )

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -71,6 +71,7 @@ import sprint_lifecycle  # noqa: E402  (authoritative sprint state/ownership)
 sys.path.insert(0, str(ENGINE / "api"))
 import conductor_routes  # noqa: E402  (Step 4 directive/event contracts)
 import conversation_routes  # noqa: E402  (Feature #24 browser conversations)
+import review_routes  # noqa: E402  (Feature #26 browser Diff review)
 import sprint_routes  # noqa: E402  (sprint board API — /api/sprint-units)
 import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import pr_poller  # noqa: E402  (watched-PR polling — the service scheduler)
@@ -3702,6 +3703,14 @@ def dispatch_http(method: str, path: str, headers_raw: str,
     if parsed.path.startswith(("/api/directives",
                                "/api/sentinel-events")):
         return conductor_routes.handle(method, path, headers_raw, body)
+    if (
+        parsed.path.startswith("/api/review-targets/")
+        or (
+            parsed.path.startswith("/api/conversations/")
+            and parsed.path.endswith("/review-targets")
+        )
+    ):
+        return review_routes.handle(method, path, headers_raw, body)
     if parsed.path.startswith("/api/conversations"):
         return conversation_routes.handle(method, path, headers_raw, body)
     if parsed.path.startswith((

--- a/.super-coder/scripts/git_review.py
+++ b/.super-coder/scripts/git_review.py
@@ -664,6 +664,14 @@ def _sha(
     *,
     runner: Callable[..., Any],
 ) -> str:
+    if (
+        not isinstance(ref, str)
+        or not ref
+        or len(ref.encode("utf-8", errors="surrogateescape")) > 1024
+        or ref.startswith("-")
+        or any(ord(char) < 32 or ord(char) == 127 for char in ref)
+    ):
+        raise GitReadError("REVIEW_REF_MISSING", "Git ref is invalid")
     payload, _ = _run_git(
         worktree,
         ("rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"),
@@ -686,6 +694,37 @@ def _optional_sha(
         return _sha(worktree, ref, runner=runner)
     except GitReadError:
         return None
+
+
+def resolve_commit(
+    worktree: str | Path,
+    ref: str,
+    *,
+    runner: Callable[..., Any] = _run_read_process,
+) -> str:
+    """Resolve one server-selected ref to an exact commit SHA."""
+    resolved = _resolve_worktree(worktree)
+    return _sha(resolved, ref, runner=runner)
+
+
+def commit_is_ancestor(
+    worktree: str | Path,
+    ancestor_ref: str,
+    descendant_ref: str,
+    *,
+    runner: Callable[..., Any] = _run_read_process,
+) -> bool:
+    """Return whether ``ancestor_ref`` reaches ``descendant_ref``."""
+    resolved = _resolve_worktree(worktree)
+    ancestor_sha = _sha(resolved, ancestor_ref, runner=runner)
+    descendant_sha = _sha(resolved, descendant_ref, runner=runner)
+    merge_raw, _ = _run_git(
+        resolved,
+        ("merge-base", ancestor_sha, descendant_sha),
+        runner=runner,
+        output_limit=128,
+    )
+    return merge_raw.decode("ascii", errors="replace").strip().lower() == ancestor_sha
 
 
 def collect_workspace(

--- a/tests/test_conversation_review_api.py
+++ b/tests/test_conversation_review_api.py
@@ -1,0 +1,459 @@
+"""Feature #26 authenticated browser review GET resources."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import unittest
+from functools import partial
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import patch
+from urllib.parse import quote
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+TESTS = ROOT / "tests"
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+sys.path.insert(0, str(TESTS))
+
+import git_review
+import review_routes
+import server
+from github_pull_requests import GitHubReadError, PullRequest
+from review_fixtures import ReviewRepository
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+class FakeReader:
+    pull_requests: ClassVar[list[PullRequest]] = []
+    available = True
+    patch_text = (
+        "diff --git a/api.txt b/api.txt\n"
+        "new file mode 100644\n"
+        "index 0000000..257cc56\n"
+        "--- /dev/null\n"
+        "+++ b/api.txt\n"
+        "@@ -0,0 +1 @@\n"
+        "+review api\n"
+    )
+
+    def __init__(self, _worktree) -> None:
+        pass
+
+    def _available(self) -> None:
+        if not self.available:
+            raise GitHubReadError("fixture GitHub is unavailable")
+
+    def list(self) -> list[PullRequest]:
+        self._available()
+        return list(self.pull_requests)
+
+    def get(self, number: int) -> PullRequest:
+        self._available()
+        return next(item for item in self.pull_requests if item.number == number)
+
+    def patch(self, _number: int) -> str:
+        self._available()
+        return self.patch_text
+
+
+class ReviewDispatchTest(unittest.TestCase):
+    def test_real_server_dispatches_both_review_resource_families(self) -> None:
+        expected = (299, [("X-Review", "yes")], b"review")
+        conversation_id = "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        paths = (
+            f"/api/conversations/{conversation_id}/review-targets?refresh=remote",
+            "/api/review-targets/gt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/files",
+        )
+        with patch.object(server.review_routes, "handle", return_value=expected) as call:
+            for path in paths:
+                with self.subTest(path=path):
+                    self.assertEqual(
+                        server.dispatch_http(
+                            "GET",
+                            path,
+                            "Host: 127.0.0.1\r\n\r\n",
+                            b"",
+                        ),
+                        expected,
+                    )
+            self.assertEqual(call.call_count, 2)
+
+
+class ConversationReviewApiTest(unittest.TestCase):
+    conversation_id = "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    headers = "Host: 127.0.0.1\r\n\r\n"
+
+    def setUp(self) -> None:
+        self.fixture = ReviewRepository()
+        self.addCleanup(self.fixture.cleanup)
+        self.fixture.branch("feature/review-api")
+        self.fixture.write("api.txt", "review api\n")
+        self.fixture.write("second.txt", "second\n")
+        self.head_sha = self.fixture.commit("review api")
+        self.db_path = self.fixture.root / "shell.db"
+        con = sqlite3.connect(self.db_path)
+        apply_schema(con)
+        con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id,api_key) "
+            "VALUES (1,'Dev','dev','dev','prompt',1,'shell-token')"
+        )
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,owner_user_id,harness,worktree,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES (?,1,'normal',1,'codex',?,'create','hash')",
+            (self.conversation_id, str(self.fixture.repo)),
+        )
+        con.commit()
+        con.close()
+        self.original_db_path = review_routes.DB_PATH
+        self.original_reader = review_routes.READER_FACTORY
+        self.original_cache = review_routes.CACHE_FACTORY
+        review_routes.DB_PATH = self.db_path
+        review_routes.READER_FACTORY = FakeReader
+        review_routes.CACHE_FACTORY = partial(
+            git_review.MergedPatchCache,
+            self.fixture.root / "review-cache",
+        )
+        review_routes._REMOTE_ATTEMPTS.clear()
+        review_routes._REMOTE_RESULTS.clear()
+        FakeReader.pull_requests = []
+        FakeReader.available = True
+        self.addCleanup(self._restore)
+
+    def _restore(self) -> None:
+        review_routes.DB_PATH = self.original_db_path
+        review_routes.READER_FACTORY = self.original_reader
+        review_routes.CACHE_FACTORY = self.original_cache
+        review_routes._REMOTE_ATTEMPTS.clear()
+        review_routes._REMOTE_RESULTS.clear()
+        FakeReader.pull_requests = []
+        FakeReader.available = True
+
+    def request(self, path: str, *, headers: str | None = None):
+        status, response_headers, body = review_routes.handle(
+            "GET",
+            path,
+            headers or self.headers,
+            b"",
+        )
+        value = json.loads(body) if body else None
+        return status, dict(response_headers), value
+
+    def target_id(self) -> str:
+        status, _headers, body = self.request(
+            f"/api/conversations/{self.conversation_id}/review-targets"
+        )
+        self.assertEqual(status, 200, body)
+        return next(
+            item["target_id"]
+            for item in body["items"]
+            if item["kind"] == "workspace"
+        )
+
+    def test_owned_targets_hide_worktree_and_expose_fresh_selection(self) -> None:
+        status, headers, body = self.request(
+            f"/api/conversations/{self.conversation_id}/review-targets"
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers["Cache-Control"], "no-store")
+        self.assertEqual(body["freshness"]["local"], "fresh")
+        self.assertEqual(len(body["items"]), 1)
+        self.assertEqual(body["items"][0]["kind"], "workspace")
+        self.assertEqual(
+            body["selected_target_id"],
+            body["items"][0]["target_id"],
+        )
+        self.assertNotIn(str(self.fixture.repo), json.dumps(body))
+
+        not_modified, response_headers, response_body = self.request(
+            f"/api/conversations/{self.conversation_id}/review-targets",
+            headers=(
+                "Host: 127.0.0.1\r\n"
+                f"If-None-Match: {headers['ETag']}\r\n\r\n"
+            ),
+        )
+        self.assertEqual(not_modified, 304)
+        self.assertEqual(response_headers["Cache-Control"], "no-store")
+        self.assertIsNone(response_body)
+
+    def test_files_diff_and_commits_are_server_selected_and_bounded(self) -> None:
+        target_id = self.target_id()
+        status, headers, files = self.request(
+            f"/api/review-targets/{target_id}/files?scope=review&limit=1"
+        )
+        self.assertEqual(status, 200, files)
+        self.assertEqual(files["items"][0]["path"], "api.txt")
+        self.assertTrue(files["items"][0]["file_id"].startswith("rf_"))
+        self.assertIsNotNone(files["next_cursor"])
+        status, second_headers, second_page = self.request(
+            f"/api/review-targets/{target_id}/files?scope=review&limit=1"
+            f"&cursor={files['next_cursor']}"
+        )
+        self.assertEqual(status, 200, second_page)
+        self.assertEqual(second_page["items"][0]["path"], "second.txt")
+        self.assertNotEqual(headers["ETag"], second_headers["ETag"])
+
+        status, _headers, patch = self.request(
+            f"/api/review-targets/{target_id}/diff"
+            "?scope=review&path=api.txt"
+        )
+        self.assertEqual(status, 200, patch)
+        self.assertIn("+review api", patch["patch"])
+
+        status, _headers, commits = self.request(
+            f"/api/review-targets/{target_id}/commits?limit=1"
+        )
+        self.assertEqual(status, 200, commits)
+        self.assertEqual(commits["items"][0]["sha"], self.head_sha)
+        self.assertNotIn("body", commits["items"][0])
+
+        status, _headers, error = self.request(
+            f"/api/review-targets/{target_id}/commits?ref=HEAD"
+        )
+        self.assertEqual(status, 422)
+        self.assertEqual(error["error"]["code"], "VALIDATION_ERROR")
+
+        status, _headers, error = self.request(
+            f"/api/review-targets/{target_id}/diff?scope=review&path="
+            + quote("../secret", safe="")
+        )
+        self.assertEqual(status, 422)
+        self.assertEqual(error["error"]["code"], "REVIEW_PATH_INVALID")
+
+        not_modified, _, response_body = self.request(
+            f"/api/review-targets/{target_id}/files?scope=review&limit=1",
+            headers=(
+                "Host: 127.0.0.1\r\n"
+                f"If-None-Match: {headers['ETag']}\r\n\r\n"
+            ),
+        )
+        self.assertEqual(not_modified, 304)
+        self.assertIsNone(response_body)
+
+    def test_target_ownership_and_operator_auth_do_not_leak(self) -> None:
+        con = sqlite3.connect(self.db_path)
+        con.execute("INSERT INTO users (user_id,username) VALUES (2,'other')")
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (2,'Other','other','dev','prompt',2)"
+        )
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,owner_user_id,harness,worktree,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES ('cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',2,'normal',2,"
+            "'codex',?,'other-create','other-hash')",
+            (str(self.fixture.repo),),
+        )
+        con.execute(
+            "INSERT INTO conversation_git_targets "
+            "(target_id,conversation_id,branch_name,base_ref,first_head_sha,"
+            "latest_head_sha) VALUES "
+            "('gt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',"
+            "'cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','private','main',?,?)",
+            (self.head_sha, self.head_sha),
+        )
+        con.commit()
+        con.close()
+
+        status, _headers, body = self.request(
+            "/api/review-targets/gt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/files"
+        )
+        self.assertEqual(status, 404)
+        self.assertEqual(body["error"]["code"], "REVIEW_TARGET_NOT_FOUND")
+
+        status, _headers, body = self.request(
+            f"/api/conversations/{self.conversation_id}/review-targets",
+            headers=(
+                "Host: 127.0.0.1\r\n"
+                "Authorization: Bearer shell-token\r\n\r\n"
+            ),
+        )
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error"]["code"], "OPERATOR_REQUIRED")
+
+        status, _headers, body = self.request(
+            f"/api/conversations/{self.conversation_id}/review-targets",
+            headers=(
+                "Host: 127.0.0.1\r\n"
+                "Origin: https://attacker.example\r\n"
+                "Sec-Fetch-Site: cross-site\r\n\r\n"
+            ),
+        )
+        self.assertEqual(status, 403)
+        self.assertEqual(body["error"]["code"], "NOT_SAME_ORIGIN")
+
+    def test_stale_cursor_and_mid_read_target_change_are_conflicts(self) -> None:
+        target_id = self.target_id()
+        status, _headers, first_page = self.request(
+            f"/api/review-targets/{target_id}/files?scope=review&limit=1"
+        )
+        self.assertEqual(status, 200, first_page)
+        self.fixture.write("later-untracked.txt", "later\n")
+
+        status, _headers, stale = self.request(
+            f"/api/review-targets/{target_id}/files?scope=review&limit=1"
+            f"&cursor={first_page['next_cursor']}"
+        )
+        self.assertEqual(status, 409)
+        self.assertEqual(stale["error"]["code"], "REVIEW_TARGET_CHANGED")
+
+        original_projection = review_routes._file_projection
+
+        def change_target(row, owner_user_id, scope):
+            projection = original_projection(row, owner_user_id, scope)
+            con = sqlite3.connect(self.db_path)
+            con.execute(
+                "UPDATE conversation_git_targets SET latest_head_sha=? "
+                "WHERE target_id=?",
+                ("f" * 40, target_id),
+            )
+            con.commit()
+            con.close()
+            return projection
+
+        with patch.object(review_routes, "_file_projection", change_target):
+            status, _headers, changed = self.request(
+                f"/api/review-targets/{target_id}/files?scope=review"
+            )
+        self.assertEqual(status, 409)
+        self.assertEqual(changed["error"]["code"], "REVIEW_TARGET_CHANGED")
+
+    def test_exact_pr_is_persisted_and_cached_metadata_survives_outage(self) -> None:
+        self.target_id()
+        pull_request = PullRequest(
+            number=815,
+            head_ref="feature/review-api",
+            base_ref="main",
+            head_sha=self.head_sha,
+            state="OPEN",
+            merged_at=None,
+            merge_sha=None,
+            title="Review API",
+            url="https://example.test/pull/815",
+            review_decision="APPROVED",
+            checks="SUCCESS",
+            checks_failed=False,
+        )
+        FakeReader.pull_requests = [pull_request]
+        review_routes._REMOTE_ATTEMPTS.clear()
+
+        status, _headers, body = self.request(
+            f"/api/conversations/{self.conversation_id}/review-targets"
+            "?refresh=remote"
+        )
+        self.assertEqual(status, 200, body)
+        pr_item = next(item for item in body["items"] if item["pr_number"] == 815)
+        self.assertEqual(pr_item["lifecycle"], "pr_open")
+        self.assertEqual(pr_item["freshness"]["remote"], "fresh")
+
+        status, _headers, files = self.request(
+            f"/api/review-targets/{pr_item['target_id']}/files?scope=review"
+        )
+        self.assertEqual(status, 200, files)
+        self.assertEqual(files["items"][0]["path"], "api.txt")
+
+        FakeReader.available = False
+        review_routes._REMOTE_ATTEMPTS.clear()
+        status, _headers, offline = self.request(
+            f"/api/conversations/{self.conversation_id}/review-targets"
+            "?refresh=remote"
+        )
+        self.assertEqual(status, 200, offline)
+        cached = next(item for item in offline["items"] if item["pr_number"] == 815)
+        self.assertEqual(cached["freshness"]["remote"], "cached")
+        self.assertEqual(offline["freshness"]["remote"], "unavailable")
+        self.assertEqual(cached["title"], "Review API")
+
+    def test_multiple_pr_identities_and_merged_patch_cache_survive_cleanup(
+        self,
+    ) -> None:
+        self.target_id()
+        open_pr = PullRequest(
+            number=816,
+            head_ref="feature/review-api",
+            base_ref="main",
+            head_sha=self.head_sha,
+            state="OPEN",
+            merged_at=None,
+            merge_sha=None,
+            title="Later delivery",
+            url="https://example.test/pull/816",
+            review_decision=None,
+            checks="PENDING",
+            checks_failed=False,
+        )
+        merged_pr = PullRequest(
+            number=815,
+            head_ref="feature/review-api",
+            base_ref="main",
+            head_sha=self.head_sha,
+            state="MERGED",
+            merged_at="2026-07-30T20:29:37Z",
+            merge_sha="e" * 40,
+            title="Merged delivery",
+            url="https://example.test/pull/815",
+            review_decision="APPROVED",
+            checks="SUCCESS",
+            checks_failed=False,
+        )
+        FakeReader.pull_requests = [open_pr, merged_pr]
+        review_routes._REMOTE_ATTEMPTS.clear()
+
+        status, _headers, body = self.request(
+            f"/api/conversations/{self.conversation_id}/review-targets"
+            "?refresh=remote"
+        )
+        self.assertEqual(status, 200, body)
+        self.assertEqual(
+            {item["pr_number"] for item in body["items"] if item["pr_number"]},
+            {815, 816},
+        )
+        merged_target = next(
+            item for item in body["items"] if item["pr_number"] == 815
+        )
+
+        status, _headers, fresh = self.request(
+            f"/api/review-targets/{merged_target['target_id']}/files"
+            "?scope=review"
+        )
+        self.assertEqual(status, 200, fresh)
+        self.assertEqual(fresh["freshness"], "fresh")
+        con = sqlite3.connect(self.db_path)
+        artifact = con.execute(
+            "SELECT patch_artifact,patch_sha256 "
+            "FROM conversation_git_targets WHERE target_id=?",
+            (merged_target["target_id"],),
+        ).fetchone()
+        con.close()
+        self.assertIsNotNone(artifact[0])
+        self.assertFalse(artifact[0].startswith("/"))
+        self.assertEqual(len(artifact[1]), 64)
+
+        FakeReader.available = False
+        status, _headers, cached = self.request(
+            f"/api/review-targets/{merged_target['target_id']}/files"
+            "?scope=review"
+        )
+        self.assertEqual(status, 200, cached)
+        self.assertEqual(cached["freshness"], "cached")
+        self.assertEqual(cached["items"][0]["path"], "api.txt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_git_review.py
+++ b/tests/test_git_review.py
@@ -167,6 +167,36 @@ class LocalReviewProjectionTest(unittest.TestCase):
         self.assertTrue(pushed.pushed)
         self.assertEqual(pushed.remote_branch_sha, pushed.head_sha)
 
+    def test_public_commit_resolution_and_ancestry_are_exact(self) -> None:
+        base_sha = self.fixture.git("rev-parse", "HEAD")
+        self.fixture.branch("feature/identity")
+        self.fixture.write("identity.txt", "identity\n")
+        head_sha = self.fixture.commit("identity")
+
+        self.assertEqual(
+            git_review.resolve_commit(self.fixture.repo, "feature/identity"),
+            head_sha,
+        )
+        self.assertTrue(
+            git_review.commit_is_ancestor(
+                self.fixture.repo,
+                base_sha,
+                head_sha,
+            )
+        )
+        self.assertFalse(
+            git_review.commit_is_ancestor(
+                self.fixture.repo,
+                head_sha,
+                base_sha,
+            )
+        )
+        with self.assertRaisesRegex(
+            git_review.GitReadError,
+            "Git ref is invalid",
+        ):
+            git_review.resolve_commit(self.fixture.repo, "--help")
+
     def test_conflict_and_local_only_overlay_are_explicit(self) -> None:
         self.fixture.build_conflict_case()
         conflict = git_review.collect_workspace(self.fixture.repo)


### PR DESCRIPTION
## Summary

- add authenticated, same-origin conversation review-target discovery and server-side PR enrichment
- add ownership-isolated files, diff, and commits GET resources with strict filters, cursor pagination, ETags, and uniform errors
- preserve PR-number identity across branch reuse, cache merged canonical patches, and revalidate target/worktree fingerprints around external reads
- expose only server-selected refs and sanitized review projections; absolute worktrees remain internal

## Verification

- `./sc test` — 1,696 passed
- `./sc verify` — passed
- focused `./sc lint` on all changed review/service/test files — passed
- `git diff --check` — passed

## Existing repository baselines

- whole-tree lint remains red on 1,106 pre-existing findings: #785
- render-check remains red only on `skills_sc/README.md` and `skills_sc/sprint_onboarding.md`: #809

Implements Feature #26 spec task 152.
