### PR TITLE
feat: bound browser chat history and rendering

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -18,6 +18,7 @@ import re
 import sys
 import time
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -41,6 +42,9 @@ _CONVERSATION_STATES = frozenset(
 _ID = re.compile(r"^cv_[0-9a-f]{32}$")
 _DETAIL_PATH = re.compile(r"^/api/conversations/(cv_[0-9a-f]{32})$")
 _MESSAGES_PATH = re.compile(r"^/api/conversations/(cv_[0-9a-f]{32})/messages$")
+_TRANSCRIPT_PATH = re.compile(
+    r"^/api/conversations/(cv_[0-9a-f]{32})/transcript$"
+)
 _EVENTS_PATH = re.compile(r"^/api/conversations/(cv_[0-9a-f]{32})/events$")
 _INTERRUPTIONS_PATH = re.compile(
     r"^/api/conversations/(cv_[0-9a-f]{32})/interruptions$"
@@ -69,6 +73,33 @@ _SENSITIVE_EVENT_KEYS = frozenset(
 )
 SSE_HEARTBEAT_SECONDS = 15.0
 SSE_BATCH = 200
+TRANSCRIPT_MAX_TURNS = 200
+TRANSCRIPT_MAX_SOURCE_EVENTS = 20_000
+TRANSCRIPT_MAX_SOURCE_BYTES = 8 * 1024 * 1024
+TRANSCRIPT_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+TRANSCRIPT_PROJECTION_VERSION = 1
+TRANSCRIPT_MAX_WARNINGS = 20
+TRANSCRIPT_MAX_ACTIVITY_LABEL_BYTES = 1024
+
+
+@dataclass(frozen=True)
+class TranscriptLimits:
+    max_turns: int = TRANSCRIPT_MAX_TURNS
+    max_source_events: int = TRANSCRIPT_MAX_SOURCE_EVENTS
+    max_source_bytes: int = TRANSCRIPT_MAX_SOURCE_BYTES
+    max_response_bytes: int = TRANSCRIPT_MAX_RESPONSE_BYTES
+
+    def __post_init__(self) -> None:
+        if min(
+            self.max_turns,
+            self.max_source_events,
+            self.max_source_bytes,
+            self.max_response_bytes,
+        ) <= 0:
+            raise ValueError("transcript limits must be positive")
+
+
+DEFAULT_TRANSCRIPT_LIMITS = TranscriptLimits()
 
 
 class ApiError(RuntimeError):
@@ -284,6 +315,19 @@ def _limit(query, *, default: int = 50, maximum: int = 200) -> int:
     return value
 
 
+def _strict_boolean(query, name: str) -> bool | None:
+    values = query.get(name)
+    if values is None:
+        return None
+    if len(values) != 1 or values[0] not in ("true", "false"):
+        raise ApiError(
+            422,
+            "VALIDATION_ERROR",
+            f"{name} must be exactly one lowercase true or false value",
+        )
+    return values[0] == "true"
+
+
 def _append_event(
     con,
     conversation_id: str,
@@ -320,13 +364,22 @@ def _conversation_row(con, conversation_id: str, owner_user_id: int):
     return con.execute(
         "SELECT c.conversation_id,c.shell_id,c.mode,c.owner_user_id,c.harness,"
         "c.provider,c.model,c.effort,c.state,c.title,c.starred,c.created_at,"
-        "c.last_activity_at,c.closed_at,c.version,s.display_name,s.shortname,"
+        "c.last_activity_at,c.closed_at,c.version,c.harness_session_ref,"
+        "s.display_name,s.shortname,"
         "CASE WHEN c.state!='closed' THEN ("
         " SELECT requested.created_at FROM conversation_events requested "
         " WHERE requested.conversation_id=c.conversation_id "
         " AND requested.event_type='conversation.close.requested' "
         " ORDER BY requested.sequence DESC LIMIT 1"
-        ") END AS close_requested_at "
+        ") END AS close_requested_at,"
+        "(SELECT COUNT(*) FROM conversation_messages queued "
+        " WHERE queued.conversation_id=c.conversation_id "
+        " AND queued.message_kind!='control' "
+        " AND queued.state IN ('accepted','queued')) AS queued_count,"
+        "(SELECT active.run_id FROM conversation_runs active "
+        " WHERE active.conversation_id=c.conversation_id "
+        " AND active.state IN ('leased','starting','running') "
+        " ORDER BY active.run_id DESC LIMIT 1) AS active_run_id "
         "FROM conversations c JOIN shells s ON s.shell_id=c.shell_id "
         "WHERE c.conversation_id=? AND c.mode='normal' AND c.owner_user_id=?",
         (conversation_id, owner_user_id),
@@ -790,15 +843,31 @@ def _list_conversations(con, operator: dict, query):
     clauses = ["c.mode='normal'", "c.owner_user_id=?"]
     params: list = [operator["user_id"]]
     shell = query.get("shell_id", [None])[0]
+    shell_id = None
     if shell not in (None, ""):
+        shell_id = _integer(shell, "shell_id")
         clauses.append("c.shell_id=?")
-        params.append(_integer(shell, "shell_id"))
+        params.append(shell_id)
     state = query.get("state", [None])[0]
     if state:
         if state not in _CONVERSATION_STATES:
             raise ApiError(422, "VALIDATION_ERROR", "invalid conversation state")
         clauses.append("c.state=?")
         params.append(state)
+    starred = _strict_boolean(query, "starred")
+    if starred is not None:
+        clauses.append("c.starred=?")
+        params.append(int(starred))
+    open_only = _strict_boolean(query, "open")
+    if open_only is not None:
+        compatible = state != "closed" if open_only else state in (None, "closed")
+        if state is not None and not compatible:
+            raise ApiError(
+                422,
+                "VALIDATION_ERROR",
+                "open and state filters cannot both be true",
+            )
+        clauses.append("c.state!='closed'" if open_only else "c.state='closed'")
     mode = query.get("mode", [None])[0]
     if mode and mode != "normal":
         raise ApiError(
@@ -806,6 +875,14 @@ def _list_conversations(con, operator: dict, query):
             "VALIDATION_ERROR",
             "this endpoint exposes normal conversations only",
         )
+    scope = {
+        "owner_user_id": int(operator["user_id"]),
+        "shell_id": shell_id,
+        "starred": starred,
+        "open": open_only,
+        "state": state or None,
+        "mode": "normal",
+    }
     cursor = query.get("cursor", [None])[0]
     if cursor:
         decoded = _cursor_decode(cursor, "conversation")
@@ -813,6 +890,12 @@ def _list_conversations(con, operator: dict, query):
             str(decoded.get("id", ""))
         ):
             raise ApiError(422, "CURSOR_INVALID", "invalid conversation cursor")
+        if decoded.get("scope") != scope:
+            raise ApiError(
+                422,
+                "CURSOR_INVALID",
+                "conversation cursor does not match the requested filter scope",
+            )
         clauses.append(
             "(c.last_activity_at<? OR (c.last_activity_at=? AND c.conversation_id<?))"
         )
@@ -837,7 +920,12 @@ def _list_conversations(con, operator: dict, query):
     if len(rows) > limit:
         last = page[-1]
         next_cursor = _cursor_encode(
-            {"v": 1, "a": last["last_activity_at"], "id": last["conversation_id"]}
+            {
+                "v": 1,
+                "a": last["last_activity_at"],
+                "id": last["conversation_id"],
+                "scope": scope,
+            }
         )
     return _json(
         200,
@@ -1238,6 +1326,502 @@ def _interrupt(con, operator: dict, conversation_id: str, headers, body: dict):
     )
 
 
+def _utf8_prefix(value: str, maximum: int) -> str:
+    raw = value.encode()
+    if len(raw) <= maximum:
+        return value
+    return raw[:maximum].decode("utf-8", errors="ignore")
+
+
+def _transcript_activity_label(event_type: str, payload: dict) -> str:
+    if event_type == "permission.requested":
+        label = "Waiting for permission"
+    elif event_type == "input.requested":
+        label = "Waiting for input"
+    elif event_type == "run.interrupted":
+        label = "Turn interrupted"
+    elif event_type == "run.unknown":
+        label = "Turn outcome could not be proven"
+    else:
+        detail = payload.get("error") or payload.get("detail")
+        label = f"Turn failed — {detail}" if detail else "Turn failed"
+    return _utf8_prefix(label, TRANSCRIPT_MAX_ACTIVITY_LABEL_BYTES)
+
+
+def _transcript_size(projection: dict) -> int:
+    return len(
+        json.dumps(
+            projection,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode()
+    )
+
+
+def _transcript_truncation(
+    *,
+    reason: str,
+    omitted_message_count: int,
+    omitted_source_event_count: int,
+    omitted_through_sequence: int,
+    retained_from_sequence: int,
+) -> dict:
+    return {
+        "reason": reason,
+        "omitted_message_count": max(0, int(omitted_message_count)),
+        "omitted_source_event_count": max(
+            0, int(omitted_source_event_count)
+        ),
+        "omitted_through_sequence": max(0, int(omitted_through_sequence)),
+        "retained_from_sequence": max(0, int(retained_from_sequence)),
+    }
+
+
+def _bound_transcript_response(
+    projection: dict,
+    *,
+    limits: TranscriptLimits,
+    total_messages: int,
+    total_events: int,
+) -> None:
+    if _transcript_size(projection) <= limits.max_response_bytes:
+        return
+
+    items = projection["items"]
+    projection["truncation"] = _transcript_truncation(
+        reason="response_byte_limit",
+        omitted_message_count=max(
+            0,
+            total_messages
+            - len({item["message_id"] for item in items if item["kind"] == "user"}),
+        ),
+        omitted_source_event_count=0,
+        omitted_through_sequence=0,
+        retained_from_sequence=min(
+            (int(item["order_sequence"]) for item in items),
+            default=projection["through_sequence"],
+        ),
+    )
+
+    def group_key(item: dict) -> tuple[str, int | str]:
+        message_id = item.get("message_id")
+        return (
+            ("message", int(message_id))
+            if message_id is not None
+            else ("item", item["item_id"])
+        )
+
+    while _transcript_size(projection) > limits.max_response_bytes:
+        keys = []
+        for item in items:
+            key = group_key(item)
+            if key not in keys:
+                keys.append(key)
+        if len(keys) <= 1:
+            break
+        removed = keys[0]
+        items[:] = [item for item in items if group_key(item) != removed]
+
+    retained_from = min(
+        (int(item["order_sequence"]) for item in items),
+        default=projection["through_sequence"],
+    )
+    omitted_events = min(
+        total_events,
+        max(0, retained_from - 1),
+    )
+    retained_users = {
+        item["message_id"] for item in items if item["kind"] == "user"
+    }
+    projection["truncation"] = _transcript_truncation(
+        reason="response_byte_limit",
+        omitted_message_count=max(0, total_messages - len(retained_users)),
+        omitted_source_event_count=min(total_events, omitted_events),
+        omitted_through_sequence=max(0, retained_from - 1),
+        retained_from_sequence=retained_from,
+    )
+
+    for item in sorted(
+        items,
+        key=lambda candidate: len(str(candidate.get("text", "")).encode()),
+        reverse=True,
+    ):
+        if _transcript_size(projection) <= limits.max_response_bytes:
+            break
+        text = item.get("text")
+        if not isinstance(text, str) or not text:
+            continue
+        low = 0
+        high = len(text.encode())
+        while low < high:
+            middle = (low + high + 1) // 2
+            candidate = _utf8_prefix(text, middle)
+            item["text"] = candidate
+            item["text_truncated"] = True
+            if _transcript_size(projection) <= limits.max_response_bytes:
+                low = middle
+            else:
+                high = middle - 1
+        item["text"] = _utf8_prefix(text, low)
+        item["text_truncated"] = True
+
+    if _transcript_size(projection) > limits.max_response_bytes:
+        raise ApiError(
+            503,
+            "TRANSCRIPT_PROJECTION_UNAVAILABLE",
+            "the transcript control envelope exceeds its response limit",
+        )
+
+
+def _transcript_projection(
+    con,
+    conversation_id: str,
+    *,
+    owner_user_id: int,
+    limits: TranscriptLimits = DEFAULT_TRANSCRIPT_LIMITS,
+) -> dict:
+    if con.in_transaction:
+        raise RuntimeError("transcript projection requires a fresh read view")
+
+    con.execute("BEGIN")
+    try:
+        conversation = _require_conversation(
+            con,
+            conversation_id,
+            owner_user_id,
+        )
+        through_sequence = int(
+            con.execute(
+                "SELECT COALESCE(MAX(sequence),0) FROM conversation_events "
+                "WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0]
+        )
+        message_rows = con.execute(
+            "WITH ranked AS ("
+            " SELECT message_id,body,state,created_at,completed_at,"
+            "ROW_NUMBER() OVER (ORDER BY message_id DESC) AS source_rank,"
+            "COUNT(*) OVER() AS total_messages,"
+            "SUM(length(CAST(body AS BLOB))) OVER ("
+            " ORDER BY message_id DESC ROWS UNBOUNDED PRECEDING"
+            ") AS message_source_bytes "
+            " FROM conversation_messages "
+            " WHERE conversation_id=? AND message_kind='prompt'"
+            ") SELECT * FROM ranked WHERE source_rank<=? "
+            "AND (message_source_bytes<=? OR source_rank=1) "
+            "ORDER BY message_id",
+            (
+                conversation_id,
+                limits.max_turns,
+                limits.max_source_bytes,
+            ),
+        ).fetchall()
+        total_messages = (
+            int(message_rows[0]["total_messages"]) if message_rows else 0
+        )
+        message_source_bytes = max(
+            (int(row["message_source_bytes"]) for row in message_rows),
+            default=0,
+        )
+        remaining_source_bytes = max(
+            1,
+            limits.max_source_bytes - message_source_bytes,
+        )
+        message_ids = [int(row["message_id"]) for row in message_rows]
+        marks = ",".join("?" for _ in message_ids)
+        run_where = (
+            f"r.trigger_message_id IN ({marks})"
+            if marks
+            else "0"
+        )
+        active_run_id = conversation["active_run_id"]
+        run_rows = con.execute(
+            "SELECT r.run_id,r.trigger_message_id,r.state,"
+            "r.started_at,r.ended_at,r.error_code,r.error_detail,"
+            "r.harness_session_before,r.harness_session_after,r.runner_ref,"
+            "(SELECT COUNT(*) FROM conversation_events delta_count "
+            " WHERE delta_count.run_id=r.run_id "
+            " AND delta_count.event_type='assistant.delta' "
+            " AND delta_count.sequence<=?) AS assistant_delta_count "
+            "FROM conversation_runs r WHERE r.conversation_id=? AND ("
+            + run_where
+            + (" OR r.run_id=?" if active_run_id is not None else "")
+            + ") ORDER BY r.run_id",
+            (
+                through_sequence,
+                conversation_id,
+                *message_ids,
+                *((int(active_run_id),) if active_run_id is not None else ()),
+            ),
+        ).fetchall()
+        event_rows = con.execute(
+            "WITH ranked AS ("
+            " SELECT sequence,event_type,payload_version,payload,message_id,"
+            "run_id,created_at,"
+            "ROW_NUMBER() OVER (ORDER BY sequence DESC) AS source_rank,"
+            "COUNT(*) OVER () AS total_events,"
+            "SUM(length(CAST(payload AS BLOB))) OVER ("
+            " ORDER BY sequence DESC ROWS UNBOUNDED PRECEDING"
+            ") AS source_bytes,"
+            "COUNT(*) OVER ("
+            " ORDER BY sequence ROWS BETWEEN UNBOUNDED PRECEDING "
+            " AND 1 PRECEDING"
+            ") AS older_count,"
+            "LAG(sequence) OVER (ORDER BY sequence) AS prior_sequence "
+            " FROM conversation_events "
+            " WHERE conversation_id=? AND sequence<=?"
+            ") SELECT * FROM ranked "
+            "WHERE source_rank<=? "
+            "AND (source_bytes<=? OR source_rank=1) "
+            "ORDER BY sequence",
+            (
+                conversation_id,
+                through_sequence,
+                limits.max_source_events,
+                remaining_source_bytes,
+            ),
+        ).fetchall()
+
+        total_events = (
+            int(event_rows[0]["total_events"]) if event_rows else 0
+        )
+        secrets = tuple(sorted({
+            value
+            for value in (
+                conversation["harness_session_ref"],
+                *(
+                    candidate
+                    for row in run_rows
+                    for candidate in (
+                        row["harness_session_before"],
+                        row["harness_session_after"],
+                        row["runner_ref"],
+                    )
+                ),
+            )
+            if isinstance(value, str) and value
+        }, key=len, reverse=True))
+
+        warnings = []
+        events = []
+        for row in event_rows:
+            sequence = int(row["sequence"])
+            if int(row["payload_version"]) != 1:
+                if len(warnings) < TRANSCRIPT_MAX_WARNINGS:
+                    warnings.append({
+                        "sequence": sequence,
+                        "code": "UNSUPPORTED_PAYLOAD_VERSION",
+                    })
+                continue
+            try:
+                payload = json.loads(row["payload"])
+            except (TypeError, ValueError):
+                payload = None
+            if not isinstance(payload, dict):
+                if len(warnings) < TRANSCRIPT_MAX_WARNINGS:
+                    warnings.append({
+                        "sequence": sequence,
+                        "code": "MALFORMED_EVENT_PAYLOAD",
+                    })
+                continue
+            if (
+                row["event_type"] == "assistant.delta"
+                and not isinstance(payload.get("text"), str)
+            ):
+                if len(warnings) < TRANSCRIPT_MAX_WARNINGS:
+                    warnings.append({
+                        "sequence": sequence,
+                        "code": "MALFORMED_EVENT_PAYLOAD",
+                    })
+                continue
+            events.append({
+                "sequence": sequence,
+                "event_type": row["event_type"],
+                "payload": _redact_event_value(payload, secrets),
+                "message_id": row["message_id"],
+                "run_id": row["run_id"],
+                "created_at": row["created_at"],
+            })
+
+        accepted_sequence = {
+            int(event["message_id"]): event["sequence"]
+            for event in events
+            if event["event_type"] == "message.accepted"
+            and event["message_id"] is not None
+        }
+        deltas_by_run: dict[int, list[dict]] = {}
+        activities = []
+        activity_types = {
+            "permission.requested",
+            "input.requested",
+            "run.failed",
+            "run.interrupted",
+            "run.unknown",
+        }
+        for event in events:
+            if event["event_type"] == "assistant.delta" and event["run_id"] is not None:
+                deltas_by_run.setdefault(int(event["run_id"]), []).append(event)
+            elif event["event_type"] in activity_types:
+                activities.append(event)
+
+        run_by_message: dict[int, list] = {}
+        for row in run_rows:
+            run_by_message.setdefault(
+                int(row["trigger_message_id"]),
+                [],
+            ).append(row)
+
+        items = []
+        retained_messages = set()
+        for message in message_rows:
+            message_id = int(message["message_id"])
+            order_sequence = accepted_sequence.get(message_id)
+            message_runs = run_by_message.get(message_id, [])
+            loaded_complete = all(
+                len(deltas_by_run.get(int(run["run_id"]), []))
+                == int(run["assistant_delta_count"])
+                for run in message_runs
+            )
+            non_terminal = any(
+                run["state"] in ("leased", "starting", "running")
+                for run in message_runs
+            )
+            if order_sequence is None or (not loaded_complete and not non_terminal):
+                continue
+            retained_messages.add(message_id)
+            items.append({
+                "item_id": f"message:{message_id}",
+                "kind": "user",
+                "order_sequence": order_sequence,
+                "message_id": message_id,
+                "run_id": None,
+                "created_at": message["created_at"],
+                "text": message["body"],
+                "state": message["state"],
+                "completed_at": message["completed_at"],
+                "text_truncated": False,
+            })
+            for run in message_runs:
+                run_id = int(run["run_id"])
+                deltas = deltas_by_run.get(run_id, [])
+                if not deltas:
+                    continue
+                items.append({
+                    "item_id": f"run:{run_id}:assistant",
+                    "kind": "assistant",
+                    "order_sequence": deltas[0]["sequence"],
+                    "message_id": message_id,
+                    "run_id": run_id,
+                    "created_at": deltas[0]["created_at"],
+                    "text": "".join(delta["payload"]["text"] for delta in deltas),
+                    "outcome": run["state"],
+                    "first_sequence": deltas[0]["sequence"],
+                    "last_sequence": deltas[-1]["sequence"],
+                    "text_truncated": False,
+                })
+
+        for event in activities:
+            message_id = (
+                int(event["message_id"])
+                if event["message_id"] is not None
+                else None
+            )
+            if message_id is not None and message_id not in retained_messages:
+                continue
+            items.append({
+                "item_id": f"event:{event['sequence']}",
+                "kind": "activity",
+                "order_sequence": event["sequence"],
+                "message_id": message_id,
+                "run_id": (
+                    int(event["run_id"])
+                    if event["run_id"] is not None
+                    else None
+                ),
+                "created_at": event["created_at"],
+                "activity_type": event["event_type"],
+                "label": _transcript_activity_label(
+                    event["event_type"],
+                    event["payload"],
+                ),
+                "sequence": event["sequence"],
+            })
+        items.sort(key=lambda item: (item["order_sequence"], item["item_id"]))
+
+        message_source_limited = (
+            len(message_rows) < min(total_messages, limits.max_turns)
+        )
+        source_reason = "source_byte_limit" if message_source_limited else None
+        if len(event_rows) < total_events:
+            if len(event_rows) < min(total_events, limits.max_source_events):
+                source_reason = "source_byte_limit"
+            elif source_reason is None:
+                source_reason = "source_event_limit"
+        turn_limited = total_messages > len(message_rows)
+        reason = source_reason or ("turn_limit" if turn_limited else None)
+        retained_from = min(
+            (int(item["order_sequence"]) for item in items),
+            default=through_sequence,
+        )
+        earliest_source = event_rows[0] if event_rows else None
+        omitted_rows = [
+            row for row in event_rows
+            if int(row["sequence"]) < retained_from
+        ]
+        source_omitted = 0
+        omitted_through = 0
+        if earliest_source is not None and reason:
+            source_omitted = (
+                int(earliest_source["older_count"]) + len(omitted_rows)
+            )
+            omitted_through = max(
+                int(earliest_source["prior_sequence"] or 0),
+                max(
+                    (int(row["sequence"]) for row in omitted_rows),
+                    default=0,
+                ),
+            )
+        projection = {
+            "conversation_id": conversation_id,
+            "projection_version": TRANSCRIPT_PROJECTION_VERSION,
+            "through_sequence": through_sequence,
+            "controls": {
+                "conversation_version": int(conversation["version"]),
+                "conversation_state": conversation["state"],
+                "queued_count": int(conversation["queued_count"]),
+                "active_run_id": (
+                    int(active_run_id) if active_run_id is not None else None
+                ),
+                "close_requested_at": conversation["close_requested_at"],
+            },
+            "items": items,
+            "truncation": (
+                _transcript_truncation(
+                    reason=reason,
+                    omitted_message_count=max(
+                        0, total_messages - len(retained_messages)
+                    ),
+                    omitted_source_event_count=source_omitted,
+                    omitted_through_sequence=omitted_through,
+                    retained_from_sequence=retained_from,
+                )
+                if reason
+                else None
+            ),
+        }
+        if warnings:
+            projection["warnings"] = warnings
+        _bound_transcript_response(
+            projection,
+            limits=limits,
+            total_messages=total_messages,
+            total_events=total_events,
+        )
+        return projection
+    finally:
+        con.rollback()
+
+
 def handle(method: str, path: str, headers_raw: str, raw_body: bytes) -> tuple:
     headers = _parse_headers(headers_raw)
     if not _host_ok(headers):
@@ -1247,7 +1831,7 @@ def handle(method: str, path: str, headers_raw: str, raw_body: bytes) -> tuple:
             "conversation API serves 127.0.0.1/localhost only",
         )
     parsed = urlparse(path)
-    query = parse_qs(parsed.query)
+    query = parse_qs(parsed.query, keep_blank_values=True)
     con = _db()
     try:
         try:
@@ -1287,6 +1871,16 @@ def handle(method: str, path: str, headers_raw: str, raw_body: bytes) -> tuple:
                     return _create_message(
                         con, operator, conversation_id, headers, body
                     )
+            transcript = _TRANSCRIPT_PATH.fullmatch(parsed.path)
+            if transcript and method == "GET":
+                return _json(
+                    200,
+                    _transcript_projection(
+                        con,
+                        transcript.group(1),
+                        owner_user_id=operator["user_id"],
+                    ),
+                )
             interruptions = _INTERRUPTIONS_PATH.fullmatch(parsed.path)
             if interruptions and method == "POST":
                 return _interrupt(con, operator, interruptions.group(1), headers, body)
@@ -1390,22 +1984,21 @@ def _after_sequence(query, headers) -> int:
     cursor = query.get("cursor", [None])[0]
     last_event = headers.get("Last-Event-ID")
     raw_after = query.get("after", [None])[0]
-    supplied = sum(value not in (None, "") for value in (cursor, last_event, raw_after))
-    if supplied > 1:
+    if cursor not in (None, "") and raw_after not in (None, ""):
         raise ApiError(
             422,
             "CURSOR_INVALID",
-            "supply only one of cursor, after, or Last-Event-ID",
+            "cursor and after are mutually exclusive",
         )
     if cursor:
         decoded = _cursor_decode(cursor, "event")
         after = _integer(decoded.get("sequence"), "event sequence")
-    elif last_event:
-        after = _integer(last_event, "Last-Event-ID")
     elif raw_after:
         after = _integer(raw_after, "after")
     else:
         after = 0
+    if last_event not in (None, ""):
+        after = max(after, _integer(last_event, "Last-Event-ID"))
     if after < 0:
         raise ApiError(422, "CURSOR_INVALID", "event sequence cannot be negative")
     return after
@@ -1414,6 +2007,7 @@ def _after_sequence(query, headers) -> int:
 def _event_batch(conversation_id: str, after: int) -> list[dict]:
     con = _db()
     try:
+        con.execute("BEGIN")
         secret_values = [
             row[0]
             for row in con.execute(
@@ -1439,6 +2033,8 @@ def _event_batch(conversation_id: str, after: int) -> list[dict]:
         ).fetchall()
         return [_event_projection(row, secrets) for row in rows]
     finally:
+        if con.in_transaction:
+            con.rollback()
         con.close()
 
 

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3385,7 +3385,26 @@ let chatRenderGeneration = 0;
 let chatPendingSend = null;
 let chatModeController = null;
 let chatReviewCleanup = null;
+let chatConfiguration = null;
+let chatConfigurationPromise = null;
 const chatReviewViewed = new Map();
+
+function chatLoadConfiguration() {
+  if (chatConfiguration) return Promise.resolve(chatConfiguration);
+  if (chatConfigurationPromise) return chatConfigurationPromise;
+  const request = Promise.all([
+    api("/flavor-defaults"),
+    api("/models"),
+  ]).then(([defaults, catalog]) => {
+    chatConfiguration = { defaults, catalog };
+    return chatConfiguration;
+  });
+  chatConfigurationPromise = request;
+  request.catch(() => {
+    if (chatConfigurationPromise === request) chatConfigurationPromise = null;
+  });
+  return request;
+}
 
 function chatStopStream() {
   if (chatSource) chatSource.close();
@@ -3545,132 +3564,23 @@ async function chatCloseForSwitch(conversation) {
   }
 }
 
-function chatActivity(events) {
-  return events.filter((event) => [
-    "permission.requested",
-    "input.requested",
-    "run.failed",
-    "run.interrupted",
-    "run.unknown",
-  ].includes(event.event_type));
-}
-
-function chatAssistantRuns(events) {
-  const runs = [];
-  const byId = new Map();
-  for (const event of events) {
-    if (event.event_type !== "assistant.delta") continue;
-    const id = event.run_id || `message-${event.message_id || "unknown"}`;
-    let run = byId.get(id);
-    if (!run) {
-      run = {
-        id,
-        text: "",
-        created_at: event.created_at,
-        message_id: event.message_id,
-        sequence: event.sequence,
-      };
-      byId.set(id, run);
-      runs.push(run);
-    }
-    run.text += event.payload?.text || "";
-  }
-  return runs;
-}
-
 function chatBubble(kind, body, meta = "", conversation = null) {
   const bubble = el("article", { className: `chat-bubble chat-${kind}` });
   bubble.append(el("div", { className: "chat-who" },
     kind === "user" ? "You"
       : kind === "assistant" ? chatShellLabel(conversation)
       : "Activity"));
-  bubble.append(kind === "activity"
+  const content = kind === "activity"
     ? el("div", { className: "chat-activity-text" }, body)
-    : mdBlock(body));
+    : mdBlock(body);
+  if (kind === "assistant") content.classList.add("chat-assistant-body");
+  bubble.append(content);
   if (meta) bubble.append(el("div", { className: "chat-meta" }, meta));
   return bubble;
 }
 
 function chatTranscriptAtBottom(transcript) {
   return transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight <= 32;
-}
-
-function chatPaintTranscript(
-  transcript, messages, events, conversation, retry, shouldFollow, onPosition,
-) {
-  const previousTop = transcript.scrollTop;
-  const followTail = shouldFollow();
-  const assistants = chatAssistantRuns(events);
-  const activities = chatActivity(events);
-  const items = [];
-  const addActivity = (activity) => {
-    const payload = activity.payload || {};
-    const type = activity.event_type;
-    const label = type === "permission.requested" ? "Waiting for permission"
-      : type === "input.requested" ? "Waiting for input"
-      : type === "run.interrupted" ? "Turn interrupted"
-      : type === "run.unknown" ? "Turn outcome could not be proven"
-      : `Turn failed${payload.error ? ` — ${payload.error}` : ""}`;
-    items.push({
-      node: chatBubble("activity", label),
-      failed: false,
-    });
-  };
-  for (const message of [...messages].sort((a, b) => a.message_id - b.message_id)) {
-    if (message.message_kind === "control") continue;
-    items.push({
-      node: chatBubble("user", message.body, message.state),
-      failed: message.state === "failed",
-      text: message.body,
-    });
-    for (const run of assistants.filter((item) => item.message_id === message.message_id))
-      items.push({
-        node: chatBubble("assistant", run.text, "", conversation),
-        failed: false,
-      });
-    for (const activity of activities.filter(
-      (item) => item.message_id === message.message_id))
-      addActivity(activity);
-  }
-  // Conversation-scoped events are uncommon, but keeping them visible is
-  // better than dropping a recovery/error signal whose message link is absent.
-  for (const run of assistants.filter((item) => item.message_id == null))
-    items.push({
-      node: chatBubble("assistant", run.text, "", conversation),
-      failed: false,
-    });
-  for (const activity of activities) {
-    if (activity.message_id == null) addActivity(activity);
-  }
-  if (conversation.state === "running") {
-    items.push({
-      node: chatWorkingIndicator(),
-      failed: false,
-    });
-  }
-  for (const item of items) {
-    if (item.failed) {
-      const button = el("button", {
-        className: "chat-retry",
-        type: "button",
-        textContent: "Retry",
-      });
-      button.onclick = () => retry(item.text);
-      item.node.append(button);
-    }
-  }
-  if (!items.length) {
-    items.push({
-      node: el("div", { className: "chat-empty" },
-        `Start a conversation with ${conversation.shell.display_name}.`),
-      failed: false,
-    });
-  }
-  transcript.replaceChildren(...items.map((item) => item.node));
-  requestAnimationFrame(() => {
-    transcript.scrollTop = followTail ? transcript.scrollHeight : previousTop;
-    onPosition();
-  });
 }
 
 async function chatRefreshConversation(conversationId, generation, onUpdate) {
@@ -3683,9 +3593,12 @@ async function chatRefreshConversation(conversationId, generation, onUpdate) {
   } catch { /* SSE remains authoritative enough to keep the open view usable. */ }
 }
 
-function chatOpenStream(conversationId, generation, onEvent, onState) {
+function chatOpenStream(
+  conversationId, generation, afterSequence, onEvent, onState,
+) {
   chatStopStream();
-  const source = new EventSource(`/api/conversations/${conversationId}/events`);
+  const source = new EventSource(
+    `/api/conversations/${conversationId}/events?after=${afterSequence}`);
   chatSource = source;
   source.onopen = () => onState("connected");
   source.onerror = () => onState("reconnecting");
@@ -3695,7 +3608,7 @@ function chatOpenStream(conversationId, generation, onEvent, onState) {
     "message.accepted", "session.started", "run.started",
     "assistant.delta", "tool.started", "tool.completed", "permission.requested",
     "input.requested", "usage", "run.completed", "run.failed",
-    "run.interrupted", "run.unknown",
+    "run.interrupt.requested", "run.interrupted", "run.unknown",
   ];
   for (const type of types) {
     source.addEventListener(type, (raw) => {
@@ -4571,14 +4484,203 @@ async function chatRenderNew(host, shell, defaults, catalog) {
   host.replaceChildren(form);
 }
 
-async function chatRenderOpen(host, initialConversation, initialMessages) {
+function chatCreateTranscriptState(snapshot) {
+  if (snapshot.projection_version !== 1)
+    throw new Error("Unsupported transcript projection.");
+  const items = new Map();
+  for (const item of snapshot.items || []) {
+    if (!item.item_id || items.has(item.item_id))
+      throw new Error("Transcript contains a keyed identity conflict.");
+    items.set(item.item_id, { ...item });
+  }
+  return {
+    projectionVersion: snapshot.projection_version,
+    throughSequence: Number(snapshot.through_sequence || 0),
+    lastSequence: Number(snapshot.through_sequence || 0),
+    items,
+    order: [...items.keys()].sort((left, right) => {
+      const a = items.get(left);
+      const b = items.get(right);
+      return Number(a.order_sequence) - Number(b.order_sequence)
+        || left.localeCompare(right);
+    }),
+    nodes: new Map(),
+    dirty: new Set(items.keys()),
+    fullBuild: true,
+    hiddenDirty: false,
+    frame: null,
+    truncation: snapshot.truncation || null,
+    reconcileError: null,
+  };
+}
+
+function chatTranscriptItemNode(item, conversation, retry) {
+  if (item.kind === "activity")
+    return chatBubble("activity", item.label || item.activity_type);
+  const node = chatBubble(
+    item.kind,
+    item.text || "",
+    item.kind === "user" ? item.state || "" : "",
+    conversation,
+  );
+  if (item.kind === "user" && item.state === "failed") {
+    const button = el("button", {
+      className: "chat-retry",
+      type: "button",
+      textContent: "Retry",
+    });
+    button.onclick = () => retry(item.text);
+    node.append(button);
+  }
+  return node;
+}
+
+function chatUpdateTranscriptNode(node, item, retry) {
+  if (item.kind === "assistant") {
+    const body = node.querySelector(".chat-assistant-body");
+    const rendered = mdBlock(item.text || "");
+    body.replaceChildren(...rendered.childNodes);
+    return;
+  }
+  if (item.kind !== "user") return;
+  let meta = node.querySelector(".chat-meta");
+  if (item.state) {
+    if (!meta) {
+      meta = el("div", { className: "chat-meta" });
+      node.append(meta);
+    }
+    meta.textContent = item.state;
+  }
+  let retryButton = node.querySelector(".chat-retry");
+  if (item.state === "failed" && !retryButton) {
+    retryButton = el("button", {
+      className: "chat-retry",
+      type: "button",
+      textContent: "Retry",
+    });
+    retryButton.onclick = () => retry(item.text);
+    node.append(retryButton);
+  } else if (item.state !== "failed" && retryButton) {
+    retryButton.remove();
+  }
+}
+
+function chatTranscriptBanner(state) {
+  if (!state.truncation) return null;
+  return el(
+    "div",
+    { className: "chat-transcript-omission", role: "status" },
+    "Earlier transcript omitted from this view; durable history was not deleted.",
+  );
+}
+
+function chatReconcileBanner(state, reconcile) {
+  if (!state.reconcileError) return null;
+  const retry = el("button", {
+    className: "act",
+    type: "button",
+    textContent: "Retry",
+  });
+  retry.onclick = reconcile;
+  return el(
+    "div",
+    { className: "chat-transcript-reconcile error" },
+    `Transcript reconciliation failed — ${state.reconcileError.message} `,
+    retry,
+  );
+}
+
+function chatFlushTranscript(
+  transcript,
+  state,
+  conversation,
+  retry,
+  reconcile,
+  shouldFollow,
+  onPosition,
+) {
+  const previousTop = transcript.scrollTop;
+  const followTail = shouldFollow();
+  if (state.fullBuild) {
+    state.nodes.clear();
+    const nodes = [];
+    const banner = chatTranscriptBanner(state);
+    const reconcileBanner = chatReconcileBanner(state, reconcile);
+    if (banner) nodes.push(banner);
+    if (reconcileBanner) nodes.push(reconcileBanner);
+    for (const id of state.order) {
+      const item = state.items.get(id);
+      const node = chatTranscriptItemNode(item, conversation, retry);
+      state.nodes.set(id, node);
+      nodes.push(node);
+    }
+    if (!state.order.length) {
+      nodes.push(el(
+        "div",
+        { className: "chat-empty" },
+        `Start a conversation with ${conversation.shell.display_name}.`,
+      ));
+    }
+    transcript.replaceChildren(...nodes);
+    state.fullBuild = false;
+    state.dirty.clear();
+  } else {
+    if (state.order.length && state.nodes.size === 0)
+      transcript.querySelector(".chat-empty")?.remove();
+    for (const id of state.order) {
+      if (!state.dirty.has(id)) continue;
+      const item = state.items.get(id);
+      let node = state.nodes.get(id);
+      if (!node) {
+        node = chatTranscriptItemNode(item, conversation, retry);
+        state.nodes.set(id, node);
+        const index = state.order.indexOf(id);
+        const next = state.order
+          .slice(index + 1)
+          .map((nextId) => state.nodes.get(nextId))
+          .find(Boolean);
+        const working = transcript.querySelector(".chat-working-indicator");
+        transcript.insertBefore(node, next || working || null);
+      } else {
+        chatUpdateTranscriptNode(node, item, retry);
+      }
+    }
+    state.dirty.clear();
+  }
+  const working = transcript.querySelector(".chat-working-indicator");
+  if (conversation.state === "running" && !working)
+    transcript.append(chatWorkingIndicator());
+  else if (conversation.state !== "running" && working)
+    working.remove();
+  transcript.scrollTop = followTail ? transcript.scrollHeight : previousTop;
+  onPosition();
+}
+
+async function chatRenderOpen(host, initialConversation, initialSnapshot) {
   const generation = chatRenderGeneration;
   let conversation = initialConversation;
-  let messages = [...initialMessages];
-  const events = [];
-  const seen = new Set();
+  let transcriptState = chatCreateTranscriptState(initialSnapshot);
+  let messages = [...transcriptState.items.values()]
+    .filter((item) => item.kind === "user")
+    .map((item) => ({
+      message_id: item.message_id,
+      message_kind: "prompt",
+      body: item.text,
+      state: item.state,
+      created_at: item.created_at,
+      completed_at: item.completed_at,
+    }));
+  conversation = {
+    ...conversation,
+    version: initialSnapshot.controls.conversation_version,
+    state: initialSnapshot.controls.conversation_state,
+    close_requested_at: initialSnapshot.controls.close_requested_at,
+    active_run_id: initialSnapshot.controls.active_run_id,
+  };
   let streamStatus = "connecting";
   let stopRequest = null;
+  let reconcilePromise = null;
+  let reconcileFailures = 0;
   let currentMode = CHAT_MODES.includes(chatRouteMode) ? chatRouteMode : "chat";
 
   const header = el("div", { className: "chat-pane-head" });
@@ -4665,6 +4767,73 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     composer.focus();
     await submit();
   };
+  const flushTranscript = () => chatFlushTranscript(
+    transcript,
+    transcriptState,
+    conversation,
+    retry,
+    () => reconcileTranscript(true),
+    () => followTranscriptTail,
+    updateTranscriptFollow,
+  );
+  const scheduleTranscript = () => {
+    if (currentMode !== "chat") {
+      transcriptState.hiddenDirty = true;
+      return;
+    }
+    if (transcriptState.frame !== null) return;
+    transcriptState.frame = requestAnimationFrame(() => {
+      transcriptState.frame = null;
+      transcriptState.hiddenDirty = false;
+      flushTranscript();
+    });
+  };
+  const installSnapshot = (snapshot) => {
+    if (snapshot.conversation_id !== conversation.conversation_id)
+      throw new Error("Transcript conversation identity changed.");
+    if (transcriptState.frame !== null)
+      cancelAnimationFrame(transcriptState.frame);
+    transcriptState = chatCreateTranscriptState(snapshot);
+    messages = [...transcriptState.items.values()]
+      .filter((item) => item.kind === "user")
+      .map((item) => ({
+        message_id: item.message_id,
+        message_kind: "prompt",
+        body: item.text,
+        state: item.state,
+        created_at: item.created_at,
+        completed_at: item.completed_at,
+      }));
+    conversation.version = snapshot.controls.conversation_version;
+    conversation.state = snapshot.controls.conversation_state;
+    conversation.close_requested_at = snapshot.controls.close_requested_at;
+    conversation.active_run_id = snapshot.controls.active_run_id;
+  };
+  const reconcileTranscript = async (manual = false) => {
+    if (manual) reconcileFailures = 0;
+    if (reconcilePromise || (!manual && reconcileFailures >= 2))
+      return reconcilePromise;
+    const request = chatApi(
+      `/conversations/${conversation.conversation_id}/transcript`,
+    );
+    reconcilePromise = request;
+    try {
+      const snapshot = await request;
+      if (generation !== chatRenderGeneration) return;
+      installSnapshot(snapshot);
+      reconcileFailures = 0;
+      transcriptState.reconcileError = null;
+      paint();
+    } catch (error) {
+      reconcileFailures += 1;
+      transcriptState.reconcileError = error;
+      transcriptState.fullBuild = true;
+      if (currentMode === "chat") scheduleTranscript();
+    } finally {
+      if (reconcilePromise === request) reconcilePromise = null;
+    }
+    return null;
+  };
   const setMode = (mode) => {
     currentMode = CHAT_MODES.includes(mode) ? mode : "chat";
     chatRouteMode = currentMode;
@@ -4677,6 +4846,8 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     chatModeButton.setAttribute("aria-selected", String(currentMode === "chat"));
     diffModeButton.setAttribute("aria-selected", String(currentMode === "diff"));
     reviewWorkspace.setMode(currentMode);
+    if (currentMode === "chat" && transcriptState.hiddenDirty)
+      scheduleTranscript();
   };
   const selectMode = (mode) => {
     if (mode === currentMode) return;
@@ -4735,15 +4906,7 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     composer.placeholder = closed
       ? "This conversation is closed."
       : closing ? "Stopping work and closing…" : "Message this shell…";
-    chatPaintTranscript(
-      transcript,
-      messages,
-      events,
-      conversation,
-      retry,
-      () => followTranscriptTail,
-      updateTranscriptFollow,
-    );
+    scheduleTranscript();
   };
   const refresh = () => chatRefreshConversation(
     conversation.conversation_id,
@@ -4751,6 +4914,14 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
     (next, nextMessages) => {
       conversation = next;
       messages = nextMessages;
+      for (const message of nextMessages) {
+        const item = transcriptState.items.get(
+          `message:${message.message_id}`);
+        if (!item || item.state === message.state) continue;
+        item.state = message.state;
+        item.completed_at = message.completed_at;
+        transcriptState.dirty.add(item.item_id);
+      }
       paint();
     });
 
@@ -4807,6 +4978,23 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
         "POST", { text }, chatPendingSend.key);
       if (!messages.some((item) => item.message_id === result.message.message_id))
         messages.push(result.message);
+      const userItemId = `message:${result.message.message_id}`;
+      if (!transcriptState.items.has(userItemId)) {
+        transcriptState.items.set(userItemId, {
+          item_id: userItemId,
+          kind: "user",
+          order_sequence: transcriptState.lastSequence + 1,
+          message_id: result.message.message_id,
+          run_id: null,
+          created_at: result.message.created_at,
+          text,
+          state: result.message.state,
+          completed_at: result.message.completed_at,
+          text_truncated: false,
+        });
+        transcriptState.order.push(userItemId);
+        transcriptState.dirty.add(userItemId);
+      }
       chatPendingSend = null;
       composer.value = "";
       pending.hidden = true;
@@ -4856,43 +5044,154 @@ async function chatRenderOpen(host, initialConversation, initialMessages) {
   };
   setMode(currentMode);
   paint();
+  const activityLabel = (event) => {
+    const payload = event.payload || {};
+    if (event.event_type === "permission.requested")
+      return "Waiting for permission";
+    if (event.event_type === "input.requested") return "Waiting for input";
+    if (event.event_type === "run.interrupted") return "Turn interrupted";
+    if (event.event_type === "run.unknown")
+      return "Turn outcome could not be proven";
+    return payload.error
+      ? `Turn failed — ${payload.error}`
+      : "Turn failed";
+  };
+  const reduceEvent = (event) => {
+    const sequence = Number(event.sequence);
+    if (!Number.isFinite(sequence) || sequence <= transcriptState.lastSequence)
+      return;
+    if (sequence !== transcriptState.lastSequence + 1) {
+      reconcileTranscript();
+      return;
+    }
+    const type = event.event_type;
+    const message = messages.find(
+      (item) => item.message_id === event.message_id);
+    const userItem = event.message_id == null
+      ? null
+      : transcriptState.items.get(`message:${event.message_id}`);
+
+    if (type === "message.accepted") {
+      if (!userItem) {
+        reconcileTranscript();
+        return;
+      }
+      userItem.order_sequence = sequence;
+      userItem.state = "queued";
+      transcriptState.order.sort((left, right) => {
+        const a = transcriptState.items.get(left);
+        const b = transcriptState.items.get(right);
+        return Number(a.order_sequence) - Number(b.order_sequence)
+          || left.localeCompare(right);
+      });
+      transcriptState.dirty.add(userItem.item_id);
+    } else if (type === "assistant.delta") {
+      if (typeof event.payload?.text !== "string") {
+        reconcileTranscript();
+        return;
+      }
+      const runId = event.run_id;
+      const itemId = `run:${runId}:assistant`;
+      let assistant = transcriptState.items.get(itemId);
+      if (assistant && assistant.message_id !== event.message_id) {
+        reconcileTranscript();
+        return;
+      }
+      if (!assistant) {
+        assistant = {
+          item_id: itemId,
+          kind: "assistant",
+          order_sequence: sequence,
+          message_id: event.message_id,
+          run_id: runId,
+          created_at: event.created_at,
+          text: "",
+          outcome: null,
+          first_sequence: sequence,
+          last_sequence: sequence,
+          text_truncated: false,
+        };
+        transcriptState.items.set(itemId, assistant);
+        transcriptState.order.push(itemId);
+      }
+      assistant.text += event.payload?.text || "";
+      assistant.last_sequence = sequence;
+      transcriptState.dirty.add(itemId);
+    } else if ([
+      "permission.requested",
+      "input.requested",
+      "run.failed",
+      "run.interrupted",
+      "run.unknown",
+    ].includes(type)) {
+      const itemId = `event:${sequence}`;
+      transcriptState.items.set(itemId, {
+        item_id: itemId,
+        kind: "activity",
+        order_sequence: sequence,
+        message_id: event.message_id,
+        run_id: event.run_id,
+        created_at: event.created_at,
+        activity_type: type,
+        label: activityLabel(event),
+        sequence,
+      });
+      transcriptState.order.push(itemId);
+      transcriptState.dirty.add(itemId);
+    }
+
+    transcriptState.lastSequence = sequence;
+    if (message && type === "run.started") message.state = "running";
+    if (message && type === "run.completed") message.state = "completed";
+    if (message && ["run.failed", "run.unknown"].includes(type))
+      message.state = "failed";
+    if (message && type === "run.interrupted") message.state = "cancelled";
+    if (userItem && message) {
+      userItem.state = message.state;
+      userItem.completed_at = message.completed_at;
+      if (type !== "assistant.delta")
+        transcriptState.dirty.add(userItem.item_id);
+    }
+    if (type === "message.accepted" && conversation.state !== "running")
+      conversation.state = "queued";
+    if (type === "run.started") {
+      conversation.state = "running";
+      conversation.active_run_id = event.run_id;
+    }
+    if (type === "conversation.updated" || type === "conversation.renamed")
+      Object.assign(conversation, event.payload || {});
+    if (type === "conversation.close.requested")
+      conversation.close_requested_at = event.created_at || true;
+    if (["permission.requested", "input.requested"].includes(type))
+      conversation.state = "waiting";
+    if (["run.completed", "run.interrupted"].includes(type))
+      conversation.state = chatQueuedCount(messages) ? "queued" : "idle";
+    if (["run.failed", "run.unknown"].includes(type))
+      conversation.state = "error";
+    if (type === "conversation.closed") conversation.state = "closed";
+    if (["run.completed", "run.failed", "run.interrupted", "run.unknown"]
+      .includes(type)) {
+      stopRequest = null;
+      conversation.active_run_id = null;
+    }
+
+    if (type === "assistant.delta") {
+      scheduleTranscript();
+      return;
+    }
+    paint();
+    if (["message.accepted", "run.completed", "run.failed",
+         "run.interrupted", "run.unknown",
+         "conversation.updated", "conversation.renamed",
+         "conversation.close.requested",
+         "conversation.closed"].includes(type))
+      refresh();
+  };
   chatOpenStream(
     conversation.conversation_id,
     generation,
-    (event) => {
-      if (seen.has(event.sequence)) return;
-      seen.add(event.sequence);
-      events.push(event);
-      const message = messages.find((item) => item.message_id === event.message_id);
-      if (message && event.event_type === "run.started") message.state = "running";
-      if (message && event.event_type === "run.completed") message.state = "completed";
-      if (message && ["run.failed", "run.unknown"].includes(event.event_type))
-        message.state = "failed";
-      if (message && event.event_type === "run.interrupted")
-        message.state = "cancelled";
-      if (event.event_type === "message.accepted"
-          && conversation.state !== "running")
-        conversation.state = "queued";
-      if (event.event_type === "run.started") conversation.state = "running";
-      if (event.event_type === "conversation.close.requested")
-        conversation.close_requested_at = event.created_at || true;
-      if (["permission.requested", "input.requested"].includes(event.event_type))
-        conversation.state = "waiting";
-      if (["run.completed", "run.interrupted"].includes(event.event_type))
-        conversation.state = chatQueuedCount(messages) ? "queued" : "idle";
-      if (["run.failed", "run.unknown"].includes(event.event_type))
-        conversation.state = "error";
-      if (["run.completed", "run.failed", "run.interrupted", "run.unknown"]
-        .includes(event.event_type))
-        stopRequest = null;
-      paint();
-      if (["message.accepted", "run.completed", "run.failed",
-           "run.interrupted", "run.unknown",
-           "conversation.updated", "conversation.renamed",
-           "conversation.close.requested",
-           "conversation.closed"].includes(event.event_type))
-        refresh();
-    },
+    transcriptState.throughSequence,
+    reduceEvent,
     (value) => {
       streamStatus = value;
       updateStreamStatus();
@@ -4906,59 +5205,100 @@ async function renderInterface(root) {
   chatStopReview();
   chatModeController = null;
   const generation = ++chatRenderGeneration;
-  root.replaceChildren(el("div", { className: "chat-loading" }, "Loading conversations…"));
-  const [{ shells: allShells }, defaults, catalog, allConversations] = await Promise.all([
-    api("/shells"),
-    api("/flavor-defaults"),
-    api("/models").catch(() => ({ harnesses: {}, stale: true })),
-    chatApi("/conversations?limit=100"),
+  root.replaceChildren(
+    el("div", { className: "chat-loading" }, "Loading conversations…"));
+
+  const shellRequest = api("/shells");
+  const openRequest = chatApi("/conversations?open=true&limit=100")
+    .catch((error) => ({ items: [], next_cursor: null, error }));
+  const deepLinked = chatRouteConversation
+    && chatRouteConversation !== CHAT_CONFIGURE_ROUTE;
+  const detailRequest = deepLinked
+    ? chatApi(`/conversations/${chatRouteConversation}`)
+      .then((conversation) => ({ conversation }))
+      .catch((error) => ({ error }))
+    : Promise.resolve({ conversation: null });
+  const [{ shells: allShells }, openPage, detailResult] = await Promise.all([
+    shellRequest,
+    openRequest,
+    detailRequest,
   ]);
-  const shells = allShells.filter((item) => item.flavor !== "conductor");
   if (generation !== chatRenderGeneration) return;
+
+  const shells = allShells.filter((item) => item.flavor !== "conductor");
   if (!shells.length) {
     root.replaceChildren(el("div", { className: "card muted" }, "No shells."));
     return;
   }
-  const openConversation = allConversations.items.find(
+
+  let selectedConversation = detailResult.conversation;
+  if (selectedConversation
+      && selectedConversation.shell.shortname !== chatRouteShell) {
+    chatRouteShell = selectedConversation.shell.shortname;
+    history.replaceState(
+      null,
+      "",
+      `#${chatModeHash(
+        chatRouteShell,
+        selectedConversation.conversation_id,
+        chatRouteMode,
+      )}`,
+    );
+  }
+  const openConversation = openPage.items.find(
     (item) => item.state !== "closed");
-  const shell = shells.find((item) => item.shortname === chatRouteShell)
-    || (!chatRouteShell && openConversation
-      ? shells.find((item) => item.shell_id === openConversation.shell.shell_id)
-      : null)
-    || shells[0];
-  const conversations = allConversations.items.filter(
-    (item) => item.shell.shell_id === shell.shell_id);
+  const shell = selectedConversation?.shell
+    ? shells.find(
+      (item) => item.shell_id === selectedConversation.shell.shell_id)
+    : shells.find((item) => item.shortname === chatRouteShell)
+      || (!chatRouteShell && openConversation
+        ? shells.find(
+          (item) => item.shell_id === openConversation.shell.shell_id)
+        : null)
+      || shells[0];
   const configuring = chatRouteConversation === CHAT_CONFIGURE_ROUTE;
-  let selectedId = configuring
-    ? ""
-    : chatRouteConversation
-      || conversations.find((item) => item.state !== "closed")?.conversation_id
-      || "";
-  if (selectedId && !conversations.some((item) => item.conversation_id === selectedId))
-    selectedId = "";
-  let selectedConversation = allConversations.items.find(
-    (item) => item.conversation_id === selectedId);
+  if (!selectedConversation && !configuring && !deepLinked) {
+    selectedConversation = openPage.items.find(
+      (item) => item.shell.shell_id === shell.shell_id
+        && item.state !== "closed",
+    ) || null;
+  }
+  const selectedId = selectedConversation?.conversation_id
+    || (deepLinked ? chatRouteConversation : "");
+
+  const recentRequest = chatApi(
+    `/conversations?shell_id=${shell.shell_id}&starred=false&limit=20`,
+  ).catch((error) => ({ items: [], next_cursor: null, error }));
+  const recentPage = await recentRequest;
+  if (generation !== chatRenderGeneration) return;
 
   const layout = el("div", { className: "chat-layout" });
   const rail = el("aside", { className: "chat-rail" });
   rail.append(el("div", { className: "chat-rail-title" }, "Shells"));
   const orderedFlavors = [
-    ...CHAT_FLAVOR_ORDER.filter((flavor) => shells.some((item) => item.flavor === flavor)),
+    ...CHAT_FLAVOR_ORDER.filter(
+      (flavor) => shells.some((item) => item.flavor === flavor)),
     ...[...new Set(shells.map((item) => item.flavor || "bespoke"))]
       .filter((flavor) => !CHAT_FLAVOR_ORDER.includes(flavor)).sort(),
   ];
   const orderedShells = orderedFlavors.flatMap((flavor) =>
     shells.filter((item) => (item.flavor || "bespoke") === flavor));
   const shellItems = new Map();
+  const openByShell = new Map();
+  for (const conversation of openPage.items) {
+    if (conversation.state !== "closed")
+      openByShell.set(
+        conversation.shell.shell_id,
+        conversation.state || "idle",
+      );
+  }
   let previousFlavor = "";
   for (const item of orderedShells) {
     const flavor = item.flavor || "bespoke";
     if (previousFlavor && flavor !== previousFlavor)
-      rail.append(el("div", { className: "chat-shell-divider", role: "separator" }));
+      rail.append(
+        el("div", { className: "chat-shell-divider", role: "separator" }));
     previousFlavor = flavor;
-    const active = allConversations.items.find(
-      (conversation) => conversation.shell.shell_id === item.shell_id
-        && conversation.state !== "closed");
     const button = el("button", {
       className: "chat-shell"
         + (item.shell_id === shell.shell_id ? " selected" : ""),
@@ -4966,7 +5306,7 @@ async function renderInterface(root) {
     },
     el("span", { className: "chat-shell-name" }, item.display_name),
     el("span", { className: "chat-shell-shortname" }, item.shortname || ""));
-    chatPaintShellState(button, active?.state);
+    chatPaintShellState(button, openByShell.get(item.shell_id));
     shellItems.set(item.shell_id, button);
     button.onclick = () => {
       if (item.shell_id === shell.shell_id) return;
@@ -5015,9 +5355,59 @@ async function renderInterface(root) {
         el("span", { className: "chat-shortname" }, ` /${shell.shortname}`)),
       configure),
     newChat));
+
   const history = el("div", { className: "chat-history-list" });
+  const summaries = new Map();
   const historyItems = new Map();
-  for (const conversation of conversations) {
+  const recentIds = [];
+  const starredIds = new Set();
+  let moreCursor = recentPage.next_cursor;
+  let moreInFlight = false;
+  let starsInFlight = false;
+  const starsStatus = el(
+    "div",
+    { className: "chat-history-status" },
+    "Loading starred chats…",
+  );
+  const more = el("button", {
+    className: "chat-history-more",
+    type: "button",
+    textContent: "More",
+  });
+
+  const acceptSummary = (conversation) => {
+    const current = summaries.get(conversation.conversation_id);
+    if (current && Number(current.version || 0) > Number(conversation.version || 0))
+      return current;
+    summaries.set(conversation.conversation_id, conversation);
+    return conversation;
+  };
+  for (const conversation of recentPage.items) {
+    acceptSummary(conversation);
+    recentIds.push(conversation.conversation_id);
+  }
+  if (selectedConversation) acceptSummary(selectedConversation);
+
+  const historyOrder = () => {
+    const pinned = [...starredIds]
+      .map((id) => summaries.get(id))
+      .filter(Boolean)
+      .sort((left, right) =>
+        String(right.last_activity_at || "").localeCompare(
+          String(left.last_activity_at || ""))
+        || right.conversation_id.localeCompare(left.conversation_id));
+    const recent = recentIds
+      .map((id) => summaries.get(id))
+      .filter((conversation) => conversation && !conversation.starred);
+    const selected = selectedId && !pinned.some(
+      (item) => item.conversation_id === selectedId)
+      && !recent.some((item) => item.conversation_id === selectedId)
+      ? summaries.get(selectedId)
+      : null;
+    return [...pinned, ...recent, ...(selected ? [selected] : [])];
+  };
+
+  const historyCard = (conversation) => {
     const card = el("div", {
       className: "chat-history-item"
         + (conversation.conversation_id === selectedId ? " selected" : ""),
@@ -5037,11 +5427,11 @@ async function renderInterface(root) {
     open.append(context, name, state);
     card.append(open, star);
     chatPaintHistoryItem(item, conversation);
-    historyItems.set(conversation.conversation_id, item);
     open.onclick = async () => {
-      if (conversation.conversation_id === selectedId) return;
+      const target = item.conversation;
+      if (target.conversation_id === selectedId) return;
       if (await chatCloseForSwitch(selectedConversation))
-        location.hash = chatHash(shell.shortname, conversation.conversation_id);
+        location.hash = chatHash(shell.shortname, target.conversation_id);
     };
     star.onclick = async (event) => {
       event.stopPropagation();
@@ -5053,62 +5443,273 @@ async function renderInterface(root) {
           "PATCH",
           { version: current.version, starred: !current.starred },
         );
-        chatPaintHistoryItem(item, updated);
+        acceptSummary(updated);
+        if (updated.starred) {
+          starredIds.add(updated.conversation_id);
+          const index = recentIds.indexOf(updated.conversation_id);
+          if (index >= 0) recentIds.splice(index, 1);
+        } else {
+          starredIds.delete(updated.conversation_id);
+          if (!recentIds.includes(updated.conversation_id)
+              && updated.conversation_id === selectedId)
+            recentIds.push(updated.conversation_id);
+        }
         if (updated.conversation_id === selectedConversation?.conversation_id)
           selectedConversation = updated;
+        renderHistory();
       } catch (error) {
         toast(`${error.code}: ${error.message}`);
       } finally {
         star.disabled = false;
       }
     };
-    history.append(card);
-  }
-  if (!conversations.length)
-    history.append(el("div", { className: "chat-history-empty" }, "No chats yet."));
+    historyItems.set(conversation.conversation_id, item);
+    return item;
+  };
+
+  const renderHistory = () => {
+    const cards = historyOrder().map((conversation) => {
+      let item = historyItems.get(conversation.conversation_id);
+      if (!item) item = historyCard(conversation);
+      chatPaintHistoryItem(item, conversation);
+      item.card.classList.toggle(
+        "selected",
+        conversation.conversation_id === selectedId,
+      );
+      return item.card;
+    });
+    history.replaceChildren(...cards);
+    if (!cards.length && !recentPage.error)
+      history.append(
+        el("div", { className: "chat-history-empty" }, "No chats yet."));
+    if (recentPage.error)
+      history.append(el(
+        "div",
+        { className: "chat-history-status error" },
+        `Recent chats unavailable — ${recentPage.error.message}`,
+      ));
+    if (!starsStatus.hidden) history.append(starsStatus);
+    if (moreCursor) history.append(more);
+  };
+  more.onclick = async () => {
+    if (moreInFlight || !moreCursor) return;
+    moreInFlight = true;
+    more.disabled = true;
+    more.textContent = "Loading…";
+    const requestedCursor = moreCursor;
+    try {
+      const page = await chatApi(
+        `/conversations?shell_id=${shell.shell_id}`
+        + `&starred=false&limit=20&cursor=${encodeURIComponent(requestedCursor)}`,
+      );
+      if (generation !== chatRenderGeneration) return;
+      for (const conversation of page.items) {
+        acceptSummary(conversation);
+        if (!recentIds.includes(conversation.conversation_id))
+          recentIds.push(conversation.conversation_id);
+      }
+      moreCursor = page.next_cursor;
+      more.textContent = "More";
+      renderHistory();
+    } catch (error) {
+      moreCursor = requestedCursor;
+      more.textContent = "Retry";
+      toast(`${error.code}: ${error.message}`);
+    } finally {
+      moreInFlight = false;
+      more.disabled = false;
+    }
+  };
   side.append(history);
+  renderHistory();
+
+  const pane = el("section", { className: "chat-pane" });
+  layout.append(rail, side, pane);
+  root.replaceChildren(layout);
+
+  const loadStars = async () => {
+    if (starsInFlight) return;
+    starsInFlight = true;
+    starsStatus.hidden = false;
+    starsStatus.classList.remove("error");
+    starsStatus.textContent = "Loading starred chats…";
+    renderHistory();
+    let cursor = null;
+    try {
+      do {
+        const suffix = cursor
+          ? `&cursor=${encodeURIComponent(cursor)}`
+          : "";
+        const page = await chatApi(
+          `/conversations?shell_id=${shell.shell_id}`
+          + `&starred=true&limit=100${suffix}`,
+        );
+        if (generation !== chatRenderGeneration) return;
+        for (const conversation of page.items) {
+          acceptSummary(conversation);
+          starredIds.add(conversation.conversation_id);
+        }
+        cursor = page.next_cursor;
+        renderHistory();
+      } while (cursor);
+      starsStatus.hidden = true;
+    } catch (error) {
+      const retry = el("button", {
+        className: "chat-history-retry",
+        type: "button",
+        textContent: "Retry",
+      });
+      retry.onclick = loadStars;
+      starsStatus.replaceChildren(
+        `Starred chats unavailable — ${error.message} `,
+        retry,
+      );
+      starsStatus.classList.add("error");
+      starsStatus.hidden = false;
+    } finally {
+      starsInFlight = false;
+    }
+    renderHistory();
+  };
+  loadStars();
+
   let historyPollInFlight = false;
   const pollHistory = async () => {
     if (document.hidden || historyPollInFlight) return;
     historyPollInFlight = true;
     try {
-      const page = await chatApi("/conversations?limit=100");
+      let cursor = null;
+      const nextOpenByShell = new Map();
+      do {
+        const suffix = cursor
+          ? `&cursor=${encodeURIComponent(cursor)}`
+          : "";
+        const page = await chatApi(
+          `/conversations?open=true&limit=100${suffix}`,
+        );
+        for (const conversation of page.items) {
+          nextOpenByShell.set(
+            conversation.shell.shell_id,
+            conversation.state || "idle",
+          );
+          const item = historyItems.get(conversation.conversation_id);
+          if (item) {
+            const accepted = acceptSummary(conversation);
+            chatPaintHistoryItem(item, accepted);
+          }
+          if (conversation.conversation_id
+              === selectedConversation?.conversation_id)
+            selectedConversation = acceptSummary(conversation);
+        }
+        cursor = page.next_cursor;
+      } while (cursor);
       if (generation !== chatRenderGeneration || !chatHistoryPollTimer) return;
-      const openByShell = new Map();
-      for (const conversation of page.items) {
-        if (conversation.state !== "closed")
-          openByShell.set(conversation.shell.shell_id, conversation.state || "idle");
-        if (conversation.shell.shell_id !== shell.shell_id) continue;
-        const item = historyItems.get(conversation.conversation_id);
-        if (item) chatPaintHistoryItem(item, conversation);
-        if (conversation.conversation_id === selectedConversation?.conversation_id)
-          selectedConversation = conversation;
-      }
       for (const [shellId, button] of shellItems)
-        chatPaintShellState(button, openByShell.get(shellId));
+        chatPaintShellState(button, nextOpenByShell.get(shellId));
     } catch { /* The next poll retries without disrupting the open chat. */ }
     finally { historyPollInFlight = false; }
   };
   chatHistoryPollTimer = setInterval(pollHistory, CHAT_HISTORY_POLL_MS);
 
-  const pane = el("section", { className: "chat-pane" });
-  layout.append(rail, side, pane);
-  root.replaceChildren(layout);
-  if (!selectedId) {
-    if (configuring) {
-      await chatRenderNew(pane, shell, defaults, catalog);
-    } else {
-      pane.append(el("div", { className: "chat-empty chat-no-selection" },
-        "No chat selected."));
-    }
+  if (configuring) {
+    const loadConfiguration = async () => {
+      pane.replaceChildren(
+        el("div", { className: "chat-loading" }, "Loading configuration…"));
+      try {
+        const { defaults, catalog } = await chatLoadConfiguration();
+        if (generation !== chatRenderGeneration) return;
+        await chatRenderNew(pane, shell, defaults, catalog);
+      } catch (error) {
+        if (generation !== chatRenderGeneration) return;
+        const retry = el("button", {
+          className: "act",
+          type: "button",
+          textContent: "Retry",
+        });
+        retry.onclick = loadConfiguration;
+        pane.replaceChildren(el(
+          "div",
+          { className: "card chat-config-error" },
+          el("div", {}, `Configuration unavailable — ${error.message}`),
+          retry,
+        ));
+      }
+    };
+    await loadConfiguration();
     return;
   }
-  const [conversation, messagePage] = await Promise.all([
-    chatApi(`/conversations/${selectedId}`),
-    chatApi(`/conversations/${selectedId}/messages?limit=100`),
-  ]);
-  if (generation !== chatRenderGeneration) return;
-  await chatRenderOpen(pane, conversation, messagePage.items);
+  if (!selectedId) {
+    pane.append(el("div", { className: "chat-empty chat-no-selection" },
+      "No chat selected."));
+    return;
+  }
+  if (detailResult.error) {
+    const retry = el("button", {
+      className: "act",
+      type: "button",
+      textContent: "Retry",
+    });
+    retry.onclick = () => renderInterface(root);
+    pane.replaceChildren(el(
+      "div",
+      { className: "card" },
+      `Conversation unavailable — ${detailResult.error.message}`,
+      retry,
+    ));
+    return;
+  }
+  const conversation = selectedConversation
+    || await chatApi(`/conversations/${selectedId}`);
+  const loadTranscript = async () => {
+    pane.replaceChildren(
+      el("div", { className: "chat-loading" }, "Loading transcript…"));
+    try {
+      const snapshot = await chatApi(
+        `/conversations/${selectedId}/transcript`);
+      if (generation !== chatRenderGeneration) return;
+      await chatRenderOpen(pane, conversation, snapshot);
+    } catch (error) {
+      if (generation !== chatRenderGeneration) return;
+      const retry = el("button", {
+        className: "act",
+        type: "button",
+        textContent: "Retry",
+      });
+      retry.onclick = loadTranscript;
+      const close = el("button", {
+        className: "act danger",
+        type: "button",
+        textContent: "Close",
+        disabled: conversation.state === "closed",
+      });
+      close.onclick = async () => {
+        close.disabled = true;
+        try {
+          const latest = await chatApi(
+            `/conversations/${conversation.conversation_id}`);
+          if (latest.state !== "closed") {
+            await chatApi(
+              `/conversations/${conversation.conversation_id}`,
+              "PATCH",
+              { version: latest.version, state: "closed" },
+            );
+          }
+          await renderInterface(root);
+        } catch (closeError) {
+          close.disabled = false;
+          toast(`${closeError.code}: ${closeError.message}`);
+        }
+      };
+      pane.replaceChildren(el(
+        "div",
+        { className: "card chat-transcript-error" },
+        el("h2", {}, chatHeaderLabel(conversation)),
+        el("div", {}, `Transcript unavailable — ${error.message}`),
+        el("div", { className: "row" }, retry, close),
+      ));
+    }
+  };
+  await loadTranscript();
 }
 
 // ── Tabs + boot ────────────────────────────────────────────────────────────────

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -172,6 +172,28 @@ body.interface-view main {
 }
 .chat-history-star:disabled { cursor: default; opacity: .4; }
 .chat-history-empty { color: var(--dim); padding: 1rem .65rem; font-size: .8rem; }
+.chat-history-status {
+  color: var(--dim); padding: .7rem .65rem; font-size: .72rem;
+}
+.chat-history-status.error { color: #ef9aa1; }
+.chat-history-retry {
+  border: 0; background: transparent; color: var(--accent); cursor: pointer;
+  font: inherit; padding: 0;
+}
+.chat-history-more {
+  width: 100%; margin-top: .35rem; padding: .45rem;
+  border: 1px solid var(--line); border-radius: 7px;
+  background: transparent; color: var(--accent); cursor: pointer;
+}
+.chat-history-more:disabled { color: var(--dim); cursor: default; }
+.chat-config-error { display: grid; gap: .7rem; justify-items: start; }
+.chat-transcript-omission, .chat-transcript-reconcile {
+  margin: .35rem 0 .75rem; padding: .55rem .7rem;
+  border: 1px solid var(--line); border-radius: 7px;
+  color: var(--dim); font-size: .75rem;
+}
+.chat-transcript-reconcile.error { color: #ef9aa1; }
+.chat-transcript-error { display: grid; gap: .7rem; align-content: start; }
 .chat-state {
   display: inline-flex; align-items: center; width: fit-content; flex: none;
   border: 1px solid var(--line); border-radius: 99px; padding: .06rem .4rem;

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -139,6 +139,117 @@ class ConversationApiCase(unittest.TestCase):
         self.assertEqual(status, 201, obj)
         return obj
 
+    def seed_conversation(
+        self,
+        con: sqlite3.Connection,
+        *,
+        number: int,
+        shell_id: int = 1,
+        owner_user_id: int = 1,
+        state: str = "closed",
+        starred: bool = False,
+        activity: str | None = None,
+    ) -> str:
+        conversation_id = f"cv_{number:032x}"
+        timestamp = activity or f"2026-07-30 12:{number % 60:02d}:00"
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,mode,owner_user_id,harness,effort,"
+            "worktree,state,title,starred,creation_idempotency_key,"
+            "creation_request_hash,created_at,last_activity_at,closed_at) "
+            "VALUES (?,?,'normal',?,'codex','high',?,?,?,?,?,?,?, ?,?)",
+            (
+                conversation_id,
+                shell_id,
+                owner_user_id,
+                str(self.root / ".sc-worktrees" / "dev"),
+                state,
+                f"Fixture {number}",
+                int(starred),
+                f"fixture-{number}",
+                f"hash-{number}",
+                timestamp,
+                timestamp,
+                timestamp if state == "closed" else None,
+            ),
+        )
+        return conversation_id
+
+    def seed_transcript(
+        self,
+        con: sqlite3.Connection,
+        *,
+        conversation_id: str,
+        turns: int = 1,
+        deltas_per_turn: int = 4000,
+        delta_text: str = "x",
+    ) -> tuple[list[int], int]:
+        sequence = 0
+        message_ids: list[int] = []
+        for turn in range(turns):
+            body = f"prompt {turn}"
+            cursor = con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state,completed_at) "
+                "VALUES (?,'user','operator','prompt',?,?,?,'completed',datetime('now'))",
+                (conversation_id, body, f"prompt-{turn}", f"hash-{turn}"),
+            )
+            message_id = int(cursor.lastrowid)
+            message_ids.append(message_id)
+            run = con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,lease_owner,"
+                "lease_expires_at,state,started_at,ended_at) "
+                "VALUES (?,1,?,'fixture','2026-07-30 13:00:00','succeeded',"
+                "'2026-07-30 12:00:00','2026-07-30 12:01:00')",
+                (conversation_id, message_id),
+            )
+            run_id = int(run.lastrowid)
+            sequence += 1
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,'message.accepted',?, ?,NULL)",
+                (
+                    conversation_id,
+                    sequence,
+                    json.dumps({"text": body}),
+                    message_id,
+                ),
+            )
+            sequence += 1
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,'run.started','{}',?,?)",
+                (conversation_id, sequence, message_id, run_id),
+            )
+            con.executemany(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,'assistant.delta',?,?,?)",
+                (
+                    (
+                        conversation_id,
+                        sequence + offset,
+                        json.dumps({"text": delta_text}),
+                        message_id,
+                        run_id,
+                    )
+                    for offset in range(1, deltas_per_turn + 1)
+                ),
+            )
+            sequence += deltas_per_turn
+            sequence += 1
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,'run.completed','{}',?,?)",
+                (conversation_id, sequence, message_id, run_id),
+            )
+        return message_ids, sequence
+
     def test_creation_observation_is_post_commit_and_cannot_fail_create(self):
         def observer(db_path, conversation_id):
             probe = sqlite3.connect(db_path, timeout=0.1)
@@ -1082,6 +1193,477 @@ class ConversationResourceTest(ConversationApiCase):
         ).fetchone()
         con.close()
         self.assertEqual(event["event_type"], "run.interrupt.requested")
+
+
+class ConversationPerformanceFixtureTest(ConversationApiCase):
+    def test_filtered_history_pages_bind_scope_and_exclude_other_owners(self) -> None:
+        with closing(self.connect()) as con:
+            recent = [
+                self.seed_conversation(
+                    con,
+                    number=number,
+                    activity=f"2026-07-30 14:{number:02d}:00",
+                )
+                for number in range(25)
+            ]
+            starred = [
+                self.seed_conversation(
+                    con,
+                    number=100 + number,
+                    starred=True,
+                    activity=f"2026-07-29 09:{number:02d}:00",
+                )
+                for number in range(3)
+            ]
+            other_owner = self.seed_conversation(
+                con,
+                number=999,
+                owner_user_id=2,
+                starred=True,
+                activity="2026-07-31 23:59:00",
+            )
+            con.commit()
+
+        status, _, first = self.request(
+            "GET",
+            "/api/conversations?shell_id=1&starred=false&limit=20",
+        )
+        self.assertEqual(status, 200, first)
+        self.assertEqual(len(first["items"]), 20)
+        self.assertEqual(
+            [item["conversation_id"] for item in first["items"]],
+            list(reversed(recent[5:])),
+        )
+        self.assertTrue(all(not item["starred"] for item in first["items"]))
+        self.assertIsInstance(first["next_cursor"], str)
+        self.assertGreater(len(first["next_cursor"]), 10)
+        self.assertNotIn(other_owner, {
+            item["conversation_id"] for item in first["items"]
+        })
+
+        with closing(self.connect()) as con:
+            con.execute(
+                "UPDATE conversations SET starred=1 WHERE conversation_id=?",
+                (recent[4],),
+            )
+            con.commit()
+        status, _, second = self.request(
+            "GET",
+            "/api/conversations?shell_id=1&starred=false&limit=20"
+            f"&cursor={first['next_cursor']}",
+        )
+        self.assertEqual(status, 200, second)
+        self.assertEqual(
+            [item["conversation_id"] for item in second["items"]],
+            list(reversed(recent[:4])),
+        )
+        self.assertIsNone(second["next_cursor"])
+
+        status, _, pinned = self.request(
+            "GET",
+            "/api/conversations?shell_id=1&starred=true&limit=2",
+        )
+        self.assertEqual(status, 200, pinned)
+        self.assertEqual(
+            [item["conversation_id"] for item in pinned["items"]],
+            [recent[4], starred[2]],
+        )
+        self.assertEqual(len(pinned["items"]), 2)
+        self.assertTrue(all(item["starred"] for item in pinned["items"]))
+        self.assertIsInstance(pinned["next_cursor"], str)
+        self.assertGreater(len(pinned["next_cursor"]), 10)
+
+        status, _, wrong_scope = self.request(
+            "GET",
+            "/api/conversations?shell_id=1&starred=true&limit=20"
+            f"&cursor={first['next_cursor']}",
+        )
+        self.assertEqual(status, 422, wrong_scope)
+        self.assertEqual(wrong_scope["error"]["code"], "CURSOR_INVALID")
+
+    def test_history_boolean_validation_and_open_state_compatibility(self) -> None:
+        with closing(self.connect()) as con:
+            idle_id = self.seed_conversation(
+                con,
+                number=1,
+                state="idle",
+                activity="2026-07-30 12:02:00",
+            )
+            closed_id = self.seed_conversation(
+                con,
+                number=2,
+                state="closed",
+                activity="2026-07-30 12:01:00",
+            )
+            con.commit()
+
+        for query in (
+            "starred=TRUE",
+            "starred=1",
+            "starred=",
+            "starred=true&starred=false",
+            "open=yes",
+            "open=true&open=true",
+        ):
+            with self.subTest(query=query):
+                status, _, error = self.request(
+                    "GET", f"/api/conversations?{query}"
+                )
+                self.assertEqual(status, 422, error)
+                self.assertEqual(error["error"]["code"], "VALIDATION_ERROR")
+
+        status, _, open_page = self.request(
+            "GET", "/api/conversations?open=true&state=idle"
+        )
+        self.assertEqual(status, 200, open_page)
+        self.assertEqual(
+            [item["conversation_id"] for item in open_page["items"]],
+            [idle_id],
+        )
+        status, _, closed_page = self.request(
+            "GET", "/api/conversations?open=false&state=closed"
+        )
+        self.assertEqual(status, 200, closed_page)
+        self.assertEqual(
+            [item["conversation_id"] for item in closed_page["items"]],
+            [closed_id],
+        )
+        for query in ("open=true&state=closed", "open=false&state=running"):
+            with self.subTest(query=query):
+                status, _, error = self.request(
+                    "GET", f"/api/conversations?{query}"
+                )
+                self.assertEqual(status, 422, error)
+                self.assertEqual(error["error"]["code"], "VALIDATION_ERROR")
+
+    def test_filtered_history_uses_the_existing_shell_activity_index(self) -> None:
+        with closing(self.connect()) as con:
+            for number in range(60):
+                self.seed_conversation(
+                    con,
+                    number=number,
+                    starred=number % 9 == 0,
+                    activity=f"2026-07-{1 + number % 28:02d} 12:00:00",
+                )
+            con.commit()
+            details = [
+                str(row["detail"])
+                for row in con.execute(
+                    "EXPLAIN QUERY PLAN "
+                    "SELECT c.conversation_id FROM conversations c "
+                    "WHERE c.mode='normal' AND c.owner_user_id=? "
+                    "AND c.shell_id=? AND c.starred=? "
+                    "ORDER BY c.last_activity_at DESC,c.conversation_id DESC "
+                    "LIMIT ?",
+                    (1, 1, 0, 21),
+                ).fetchall()
+            ]
+
+        self.assertTrue(any(
+            "idx_conversations_shell_activity" in detail
+            for detail in details
+        ), details)
+        self.assertFalse(any(
+            "USE TEMP B-TREE" in detail or detail.startswith("SCAN c")
+            for detail in details
+        ), details)
+
+    def test_large_transcript_fixture_materializes_deltas_at_one_watermark(
+        self,
+    ) -> None:
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=700,
+                state="closed",
+            )
+            message_ids, through_sequence = self.seed_transcript(
+                con,
+                conversation_id=conversation_id,
+            )
+            source_rows = con.execute(
+                "SELECT COUNT(*) FROM conversation_events "
+                "WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0]
+            con.commit()
+
+        status, headers, transcript = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/transcript",
+        )
+        self.assertEqual(status, 200, transcript)
+        self.assertEqual(headers["Cache-Control"], "no-store")
+        self.assertEqual(transcript["conversation_id"], conversation_id)
+        self.assertEqual(transcript["projection_version"], 1)
+        self.assertEqual(transcript["through_sequence"], through_sequence)
+        self.assertEqual(transcript["truncation"], None)
+        self.assertEqual(
+            [
+                (
+                    item["item_id"],
+                    item["kind"],
+                    item["message_id"],
+                    item["run_id"],
+                )
+                for item in transcript["items"]
+            ],
+            [
+                (f"message:{message_ids[0]}", "user", message_ids[0], None),
+                (
+                    f"run:{transcript['items'][1]['run_id']}:assistant",
+                    "assistant",
+                    message_ids[0],
+                    transcript["items"][1]["run_id"],
+                ),
+            ],
+        )
+        self.assertEqual(transcript["items"][1]["text"], "x" * 4000)
+        self.assertEqual(source_rows, 4003)
+        self.assertNotIn("assistant.delta", json.dumps(transcript))
+
+        with closing(self.connect()) as con:
+            self.assertEqual(
+                con.execute(
+                    "SELECT COUNT(*) FROM conversation_events "
+                    "WHERE conversation_id=?",
+                    (conversation_id,),
+                ).fetchone()[0],
+                source_rows,
+            )
+
+    def test_transcript_caps_are_injected_explicit_and_never_mutate_sources(
+        self,
+    ) -> None:
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=701,
+                state="closed",
+            )
+            self.seed_transcript(
+                con,
+                conversation_id=conversation_id,
+                turns=3,
+                deltas_per_turn=12,
+                delta_text="é" * 20,
+            )
+            source_rows = con.execute(
+                "SELECT COUNT(*) FROM conversation_events "
+                "WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0]
+            con.commit()
+
+            cases = (
+                (
+                    "turn_limit",
+                    conversation_routes.TranscriptLimits(
+                        max_turns=1,
+                        max_source_events=1000,
+                        max_source_bytes=1_000_000,
+                        max_response_bytes=1_000_000,
+                    ),
+                ),
+                (
+                    "source_event_limit",
+                    conversation_routes.TranscriptLimits(
+                        max_turns=200,
+                        max_source_events=10,
+                        max_source_bytes=1_000_000,
+                        max_response_bytes=1_000_000,
+                    ),
+                ),
+                (
+                    "source_byte_limit",
+                    conversation_routes.TranscriptLimits(
+                        max_turns=200,
+                        max_source_events=1000,
+                        max_source_bytes=400,
+                        max_response_bytes=1_000_000,
+                    ),
+                ),
+                (
+                    "response_byte_limit",
+                    conversation_routes.TranscriptLimits(
+                        max_turns=200,
+                        max_source_events=1000,
+                        max_source_bytes=1_000_000,
+                        max_response_bytes=1400,
+                    ),
+                ),
+            )
+            for reason, limits in cases:
+                with self.subTest(reason=reason):
+                    projected = conversation_routes._transcript_projection(
+                        con,
+                        conversation_id,
+                        owner_user_id=1,
+                        limits=limits,
+                    )
+                    encoded = json.dumps(
+                        projected,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ).encode()
+                    self.assertLessEqual(len(encoded), limits.max_response_bytes)
+                    self.assertEqual(projected["truncation"]["reason"], reason)
+                    self.assertGreaterEqual(
+                        projected["truncation"]["omitted_source_event_count"],
+                        0,
+                    )
+                    self.assertNotIn("assistant.delta", encoded.decode())
+
+            self.assertEqual(
+                con.execute(
+                    "SELECT COUNT(*) FROM conversation_events "
+                    "WHERE conversation_id=?",
+                    (conversation_id,),
+                ).fetchone()[0],
+                source_rows,
+            )
+
+    def test_snapshot_race_replays_the_post_watermark_event_exactly_once(
+        self,
+    ) -> None:
+        with closing(self.connect()) as setup:
+            conversation_id = self.seed_conversation(
+                setup,
+                number=702,
+                state="closed",
+            )
+            _message_ids, through_sequence = self.seed_transcript(
+                setup,
+                conversation_id=conversation_id,
+                deltas_per_turn=3,
+            )
+            setup.commit()
+
+        reader = conversation_routes.db_driver.connect(str(self.db_path))
+        self.addCleanup(reader.close)
+        writer = sqlite3.connect(self.db_path)
+        writer.execute("PRAGMA foreign_keys=ON")
+        self.addCleanup(writer.close)
+        inserted = False
+
+        def insert_after_watermark(statement: str) -> None:
+            nonlocal inserted
+            if (
+                inserted
+                or not statement.startswith("WITH ranked AS")
+                or "FROM conversation_messages" not in statement
+            ):
+                return
+            inserted = True
+            writer.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload) "
+                "VALUES (?,?,'run.unknown',?)",
+                (
+                    conversation_id,
+                    through_sequence + 1,
+                    json.dumps({"detail": "committed after snapshot"}),
+                ),
+            )
+            writer.commit()
+
+        reader.set_trace_callback(insert_after_watermark)
+        projection = conversation_routes._transcript_projection(
+            reader,
+            conversation_id,
+            owner_user_id=1,
+        )
+        reader.set_trace_callback(None)
+        self.assertTrue(inserted)
+        self.assertEqual(projection["through_sequence"], through_sequence)
+        self.assertNotIn(
+            "committed after snapshot",
+            json.dumps(projection),
+        )
+
+        replay = conversation_routes._event_batch(
+            conversation_id,
+            projection["through_sequence"],
+        )
+        self.assertEqual(
+            [
+                (
+                    event["sequence"],
+                    event["event_type"],
+                    event["payload"]["detail"],
+                )
+                for event in replay
+            ],
+            [
+                (
+                    through_sequence + 1,
+                    "run.unknown",
+                    "committed after snapshot",
+                )
+            ],
+        )
+
+    def test_snapshot_projection_uses_one_fixed_five_read_view(self) -> None:
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=703,
+                state="closed",
+            )
+            self.seed_transcript(
+                con,
+                conversation_id=conversation_id,
+                turns=2,
+                deltas_per_turn=10,
+            )
+            con.commit()
+            statements: list[str] = []
+            con.set_trace_callback(statements.append)
+            projection = conversation_routes._transcript_projection(
+                con,
+                conversation_id,
+                owner_user_id=1,
+            )
+            con.set_trace_callback(None)
+
+        reads = [
+            statement
+            for statement in statements
+            if statement.startswith(("SELECT", "WITH"))
+        ]
+        self.assertEqual(len(reads), 5, reads)
+        self.assertEqual(
+            sum(statement == "BEGIN" for statement in statements),
+            1,
+        )
+        self.assertEqual(
+            sum(statement == "ROLLBACK" for statement in statements),
+            1,
+        )
+        self.assertEqual(len(projection["items"]), 4)
+
+    def test_sse_reconnect_advances_past_the_snapshot_bootstrap(self) -> None:
+        query = {"after": ["4003"]}
+        self.assertEqual(
+            conversation_routes._after_sequence(
+                query,
+                {"Last-Event-ID": "4010"},
+            ),
+            4010,
+        )
+        self.assertEqual(
+            conversation_routes._after_sequence(
+                {"after": ["4010"]},
+                {"Last-Event-ID": "4003"},
+            ),
+            4010,
+        )
+        with self.assertRaises(conversation_routes.ApiError) as invalid:
+            conversation_routes._after_sequence(
+                {"cursor": ["opaque"], "after": ["4003"]},
+                {"Last-Event-ID": "4010"},
+            )
+        self.assertEqual(invalid.exception.code, "CURSOR_INVALID")
 
 
 class ConversationEventStreamTest(ConversationApiCase):

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -511,3 +511,292 @@ index 1111111..2222222 100644
     assert not browser_errors
     assert (tmp_path / "diff-desktop.png").stat().st_size > 10_000
     assert (tmp_path / "diff-mobile.png").stat().st_size > 10_000
+
+
+def test_chat_performance_uses_bounded_requests_and_keyed_frames(static_ui):
+    requests: list[tuple[str, str]] = []
+    browser_errors: list[str] = []
+    selected = {
+        **conversation(),
+        "title": "Deep linked fixture",
+        "last_activity_at": "2026-07-20 12:00:00",
+    }
+
+    def summary(number: int, *, starred: bool = False) -> dict:
+        return {
+            **conversation(),
+            "conversation_id": f"cv_{number:032x}",
+            "state": "closed",
+            "version": 1,
+            "title": f"{'Starred' if starred else 'Recent'} {number:02d}",
+            "starred": starred,
+            "created_at": f"2026-07-{1 + number % 20:02d} 10:00:00",
+            "last_activity_at": f"2026-07-{1 + number % 20:02d} 10:00:00",
+        }
+
+    recent = [summary(number) for number in range(1, 61)]
+    stars = [summary(100 + number, starred=True) for number in range(3)]
+    transcript = {
+        "conversation_id": CONVERSATION_ID,
+        "projection_version": 1,
+        "through_sequence": 7000,
+        "controls": {
+            "conversation_version": 4,
+            "conversation_state": "running",
+            "queued_count": 0,
+            "active_run_id": 77,
+            "close_requested_at": None,
+        },
+        "items": [
+            {
+                "item_id": "message:1",
+                "kind": "user",
+                "order_sequence": 1,
+                "message_id": 1,
+                "run_id": None,
+                "created_at": "2026-07-30 20:00:00",
+                "text": "keep this completed node",
+                "state": "completed",
+                "completed_at": "2026-07-30 20:00:01",
+                "text_truncated": False,
+            },
+            {
+                "item_id": "run:77:assistant",
+                "kind": "assistant",
+                "order_sequence": 2,
+                "message_id": 1,
+                "run_id": 77,
+                "created_at": "2026-07-30 20:00:02",
+                "text": "initial",
+                "outcome": None,
+                "first_sequence": 2,
+                "last_sequence": 7000,
+                "text_truncated": False,
+            },
+        ],
+        "truncation": None,
+    }
+
+    def fulfill(route, payload, *, status=200):
+        route.fulfill(
+            status=status,
+            content_type="application/json",
+            body=json.dumps(payload),
+        )
+
+    def route_api(route):
+        parsed = urlparse(route.request.url)
+        query = parse_qs(parsed.query)
+        requests.append((parsed.path, parsed.query))
+        if parsed.path == "/api/health":
+            return fulfill(route, {"repo": "subfloor"})
+        if parsed.path == "/api/shells":
+            return fulfill(
+                route,
+                {
+                    "shells": [
+                        {
+                            "shell_id": 1,
+                            "display_name": "CC",
+                            "shortname": "cc",
+                            "flavor": "dev",
+                        }
+                    ]
+                },
+            )
+        if parsed.path == "/api/sprints":
+            return fulfill(route, {"items": []})
+        if parsed.path == "/api/models":
+            return fulfill(route, {"harnesses": {}})
+        if parsed.path == "/api/flavor-defaults":
+            return fulfill(route, {"flavors": {}})
+        if parsed.path == "/api/conversations":
+            if query.get("open") == ["true"]:
+                return fulfill(route, {"items": [selected], "next_cursor": None})
+            if query.get("starred") == ["true"]:
+                return fulfill(route, {"items": stars, "next_cursor": None})
+            if query.get("starred") == ["false"]:
+                cursor = query.get("cursor", [None])[0]
+                start = int(cursor or 0)
+                page = recent[start:start + 20]
+                next_cursor = str(start + 20) if start + 20 < len(recent) else None
+                return fulfill(
+                    route,
+                    {"items": page, "next_cursor": next_cursor},
+                )
+            return fulfill(
+                route,
+                {"items": [selected, *recent[:20]], "next_cursor": None},
+            )
+        if parsed.path == f"/api/conversations/{CONVERSATION_ID}":
+            return fulfill(route, selected)
+        if parsed.path == f"/api/conversations/{CONVERSATION_ID}/transcript":
+            return fulfill(route, transcript)
+        if parsed.path == f"/api/conversations/{CONVERSATION_ID}/messages":
+            return fulfill(
+                route,
+                {
+                    "items": [
+                        {
+                            "message_id": 1,
+                            "message_kind": "prompt",
+                            "body": "keep this completed node",
+                            "state": "completed",
+                        }
+                    ]
+                },
+            )
+        if parsed.path == f"/api/conversations/{CONVERSATION_ID}/review-targets":
+            return fulfill(route, target_page())
+        return fulfill(
+            route,
+            {"error": {"code": "UNMOCKED", "message": parsed.path}},
+            status=404,
+        )
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        page = browser.new_page(viewport={"width": 1440, "height": 960})
+        page.add_init_script(
+            """
+            window.__chatPerf = {
+              rafScheduled: 0,
+              rafOutstanding: 0,
+              maxRafOutstanding: 0,
+              markdownParses: 0,
+              transcriptReplacements: 0,
+              assistantReplacements: 0,
+            };
+            const nativeFrame = window.requestAnimationFrame.bind(window);
+            window.requestAnimationFrame = (callback) => {
+              const perf = window.__chatPerf;
+              perf.rafScheduled += 1;
+              perf.rafOutstanding += 1;
+              perf.maxRafOutstanding = Math.max(
+                perf.maxRafOutstanding, perf.rafOutstanding);
+              return nativeFrame((timestamp) => {
+                perf.rafOutstanding -= 1;
+                callback(timestamp);
+              });
+            };
+            const nativeReplace = Element.prototype.replaceChildren;
+            Element.prototype.replaceChildren = function(...children) {
+              if (this.classList?.contains("chat-transcript"))
+                window.__chatPerf.transcriptReplacements += 1;
+              if (this.classList?.contains("chat-assistant-body"))
+                window.__chatPerf.assistantReplacements += 1;
+              return nativeReplace.apply(this, children);
+            };
+            window.__fakeEventSources = [];
+            class FakeEventSource {
+              constructor(url) {
+                this.url = url;
+                this.listeners = {};
+                window.__fakeEventSources.push(this);
+                queueMicrotask(() => this.onopen && this.onopen());
+              }
+              addEventListener(type, callback) {
+                (this.listeners[type] ||= []).push(callback);
+              }
+              emit(type, payload) {
+                for (const callback of this.listeners[type] || [])
+                  callback({ data: JSON.stringify(payload) });
+              }
+              close() {}
+            }
+            window.EventSource = FakeEventSource;
+            """
+        )
+        page.route("**/api/**", route_api)
+        page.on(
+            "pageerror",
+            lambda error: browser_errors.append(f"pageerror: {error}"),
+        )
+        page.goto(
+            f"{static_ui}/#interface/cc/{CONVERSATION_ID}",
+            wait_until="networkidle",
+        )
+        page.locator(".chat-transcript").wait_for()
+        page.evaluate(
+            """
+            const nativeParse = marked.parse.bind(marked);
+            marked.parse = (...args) => {
+              window.__chatPerf.markdownParses += 1;
+              return nativeParse(...args);
+            };
+            window.__completedChatNode =
+              document.querySelector('.chat-bubble.chat-user');
+            """
+        )
+
+        assert not [
+            path for path, _query in requests
+            if path in {"/api/models", "/api/flavor-defaults"}
+        ]
+        assert sum(
+            path.endswith("/transcript") for path, _query in requests
+        ) == 1
+        assert page.evaluate("window.__fakeEventSources.length") == 1
+        assert page.evaluate("window.__fakeEventSources[0].url").endswith(
+            f"/events?after={transcript['through_sequence']}"
+        )
+        assert page.locator(".chat-history-item").count() == 24
+
+        before_more = len(requests)
+        page.get_by_role("button", name="More").click()
+        page.get_by_text("Recent 21", exact=True).wait_for()
+        assert page.locator(".chat-history-item").count() == 44
+        added_requests = requests[before_more:]
+        assert sum(
+            path == "/api/conversations" and "starred=false" in query
+            for path, query in added_requests
+        ) == 1
+        assert not [
+            path for path, _query in added_requests
+            if path.endswith("/transcript") or "/review-targets" in path
+        ]
+
+        page.get_by_role("tab", name="Diff").click()
+        page.locator(".review-workspace").wait_for()
+        page.evaluate(
+            """
+            Object.assign(window.__chatPerf, {
+              rafScheduled: 0,
+              rafOutstanding: 0,
+              maxRafOutstanding: 0,
+              markdownParses: 0,
+              transcriptReplacements: 0,
+              assistantReplacements: 0,
+            });
+            for (let offset = 1; offset <= 500; offset += 1) {
+              window.__fakeEventSources[0].emit("assistant.delta", {
+                sequence: 7000 + offset,
+                event_type: "assistant.delta",
+                message_id: 1,
+                run_id: 77,
+                created_at: "2026-07-30 20:01:00",
+                payload: { text: "x" },
+              });
+            }
+            """
+        )
+        page.wait_for_timeout(100)
+        hidden_counts = page.evaluate("window.__chatPerf")
+        assert hidden_counts["markdownParses"] == 0
+        assert hidden_counts["transcriptReplacements"] == 0
+        assert hidden_counts["assistantReplacements"] == 0
+
+        page.get_by_role("tab", name="Chat").click()
+        page.get_by_text("initial" + ("x" * 500), exact=True).wait_for()
+        catch_up = page.evaluate("window.__chatPerf")
+        assert catch_up["maxRafOutstanding"] <= 1
+        assert catch_up["markdownParses"] <= 1
+        assert catch_up["assistantReplacements"] <= 1
+        assert catch_up["transcriptReplacements"] == 0
+        assert page.evaluate(
+            "window.__completedChatNode === "
+            "document.querySelector('.chat-bubble.chat-user')"
+        )
+        browser.close()
+
+    assert not browser_errors

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -20,10 +20,7 @@ def test_interface_is_a_first_class_reload_safe_view():
 
 
 def test_open_chat_restore_matches_the_flat_shell_projection():
-    assert (
-        "shells.find((item) => item.shell_id === openConversation.shell.shell_id)"
-        in APP
-    )
+    assert "item.shell_id === openConversation.shell.shell_id" in APP
     assert (
         "shells.find((item) => item.shell.shell_id "
         "=== openConversation.shell.shell_id)"
@@ -76,6 +73,37 @@ def test_transcript_streams_normalized_events_and_reconnects_natively():
     assert "mdBlock(body)" in interface
 
 
+def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    keyed = interface[interface.index("function chatCreateTranscriptState"):
+                      interface.index("async function renderInterface")]
+
+    assert "snapshot.projection_version !== 1" in keyed
+    assert "items.has(item.item_id)" in keyed
+    assert "nodes: new Map()" in keyed
+    assert "dirty: new Set(items.keys())" in keyed
+    assert "transcript.replaceChildren(...nodes)" in keyed
+    assert "chatUpdateTranscriptNode(node, item, retry)" in keyed
+    assert 'node.querySelector(".chat-assistant-body")' in keyed
+    assert "body.replaceChildren(...rendered.childNodes)" in keyed
+    assert "if (transcriptState.frame !== null) return" in keyed
+    assert "transcriptState.frame = requestAnimationFrame" in keyed
+    assert 'if (currentMode !== "chat")' in keyed
+    assert "transcriptState.hiddenDirty = true" in keyed
+    assert "sequence !== transcriptState.lastSequence + 1" in keyed
+    assert "if (reconcilePromise" in keyed
+    assert "`run:${runId}:assistant`" in keyed
+    assert "assistant.text += event.payload?.text || \"\"" in keyed
+    assert "transcriptState.throughSequence" in keyed
+    assert "/events?after=${afterSequence}" in interface
+    assert "/transcript`" in keyed
+    assert "/messages?limit=100" not in interface[
+      interface.index("const loadTranscript = async"):
+      interface.index("await loadTranscript()")
+    ]
+
+
 def test_connection_status_is_attached_to_transcript_without_visible_copy():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
@@ -96,8 +124,9 @@ def test_transcript_hides_routine_tools_but_keeps_actionable_activity():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
     activity = interface[
-        interface.index("function chatActivity"):
-        interface.index("function chatAssistantRuns")
+        interface.index("const activityLabel = (event) =>"):
+        interface.index("chatOpenStream(", interface.index(
+          "const activityLabel = (event) =>"))
     ]
     assert '"tool.started"' not in activity
     assert '"tool.completed"' not in activity
@@ -138,7 +167,7 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert 'className: "chat-queue-state"' in interface
     assert 'queueState.textContent = `${queued} queued`' in interface
     assert 'conversation.state !== "running"' in interface
-    assert 'event.event_type === "run.started") message.state = "running"' in interface
+    assert 'type === "run.started") message.state = "running"' in interface
     assert 'textContent: "Interrupt"' not in interface
     assert 'textContent: "Retry"' in interface
     assert 'textContent: "Close"' in interface
@@ -201,7 +230,7 @@ def test_chat_switch_refetches_authoritative_version_before_close():
                     APP.index("// ── Tabs + boot")]
     close_for_switch = interface[
         interface.index("async function chatCloseForSwitch"):
-        interface.index("function chatActivity")
+        interface.index("function chatBubble")
     ]
     assert "const latest = await chatApi(" in close_for_switch
     assert 'if (latest.state === "closed") return true' in close_for_switch
@@ -221,7 +250,7 @@ def test_conversation_identity_uses_shell_context_and_neutral_user_label():
     assert '"Untitled chat"' in interface
     assert 'className: "chat-history-context"' in interface
     assert 'className: "chat-shell-shortname"' in interface
-    assert "chatPaintShellState(button, active?.state)" in interface
+    assert "chatPaintShellState(button, openByShell.get(item.shell_id))" in interface
 
 
 def test_interface_owns_scroll_with_fixed_history_and_conversation_controls():
@@ -267,18 +296,17 @@ def test_history_metadata_and_all_shell_accents_poll_without_repainting_interfac
     assert "const shellItems = new Map()" in interface
     assert "historyItems.set(conversation.conversation_id, item)" in interface
     assert "shellItems.set(item.shell_id, button)" in interface
-    assert 'await chatApi("/conversations?limit=100")' in interface
+    assert "`/conversations?open=true&limit=100${suffix}`" in interface
     assert "generation !== chatRenderGeneration || !chatHistoryPollTimer" in interface
     assert "historyItems.get(conversation.conversation_id)" in interface
     assert "chatPaintHistoryItem(item, conversation)" in interface
     assert "item.name.textContent = chatConversationName(conversation)" in interface
     assert "chatPaintStar(item.star, Boolean(conversation.starred))" in interface
-    assert "selectedConversation = conversation" in interface
-    assert "const openByShell = new Map()" in interface
-    assert 'if (conversation.state !== "closed")' in interface
-    assert "openByShell.set(conversation.shell.shell_id" in interface
+    assert "selectedConversation = acceptSummary(conversation)" in interface
+    assert "const nextOpenByShell = new Map()" in interface
+    assert "nextOpenByShell.set(" in interface
     assert "for (const [shellId, button] of shellItems)" in interface
-    assert "chatPaintShellState(button, openByShell.get(shellId))" in interface
+    assert "chatPaintShellState(button, nextOpenByShell.get(shellId))" in interface
     assert "if (document.hidden || historyPollInFlight) return" in interface
     assert "finally { historyPollInFlight = false; }" in interface
     assert "setInterval(pollHistory, CHAT_HISTORY_POLL_MS)" in interface
@@ -287,11 +315,74 @@ def test_history_metadata_and_all_shell_accents_poll_without_repainting_interfac
     assert "renderInterface(" not in poll
 
 
+def test_interface_arrival_defers_configuration_and_phases_history_requests():
+    interface = APP[APP.index("async function renderInterface"):
+                    APP.index("// ── Tabs + boot")]
+    loader = APP[APP.index("function chatLoadConfiguration"):
+                 APP.index("function chatStopStream")]
+
+    assert 'api("/models")' not in interface
+    assert 'api("/flavor-defaults")' not in interface
+    assert 'api("/flavor-defaults")' in loader
+    assert 'api("/models")' in loader
+    assert "if (chatConfiguration) return Promise.resolve(chatConfiguration)" in loader
+    assert "if (chatConfigurationPromise) return chatConfigurationPromise" in loader
+    assert "chatConfigurationPromise = null" in loader
+    assert 'chatApi("/conversations?open=true&limit=100")' in interface
+    assert "starred=false&limit=20" in interface
+    assert "starred=true&limit=100" in interface
+    assert "const recentPage = await recentRequest" in interface
+    assert "loadStars();" in interface
+    assert "await loadStars()" not in interface
+    assert 'textContent: "Retry"' in interface
+    assert "chatRenderNew(pane, shell, defaults, catalog)" in interface
+
+
+def test_history_more_and_deep_links_are_keyed_and_failure_isolated():
+    interface = APP[APP.index("async function renderInterface"):
+                    APP.index("// ── Tabs + boot")]
+
+    assert "const detailRequest = deepLinked" in interface
+    assert "chatApi(`/conversations/${chatRouteConversation}`)" in interface
+    assert "selectedConversation.shell.shortname !== chatRouteShell" in interface
+    assert "history.replaceState(" in interface
+    assert "const summaries = new Map()" in interface
+    assert "const historyItems = new Map()" in interface
+    assert "const starredIds = new Set()" in interface
+    assert "if (moreInFlight || !moreCursor) return" in interface
+    assert "const requestedCursor = moreCursor" in interface
+    assert "moreCursor = requestedCursor" in interface
+    assert 'more.textContent = "Retry"' in interface
+    assert "if (!recentIds.includes(conversation.conversation_id))" in interface
+    assert "selected ? [selected] : []" in interface
+    assert "if (starsInFlight) return" in interface
+    assert "Starred chats unavailable" in interface
+
+
+def test_history_poll_only_reconciles_open_pages_without_advancing_history():
+    interface = APP[APP.index("async function renderInterface"):
+                    APP.index("// ── Tabs + boot")]
+    poll = interface[interface.index("const pollHistory = async"):
+                     interface.index(
+                       "chatHistoryPollTimer = setInterval",
+                       interface.index("const pollHistory = async"),
+                     )]
+
+    assert "`/conversations?open=true&limit=100${suffix}`" in poll
+    assert "cursor = page.next_cursor" in poll
+    assert "starred=true" not in poll
+    assert "starred=false" not in poll
+    assert "moreCursor" not in poll
+    assert "renderInterface(" not in poll
+    assert "historyItems.get(conversation.conversation_id)" in poll
+    assert "chatPaintShellState(button, nextOpenByShell.get(shellId))" in poll
+
+
 def test_history_card_has_independent_durable_star_button():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
     history = interface[interface.index('const history = el("div"'):
-                        interface.index("if (!conversations.length)")]
+                        interface.index("const renderHistory =")]
 
     assert 'const card = el("div", {' in history
     assert 'className: "chat-history-open"' in history
@@ -300,7 +391,8 @@ def test_history_card_has_independent_durable_star_button():
     assert "card.append(open, star)" in history
     assert "event.stopPropagation()" in history
     assert '{ version: current.version, starred: !current.starred }' in history
-    assert "chatPaintHistoryItem(item, updated)" in history
+    assert "acceptSummary(updated)" in history
+    assert "renderHistory()" in history
     assert 'button.textContent = starred ? "★" : "☆"' in interface
     assert 'button.setAttribute("aria-pressed", String(starred))' in interface
     assert ".chat-history-star:hover, .chat-history-star.starred" in STYLE
@@ -310,8 +402,8 @@ def test_history_card_has_independent_durable_star_button():
 def test_working_state_is_plain_animated_transcript_text_not_a_header_pill():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
-    transcript = interface[interface.index("function chatPaintTranscript"):
-                           interface.index("async function chatRefreshConversation")]
+    transcript = interface[interface.index("function chatFlushTranscript"):
+                           interface.index("async function chatRenderOpen")]
     header = interface[interface.index("async function chatRenderOpen"):
                        interface.index("async function submit()")]
     indicator_style = STYLE[STYLE.index(".chat-working-indicator {"):
@@ -320,8 +412,8 @@ def test_working_state_is_plain_animated_transcript_text_not_a_header_pill():
     assert 'indicator.append("<Working>", chatWorkingDots())' in interface
     assert 'className: "chat-working-indicator"' in interface
     assert 'role: "status"' in interface
-    assert 'if (conversation.state === "running")' in transcript
-    assert "node: chatWorkingIndicator()" in transcript
+    assert 'if (conversation.state === "running" && !working)' in transcript
+    assert "transcript.append(chatWorkingIndicator())" in transcript
     assert "chatStatePill(conversation.state)" not in transcript
     assert "header.append(title, queueState, actions)" in header
     assert "chatStatePill(conversation.state)" not in header


### PR DESCRIPTION
## Summary
- add strict filtered conversation history with scope-bound cursors and reuse the existing shell/activity index
- add a bounded same-snapshot transcript projection plus reconnect-safe SSE bootstrap semantics
- phase Interface/configuration/history loading and render live transcripts through keyed, frame-coalesced updates
- add deterministic API and optional Playwright performance fixtures

## Trade-off
The transcript remains an on-demand read projection with no cache table or per-delta writes. `EXPLAIN QUERY PLAN` proves the existing shell/activity index serves filtered ordering, so this change deliberately adds no migration.

## Verification
- `pytest` focused conversation integration: 125 passed, 160 subtests
- full `pytest tests/`: 1718 passed, 1 skipped, 803 subtests
- `./sc render-check`
- `node --check .super-coder/ui/app.js`
- changed-code Ruff gate (excluding two pre-existing warnings on an untouched line)
- `git diff --check`

The optional Playwright fixture is included for the provisioned browser lane; this host does not have Playwright/Chromium installed.

Spec #42 · Feature #24 · Decision #32