### PR TITLE
feat: build browser Diff review workspace

### DIFF
--- a/.super-coder/api/review_routes.py
+++ b/.super-coder/api/review_routes.py
@@ -521,25 +521,36 @@ def _target_summary(
 
 def _selected_target(items: list[dict[str, Any]]) -> str | None:
     priority = {
-        "pr_open": 0,
-        "checks_failed": 0,
-        "workspace": 1,
-        "pushed": 2,
-        "local": 3,
-        "pr_merged": 4,
-        "pr_closed": 5,
+        "pr_open": 1,
+        "checks_failed": 1,
+        "workspace": 2,
+        "pushed": 3,
+        "local": 4,
+        "pr_merged": 5,
+        "pr_closed": 6,
     }
     if not items:
         return None
+
+    def target_priority(item: dict[str, Any]) -> int:
+        facts = item["facts"]
+        if item["kind"] == "workspace" and (
+            facts["dirty"]
+            or (facts["ahead"] or 0) > 0
+            or facts["pushed"] is False
+        ):
+            return 0
+        return priority.get(
+            item["kind"]
+            if item["kind"] == "workspace"
+            else item["lifecycle"],
+            10,
+        )
+
     return min(
         enumerate(items),
         key=lambda pair: (
-            priority.get(
-                pair[1]["kind"]
-                if pair[1]["kind"] == "workspace"
-                else pair[1]["lifecycle"],
-                10,
-            ),
+            target_priority(pair[1]),
             pair[0],
         ),
     )[1]["target_id"]

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3374,12 +3374,18 @@ const CHAT_FLAVOR_ORDER = [
 ];
 const CHAT_CONFIGURE_ROUTE = "configure";
 const CHAT_HISTORY_POLL_MS = 2000;
+const CHAT_REVIEW_POLL_MS = 2000;
+const CHAT_MODES = ["chat", "diff"];
 let chatRouteShell = "";
 let chatRouteConversation = "";
+let chatRouteMode = "chat";
 let chatSource = null;
 let chatHistoryPollTimer = null;
 let chatRenderGeneration = 0;
 let chatPendingSend = null;
+let chatModeController = null;
+let chatReviewCleanup = null;
+const chatReviewViewed = new Map();
 
 function chatStopStream() {
   if (chatSource) chatSource.close();
@@ -3391,9 +3397,20 @@ function chatStopHistoryPoll() {
   chatHistoryPollTimer = null;
 }
 
+function chatStopReview() {
+  if (chatReviewCleanup) chatReviewCleanup();
+  chatReviewCleanup = null;
+  document.body.classList.remove("chat-diff-view");
+}
+
 function chatHash(shortname, conversationId = "") {
   return `interface/${encodeURIComponent(shortname)}`
     + (conversationId ? `/${encodeURIComponent(conversationId)}` : "");
+}
+
+function chatModeHash(shortname, conversationId, mode = "chat") {
+  return chatHash(shortname, conversationId)
+    + (mode === "diff" ? "/diff" : "");
 }
 
 function chatModelLabel(conversation) {
@@ -3582,6 +3599,7 @@ function chatPaintTranscript(
   transcript, messages, events, conversation, retry, shouldFollow, onPosition,
 ) {
   const previousTop = transcript.scrollTop;
+  const followTail = shouldFollow();
   const assistants = chatAssistantRuns(events);
   const activities = chatActivity(events);
   const items = [];
@@ -3650,7 +3668,7 @@ function chatPaintTranscript(
   }
   transcript.replaceChildren(...items.map((item) => item.node));
   requestAnimationFrame(() => {
-    transcript.scrollTop = shouldFollow() ? transcript.scrollHeight : previousTop;
+    transcript.scrollTop = followTail ? transcript.scrollHeight : previousTop;
     onPosition();
   });
 }
@@ -3723,6 +3741,762 @@ function chatCreateConversation(shell, fields = {}) {
     { shell_id: shell.shell_id, ...fields },
     requestKey(),
   );
+}
+
+async function reviewApi(path, etagValue = "") {
+  const headers = etagValue ? { "If-None-Match": etagValue } : {};
+  let response;
+  try {
+    response = await fetch("/api" + path, { method: "GET", headers });
+  } catch (cause) {
+    const error = new Error("Review data could not be reached.");
+    error.code = "REVIEW_REMOTE_UNAVAILABLE";
+    error.cause = cause;
+    throw error;
+  }
+  if (response.status === 304) {
+    return {
+      notModified: true,
+      etag: response.headers.get("ETag") || etagValue,
+      data: null,
+    };
+  }
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const detail = data.error || {};
+    const error = new Error(detail.message || response.statusText);
+    error.code = detail.code || "REVIEW_TARGET_UNAVAILABLE";
+    error.details = detail.details || {};
+    error.status = response.status;
+    throw error;
+  }
+  return {
+    notModified: false,
+    etag: response.headers.get("ETag") || "",
+    data,
+  };
+}
+
+function reviewLifecycleLabel(lifecycle) {
+  return {
+    local: "LOCAL BRANCH",
+    local_branch: "LOCAL BRANCH",
+    pushed: "PUSHED",
+    pr_open: "PR OPEN",
+    checks_failed: "CHECKS FAILED",
+    pr_merged: "PR MERGED",
+    pr_closed: "PR CLOSED",
+    remote_unknown: "REMOTE UNKNOWN",
+  }[lifecycle] || String(lifecycle || "LOCAL BRANCH").replaceAll("_", " ").toUpperCase();
+}
+
+function reviewTargetLabel(target) {
+  if (target.pr_number)
+    return `PR #${target.pr_number} · ${target.branch || "branch unavailable"} · `
+      + reviewLifecycleLabel(target.lifecycle).toLowerCase();
+  if (target.kind === "workspace")
+    return `Live workspace · ${target.branch || "detached HEAD"}`;
+  return `Branch ${target.branch || "detached HEAD"} · `
+    + reviewLifecycleLabel(target.lifecycle).toLowerCase();
+}
+
+function reviewObservedLabel(value) {
+  if (!value) return "observed just now";
+  const parsed = new Date(/(?:Z|[+-]\d\d:\d\d)$/.test(value) ? value : `${value}Z`);
+  return Number.isNaN(parsed.getTime())
+    ? `observed ${value}`
+    : `observed ${parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+}
+
+function reviewViewedKey(targetId, fingerprint) {
+  return `${targetId}:${fingerprint || "unknown"}`;
+}
+
+function reviewTypedState(title, detail = "", tone = "") {
+  const state = el("div", {
+    className: `review-typed-state${tone ? ` ${tone}` : ""}`,
+  }, el("strong", {}, title));
+  if (detail) state.append(el("span", {}, detail));
+  return state;
+}
+
+function reviewPatchRows(text) {
+  const patch = el("div", { className: "review-patch" });
+  let oldLine = null;
+  let newLine = null;
+  for (const line of String(text || "").split("\n")) {
+    let kind = "context";
+    let oldNumber = "";
+    let newNumber = "";
+    const hunk = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunk) {
+      kind = "hunk";
+      oldLine = Number(hunk[1]);
+      newLine = Number(hunk[2]);
+    } else if (line.startsWith("diff --git ") || line.startsWith("index ")
+        || line.startsWith("--- ") || line.startsWith("+++ ")) {
+      kind = "header";
+    } else if (line.startsWith("+")) {
+      kind = "add";
+      newNumber = newLine ?? "";
+      if (newLine !== null) newLine += 1;
+    } else if (line.startsWith("-")) {
+      kind = "delete";
+      oldNumber = oldLine ?? "";
+      if (oldLine !== null) oldLine += 1;
+    } else if (line.startsWith("\\")) {
+      kind = "notice";
+    } else {
+      oldNumber = oldLine ?? "";
+      newNumber = newLine ?? "";
+      if (oldLine !== null) oldLine += 1;
+      if (newLine !== null) newLine += 1;
+    }
+    const row = el("div", { className: `review-line review-line-${kind}` });
+    row.append(
+      el("span", { className: "review-line-number" }, oldNumber),
+      el("span", { className: "review-line-number" }, newNumber),
+      el("span", { className: "review-line-code" }, line),
+    );
+    patch.append(row);
+  }
+  return patch;
+}
+
+function reviewFileTree(files, selectedPath, viewed, onSelect) {
+  const tree = { directories: new Map(), files: [] };
+  for (const file of files) {
+    const parts = file.path.split("/");
+    let node = tree;
+    for (const part of parts.slice(0, -1)) {
+      if (!node.directories.has(part))
+        node.directories.set(part, { directories: new Map(), files: [] });
+      node = node.directories.get(part);
+    }
+    node.files.push(file);
+  }
+  const renderNode = (node, depth = 0) => {
+    const fragment = document.createDocumentFragment();
+    for (const [name, child] of [...node.directories].sort(([a], [b]) => a.localeCompare(b))) {
+      fragment.append(el("div", {
+        className: "review-tree-directory",
+        style: `--review-depth:${depth}`,
+      }, el("span", { ariaHidden: "true" }, "▾"), name));
+      fragment.append(renderNode(child, depth + 1));
+    }
+    for (const file of [...node.files].sort((a, b) => a.path.localeCompare(b.path))) {
+      const status = file.conflict ? "!" : file.status === "untracked" ? "?"
+        : file.status?.slice(0, 1).toUpperCase() || "M";
+      const button = el("button", {
+        className: "review-file-row"
+          + (file.path === selectedPath ? " selected" : "")
+          + (viewed.has(file.path) ? " viewed" : ""),
+        type: "button",
+        style: `--review-depth:${depth}`,
+        title: file.old_path ? `${file.old_path} → ${file.path}` : file.path,
+      });
+      const fileFacts = [
+        file.binary ? "binary" : "",
+        file.submodule ? "submodule" : "",
+        file.oversized ? "large" : "",
+        file.generated ? "generated" : "",
+      ].filter(Boolean);
+      button.append(
+        el("span", { className: `review-file-status status-${file.status}` }, status),
+        el("span", { className: "review-file-path" }, file.path.split("/").at(-1)),
+        el("span", { className: "review-file-counts" },
+          fileFacts.length ? fileFacts.join(" · ")
+            : [file.additions != null ? `+${file.additions}` : "",
+              file.deletions != null ? `−${file.deletions}` : ""]
+              .filter(Boolean).join(" ")),
+      );
+      button.onclick = () => onSelect(file);
+      fragment.append(button);
+    }
+    return fragment;
+  };
+  const host = el("div", { className: "review-file-tree" });
+  host.append(renderNode(tree));
+  return host;
+}
+
+function chatReviewWorkspace(host, conversation) {
+  const state = {
+    mode: "chat",
+    loaded: false,
+    loadingTargets: false,
+    loadingContent: false,
+    pollInFlight: false,
+    pollTimer: null,
+    requestGeneration: 0,
+    responseCache: new Map(),
+    targetsEtag: "",
+    gitFingerprint: "",
+    targets: [],
+    targetId: "",
+    targetFingerprint: "",
+    freshness: null,
+    scope: "review",
+    files: [],
+    fileFingerprint: "",
+    filesTruncated: false,
+    selectedPath: "",
+    patch: null,
+    patchError: null,
+    patchLoading: false,
+    commits: [],
+    commitsTruncated: false,
+    pathFilter: "",
+    statusFilter: "",
+    hideViewed: false,
+    hideGenerated: false,
+    hideBinary: false,
+    hideDeleted: false,
+    error: null,
+  };
+
+  const selectedTarget = () =>
+    state.targets.find((target) => target.target_id === state.targetId) || null;
+  const selectedFile = () =>
+    state.files.find((file) => file.path === state.selectedPath) || null;
+  const viewedFiles = () => {
+    const key = reviewViewedKey(state.targetId, state.fileFingerprint);
+    if (!chatReviewViewed.has(key)) chatReviewViewed.set(key, new Set());
+    return chatReviewViewed.get(key);
+  };
+
+  const targetFacts = (target) => {
+    if (!target) return [];
+    const facts = [];
+    if (target.facts?.dirty) facts.push("dirty workspace");
+    if (target.facts?.ahead) facts.push(`${target.facts.ahead} unpushed commit${target.facts.ahead === 1 ? "" : "s"}`);
+    if (target.facts?.behind) facts.push(`${target.facts.behind} behind base`);
+    if (target.facts?.cleanup_pending) facts.push("cleanup pending");
+    if (target.facts?.pushed === false && target.kind !== "pull_request")
+      facts.push("not pushed");
+    if (target.freshness?.remote === "cached") facts.push("cached remote");
+    return facts;
+  };
+
+  const patchBody = () => {
+    const file = selectedFile();
+    if (!file) return reviewTypedState(
+      "Select a file",
+      "Choose a path from the navigator to read its bounded patch.",
+    );
+    if (state.patchLoading) return reviewTypedState("Loading patch…", file.path);
+    if (state.patchError) {
+      const code = state.patchError.code || "REVIEW_TARGET_UNAVAILABLE";
+      return reviewTypedState(code, state.patchError.message, "error");
+    }
+    if (!state.patch) return reviewTypedState("Patch unavailable", file.path);
+    if (state.patch.binary || file.binary)
+      return reviewTypedState("Binary file", "Raw binary bytes are never transported.");
+    if (!state.patch.patch) {
+      const reason = state.patch.unavailable_reason || "unavailable";
+      return reviewTypedState(
+        reason === "oversized" ? "Patch too large" : "Patch unavailable",
+        reason === "oversized"
+          ? "The file remains listed, but its patch exceeds the review limit."
+          : `No textual patch is available (${reason}).`,
+      );
+    }
+    const wrapper = el("div", { className: "review-patch-wrap" });
+    if (state.patch.truncated)
+      wrapper.append(reviewTypedState(
+        "Patch truncated",
+        "Showing the bounded portion returned by the server.",
+        "warning",
+      ));
+    wrapper.append(reviewPatchRows(state.patch.patch));
+    return wrapper;
+  };
+
+  const commitBody = () => {
+    if (state.error)
+      return reviewTypedState(
+        state.error.code || "REVIEW_TARGET_UNAVAILABLE",
+        state.error.message,
+        "error",
+      );
+    if (state.loadingContent)
+      return reviewTypedState("Loading commits…", "Reading the bounded change history.");
+    if (!state.commits.length)
+      return reviewTypedState("No commits in this change set.");
+    const list = el("div", { className: "review-commit-list" });
+    for (const commit of state.commits) {
+      list.append(el("article", { className: "review-commit" },
+        el("code", {}, commit.short_sha),
+        el("div", { className: "review-commit-main" },
+          el("strong", {}, commit.subject),
+          el("span", {}, `${commit.author} · ${commit.authored_at}`))));
+    }
+    if (state.commitsTruncated)
+      list.append(reviewTypedState(
+        "Commit list truncated",
+        "The server returned its bounded commit projection.",
+        "warning",
+      ));
+    return list;
+  };
+
+  const filteredFiles = () => {
+    const needle = state.pathFilter.trim().toLowerCase();
+    const viewed = viewedFiles();
+    return state.files.filter((file) =>
+      (!needle || file.path.toLowerCase().includes(needle))
+      && (!state.statusFilter || file.status === state.statusFilter)
+      && (!state.hideViewed || !viewed.has(file.path))
+      && (!state.hideGenerated || !file.generated)
+      && (!state.hideBinary || !file.binary)
+      && (!state.hideDeleted || file.status !== "deleted"));
+  };
+
+  const toggleFilter = (label, key) => {
+    const button = el("button", {
+      className: `review-filter-toggle${state[key] ? " active" : ""}`,
+      type: "button",
+      textContent: label,
+      ariaPressed: String(state[key]),
+    });
+    button.onclick = () => {
+      state[key] = !state[key];
+      paint();
+    };
+    return button;
+  };
+
+  const selectReviewFile = (file) => {
+    if (!file) return;
+    state.selectedPath = file.path;
+    viewedFiles().add(file.path);
+    loadPatch(file);
+    paint();
+  };
+
+  const paint = () => {
+    if (state.mode !== "diff") return;
+    if (state.loadingTargets && !state.loaded) {
+      host.replaceChildren(reviewTypedState(
+        "Loading review workspace…",
+        "Reading local Git state and cached pull-request evidence.",
+      ));
+      return;
+    }
+    if (state.error && !state.targets.length) {
+      const retry = el("button", {
+        className: "act",
+        type: "button",
+        textContent: "Retry",
+      });
+      retry.onclick = () => loadTargets();
+      host.replaceChildren(reviewTypedState(
+        state.error.code || "REVIEW_TARGET_UNAVAILABLE",
+        state.error.message,
+        "error",
+      ), retry);
+      return;
+    }
+    if (!state.targets.length) {
+      const refresh = el("button", {
+        className: "act",
+        type: "button",
+        textContent: "Refresh remote",
+      });
+      refresh.onclick = () => loadTargets({ remote: true });
+      host.replaceChildren(reviewTypedState(
+        "No review targets yet.",
+        "The selected conversation has no observed branch, workspace change, or pull request.",
+      ), refresh);
+      return;
+    }
+
+    const target = selectedTarget();
+    const targetSelect = el("select", {
+      className: "review-target-select",
+      ariaLabel: "Review target",
+    });
+    for (const item of state.targets)
+      targetSelect.append(el("option", {
+        value: item.target_id,
+        selected: item.target_id === state.targetId,
+        textContent: reviewTargetLabel(item),
+      }));
+    targetSelect.onchange = () => {
+      state.targetId = targetSelect.value;
+      state.targetFingerprint = selectedTarget()?.fingerprint || "";
+      state.scope = "review";
+      state.selectedPath = "";
+      state.patch = null;
+      state.commits = [];
+      loadContent();
+    };
+    const status = el("span", {
+      className: `review-lifecycle lifecycle-${target?.lifecycle || "local"}`,
+    }, reviewLifecycleLabel(target?.lifecycle));
+    const refresh = el("button", {
+      className: "act review-refresh",
+      type: "button",
+      textContent: state.loadingTargets ? "Refreshing…" : "Refresh remote",
+      disabled: state.loadingTargets,
+    });
+    refresh.onclick = () => loadTargets({ remote: true });
+    const facts = targetFacts(target);
+    if (state.scope !== "commits" && !state.loadingContent) {
+      const additions = state.files.reduce(
+        (total, file) => total + (file.additions || 0), 0);
+      const deletions = state.files.reduce(
+        (total, file) => total + (file.deletions || 0), 0);
+      facts.push(`${state.files.length} file${state.files.length === 1 ? "" : "s"}`);
+      if (additions || deletions) facts.push(`+${additions} −${deletions}`);
+    }
+    const remoteWarning = state.freshness?.remote === "unavailable"
+      ? `Remote unavailable${state.freshness.remote_error
+        ? ` — ${state.freshness.remote_error}` : ""}. Local and cached evidence remain readable.`
+      : "";
+    const summary = el("div", { className: "review-summary" },
+      el("div", { className: "review-target-control" },
+        el("label", { className: "k" }, "Change set"),
+        targetSelect),
+      el("div", { className: "review-lifecycle-block" },
+        status,
+        el("span", { className: "review-facts" }, facts.join(" · ") || "clean local state")),
+      el("div", { className: "review-freshness" },
+        el("span", {}, reviewObservedLabel(target?.last_seen_at)),
+        remoteWarning ? el("span", { className: "warning" }, remoteWarning) : null),
+      refresh);
+
+    const scopeSwitch = el("div", {
+      className: "review-scope-switch",
+      role: "tablist",
+      ariaLabel: "Comparison scope",
+    });
+    for (const [value, label] of [
+      ["review", "Review changes"],
+      ["local", "Local only"],
+      ["commits", "Commits"],
+    ]) {
+      const button = el("button", {
+        className: value === state.scope ? "active" : "",
+        type: "button",
+        role: "tab",
+        ariaSelected: String(value === state.scope),
+        textContent: label,
+      });
+      button.onclick = () => {
+        if (state.scope === value) return;
+        state.scope = value;
+        state.selectedPath = "";
+        state.patch = null;
+        state.error = null;
+        loadContent();
+      };
+      scopeSwitch.append(button);
+    }
+
+    const workspace = el("div", { className: "review-workspace" }, summary, scopeSwitch);
+    if (state.scope === "commits") {
+      workspace.append(el("div", { className: "review-commits-pane" }, commitBody()));
+      host.replaceChildren(workspace);
+      return;
+    }
+
+    const pathInput = el("input", {
+      type: "search",
+      className: "review-path-filter",
+      placeholder: "Filter paths",
+      value: state.pathFilter,
+    });
+    pathInput.oninput = () => {
+      const start = pathInput.selectionStart;
+      state.pathFilter = pathInput.value;
+      paint();
+      const next = $(".review-path-filter", host);
+      next?.focus();
+      next?.setSelectionRange(start, start);
+    };
+    const statuses = [...new Set(state.files.map((file) => file.status))].sort();
+    const statusSelect = el("select", {
+      className: "review-status-filter",
+      ariaLabel: "File status",
+    }, el("option", { value: "", textContent: "All statuses" }));
+    for (const value of statuses)
+      statusSelect.append(el("option", {
+        value,
+        selected: value === state.statusFilter,
+        textContent: value,
+      }));
+    statusSelect.onchange = () => {
+      state.statusFilter = statusSelect.value;
+      paint();
+    };
+    const filters = el("div", { className: "review-filters" },
+      pathInput,
+      statusSelect,
+      toggleFilter("Hide viewed", "hideViewed"),
+      toggleFilter("Hide generated", "hideGenerated"),
+      toggleFilter("Hide binary", "hideBinary"),
+      toggleFilter("Hide deleted", "hideDeleted"));
+    const visibleFiles = filteredFiles();
+    const viewed = viewedFiles();
+    const navigator = el("aside", { className: "review-navigator" }, filters);
+    if (state.error) {
+      navigator.append(reviewTypedState(
+        state.error.code || "REVIEW_TARGET_UNAVAILABLE",
+        state.error.message,
+        "error",
+      ));
+    } else if (state.loadingContent) {
+      navigator.append(reviewTypedState("Loading files…"));
+    } else if (!visibleFiles.length) {
+      navigator.append(reviewTypedState("No files match this scope and filter."));
+    } else {
+      navigator.append(reviewFileTree(
+        visibleFiles,
+        state.selectedPath,
+        viewed,
+        selectReviewFile,
+      ));
+    }
+    if (state.filesTruncated)
+      navigator.append(reviewTypedState(
+        "File list truncated",
+        "The server returned its bounded file projection.",
+        "warning",
+      ));
+    const selected = selectedFile();
+    const selectedIndex = visibleFiles.findIndex(
+      (file) => file.path === state.selectedPath);
+    const previousFile = selectedIndex > 0 ? visibleFiles[selectedIndex - 1] : null;
+    const nextFile = selectedIndex >= 0 && selectedIndex < visibleFiles.length - 1
+      ? visibleFiles[selectedIndex + 1] : null;
+    const previous = el("button", {
+      type: "button",
+      className: "review-file-step",
+      textContent: "↑",
+      title: "Previous file",
+      ariaLabel: "Previous file",
+      disabled: !previousFile,
+    });
+    previous.onclick = () => selectReviewFile(previousFile);
+    const next = el("button", {
+      type: "button",
+      className: "review-file-step",
+      textContent: "↓",
+      title: "Next file",
+      ariaLabel: "Next file",
+      disabled: !nextFile,
+    });
+    next.onclick = () => selectReviewFile(nextFile);
+    const patchHead = el("div", { className: "review-patch-head" },
+      el("strong", {}, selected?.path || "Patch"),
+      selected?.old_path
+        ? el("span", {}, `renamed from ${selected.old_path}`)
+        : el("span", {}, state.scope === "local"
+          ? "local changes absent from selected head"
+          : "merge-base / canonical review patch"),
+      el("div", { className: "review-file-steps" }, previous, next));
+    const patchPane = el("section", { className: "review-patch-pane" },
+      patchHead, patchBody());
+    workspace.append(el("div", { className: "review-body" }, navigator, patchPane));
+    host.replaceChildren(workspace);
+  };
+
+  const readReviewResource = async (path) => {
+    const cached = state.responseCache.get(path);
+    const result = await reviewApi(path, cached?.etag || "");
+    if (result.notModified) {
+      if (!cached) {
+        const error = new Error("Review cache entry is unavailable.");
+        error.code = "REVIEW_TARGET_UNAVAILABLE";
+        throw error;
+      }
+      return cached.data;
+    }
+    state.responseCache.set(path, { etag: result.etag, data: result.data });
+    return result.data;
+  };
+
+  const loadPatch = async (file) => {
+    if (!file || state.scope === "commits") return;
+    const request = ++state.requestGeneration;
+    state.patchLoading = true;
+    state.patchError = null;
+    paint();
+    try {
+      const data = await readReviewResource(
+        `/review-targets/${encodeURIComponent(state.targetId)}/diff`
+        + `?scope=${encodeURIComponent(state.scope)}`
+        + `&path=${encodeURIComponent(file.path)}`,
+      );
+      if (request !== state.requestGeneration) return;
+      state.patch = data;
+    } catch (error) {
+      if (request !== state.requestGeneration) return;
+      state.patchError = error;
+      if (error.code === "REVIEW_TARGET_CHANGED") loadTargets();
+    } finally {
+      if (request === state.requestGeneration) {
+        state.patchLoading = false;
+        paint();
+      }
+    }
+  };
+
+  const loadFiles = async () => {
+    const request = ++state.requestGeneration;
+    state.loadingContent = true;
+    state.error = null;
+    paint();
+    try {
+      const items = [];
+      let cursor = "";
+      let page;
+      do {
+        const suffix = cursor ? `&cursor=${encodeURIComponent(cursor)}` : "";
+        page = await readReviewResource(
+          `/review-targets/${encodeURIComponent(state.targetId)}/files`
+          + `?scope=${encodeURIComponent(state.scope)}&limit=200${suffix}`,
+        );
+        items.push(...page.items);
+        cursor = page.next_cursor || "";
+      } while (cursor && items.length < 2000);
+      if (request !== state.requestGeneration) return;
+      const fingerprintChanged = state.fileFingerprint
+        && state.fileFingerprint !== page.fingerprint;
+      state.files = items;
+      state.fileFingerprint = page.fingerprint;
+      state.filesTruncated = Boolean(page.files_truncated || cursor);
+      if (fingerprintChanged || !items.some((file) => file.path === state.selectedPath))
+        state.selectedPath = items[0]?.path || "";
+      state.patch = null;
+      state.patchError = null;
+      state.loadingContent = false;
+      paint();
+      const file = selectedFile();
+      if (file) {
+        viewedFiles().add(file.path);
+        await loadPatch(file);
+      }
+    } catch (error) {
+      if (request !== state.requestGeneration) return;
+      state.loadingContent = false;
+      state.error = error;
+      state.files = [];
+      state.patch = null;
+      paint();
+    }
+  };
+
+  const loadCommits = async () => {
+    const request = ++state.requestGeneration;
+    state.loadingContent = true;
+    state.error = null;
+    paint();
+    try {
+      const items = [];
+      let cursor = "";
+      let page;
+      do {
+        const suffix = cursor ? `?limit=200&cursor=${encodeURIComponent(cursor)}` : "?limit=200";
+        page = await readReviewResource(
+          `/review-targets/${encodeURIComponent(state.targetId)}/commits${suffix}`,
+        );
+        items.push(...page.items);
+        cursor = page.next_cursor || "";
+      } while (cursor && items.length < 500);
+      if (request !== state.requestGeneration) return;
+      state.commits = items;
+      state.commitsTruncated = Boolean(page.commits_truncated || cursor);
+    } catch (error) {
+      if (request !== state.requestGeneration) return;
+      state.error = error;
+      state.commits = [];
+    } finally {
+      if (request === state.requestGeneration) {
+        state.loadingContent = false;
+        paint();
+      }
+    }
+  };
+
+  const loadContent = () =>
+    state.scope === "commits" ? loadCommits() : loadFiles();
+
+  const loadTargets = async ({ remote = false, polling = false } = {}) => {
+    if (state.loadingTargets) return;
+    state.loadingTargets = true;
+    if (!polling) paint();
+    const oldTargetId = state.targetId;
+    const oldTargetFingerprint = selectedTarget()?.fingerprint || "";
+    try {
+      const query = remote ? "?refresh=remote" : "";
+      const result = await reviewApi(
+        `/conversations/${conversation.conversation_id}/review-targets${query}`,
+        polling && !remote ? state.targetsEtag : "",
+      );
+      if (result.notModified) return;
+      const page = result.data;
+      state.targetsEtag = result.etag;
+      state.gitFingerprint = page.git_fingerprint;
+      state.targets = page.items;
+      state.freshness = page.freshness;
+      state.loaded = true;
+      state.error = null;
+      if (!state.targets.some((target) => target.target_id === state.targetId))
+        state.targetId = page.selected_target_id || state.targets[0]?.target_id || "";
+      const nextTargetFingerprint = selectedTarget()?.fingerprint || "";
+      state.targetFingerprint = nextTargetFingerprint;
+      if (state.targetId && (
+        state.targetId !== oldTargetId
+        || nextTargetFingerprint !== oldTargetFingerprint
+        || (!state.files.length && !state.commits.length)
+      )) {
+        await loadContent();
+      } else {
+        paint();
+      }
+    } catch (error) {
+      state.error = error;
+      state.loaded = true;
+      paint();
+    } finally {
+      state.loadingTargets = false;
+      paint();
+    }
+  };
+
+  const pollReview = async () => {
+    if (document.hidden || state.mode !== "diff" || state.pollInFlight) return;
+    state.pollInFlight = true;
+    try { await loadTargets({ polling: true }); }
+    finally { state.pollInFlight = false; }
+  };
+  const visibilityRefresh = () => {
+    if (!document.hidden && state.mode === "diff") pollReview();
+  };
+  document.addEventListener("visibilitychange", visibilityRefresh);
+
+  const setMode = (mode) => {
+    state.mode = mode;
+    if (mode === "diff") {
+      if (!state.loaded) loadTargets();
+      if (state.pollTimer === null)
+        state.pollTimer = setInterval(pollReview, CHAT_REVIEW_POLL_MS);
+      paint();
+    } else if (state.pollTimer !== null) {
+      clearInterval(state.pollTimer);
+      state.pollTimer = null;
+    }
+  };
+  const cleanup = () => {
+    state.requestGeneration += 1;
+    if (state.pollTimer !== null) clearInterval(state.pollTimer);
+    state.pollTimer = null;
+    document.removeEventListener("visibilitychange", visibilityRefresh);
+  };
+  chatReviewCleanup = cleanup;
+  return { setMode, cleanup };
 }
 
 async function chatRenderNew(host, shell, defaults, catalog) {
@@ -3805,12 +4579,30 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   const seen = new Set();
   let streamStatus = "connecting";
   let stopRequest = null;
+  let currentMode = CHAT_MODES.includes(chatRouteMode) ? chatRouteMode : "chat";
 
   const header = el("div", { className: "chat-pane-head" });
   const title = el("div", { className: "chat-pane-title" });
+  const modeSwitch = el("div", {
+    className: "chat-mode-switch",
+    role: "tablist",
+    ariaLabel: "Conversation mode",
+  });
+  const chatModeButton = el("button", {
+    type: "button",
+    role: "tab",
+    textContent: "Chat",
+  });
+  const diffModeButton = el("button", {
+    type: "button",
+    role: "tab",
+    textContent: "Diff",
+  });
+  modeSwitch.append(chatModeButton, diffModeButton);
   const queueState = el("span", { className: "chat-queue-state", hidden: true });
   const actions = el("div", { className: "chat-actions" });
   const transcriptHost = el("div", { className: "chat-transcript-host" });
+  const reviewHost = el("div", { className: "chat-review-host", hidden: true });
   const transcript = el("div", { className: "chat-transcript" });
   const jumpToLatest = el("button", {
     className: "chat-jump-latest",
@@ -3823,6 +4615,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   transcriptHost.append(transcript, jumpToLatest);
   let followTranscriptTail = true;
   const updateTranscriptFollow = () => {
+    if (currentMode !== "chat") return;
     followTranscriptTail = chatTranscriptAtBottom(transcript);
     jumpToLatest.hidden = followTranscriptTail;
   };
@@ -3843,9 +4636,17 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     textContent: "Stop",
     title: "Interrupt the active turn",
   });
+  const headerStop = el("button", {
+    className: "act danger chat-stop-header",
+    type: "button",
+    textContent: "Stop",
+    title: "Interrupt the active turn",
+    hidden: true,
+  });
   const pending = el("div", { className: "chat-pending", hidden: true });
   const composerRow = el("div", { className: "chat-composer" },
     composer, el("div", { className: "chat-compose-actions" }, pending, send, stop));
+  const reviewWorkspace = chatReviewWorkspace(reviewHost, conversation);
   const updateStreamStatus = () => {
     const connected = streamStatus === "connected";
     const connectionLabel = connected
@@ -3864,6 +4665,35 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     composer.focus();
     await submit();
   };
+  const setMode = (mode) => {
+    currentMode = CHAT_MODES.includes(mode) ? mode : "chat";
+    chatRouteMode = currentMode;
+    document.body.classList.toggle("chat-diff-view", currentMode === "diff");
+    transcriptHost.hidden = currentMode !== "chat";
+    composerRow.hidden = currentMode !== "chat";
+    reviewHost.hidden = currentMode !== "diff";
+    chatModeButton.classList.toggle("active", currentMode === "chat");
+    diffModeButton.classList.toggle("active", currentMode === "diff");
+    chatModeButton.setAttribute("aria-selected", String(currentMode === "chat"));
+    diffModeButton.setAttribute("aria-selected", String(currentMode === "diff"));
+    reviewWorkspace.setMode(currentMode);
+  };
+  const selectMode = (mode) => {
+    if (mode === currentMode) return;
+    history.pushState(
+      null,
+      "",
+      `#${chatModeHash(
+        conversation.shell.shortname,
+        conversation.conversation_id,
+        mode,
+      )}`,
+    );
+    setMode(mode);
+    paint();
+  };
+  chatModeButton.onclick = () => selectMode("chat");
+  diffModeButton.onclick = () => selectMode("diff");
   const renameConversation = async () => {
     const value = (prompt("Conversation title", conversation.title || "") || "").trim();
     if (!value) return;
@@ -3897,6 +4727,9 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     send.disabled = closed || closing;
     stop.disabled = conversation.state !== "running" || closing || Boolean(stopRequest);
     stop.textContent = stopRequest ? "Stopping…" : "Stop";
+    headerStop.disabled = stop.disabled;
+    headerStop.textContent = stop.textContent;
+    headerStop.hidden = currentMode !== "diff";
     close.disabled = closed || closing;
     close.textContent = closing ? "Closing…" : "Close";
     composer.placeholder = closed
@@ -3950,7 +4783,9 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     } catch (error) { toast(`${error.code}: ${error.message}`); refresh(); }
   };
   actions.append(analytics, close);
+  actions.insertBefore(headerStop, close);
   header.append(title, queueState, actions);
+  header.insertBefore(modeSwitch, queueState);
 
   async function submit() {
     const text = composer.value.trim();
@@ -4003,13 +4838,23 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
       paint();
     }
   };
+  headerStop.onclick = () => stop.click();
   composer.onkeydown = (event) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
       submit();
     }
   };
-  host.replaceChildren(header, transcriptHost, composerRow);
+  host.replaceChildren(header, transcriptHost, reviewHost, composerRow);
+  chatModeController = {
+    shell: conversation.shell.shortname,
+    conversationId: conversation.conversation_id,
+    setMode: (mode) => {
+      setMode(mode);
+      paint();
+    },
+  };
+  setMode(currentMode);
   paint();
   chatOpenStream(
     conversation.conversation_id,
@@ -4058,6 +4903,8 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
 async function renderInterface(root) {
   chatStopStream();
   chatStopHistoryPoll();
+  chatStopReview();
+  chatModeController = null;
   const generation = ++chatRenderGeneration;
   root.replaceChildren(el("div", { className: "chat-loading" }, "Loading conversations…"));
   const [{ shells: allShells }, defaults, catalog, allConversations] = await Promise.all([
@@ -4303,6 +5150,8 @@ function show(tab) {
   if (tab !== "interface") {
     chatStopStream();
     chatStopHistoryPoll();
+    chatStopReview();
+    chatModeController = null;
   }
   setDocumentTitle(tab);
   load(tab);
@@ -4317,9 +5166,20 @@ function show(tab) {
 function routeFromHash() {
   const raw = location.hash.slice(1);
   if (raw === "interface" || raw.startsWith("interface/")) {
-    const [, shell = "", conversation = ""] = raw.split("/");
+    const [, shell = "", conversation = "", requestedMode = ""] = raw.split("/");
+    const nextMode = requestedMode === "diff" ? "diff" : "chat";
     chatRouteShell = decodeURIComponent(shell);
     chatRouteConversation = decodeURIComponent(conversation);
+    const sameOpenConversation = Boolean(
+      chatModeController
+      && chatModeController.shell === chatRouteShell
+      && chatModeController.conversationId === chatRouteConversation
+    );
+    chatRouteMode = nextMode;
+    if (sameOpenConversation) {
+      chatModeController.setMode(nextMode);
+      return;
+    }
     show("interface");
     return;
   }
@@ -4344,6 +5204,7 @@ function routeFromHash() {
 }
 document.querySelectorAll("nav button").forEach((b) => (b.onclick = () => { location.hash = b.dataset.tab; }));
 window.addEventListener("hashchange", routeFromHash);
+window.addEventListener("popstate", routeFromHash);
 // Close any open popover menu on an outside click (one handler for all .gmenu).
 document.addEventListener("mousedown", (e) => {
   for (const m of document.querySelectorAll(".gmenu:not([hidden])"))

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -203,8 +203,8 @@ body.interface-view main {
 }
 .chat-pane-head {
   min-height: 67px; padding: .65rem 1rem; border-bottom: 1px solid var(--line);
-  display: grid; grid-template-columns: minmax(0, 1fr) auto auto;
-  align-items: center; gap: .8rem; background: var(--bg);
+  display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto;
+  align-items: center; gap: .8rem; background: var(--bg); position: relative;
 }
 .chat-pane-title h2 { margin: 0; font-size: .95rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .chat-conversation-line {
@@ -222,7 +222,29 @@ body.interface-view main {
 .chat-actions { display: flex; align-items: center; gap: .35rem; }
 .chat-actions .act { margin: 0; padding: .3rem .65rem; font-size: .72rem; }
 .chat-actions .danger { color: #ef7d86; }
+.chat-mode-switch, .review-scope-switch {
+  display: inline-flex; width: fit-content; border: 1px solid var(--line);
+  border-radius: 99px; overflow: hidden; background: var(--panel2);
+}
+.chat-pane-head > .chat-mode-switch {
+  position: absolute; left: 50%; transform: translateX(-50%);
+}
+.chat-mode-switch button, .review-scope-switch button {
+  border: 0; border-left: 1px solid var(--line); background: transparent;
+  color: var(--dim); cursor: pointer; font: inherit; font-size: .7rem;
+  padding: .3rem .72rem; white-space: nowrap;
+}
+.chat-mode-switch button:first-child, .review-scope-switch button:first-child {
+  border-left: 0;
+}
+.chat-mode-switch button:hover, .review-scope-switch button:hover { color: var(--ink); }
+.chat-mode-switch button.active, .review-scope-switch button.active {
+  color: #0b0e13; background: var(--accent); font-weight: 650;
+}
 .chat-transcript-host { position: relative; min-height: 0; overflow: hidden; }
+.chat-transcript-host[hidden], .chat-composer[hidden], .chat-review-host[hidden] {
+  display: none;
+}
 .chat-transcript {
   height: 100%; overflow-y: auto; padding: 1.2rem clamp(1rem, 4vw, 4rem);
   display: flex; flex-direction: column; gap: .8rem;
@@ -290,10 +312,197 @@ body.interface-view main {
 .chat-route-note { color: var(--dim); font-size: .72rem; margin-top: .3rem; }
 .chat-new-form .act { margin-top: 1rem; }
 
+/* ── Conversation Diff review workspace ─────────────────────────────────── */
+.chat-review-host {
+  grid-row: 2 / -1; min-width: 0; min-height: 0; overflow: hidden;
+  display: flex; flex-direction: column; background: var(--panel2);
+}
+.chat-review-host > .review-typed-state,
+.chat-review-host > .act {
+  margin: auto;
+}
+.review-workspace {
+  min-width: 0; min-height: 0; height: 100%; display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr); overflow: hidden;
+}
+.review-summary {
+  min-width: 0; padding: .7rem 1rem; border-bottom: 1px solid var(--line);
+  display: grid; grid-template-columns: minmax(220px, 1.3fr) auto minmax(130px, .7fr) auto;
+  align-items: end; gap: .8rem; background: var(--panel);
+}
+.review-summary .k {
+  display: block; margin: 0 0 .2rem; color: var(--dim); font-size: .63rem;
+  text-transform: uppercase; letter-spacing: .12em;
+}
+.review-target-control, .review-lifecycle-block, .review-freshness {
+  min-width: 0;
+}
+.review-target-select, .review-status-filter, .review-path-filter {
+  width: 100%; min-width: 0; background: var(--panel2); color: var(--ink);
+  border: 1px solid var(--line); border-radius: 7px; padding: .38rem .5rem;
+  font: inherit; font-size: .76rem;
+}
+.review-lifecycle-block { display: flex; flex-direction: column; gap: .18rem; }
+.review-lifecycle {
+  width: fit-content; border: 1px solid var(--line); border-radius: 99px;
+  padding: .08rem .45rem; color: var(--dim); font-size: .62rem;
+  font-weight: 700; letter-spacing: .08em; white-space: nowrap;
+}
+.review-lifecycle.lifecycle-pr_open { color: var(--accent); border-color: rgba(110,168,254,.45); }
+.review-lifecycle.lifecycle-checks_failed { color: #ef7d86; border-color: rgba(239,125,134,.45); }
+.review-lifecycle.lifecycle-pr_merged { color: var(--ok); border-color: rgba(76,175,125,.45); }
+.review-lifecycle.lifecycle-pr_closed { color: var(--dim); opacity: .72; }
+.review-facts, .review-freshness {
+  color: var(--dim); font-size: .66rem; overflow: hidden; text-overflow: ellipsis;
+}
+.review-freshness { display: flex; flex-direction: column; gap: .12rem; }
+.review-freshness .warning { color: var(--warn); }
+.review-refresh.act { margin: 0; padding: .34rem .7rem; font-size: .7rem; }
+.review-scope-switch { margin: .65rem auto; flex: none; }
+.review-scope-switch button { padding-inline: 1rem; }
+.review-body {
+  min-width: 0; min-height: 0; overflow: hidden; display: grid;
+  grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+  border-top: 1px solid var(--line);
+}
+.review-navigator {
+  min-width: 0; min-height: 0; overflow: hidden; display: flex;
+  flex-direction: column; border-right: 1px solid var(--line); background: var(--panel);
+}
+.review-filters {
+  flex: none; display: grid; grid-template-columns: minmax(0, 1fr) auto;
+  gap: .38rem; padding: .55rem; border-bottom: 1px solid var(--line);
+}
+.review-filters .review-status-filter { width: 104px; }
+.review-filter-toggle {
+  min-width: 0; background: transparent; color: var(--dim); border: 1px solid var(--line);
+  border-radius: 6px; padding: .25rem .38rem; cursor: pointer; font: inherit;
+  font-size: .63rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.review-filter-toggle:hover { color: var(--ink); }
+.review-filter-toggle.active { color: var(--accent); border-color: rgba(110,168,254,.5); }
+.review-file-tree { min-height: 0; overflow: auto; padding: .35rem 0 .7rem; }
+.review-tree-directory {
+  padding: .28rem .55rem .18rem calc(.55rem + var(--review-depth) * .8rem);
+  color: var(--dim); font: .68rem ui-monospace, monospace;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.review-tree-directory span { margin-right: .28rem; color: var(--lock); }
+.review-file-row {
+  width: 100%; min-width: 0; display: grid;
+  grid-template-columns: 1rem minmax(0, 1fr) auto; align-items: center; gap: .35rem;
+  padding: .35rem .55rem .35rem calc(.55rem + var(--review-depth) * .8rem);
+  border: 0; border-left: 2px solid transparent; background: transparent;
+  color: var(--dim); cursor: pointer; text-align: left; font: inherit;
+}
+.review-file-row:hover { color: var(--ink); background: var(--accent2); }
+.review-file-row.selected {
+  color: var(--ink); background: var(--panel2); border-left-color: var(--accent);
+}
+.review-file-row.viewed:not(.selected) { opacity: .58; }
+.review-file-status {
+  font: 700 .68rem ui-monospace, monospace; color: var(--warn); text-align: center;
+}
+.review-file-status.status-added, .review-file-status.status-untracked { color: var(--ok); }
+.review-file-status.status-deleted, .review-file-status.status-conflict { color: #ef7d86; }
+.review-file-path {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font: .72rem ui-monospace, monospace;
+}
+.review-file-counts { color: var(--dim); font: .61rem ui-monospace, monospace; white-space: nowrap; }
+.review-patch-pane {
+  min-width: 0; min-height: 0; overflow: hidden; display: flex; flex-direction: column;
+}
+.review-patch-head {
+  flex: none; min-width: 0; min-height: 40px; padding: .55rem .75rem;
+  display: flex; align-items: baseline; gap: .7rem; border-bottom: 1px solid var(--line);
+  background: var(--panel); overflow: hidden;
+}
+.review-patch-head strong {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font: .74rem ui-monospace, monospace;
+}
+.review-patch-head span {
+  color: var(--dim); font-size: .64rem; white-space: nowrap;
+}
+.review-file-steps { display: flex; gap: .25rem; margin-left: auto; }
+.review-file-step {
+  width: 1.65rem; height: 1.65rem; display: grid; place-items: center;
+  border: 1px solid var(--line); border-radius: 6px; background: transparent;
+  color: var(--dim); cursor: pointer; font: .76rem ui-monospace, monospace;
+}
+.review-file-step:hover:not(:disabled) { color: var(--ink); border-color: var(--accent); }
+.review-file-step:disabled { opacity: .3; cursor: default; }
+.review-patch-wrap { min-height: 0; overflow: auto; flex: 1; }
+.review-patch {
+  min-width: max-content; width: 100%; padding-bottom: .7rem;
+  font: 12px/1.55 ui-monospace, "SFMono-Regular", Consolas, monospace;
+}
+.review-line {
+  display: grid; grid-template-columns: 3.7rem 3.7rem minmax(max-content, 1fr);
+  min-height: 1.55em; white-space: pre;
+}
+.review-line-number {
+  padding: 0 .45rem; color: rgba(255,255,255,.28); text-align: right;
+  user-select: none; border-right: 1px solid var(--line-soft);
+}
+.review-line-code { padding: 0 .7rem; }
+.review-line-add { background: rgba(76,175,125,.12); }
+.review-line-add .review-line-code { color: #a9dfbd; }
+.review-line-delete { background: rgba(239,125,134,.10); }
+.review-line-delete .review-line-code { color: #f1afb4; }
+.review-line-hunk { color: #9ec2ff; background: rgba(110,168,254,.10); }
+.review-line-header { color: var(--dim); background: var(--panel); }
+.review-line-notice { color: var(--warn); }
+.review-typed-state {
+  min-width: 0; margin: 1rem; padding: .85rem; border: 1px dashed var(--line);
+  border-radius: 9px; color: var(--dim); display: flex; flex-direction: column;
+  gap: .18rem; font-size: .76rem;
+}
+.review-typed-state strong { color: var(--ink); font-size: .8rem; }
+.review-typed-state.error { border-color: rgba(239,125,134,.45); }
+.review-typed-state.error strong { color: #ef7d86; }
+.review-typed-state.warning { border-color: rgba(212,145,74,.45); }
+.review-typed-state.warning strong { color: var(--warn); }
+.review-commits-pane {
+  min-height: 0; overflow: auto; border-top: 1px solid var(--line);
+}
+.review-commit-list { max-width: 900px; margin: 0 auto; padding: .5rem 1rem 1rem; }
+.review-commit {
+  display: grid; grid-template-columns: 5.5rem minmax(0, 1fr); gap: .8rem;
+  padding: .65rem 0; border-bottom: 1px solid var(--line-soft);
+}
+.review-commit code { color: var(--accent); }
+.review-commit-main { min-width: 0; display: flex; flex-direction: column; }
+.review-commit-main strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.review-commit-main span { color: var(--dim); font-size: .68rem; }
+
 @media (max-width: 900px) {
   .chat-layout { grid-template-columns: 210px 210px minmax(0, 1fr); }
-  .chat-actions { flex-wrap: wrap; justify-content: flex-end; }
-  .chat-pane-head { align-items: start; }
+  body.chat-diff-view .chat-layout {
+    grid-template-columns: 210px minmax(0, 1fr);
+  }
+  body.chat-diff-view .chat-history { display: none; }
+  .chat-actions {
+    grid-column: 1 / -1; flex-wrap: wrap; justify-content: flex-start;
+  }
+  .chat-pane-head {
+    grid-template-columns: minmax(0, 1fr) auto; align-items: start;
+  }
+  .chat-pane-head > .chat-mode-switch {
+    position: static; grid-column: 1 / -1; grid-row: 2;
+    justify-self: center; transform: none;
+  }
+  .review-summary {
+    grid-template-columns: minmax(0, 1fr); align-items: stretch;
+  }
+  .review-refresh.act { justify-self: start; }
+  .review-body { grid-template-columns: minmax(0, 1fr); overflow-y: auto; }
+  .review-navigator {
+    max-height: 42%; min-height: 180px; border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .review-patch-pane { min-height: 420px; }
 }
 @media (max-width: 680px) {
   .chat-layout { grid-template-columns: 101px minmax(0, 1fr); }
@@ -302,6 +511,10 @@ body.interface-view main {
   .chat-shell .chat-state { display: none; }
   .chat-pane-head { grid-template-columns: minmax(0, 1fr) auto; }
   .chat-actions { grid-column: 1 / -1; justify-content: flex-start; }
+  .review-scope-switch { margin-inline: .6rem; }
+  .review-scope-switch button { flex: 1; padding-inline: .55rem; }
+  .review-filters { grid-template-columns: minmax(0, 1fr); }
+  .review-filters .review-status-filter { width: 100%; }
 }
 
 /* ── Tight card rhythm (Skill Assignments / Roadmap / Docs / Flags) ─────────

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -1,0 +1,513 @@
+"""Optional real-browser smoke for the conversation Diff workspace.
+
+The normal suite skips this module when Playwright is absent. The repository's
+visual-QA lane provisions Playwright 1.54.0, at which point this becomes an
+end-to-end DOM/runtime gate over the actual static UI and mocked read API.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright
+
+ROOT = Path(__file__).resolve().parents[1]
+UI = ROOT / ".super-coder" / "ui"
+CONVERSATION_ID = "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+TARGET_ID = "gt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+class QuietHandler(SimpleHTTPRequestHandler):
+    def log_message(self, _format: str, *_args) -> None:
+        pass
+
+
+@pytest.fixture
+def static_ui():
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", 0),
+        partial(QuietHandler, directory=str(UI)),
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def conversation() -> dict:
+    return {
+        "conversation_id": CONVERSATION_ID,
+        "state": "running",
+        "version": 4,
+        "created_at": "2026-07-30 20:00:00",
+        "title": "Diff workspace proof",
+        "starred": True,
+        "close_requested_at": None,
+        "route": {"harness": "codex", "model": "gpt-5.6"},
+        "shell": {
+            "shell_id": 1,
+            "display_name": "CC",
+            "shortname": "cc",
+        },
+    }
+
+
+def target_page() -> dict:
+    return {
+        "conversation_id": CONVERSATION_ID,
+        "selected_target_id": TARGET_ID,
+        "git_fingerprint": "git-fingerprint-1",
+        "freshness": {
+            "local": "fresh",
+            "remote": "fresh",
+            "remote_error": None,
+        },
+        "items": [
+            {
+                "target_id": TARGET_ID,
+                "kind": "workspace",
+                "branch": "feat/browser-diff-workspace",
+                "base_ref": "origin/main",
+                "head_sha": "a" * 40,
+                "pr_number": None,
+                "lifecycle": "local",
+                "title": None,
+                "url": None,
+                "fingerprint": "target-fingerprint-1",
+                "freshness": {
+                    "local": "fresh",
+                    "remote": "not_applicable",
+                },
+                "facts": {
+                    "checked_out": True,
+                    "dirty": True,
+                    "pushed": False,
+                    "ahead": 1,
+                    "behind": 3,
+                    "cleanup_pending": False,
+                },
+            },
+            {
+                "target_id": "gt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "kind": "pull_request",
+                "branch": "feat/previous-delivery",
+                "base_ref": "main",
+                "head_sha": "b" * 40,
+                "pr_number": 815,
+                "lifecycle": "pr_merged",
+                "title": "Previous merged delivery",
+                "url": "https://example.test/pull/815",
+                "fingerprint": "target-fingerprint-merged",
+                "freshness": {"local": "stored", "remote": "cached"},
+                "facts": {
+                    "checked_out": False,
+                    "dirty": False,
+                    "pushed": True,
+                    "ahead": 0,
+                    "behind": 40,
+                    "cleanup_pending": True,
+                },
+            },
+        ],
+    }
+
+
+def file_items() -> list[dict]:
+    common = {
+        "old_path": None,
+        "staged": False,
+        "unstaged": True,
+        "binary": False,
+        "conflict": False,
+        "generated": False,
+        "submodule": False,
+        "oversized": False,
+    }
+    return [
+        {
+            **common,
+            "file_id": "rf_1",
+            "path": "src/app.js",
+            "status": "modified",
+            "additions": 18,
+            "deletions": 4,
+        },
+        {
+            **common,
+            "file_id": "rf_2",
+            "path": "src/renamed.js",
+            "old_path": "src/old.js",
+            "status": "renamed",
+            "additions": 2,
+            "deletions": 2,
+            "staged": True,
+            "unstaged": False,
+        },
+        {
+            **common,
+            "file_id": "rf_3",
+            "path": "assets/logo.bin",
+            "status": "added",
+            "additions": None,
+            "deletions": None,
+            "binary": True,
+            "staged": True,
+            "unstaged": False,
+        },
+        {
+            **common,
+            "file_id": "rf_4",
+            "path": "notes/new.txt",
+            "status": "untracked",
+            "additions": 3,
+            "deletions": 0,
+        },
+        {
+            **common,
+            "file_id": "rf_5",
+            "path": "old/deleted.txt",
+            "status": "deleted",
+            "additions": 0,
+            "deletions": 8,
+        },
+        {
+            **common,
+            "file_id": "rf_6",
+            "path": "src/conflict.js",
+            "status": "conflict",
+            "additions": 4,
+            "deletions": 4,
+            "conflict": True,
+        },
+        {
+            **common,
+            "file_id": "rf_7",
+            "path": "large.txt",
+            "status": "modified",
+            "additions": None,
+            "deletions": None,
+            "oversized": True,
+        },
+    ]
+
+
+def test_diff_workspace_preserves_live_chat_and_uses_get_only(
+    static_ui,
+    tmp_path,
+):
+    requests: list[tuple[str, str, str]] = []
+    conditional_requests: list[str] = []
+    browser_errors: list[str] = []
+    remote_state = {"available": True}
+    current = conversation()
+    messages = [
+        {
+            "message_id": index,
+            "message_kind": "prompt",
+            "body": f"Review fixture message {index} " + ("context " * 12),
+            "state": "completed",
+        }
+        for index in range(1, 22)
+    ]
+    files = file_items()
+    patch = """diff --git a/src/app.js b/src/app.js
+index 1111111..2222222 100644
+--- a/src/app.js
++++ b/src/app.js
+@@ -1,3 +1,4 @@
+ const mode = 'chat';
+-const oldValue = false;
++const reviewOnly = true;
++const safe = document.createTextNode('patch');
+ export { mode };"""
+
+    def fulfill(route, payload, *, status=200, headers=None):
+        route.fulfill(
+            status=status,
+            content_type="application/json",
+            headers=headers or {},
+            body=json.dumps(payload),
+        )
+
+    def route_api(route):
+        request = route.request
+        parsed = urlparse(request.url)
+        query = parse_qs(parsed.query)
+        requests.append((request.method, parsed.path, parsed.query))
+        if request.headers.get("if-none-match"):
+            conditional_requests.append(parsed.path)
+        path = parsed.path
+        if path == "/api/health":
+            return fulfill(route, {"repo": "subfloor"})
+        if path == "/api/shells":
+            return fulfill(
+                route,
+                {
+                    "shells": [
+                        {
+                            "shell_id": 1,
+                            "display_name": "CC",
+                            "shortname": "cc",
+                            "flavor": "dev",
+                        }
+                    ]
+                },
+            )
+        if path == "/api/flavor-defaults":
+            return fulfill(
+                route,
+                {
+                    "flavors": {
+                        "dev": [
+                            {
+                                "harness": "codex",
+                                "model": "gpt-5.6",
+                                "is_default": True,
+                            }
+                        ]
+                    }
+                },
+            )
+        if path == "/api/models":
+            return fulfill(route, {"harnesses": {}})
+        if path == "/api/sprints":
+            return fulfill(route, {"items": []})
+        if path == "/api/conversations":
+            return fulfill(route, {"items": [current]})
+        if path == f"/api/conversations/{CONVERSATION_ID}":
+            return fulfill(route, current)
+        if path == f"/api/conversations/{CONVERSATION_ID}/messages":
+            return fulfill(route, {"items": messages})
+        if path == f"/api/conversations/{CONVERSATION_ID}/review-targets":
+            if (
+                request.headers.get("if-none-match") == '"targets-1"'
+                and "refresh" not in query
+            ):
+                return route.fulfill(
+                    status=304,
+                    headers={"ETag": '"targets-1"'},
+                    body="",
+                )
+            body = target_page()
+            if not remote_state["available"]:
+                body["freshness"] = {
+                    "local": "fresh",
+                    "remote": "unavailable",
+                    "remote_error": "fixture GitHub is offline",
+                }
+            return fulfill(
+                route,
+                body,
+                headers={"ETag": '"targets-1"'},
+            )
+        if path.endswith("/files") and "/api/review-targets/" in path:
+            scope = query.get("scope", ["review"])[0]
+            etag = f'"files-{scope}-1"'
+            if request.headers.get("if-none-match") == etag:
+                return route.fulfill(
+                    status=304,
+                    headers={"ETag": etag},
+                    body="",
+                )
+            return fulfill(
+                route,
+                {
+                    "target_id": TARGET_ID,
+                    "scope": scope,
+                    "items": files if scope == "review" else files[:2],
+                    "files_truncated": False,
+                    "fingerprint": f"files-{scope}-1",
+                    "freshness": "local",
+                    "next_cursor": None,
+                },
+                headers={"ETag": etag},
+            )
+        if path.endswith("/diff") and "/api/review-targets/" in path:
+            selected_path = query.get("path", [""])[0]
+            binary = selected_path.endswith(".bin")
+            oversized = selected_path == "large.txt"
+            return fulfill(
+                route,
+                {
+                    "target_id": TARGET_ID,
+                    "scope": query.get("scope", ["review"])[0],
+                    "path": selected_path,
+                    "patch": None if binary or oversized else patch,
+                    "sha256": "c" * 64,
+                    "truncated": False,
+                    "binary": binary,
+                    "unavailable_reason": "binary" if binary
+                    else "oversized" if oversized
+                    else None,
+                    "freshness": "local",
+                    "fingerprint": "files-review-1",
+                },
+            )
+        if path.endswith("/commits") and "/api/review-targets/" in path:
+            return fulfill(
+                route,
+                {
+                    "target_id": TARGET_ID,
+                    "items": [
+                        {
+                            "sha": "d" * 40,
+                            "short_sha": "ddddddd",
+                            "author": "CC",
+                            "authored_at": "2026-07-30T20:30:00Z",
+                            "subject": "Build the Diff workspace",
+                        }
+                    ],
+                    "commits_truncated": False,
+                    "fingerprint": "commits-1",
+                    "next_cursor": None,
+                },
+            )
+        return fulfill(
+            route,
+            {"error": {"code": "UNMOCKED", "message": path}},
+            status=404,
+        )
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        page = browser.new_page(viewport={"width": 1440, "height": 960})
+        page.add_init_script(
+            """
+            window.__fakeEventSources = [];
+            class FakeEventSource {
+              constructor(url) {
+                this.url = url;
+                this.listeners = {};
+                this.closed = false;
+                window.__fakeEventSources.push(this);
+                queueMicrotask(() => this.onopen && this.onopen());
+              }
+              addEventListener(type, callback) {
+                (this.listeners[type] ||= []).push(callback);
+              }
+              emit(type, payload) {
+                for (const callback of this.listeners[type] || [])
+                  callback({ data: JSON.stringify(payload) });
+              }
+              close() { this.closed = true; }
+            }
+            window.EventSource = FakeEventSource;
+            """
+        )
+        page.route("**/api/**", route_api)
+        page.on(
+            "pageerror",
+            lambda error: browser_errors.append(f"pageerror: {error}"),
+        )
+        page.on(
+            "console",
+            lambda message: browser_errors.append(f"console: {message.text}")
+            if message.type == "error"
+            else None,
+        )
+        page.goto(
+            f"{static_ui}/#interface/cc/{CONVERSATION_ID}",
+            wait_until="networkidle",
+        )
+        composer = page.locator(".chat-composer-input")
+        composer.fill("unsent draft survives mode changes")
+        transcript = page.locator(".chat-transcript")
+        page.wait_for_timeout(100)
+        transcript.evaluate(
+            "node => { node.scrollTop = 160; node.dispatchEvent(new Event('scroll')); }"
+        )
+        page.wait_for_timeout(100)
+        scroll_before = transcript.evaluate("node => node.scrollTop")
+        assert page.evaluate("window.__fakeEventSources.length") == 1
+
+        page.get_by_role("tab", name="Diff").click()
+        page.locator(".review-workspace").wait_for()
+        assert page.url.endswith(f"/{CONVERSATION_ID}/diff")
+        assert composer.input_value() == "unsent draft survives mode changes"
+        assert page.locator(".chat-stop-header").is_visible()
+        assert page.locator(".chat-stop-header").is_enabled()
+        assert page.get_by_text("LOCAL BRANCH", exact=True).is_visible()
+        assert page.get_by_text("7 files", exact=False).is_visible()
+        assert page.locator(".review-line-add").count() == 2
+        assert page.locator(".review-line-delete").count() == 1
+        assert page.locator(".status-conflict").count() == 1
+        page.get_by_title("assets/logo.bin").click()
+        page.get_by_text("Binary file", exact=True).wait_for()
+        page.get_by_title("large.txt").click()
+        page.get_by_text("Patch too large", exact=True).wait_for()
+        page.get_by_title("src/old.js → src/renamed.js").click()
+        page.get_by_text("renamed from src/old.js", exact=True).wait_for()
+        page.screenshot(path=tmp_path / "diff-desktop.png", full_page=True)
+
+        page.evaluate(
+            """
+            window.__fakeEventSources[0].emit('assistant.delta', {
+              sequence: 9001,
+              event_type: 'assistant.delta',
+              message_id: 1,
+              run_id: 77,
+              created_at: '2026-07-30T20:31:00Z',
+              payload: { text: 'background completion arrived' }
+            });
+            """
+        )
+        page.get_by_role("tab", name="Commits").click()
+        page.get_by_text("Build the Diff workspace", exact=True).wait_for()
+        page.get_by_role("tab", name="Local only").click()
+        page.locator(".review-file-row").first.wait_for()
+        page.get_by_role("button", name="Hide binary").click()
+        page.locator(".review-target-select").select_option(
+            "gt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        )
+        page.get_by_text("PR MERGED", exact=True).wait_for()
+        assert page.get_by_text("cleanup pending", exact=False).is_visible()
+        assert page.get_by_text("40 behind base", exact=False).is_visible()
+        page.locator(".review-target-select").select_option(TARGET_ID)
+        remote_state["available"] = False
+        page.get_by_role("button", name="Refresh remote").click()
+        page.get_by_text("Remote unavailable", exact=False).wait_for()
+
+        page.go_back()
+        transcript.wait_for()
+        page.wait_for_timeout(100)
+        assert composer.input_value() == "unsent draft survives mode changes"
+        assert page.get_by_text(
+            "background completion arrived",
+            exact=True,
+        ).is_visible()
+        assert abs(transcript.evaluate("node => node.scrollTop") - scroll_before) <= 1
+        assert page.evaluate("window.__fakeEventSources.length") == 1
+
+        page.go_forward()
+        page.locator(".review-workspace").wait_for()
+        page.set_viewport_size({"width": 760, "height": 900})
+        page.screenshot(path=tmp_path / "diff-mobile.png", full_page=True)
+
+        current["state"] = "closed"
+        page.reload(wait_until="networkidle")
+        page.locator(".review-workspace").wait_for()
+        assert page.get_by_role("button", name="Close").is_disabled()
+        assert page.get_by_text("LOCAL BRANCH", exact=True).is_visible()
+        browser.close()
+
+    review_requests = [
+        item for item in requests if "/review-targets" in item[1]
+    ]
+    assert review_requests
+    assert {method for method, _path, _query in review_requests} == {"GET"}
+    assert any(path.endswith("/files") for path in conditional_requests)
+    assert not browser_errors
+    assert (tmp_path / "diff-desktop.png").stat().st_size > 10_000
+    assert (tmp_path / "diff-mobile.png").stat().st_size > 10_000

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -1,0 +1,149 @@
+"""Browser Diff mode and read-only review workspace contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
+STYLE = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
+
+
+def diff_source() -> str:
+    return APP[
+        APP.index("const CHAT_REVIEW_POLL_MS"):
+        APP.index("async function renderInterface")
+    ]
+
+
+def test_diff_is_a_deep_linked_coequal_mode_without_rebuilding_chat():
+    source = diff_source()
+
+    assert "const CHAT_REVIEW_POLL_MS = 2000" in source
+    assert 'const CHAT_MODES = ["chat", "diff"]' in source
+    assert "function chatModeHash(" in source
+    assert 'mode === "diff" ? "/diff" : ""' in source
+    assert 'textContent: "Chat"' in source
+    assert 'textContent: "Diff"' in source
+    assert "history.pushState" in source
+    assert "transcriptHost.hidden = currentMode !== \"chat\"" in source
+    assert "composerRow.hidden = currentMode !== \"chat\"" in source
+    assert "reviewHost.hidden = currentMode !== \"diff\"" in source
+    mode_switch = source[
+        source.index("const selectMode ="):
+        source.index("chatModeButton.onclick", source.index("const selectMode ="))
+    ]
+    assert "chatRenderOpen(" not in mode_switch
+    assert "chatOpenStream(" not in mode_switch
+    assert "chatApi(" not in mode_switch
+
+
+def test_diff_keeps_truthful_header_controls_and_chat_state_alive():
+    source = diff_source()
+
+    assert 'className: "chat-mode-switch"' in source
+    assert 'ariaLabel: "Conversation mode"' in source
+    assert "actions.insertBefore(headerStop, close)" in source
+    assert "headerStop.hidden = currentMode !== \"diff\"" in source
+    assert "headerStop.onclick = () => stop.click()" in source
+    assert "stop.onclick = async () =>" in source
+    assert "chatOpenStream(" in source
+    assert "chatStopStream()" not in source[
+        source.index("const selectMode ="):
+        source.index("const paint =", source.index("const selectMode ="))
+    ]
+
+
+def test_review_client_is_get_only_and_uses_server_issued_identities():
+    source = diff_source()
+    client = source[
+        source.index("async function reviewApi"):
+        source.index("function reviewLifecycleLabel")
+    ]
+
+    assert 'method: "GET"' in client
+    assert '"If-None-Match"' in client
+    assert "response.status === 304" in client
+    assert "Cache-Control" not in client
+    for verb in ("POST", "PATCH", "PUT", "DELETE"):
+        assert f'"{verb}"' not in client
+    assert "/review-targets/${" in source
+    assert "encodeURIComponent(file.path)" in source
+    assert "cwd=" not in source
+    assert "ref=" not in source
+
+
+def test_workspace_has_targets_scopes_filters_tree_patch_and_commits():
+    source = diff_source()
+
+    for text in (
+        "Review changes",
+        "Local only",
+        "Commits",
+        "Filter paths",
+        "Hide viewed",
+        "Hide generated",
+        "Hide binary",
+        "Hide deleted",
+        "Refresh remote",
+        "No review targets yet.",
+        "No files match this scope and filter.",
+        "No commits in this change set.",
+    ):
+        assert text in source
+    for class_name in (
+        "review-summary",
+        "review-target-select",
+        "review-scope-switch",
+        "review-file-tree",
+        "review-file-row",
+        "review-patch",
+        "review-commit-list",
+        "review-typed-state",
+    ):
+        assert class_name in source
+    assert "function reviewPatchRows" in source
+    assert 'document.createTextNode' in APP
+    assert "innerHTML" not in source[source.index("function reviewPatchRows"):]
+
+
+def test_viewed_state_is_ephemeral_and_scoped_to_target_fingerprint():
+    source = diff_source()
+
+    assert "const chatReviewViewed = new Map()" in source
+    assert "function reviewViewedKey(targetId, fingerprint)" in source
+    assert "reviewViewedKey(state.targetId, state.fileFingerprint)" in source
+    assert "viewedFiles().add(file.path)" in source
+    assert "chatReviewViewed.get(key)" in source
+
+
+def test_local_polling_is_visible_single_flight_and_stops_in_chat():
+    source = diff_source()
+
+    assert "document.hidden || state.mode !== \"diff\" || state.pollInFlight" in source
+    assert "state.pollInFlight = true" in source
+    assert "finally { state.pollInFlight = false; }" in source
+    assert "setInterval(pollReview, CHAT_REVIEW_POLL_MS)" in source
+    assert "clearInterval(state.pollTimer)" in source
+    assert 'document.addEventListener("visibilitychange", visibilityRefresh)' in source
+    assert 'document.removeEventListener("visibilitychange", visibilityRefresh)' in source
+
+
+def test_diff_layout_is_full_width_bounded_and_responsive():
+    for selector in (
+        ".chat-review-host",
+        ".review-workspace",
+        ".review-summary",
+        ".review-body",
+        ".review-file-tree",
+        ".review-patch",
+        ".review-line",
+        ".review-line-add",
+        ".review-line-delete",
+        ".review-typed-state",
+    ):
+        assert selector in STYLE
+    assert "grid-template-columns: minmax(220px, 300px) minmax(0, 1fr)" in STYLE
+    assert "@media (max-width: 900px)" in STYLE
+    responsive = STYLE[STYLE.index("@media (max-width: 900px)"):]
+    assert "grid-template-columns: minmax(0, 1fr)" in responsive

--- a/tests/test_conversation_review_api.py
+++ b/tests/test_conversation_review_api.py
@@ -190,6 +190,43 @@ class ConversationReviewApiTest(unittest.TestCase):
         self.assertEqual(response_headers["Cache-Control"], "no-store")
         self.assertIsNone(response_body)
 
+    def test_dirty_current_workspace_is_recommended_before_its_open_pr(self) -> None:
+        workspace_target = self.target_id()
+        self.fixture.write("dirty.txt", "not committed\n")
+        FakeReader.pull_requests = [
+            PullRequest(
+                number=816,
+                head_ref="feature/review-api",
+                base_ref="main",
+                head_sha=self.head_sha,
+                state="OPEN",
+                merged_at=None,
+                merge_sha=None,
+                title="Review API",
+                url="https://example.test/pull/816",
+                review_decision=None,
+                checks="PENDING",
+                checks_failed=False,
+            )
+        ]
+        review_routes._REMOTE_ATTEMPTS.clear()
+
+        status, _headers, body = self.request(
+            f"/api/conversations/{self.conversation_id}/review-targets"
+            "?refresh=remote"
+        )
+
+        self.assertEqual(status, 200, body)
+        self.assertEqual(body["selected_target_id"], workspace_target)
+        self.assertEqual(
+            next(
+                item["kind"]
+                for item in body["items"]
+                if item["target_id"] == body["selected_target_id"]
+            ),
+            "workspace",
+        )
+
     def test_files_diff_and_commits_are_server_selected_and_bounded(self) -> None:
         target_id = self.target_id()
         status, headers, files = self.request(

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -117,9 +117,10 @@ def test_transcript_follow_pauses_for_reading_and_offers_jump_to_latest():
     ) in interface
     assert "const previousTop = transcript.scrollTop" in interface
     assert (
-        "transcript.scrollTop = shouldFollow() "
+        "transcript.scrollTop = followTail "
         "? transcript.scrollHeight : previousTop"
     ) in interface
+    assert "const followTail = shouldFollow()" in interface
     assert 'className: "chat-jump-latest"' in interface
     assert 'ariaLabel: "Jump to latest message"' in interface
     assert "transcript.onscroll = updateTranscriptFollow" in interface


### PR DESCRIPTION
Completes Feature #26 tasks #153-155.

- adds the coequal Chat and Diff mode shell without rebuilding Chat or reconnecting its stream
- builds target, lifecycle, review/local/commit, file tree, filters, viewed state, unified patch, polling, typed failures, and responsive review surfaces
- keeps review transport GET-only and restores draft, scroll, retry, Stop, Close, and streamed events across mode changes
- corrects dirty-workspace target priority ahead of open PR and fixes hidden-transcript scroll restoration
- adds static contracts plus an optional Playwright runtime gate covering desktop/mobile, binary/large/conflict/rename states, merged-behind cleanup, offline cache, closed history, ETags, and read-only requests

Verification:
- full suite: 1705 passed
- focused review/UI gate: 67 passed plus 2 subtests
- ruff and node syntax clean
- render-check passed
- exact SHA fresh-clone verify passed all 142 migrations and render-only boot