### PR TITLE
feat: add safe repository teardown

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -34,14 +34,14 @@
 #   LONG-ONLY: Interface status/start/view/attach/take-control/stop/reconcile/
 #              recover; models/job; build/logs/serve/health/ports;
 #              verify/map/render/snapshot/deps/install/rollback/
-#              update-harnesses/harness-status/feature/eject
+#              update-harnesses/harness-status/feature/eject/remove
 #              passthrough: make dos ARGS=health
 #
 SC := ./sc
 .PHONY: dos-e dos-enter dos-l dos-launch dos-r dos-restart dos-d dos-down dos-u dos-update \
         dos-t dos-test dos-h dos-help dos-url dos-build dos-logs dos-serve dos-health dos-ports \
         dos-verify dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback \
-        dos-update-harnesses dos-harness-status dos-feat dos-feature dos-eject dos-status \
+        dos-update-harnesses dos-harness-status dos-feat dos-feature dos-eject dos-remove dos-status \
         dos-start dos-view dos-attach dos-take dos-take-control dos-stop \
         dos-reconcile dos-recover dos-models dos-model-refresh dos-model-list \
         dos-model-resolve dos-job dos-setup dos
@@ -114,6 +114,8 @@ dos-feature:          ; $(SC) feature $(ARGS)
 dos-feat: dos-feature
 # One-way divergence — interactive warning + typed confirmation in ./sc eject.
 dos-eject:            ; $(SC) eject
+# One-way uninstall — ./sc remove owns confirmation, backup, and safety gates.
+dos-remove:           ; $(SC) remove $(ARGS)
 
 # Passthrough: run any ./sc subcommand — make dos ARGS=health
 dos:                  ; $(SC) $(ARGS)
@@ -190,6 +192,8 @@ dos-help:
 	@echo "    dos-harness-status          harness CLI versions in the sandbox + is a harness rebuild owed"
 	@echo "    dos-feat / dos-feature      list/enable/disable opt-in features"
 	@echo "    dos-eject                   ONE-WAY: own the engine"
+	@echo "    dos-remove                  ONE-WAY: verified DB backup, then remove subfloor from this repo"
+	@echo "                                (ARGS='--dry-run' previews; ARGS='--yes' skips only confirmation)"
 	@echo ""
 	@echo "    dos ARGS='<cmd>'            generic ./sc passthrough"
 	@echo ""

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -57,6 +57,18 @@ import ports as ports_mod  # noqa: E402
 
 # --- make-alias wiring (shared by install + update) -------------------------
 ALIASES_INCLUDE = "-include .super-coder/aliases.mk"
+INSTALLER_MAKEFILE = (
+    "# Fork Makefile — super-coder convenience aliases (make dos-e / dos-enter).\n"
+    "# Every target is dos--prefixed; add your own targets below the include.\n"
+    f"{ALIASES_INCLUDE}\n"
+)
+APPENDED_ALIASES_BLOCK = (
+    "\n# super-coder convenience aliases (designs-OS 'dos-' command standard).\n"
+    "# Appended by ./sc; every target is dos--prefixed so it can't collide with\n"
+    "# this Makefile's own targets. Delete this line to opt out — `./sc <cmd>`\n"
+    "# stays equivalent.\n"
+    f"{ALIASES_INCLUDE}\n"
+)
 # Matches an existing include of the alias file in any form: hard `include` or
 # soft `-include`, with arbitrary surrounding whitespace.
 _ALIASES_RE = re.compile(r"^\s*-?include\s+\.super-coder/aliases\.mk\s*$", re.M)
@@ -81,23 +93,14 @@ def wire_make_aliases(repo_root: Path | None = None) -> str:
     """
     mk = (repo_root or REPO_ROOT) / "Makefile"
     if not mk.exists():
-        mk.write_text(
-            "# Fork Makefile — super-coder convenience aliases (make dos-e / dos-enter).\n"
-            "# Every target is dos--prefixed; add your own targets below the include.\n"
-            f"{ALIASES_INCLUDE}\n"
-        )
+        mk.write_text(INSTALLER_MAKEFILE)
         return "wrote Makefile (-include .super-coder/aliases.mk) → `make dos-e` works"
     text = mk.read_text()
     if _ALIASES_RE.search(text):
         return "Makefile already wired (-include .super-coder/aliases.mk) — left as-is"
     sep = "" if text.endswith("\n") else "\n"
     mk.write_text(
-        text + sep
-        + "\n# super-coder convenience aliases (designs-OS 'dos-' command standard).\n"
-        + "# Appended by ./sc; every target is dos--prefixed so it can't collide with\n"
-        + "# this Makefile's own targets. Delete this line to opt out — `./sc <cmd>`\n"
-        + "# stays equivalent.\n"
-        + f"{ALIASES_INCLUDE}\n"
+        text + sep + APPENDED_ALIASES_BLOCK
     )
     return "appended -include .super-coder/aliases.mk to existing Makefile → `make dos-e` works"
 
@@ -126,6 +129,23 @@ VISUAL_QA_TEMPLATE_TARGETS = {
     "subfloor-visual-qa.yml": Path(".github/workflows/subfloor-visual-qa.yml"),
     "visual-qa.example.json": Path(".sc-state/visual-qa.example.json"),
 }
+
+# Repo-local surfaces emitted or wholly owned by an installed engine.  Teardown
+# imports this inventory so install and remove cannot quietly disagree about
+# which generated paths belong to subfloor.  Mixed host files (Makefile,
+# .gitignore, shared/) are handled surgically instead.
+GENERATED_INSTALL_PATHS = (
+    Path("CLAUDE.md"),
+    Path("AGENTS.md"),
+    Path("opencode.json"),
+    Path(".claude/settings.local.json"),
+    Path(".codex/hooks.json"),
+    Path(".claude/skills"),
+    Path("roadmap_sc.md"),
+    Path("docs_sc"),
+    Path("specs_sc"),
+    Path("skills_sc"),
+)
 
 
 def origin_basename() -> str | None:

--- a/.super-coder/scripts/remove.py
+++ b/.super-coder/scripts/remove.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+"""Safely remove an installed subfloor engine from its host repository.
+
+The removal backup is the one intentional residue:
+
+    .sc-state/db_backups/removal/<timestamp>/
+
+Everything destructive is gated on an exact target, clean shell worktrees, a
+quiesced repo runtime, and a verified WAL-safe database backup.  Machine-wide
+harnesses, credentials, images, project files, branches, and unrelated Git
+configuration are outside this command's ownership boundary.
+
+Usage:
+    ./sc remove [--dry-run] [--yes]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import signal
+import socket
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+STATE_DIR = REPO_ROOT / ".sc-state"
+DB_PATH = ENGINE / "shell_db.db"
+BACKUP_ROOT = STATE_DIR / "db_backups" / "removal"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import db_backup
+import engine_manifest
+import install
+
+BACKUP_IGNORE = "/.sc-state/db_backups/"
+BACKUP_IGNORE_COMMENT = "# subfloor removal backup — preserved after make dos-remove"
+MANAGED_WORKTREES = ".sc-worktrees"
+VISUAL_QA_WORKFLOW = Path(".github/workflows/subfloor-visual-qa.yml")
+VISUAL_QA_MARKER = "# managed-by: subfloor — visual-qa shim "
+
+_ACTIVE_MANIFEST: Path | None = None
+_ACTIVE_DATA: dict | None = None
+
+
+class RemoveError(RuntimeError):
+    """A safety gate failed; no further teardown may proceed."""
+
+
+def _run(
+    *args: str,
+    cwd: Path,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        list(args), cwd=cwd, capture_output=True, text=True, check=False
+    )
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise RemoveError(f"{' '.join(args)} failed: {detail or result.returncode}")
+    return result
+
+
+def _inside(path: Path, root: Path) -> bool:
+    try:
+        path.absolute().relative_to(root.absolute())
+        return True
+    except ValueError:
+        return False
+
+
+def validate_target(repo_root: Path = REPO_ROOT) -> Path:
+    root = repo_root.resolve()
+    if root in {Path("/"), Path.home().resolve()}:
+        raise RemoveError(f"refusing unsafe repository root: {root}")
+    if (repo_root / ".git").is_file():
+        raise RemoveError(
+            "remove must run from the main checkout, not a linked worktree"
+        )
+    top = _run("git", "rev-parse", "--show-toplevel", cwd=repo_root)
+    if top.returncode != 0:
+        raise RemoveError("remove requires the installed host to be a Git repository")
+    git_root = Path(top.stdout.strip()).resolve()
+    if git_root != root:
+        raise RemoveError(f"engine root and Git root disagree: {root} != {git_root}")
+
+    origin = _run("git", "remote", "get-url", "origin", cwd=root)
+    if origin.returncode == 0:
+        name = origin.stdout.strip().rstrip("/").split("/")[-1].removesuffix(".git")
+        if name in install.SOURCE_REPO_NAMES:
+            raise RemoveError(
+                "this is the subfloor source repository; remove is fork-only"
+            )
+    return root
+
+
+def _parse_worktrees(text: str) -> list[Path]:
+    paths: list[Path] = []
+    for line in text.splitlines():
+        if line.startswith("worktree "):
+            paths.append(Path(line.removeprefix("worktree ")))
+    return paths
+
+
+def managed_worktrees(repo_root: Path) -> list[Path]:
+    result = _run("git", "worktree", "list", "--porcelain", cwd=repo_root, check=True)
+    managed = (repo_root / MANAGED_WORKTREES).absolute()
+    return [path for path in _parse_worktrees(result.stdout) if _inside(path, managed)]
+
+
+def dirty_worktrees(worktrees: list[Path]) -> list[Path]:
+    dirty: list[Path] = []
+    for path in worktrees:
+        result = _run("git", "status", "--porcelain", "--untracked-files=all", cwd=path)
+        if result.returncode != 0 or result.stdout.strip():
+            dirty.append(path)
+    return dirty
+
+
+def remove_worktrees(repo_root: Path, worktrees: list[Path]) -> None:
+    newly_dirty = dirty_worktrees(worktrees)
+    if newly_dirty:
+        joined = "\n  - ".join(str(path) for path in newly_dirty)
+        raise RemoveError(f"worktree became dirty; refusing removal:\n  - {joined}")
+    for path in worktrees:
+        _run("git", "worktree", "remove", str(path), cwd=repo_root, check=True)
+        print(f"  removed clean worktree {path}")
+    _run("git", "worktree", "prune", cwd=repo_root, check=True)
+
+
+def engine_drift(repo_root: Path) -> tuple[dict[str, str], list[str]]:
+    edits = engine_manifest.local_edits()
+    manifest = ENGINE / "engine.manifest"
+    known: set[str] = set()
+    try:
+        known = set(json.loads(manifest.read_text()))
+    except (OSError, json.JSONDecodeError):
+        pass
+    added: list[str] = []
+    engine_root = repo_root / ".super-coder"
+    if engine_root.is_dir() and known:
+        for path in engine_root.rglob("*"):
+            if not path.is_file() or path.name == "engine.manifest":
+                continue
+            engine_rel = path.relative_to(engine_root)
+            if (
+                engine_rel.parts[0] in {"run", "logs"}
+                or path.name == "instance.json"
+                or path.name.startswith("shell_db.db")
+            ):
+                continue
+            rel = str(path.relative_to(repo_root))
+            if rel not in known and "__pycache__" not in path.parts:
+                added.append(rel)
+    return edits, sorted(added)
+
+
+def show_plan(
+    repo_root: Path,
+    worktrees: list[Path],
+    edits: dict[str, str],
+    added: list[str],
+) -> None:
+    print("subfloor remove — teardown plan")
+    print(f"  repository : {repo_root}")
+    print(f"  database   : {DB_PATH if DB_PATH.exists() else '(no live DB)'}")
+    print(f"  backups    : {BACKUP_ROOT}/<UTC timestamp>/")
+    print(f"  worktrees  : {len(worktrees)} clean managed worktree(s)")
+    if edits or added:
+        print(f"  engine drift: {len(edits)} changed + {len(added)} added file(s)")
+        for path, state in sorted(edits.items()):
+            print(f"    {state:8} {path}")
+        for path in added:
+            print(f"    added    {path}")
+    print("  remove     : repo runtime, engine, generated state, shell worktrees,")
+    print("               subfloor hook/remote/Makefile integration")
+    print("  preserve   : project files, branches, unrelated Git config, shared")
+    print("               machine tools, credentials, images, and all DB backups")
+
+
+def confirm(repo_root: Path) -> None:
+    phrase = f"REMOVE {repo_root.name}"
+    if not sys.stdin.isatty():
+        raise RemoveError(
+            f"non-interactive stdin requires --yes (confirmation is {phrase!r})"
+        )
+    try:
+        answer = input(f"Type '{phrase}' to continue: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        answer = ""
+    if answer != phrase:
+        raise RemoveError("remove aborted; nothing was stopped or deleted")
+
+
+def ensure_backup_ignore(repo_root: Path) -> None:
+    gitignore = repo_root / ".gitignore"
+    text = gitignore.read_text() if gitignore.exists() else ""
+    lines = text.splitlines()
+    if BACKUP_IGNORE in {line.strip() for line in lines}:
+        return
+    suffix = "" if not text or text.endswith("\n") else "\n"
+    gitignore.write_text(
+        text + suffix + f"\n{BACKUP_IGNORE_COMMENT}\n{BACKUP_IGNORE}\n"
+    )
+
+
+def new_backup_dir(repo_root: Path) -> Path:
+    root = repo_root / ".sc-state" / "db_backups" / "removal"
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    destination = root / stamp
+    destination.mkdir(parents=True, mode=0o700)
+    os.chmod(destination, 0o700)
+    db_backup._probe_writable(destination)
+    return destination
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _db_metadata(path: Path) -> tuple[int, str]:
+    uri = f"{path.resolve().as_uri()}?mode=ro"
+    con = sqlite3.connect(uri, uri=True)
+    try:
+        version = int(con.execute("PRAGMA user_version").fetchone()[0])
+        integrity = str(con.execute("PRAGMA integrity_check").fetchone()[0])
+    finally:
+        con.close()
+    return version, integrity
+
+
+def write_manifest(path: Path, data: dict) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+
+
+def backup_database(repo_root: Path, destination: Path) -> tuple[Path | None, dict]:
+    source = repo_root / ".super-coder" / "shell_db.db"
+    engine_ref_path = repo_root / ".sc-state" / "engine.ref"
+    engine_ref = ""
+    try:
+        engine_ref = engine_ref_path.read_text().strip()
+    except OSError:
+        pass
+    data: dict = {
+        "format_version": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "repository": str(repo_root),
+        "engine_ref": engine_ref or None,
+        "status": "preparing",
+        "removed": [],
+        "preserved": [str(destination)],
+        "errors": [],
+    }
+    if not source.exists():
+        data["database"] = None
+        data["status"] = "backed_up"
+        return None, data
+
+    source_version, _ = _db_metadata(source)
+    backup = db_backup.backup_database(source, destination, "removal", keep=1_000_000)
+    if backup is None:
+        raise RemoveError("live database disappeared before backup")
+    os.chmod(backup, 0o600)
+    backup_version, integrity = _db_metadata(backup)
+    if integrity != "ok":
+        raise RemoveError(f"backup integrity check failed: {integrity}")
+    if backup_version != source_version:
+        raise RemoveError(
+            f"backup user_version mismatch: {backup_version} != {source_version}"
+        )
+    data["database"] = {
+        "source": str(source),
+        "file": backup.name,
+        "bytes": backup.stat().st_size,
+        "sha256": _sha256(backup),
+        "user_version": backup_version,
+        "integrity_check": integrity,
+    }
+    data["status"] = "backed_up"
+    return backup, data
+
+
+def stop_running_jobs(repo_root: Path) -> None:
+    jobs = repo_root / ".super-coder" / "run" / "jobs"
+    if not jobs.is_dir():
+        return
+    for jobdir in sorted(path for path in jobs.iterdir() if path.is_dir()):
+        try:
+            meta = json.loads((jobdir / "meta.json").read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if meta.get("finished_at") is not None:
+            continue
+        pid = meta.get("pid")
+        if not pid:
+            continue
+        result = _run(str(repo_root / "sc"), "job", "kill", jobdir.name, cwd=repo_root)
+        if result.returncode != 0 and "already finished" not in result.stderr:
+            raise RemoveError(
+                f"could not stop durable job {jobdir.name}: "
+                f"{(result.stderr or result.stdout).strip()}"
+            )
+
+
+def _pg_configured(repo_root: Path) -> bool:
+    try:
+        instance = json.loads(
+            (repo_root / ".super-coder" / "instance.json").read_text()
+        )
+    except (OSError, json.JSONDecodeError):
+        return False
+    return "pg" in instance
+
+
+def quiesce_runtime(repo_root: Path) -> None:
+    stop_running_jobs(repo_root)
+    docker = shutil.which("docker")
+    result = _run(str(repo_root / "sc"), "down", cwd=repo_root)
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.returncode != 0:
+        # `sc down` ends with its PostgreSQL absence proof.  On a deliberately
+        # no-Docker host that proof cannot run even when this fork never
+        # configured a sidecar; all preceding host-broker shutdowns have still
+        # completed.  Accept only that narrow case, then prove the engine API
+        # listener is absent below.  A configured sidecar remains fail-closed.
+        if docker is None and not _pg_configured(repo_root):
+            print(
+                "→ no Docker CLI and no configured PG sidecar; checking host listener"
+            )
+        else:
+            raise RemoveError(
+                "runtime shutdown failed: "
+                + ((result.stderr or result.stdout).strip() or str(result.returncode))
+            )
+    if docker:
+        names = _run(
+            docker,
+            "ps",
+            "-a",
+            "--format",
+            "{{.Names}}",
+            cwd=repo_root,
+        )
+        if names.returncode == 0:
+            forbidden = {f"sc-{repo_root.name}", f"sc-pg-{repo_root.name}"}
+            remaining = forbidden & set(names.stdout.splitlines())
+            if remaining:
+                raise RemoveError(
+                    "runtime shutdown left container(s): "
+                    + ", ".join(sorted(remaining))
+                )
+    port_result = _run(
+        sys.executable,
+        str(repo_root / ".super-coder" / "scripts" / "ports.py"),
+        "port",
+        cwd=repo_root,
+    )
+    if port_result.returncode == 0 and port_result.stdout.strip().isdigit():
+        port = int(port_result.stdout.strip())
+        try:
+            connection = socket.create_connection(("127.0.0.1", port), timeout=0.25)
+        except OSError:
+            pass
+        else:
+            connection.close()
+            raise RemoveError(
+                f"runtime shutdown left a listener on 127.0.0.1:{port}; "
+                "stop the foreground server and retry"
+            )
+
+
+def cleanup_makefile(repo_root: Path) -> bool:
+    path = repo_root / "Makefile"
+    if not path.exists():
+        return False
+    text = path.read_text()
+    if text == install.INSTALLER_MAKEFILE:
+        path.unlink()
+        return True
+    updated = text.replace(install.APPENDED_ALIASES_BLOCK, "")
+    updated = install._ALIASES_RE.sub("", updated)
+    if updated == text:
+        return False
+    updated = re.sub(r"\n{3,}", "\n\n", updated)
+    path.write_text(updated)
+    return True
+
+
+def cleanup_gitignore(repo_root: Path) -> bool:
+    path = repo_root / ".gitignore"
+    existing = path.read_text() if path.exists() else ""
+    remove_patterns = set(install._required_ignores())
+    remove_patterns.discard(BACKUP_IGNORE)
+    remove_comments = {
+        line.strip()
+        for line in install._GITIGNORE_BLOCK.splitlines()
+        if line.strip().startswith("#")
+    }
+    remove_comments.add("# super-coder — engine ignore rules added by `./sc update`")
+    remove_comments.add(BACKUP_IGNORE_COMMENT)
+    kept = [
+        line
+        for line in existing.splitlines()
+        if line.strip() not in remove_patterns
+        and line.strip() not in remove_comments
+        and line.strip() != BACKUP_IGNORE
+    ]
+    while kept and not kept[-1].strip():
+        kept.pop()
+    updated = "\n".join(kept)
+    if updated:
+        updated += "\n\n"
+    updated += f"{BACKUP_IGNORE_COMMENT}\n{BACKUP_IGNORE}\n"
+    if updated == existing:
+        return False
+    path.write_text(updated)
+    return True
+
+
+def cleanup_hooks(repo_root: Path) -> bool:
+    current = _run("git", "config", "--get", "core.hooksPath", cwd=repo_root)
+    if current.returncode != 0:
+        return False
+    raw = current.stdout.strip()
+    configured = Path(raw).expanduser()
+    if not configured.is_absolute():
+        configured = repo_root / configured
+    if configured.resolve() != (repo_root / ".super-coder" / "hooks").resolve():
+        return False
+    _run("git", "config", "--unset", "core.hooksPath", cwd=repo_root, check=True)
+    return True
+
+
+def cleanup_upstream_remotes(repo_root: Path) -> list[str]:
+    remotes = _run("git", "remote", cwd=repo_root, check=True).stdout.splitlines()
+    removed: list[str] = []
+    for remote in remotes:
+        if remote == "origin":
+            continue
+        url = _run("git", "remote", "get-url", remote, cwd=repo_root)
+        if url.returncode != 0:
+            continue
+        name = url.stdout.strip().rstrip("/").split("/")[-1].removesuffix(".git")
+        if name not in install.SOURCE_REPO_NAMES:
+            continue
+        _run("git", "remote", "remove", remote, cwd=repo_root, check=True)
+        removed.append(remote)
+    return removed
+
+
+def _remove_path(path: Path, repo_root: Path) -> bool:
+    if not _inside(path, repo_root):
+        raise RemoveError(f"refusing path outside repository: {path}")
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+        return True
+    if path.is_dir():
+        if not path.resolve().is_relative_to(repo_root.resolve()):
+            raise RemoveError(f"refusing directory outside repository: {path}")
+        shutil.rmtree(path)
+        return True
+    return False
+
+
+def cleanup_visual_qa(repo_root: Path) -> bool:
+    path = repo_root / VISUAL_QA_WORKFLOW
+    if not path.is_file():
+        return False
+    try:
+        first = path.read_text().splitlines()[0]
+    except (OSError, IndexError):
+        return False
+    if not first.startswith(VISUAL_QA_MARKER):
+        return False
+    path.unlink()
+    return True
+
+
+def cleanup_shared_scaffolds(repo_root: Path) -> list[str]:
+    removed: list[str] = []
+    for relative in (Path("shared/redlines"), Path("shared")):
+        directory = repo_root / relative
+        keep = directory / ".gitkeep"
+        if not directory.is_dir():
+            continue
+        entries = list(directory.iterdir())
+        if entries == [keep]:
+            keep.unlink()
+            directory.rmdir()
+            removed.append(str(relative))
+    return removed
+
+
+def cleanup_state(repo_root: Path) -> list[str]:
+    state = repo_root / ".sc-state"
+    removed: list[str] = []
+    if not state.is_dir():
+        return removed
+    for child in list(state.iterdir()):
+        if child.name == "db_backups":
+            continue
+        if _remove_path(child, repo_root):
+            removed.append(str(child.relative_to(repo_root)))
+    return removed
+
+
+def remove_installation(repo_root: Path) -> tuple[list[str], list[str]]:
+    removed: list[str] = []
+    preserved: list[str] = []
+    if cleanup_hooks(repo_root):
+        removed.append("git config core.hooksPath")
+    removed.extend(f"git remote {name}" for name in cleanup_upstream_remotes(repo_root))
+    if cleanup_makefile(repo_root):
+        removed.append("Makefile subfloor alias integration")
+    if cleanup_gitignore(repo_root):
+        removed.append(".gitignore subfloor rules")
+    if cleanup_visual_qa(repo_root):
+        removed.append(str(VISUAL_QA_WORKFLOW))
+    elif (repo_root / VISUAL_QA_WORKFLOW).exists():
+        preserved.append(str(VISUAL_QA_WORKFLOW))
+    removed.extend(cleanup_shared_scaffolds(repo_root))
+
+    for relative in install.GENERATED_INSTALL_PATHS:
+        if _remove_path(repo_root / relative, repo_root):
+            removed.append(str(relative))
+    removed.extend(cleanup_state(repo_root))
+
+    # Engine and dispatcher are last: every fallible engine-backed operation
+    # above must finish while the installed command still exists.
+    for relative in (Path(".super-coder"), Path("sc")):
+        if _remove_path(repo_root / relative, repo_root):
+            removed.append(str(relative))
+    return removed, preserved
+
+
+def verify_removed(repo_root: Path) -> list[str]:
+    remaining: list[str] = []
+    for relative in (
+        Path(".super-coder"),
+        Path(".sc-worktrees"),
+        Path("sc"),
+        *install.GENERATED_INSTALL_PATHS,
+    ):
+        if (repo_root / relative).exists() or (repo_root / relative).is_symlink():
+            remaining.append(str(relative))
+    makefile = repo_root / "Makefile"
+    if makefile.is_file() and install._ALIASES_RE.search(makefile.read_text()):
+        remaining.append("Makefile alias include")
+    return remaining
+
+
+def _signal_handler(signum: int, _frame: object) -> None:
+    if _ACTIVE_MANIFEST is not None and _ACTIVE_DATA is not None:
+        _ACTIVE_DATA["status"] = "partial"
+        _ACTIVE_DATA.setdefault("errors", []).append(f"interrupted by signal {signum}")
+        try:
+            write_manifest(_ACTIVE_MANIFEST, _ACTIVE_DATA)
+        except OSError:
+            pass
+        print(
+            f"\nremove interrupted; backup manifest: {_ACTIVE_MANIFEST}",
+            file=sys.stderr,
+        )
+    raise SystemExit(128 + signum)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="./sc remove",
+        description="Safely remove subfloor from this host repository.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="show the removal plan; change nothing"
+    )
+    parser.add_argument(
+        "--yes", action="store_true", help="skip the typed confirmation only"
+    )
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    global _ACTIVE_DATA, _ACTIVE_MANIFEST
+    args = build_parser().parse_args(argv)
+    manifest_path: Path | None = None
+    data: dict | None = None
+    try:
+        repo_root = validate_target()
+        worktrees = managed_worktrees(repo_root)
+        dirty = dirty_worktrees(worktrees)
+        if dirty:
+            joined = "\n  - ".join(str(path) for path in dirty)
+            raise RemoveError(
+                f"dirty managed worktree(s) must be resolved first:\n  - {joined}"
+            )
+        edits, added = engine_drift(repo_root)
+        show_plan(repo_root, worktrees, edits, added)
+        if args.dry_run:
+            print("dry-run: no services stopped and no files changed")
+            return 0
+        if not args.yes:
+            confirm(repo_root)
+
+        ensure_backup_ignore(repo_root)
+        destination = new_backup_dir(repo_root)
+        print(f"→ backup destination ready: {destination}")
+        quiesce_runtime(repo_root)
+        remove_worktrees(repo_root, worktrees)
+
+        _backup, data = backup_database(repo_root, destination)
+        manifest_path = destination / "manifest.json"
+        _ACTIVE_DATA = data
+        _ACTIVE_MANIFEST = manifest_path
+        write_manifest(manifest_path, data)
+        if data["database"] is None:
+            print("→ no live DB existed; recorded database: null")
+        else:
+            print(
+                f"→ verified WAL-safe DB backup: {destination / data['database']['file']}"
+            )
+
+        removed, preserved = remove_installation(repo_root)
+        data["removed"].extend(removed)
+        data["preserved"].extend(preserved)
+        remaining = verify_removed(repo_root)
+        if remaining:
+            data["status"] = "partial"
+            data["errors"].append("remaining install surfaces: " + ", ".join(remaining))
+            write_manifest(manifest_path, data)
+            raise RemoveError(
+                "teardown incomplete; remaining surfaces: " + ", ".join(remaining)
+            )
+
+        data["status"] = "removed"
+        write_manifest(manifest_path, data)
+        _ACTIVE_DATA = None
+        _ACTIVE_MANIFEST = None
+        print("→ subfloor removed from this repository")
+        print(f"  preserved backup: {destination}")
+        print("  review and commit the teardown with: git status")
+        return 0
+    except (RemoveError, OSError, sqlite3.Error) as exc:
+        if manifest_path is not None and data is not None:
+            data["status"] = "partial"
+            data.setdefault("errors", []).append(str(exc))
+            try:
+                write_manifest(manifest_path, data)
+            except OSError:
+                pass
+            print(f"  backup manifest: {manifest_path}", file=sys.stderr)
+        print(f"remove: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    for _sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(_sig, _signal_handler)
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/sc
+++ b/sc
@@ -1175,6 +1175,11 @@ case "$cmd" in
   feature)      exec "$PY" "$S/feature.py" "$@" ;;
   artifact-mode) exec "$PY" "$S/artifact_policy.py" "$@" ;;
   eject)        exec "$PY" "$S/eject.py" "$@" ;;
+  remove)       if sc_help_form "$@"; then
+                  exec "$PY" "$CALLER_ENGINE/scripts/remove.py" "$@"
+                fi
+                sc_refuse_linked remove "$ROOT"
+                exec "$PY" "$S/remove.py" "$@" ;;
   init)         exec "$PY" "$S/init_fork.py" "$@" ;;
   # rebuild/migrate: the script owns the whole argument contract (help, unknown
   # tokens), so the dispatcher forwards VERBATIM and only inserts the refusal —
@@ -1592,6 +1597,8 @@ super-coder — forkable shell substrate
   ./sc feature             list the opt-in features (pg · windows · tailnet · pm2 · app-deploy) and the state of both halves (config block + skill grants)
   ./sc feature enable <f>  enable one: grant its skills to the owning flavors + create/point-at its instance.json block (disable reverses)
   ./sc eject               ONE-WAY: stop tracking upstream and own the engine — un-gitignore + stage .super-coder/ as fork source (confirm-gated)
+  ./sc remove              safely uninstall subfloor from this repo after a verified DB backup
+                             --dry-run previews; --yes skips confirmation, never safety gates
   ./sc rebuild             build the .db from schema + migrations + snapshot
   ./sc migrate             apply pending migrations to an existing .db
   ./sc snapshot            dump per-instance tables to gitignored .sc-state/local/

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1,0 +1,356 @@
+"""Safety and end-to-end coverage for ``./sc remove``."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+import install
+import remove as remove_mod
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+class RemoveFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name) / "host-project"
+        self.repo.mkdir()
+        git(self.repo, "init", "-b", "main")
+        git(self.repo, "config", "user.name", "Remove Test")
+        git(self.repo, "config", "user.email", "remove@noreply.local")
+
+        self.engine = self.repo / ".super-coder"
+        (self.engine / "hooks").mkdir(parents=True)
+        (self.engine / "scripts").mkdir()
+        (self.engine / "engine.manifest").write_text("{}\n")
+        (self.engine / "instance.json").write_text('{"installed_at":"2026-07-31"}\n')
+        (self.repo / "sc").write_text("#!/bin/sh\nexit 0\n")
+        (self.repo / "README.md").write_text("# keep me\n")
+        (self.repo / "CLAUDE.md").write_text("generated\n")
+        (self.repo / "docs_sc").mkdir()
+        (self.repo / "docs_sc" / "generated.md").write_text("generated\n")
+        (self.repo / "shared").mkdir()
+        (self.repo / "shared" / "user-notes.txt").write_text("preserve\n")
+        workflow = self.repo / ".github/workflows/subfloor-visual-qa.yml"
+        workflow.parent.mkdir(parents=True)
+        workflow.write_text(
+            "# managed-by: subfloor — visual-qa shim v3\nname: visual qa\n"
+        )
+
+        state = self.repo / ".sc-state"
+        state.mkdir()
+        (state / "engine.ref").write_text("a" * 40 + "\n")
+        (state / "content.sql").write_text("generated\n")
+        (self.repo / ".gitignore").write_text("*.keep\n" + install._GITIGNORE_BLOCK)
+        (self.repo / "Makefile").write_text(
+            "test:\n\t@echo host\n" + install.APPENDED_ALIASES_BLOCK
+        )
+        git(self.repo, "config", "core.hooksPath", str(self.engine / "hooks"))
+        git(
+            self.repo,
+            "remote",
+            "add",
+            "super-coder",
+            "https://github.com/jedbjorn/subfloor.git",
+        )
+        git(
+            self.repo,
+            "remote",
+            "add",
+            "mirror",
+            "https://example.com/acme/project.git",
+        )
+
+        self.db = self.engine / "shell_db.db"
+        self.writer = sqlite3.connect(self.db)
+        self.writer.execute("PRAGMA journal_mode=WAL")
+        self.writer.execute("PRAGMA wal_autocheckpoint=0")
+        self.writer.execute("CREATE TABLE kept (value INTEGER)")
+        self.writer.execute("INSERT INTO kept VALUES (42)")
+        self.writer.commit()
+
+        self.patchers = [
+            mock.patch.object(remove_mod, "REPO_ROOT", self.repo),
+            mock.patch.object(remove_mod, "ENGINE", self.engine),
+            mock.patch.object(remove_mod, "STATE_DIR", state),
+            mock.patch.object(remove_mod, "DB_PATH", self.db),
+            mock.patch.object(
+                remove_mod,
+                "BACKUP_ROOT",
+                state / "db_backups" / "removal",
+            ),
+            mock.patch.object(remove_mod, "validate_target", return_value=self.repo),
+            mock.patch.object(remove_mod, "managed_worktrees", return_value=[]),
+            mock.patch.object(remove_mod, "engine_drift", return_value=({}, [])),
+            mock.patch.object(remove_mod, "quiesce_runtime"),
+        ]
+        for patcher in self.patchers:
+            patcher.start()
+
+    def tearDown(self) -> None:
+        for patcher in reversed(self.patchers):
+            patcher.stop()
+        self.writer.close()
+        self.tmp.cleanup()
+
+    def removal_dir(self) -> Path:
+        roots = list((self.repo / ".sc-state/db_backups/removal").iterdir())
+        self.assertEqual(len(roots), 1)
+        return roots[0]
+
+
+class EndToEndRemoveTest(RemoveFixture):
+    def test_verified_wal_backup_and_repo_cleanup(self) -> None:
+        self.assertEqual(remove_mod.main(["--yes"]), 0)
+
+        destination = self.removal_dir()
+        backup = next(destination.glob("shell_db.removal.*.db"))
+        con = sqlite3.connect(backup)
+        try:
+            self.assertEqual(con.execute("SELECT value FROM kept").fetchall(), [(42,)])
+            self.assertEqual(con.execute("PRAGMA integrity_check").fetchone()[0], "ok")
+        finally:
+            con.close()
+
+        manifest = json.loads((destination / "manifest.json").read_text())
+        self.assertEqual(manifest["status"], "removed")
+        self.assertEqual(manifest["database"]["integrity_check"], "ok")
+        self.assertEqual(len(manifest["database"]["sha256"]), 64)
+        self.assertEqual(manifest["engine_ref"], "a" * 40)
+        self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(backup.stat().st_mode), 0o600)
+        self.assertEqual(
+            stat.S_IMODE((destination / "manifest.json").stat().st_mode), 0o600
+        )
+
+        self.assertFalse(self.engine.exists())
+        self.assertFalse((self.repo / "sc").exists())
+        self.assertFalse((self.repo / "CLAUDE.md").exists())
+        self.assertFalse((self.repo / "docs_sc").exists())
+        self.assertFalse(
+            (self.repo / ".github/workflows/subfloor-visual-qa.yml").exists()
+        )
+        self.assertEqual((self.repo / "README.md").read_text(), "# keep me\n")
+        self.assertEqual(
+            (self.repo / "shared/user-notes.txt").read_text(), "preserve\n"
+        )
+
+        makefile = (self.repo / "Makefile").read_text()
+        self.assertIn("echo host", makefile)
+        self.assertNotIn("aliases.mk", makefile)
+        gitignore = (self.repo / ".gitignore").read_text()
+        self.assertIn("*.keep", gitignore)
+        self.assertIn(remove_mod.BACKUP_IGNORE, gitignore)
+        self.assertNotIn("/.super-coder/", gitignore)
+
+        hooks = subprocess.run(
+            ["git", "config", "--get", "core.hooksPath"],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(hooks.returncode, 0)
+        self.assertNotIn("super-coder", git(self.repo, "remote").stdout.splitlines())
+        self.assertIn("mirror", git(self.repo, "remote").stdout.splitlines())
+
+    def test_no_database_is_reported_truthfully(self) -> None:
+        self.writer.close()
+        self.writer = sqlite3.connect(":memory:")
+        for suffix in ("", "-wal", "-shm"):
+            (Path(str(self.db) + suffix)).unlink(missing_ok=True)
+
+        self.assertEqual(remove_mod.main(["--yes"]), 0)
+        manifest = json.loads((self.removal_dir() / "manifest.json").read_text())
+        self.assertEqual(manifest["status"], "removed")
+        self.assertIsNone(manifest["database"])
+
+    def test_dry_run_changes_nothing(self) -> None:
+        self.assertEqual(remove_mod.main(["--dry-run"]), 0)
+        self.assertTrue(self.engine.exists())
+        self.assertTrue((self.repo / "sc").exists())
+        self.assertFalse((self.repo / ".sc-state/db_backups/removal").exists())
+        remove_mod.quiesce_runtime.assert_not_called()
+
+
+class RemoveSafetyGateTest(RemoveFixture):
+    def test_dirty_worktree_refuses_before_quiesce(self) -> None:
+        worktree = self.repo / ".sc-worktrees/dev1"
+        worktree.mkdir(parents=True)
+        with (
+            mock.patch.object(remove_mod, "managed_worktrees", return_value=[worktree]),
+            mock.patch.object(remove_mod, "dirty_worktrees", return_value=[worktree]),
+        ):
+            self.assertEqual(remove_mod.main(["--yes"]), 1)
+        self.assertTrue(self.engine.exists())
+        remove_mod.quiesce_runtime.assert_not_called()
+
+    def test_unwritable_backup_refuses_before_quiesce(self) -> None:
+        with mock.patch.object(
+            remove_mod,
+            "new_backup_dir",
+            side_effect=PermissionError("read-only fixture"),
+        ):
+            self.assertEqual(remove_mod.main(["--yes"]), 1)
+        self.assertTrue(self.engine.exists())
+        remove_mod.quiesce_runtime.assert_not_called()
+
+    def test_runtime_shutdown_failure_keeps_live_installation(self) -> None:
+        remove_mod.quiesce_runtime.side_effect = remove_mod.RemoveError(
+            "runtime fixture stayed live"
+        )
+        self.assertEqual(remove_mod.main(["--yes"]), 1)
+        self.assertTrue(self.engine.exists())
+        self.assertTrue(self.db.exists())
+        self.assertTrue((self.repo / "sc").exists())
+
+    def test_backup_failure_after_shutdown_keeps_live_installation(self) -> None:
+        with mock.patch.object(
+            remove_mod,
+            "backup_database",
+            side_effect=sqlite3.OperationalError("backup fixture failed"),
+        ):
+            self.assertEqual(remove_mod.main(["--yes"]), 1)
+        remove_mod.quiesce_runtime.assert_called_once_with(self.repo)
+        self.assertTrue(self.engine.exists())
+        self.assertTrue(self.db.exists())
+        self.assertTrue((self.repo / "sc").exists())
+
+    def test_cleanup_failure_marks_verified_backup_partial(self) -> None:
+        with mock.patch.object(
+            remove_mod,
+            "remove_installation",
+            side_effect=OSError("cleanup fixture failed"),
+        ):
+            self.assertEqual(remove_mod.main(["--yes"]), 1)
+        manifest = json.loads((self.removal_dir() / "manifest.json").read_text())
+        self.assertEqual(manifest["status"], "partial")
+        self.assertIn("cleanup fixture failed", manifest["errors"])
+        self.assertTrue(self.engine.exists())
+
+    def test_symlink_is_unlinked_without_following_target(self) -> None:
+        outside = Path(self.tmp.name) / "outside"
+        outside.mkdir()
+        (outside / "keep").write_text("safe\n")
+        link = self.repo / "linked-generated"
+        link.symlink_to(outside, target_is_directory=True)
+
+        self.assertTrue(remove_mod._remove_path(link, self.repo))
+        self.assertFalse(link.exists())
+        self.assertEqual((outside / "keep").read_text(), "safe\n")
+
+
+class TargetValidationTest(unittest.TestCase):
+    def test_source_repo_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw) / "source"
+            repo.mkdir()
+            git(repo, "init", "-b", "main")
+            git(
+                repo,
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/jedbjorn/subfloor.git",
+            )
+            with self.assertRaises(remove_mod.RemoveError):
+                remove_mod.validate_target(repo)
+
+    def test_linked_worktree_marker_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw) / "linked"
+            repo.mkdir()
+            (repo / ".git").write_text("gitdir: elsewhere\n")
+            with self.assertRaises(remove_mod.RemoveError):
+                remove_mod.validate_target(repo)
+
+
+class RuntimeQuiescenceTest(unittest.TestCase):
+    def test_foreground_listener_blocks_removal_after_down(self) -> None:
+        repo = Path("/tmp/remove-runtime-fixture")
+        results = [
+            subprocess.CompletedProcess(["sc", "down"], 0, "stopped\n", ""),
+            subprocess.CompletedProcess(["ports.py", "port"], 0, "8837\n", ""),
+        ]
+        connection = mock.Mock()
+        with (
+            mock.patch.object(remove_mod, "stop_running_jobs"),
+            mock.patch.object(remove_mod, "_run", side_effect=results),
+            mock.patch.object(remove_mod.shutil, "which", return_value=None),
+            mock.patch.object(
+                remove_mod.socket, "create_connection", return_value=connection
+            ),
+            self.assertRaises(remove_mod.RemoveError),
+        ):
+            remove_mod.quiesce_runtime(repo)
+        connection.close.assert_called_once_with()
+
+    def test_no_docker_host_without_pg_can_prove_quiescence_by_listener(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            engine = repo / ".super-coder"
+            engine.mkdir()
+            (engine / "instance.json").write_text("{}\n")
+            results = [
+                subprocess.CompletedProcess(["sc", "down"], 1, "", "no docker"),
+                subprocess.CompletedProcess(["ports.py", "port"], 0, "8837\n", ""),
+            ]
+            with (
+                mock.patch.object(remove_mod, "stop_running_jobs"),
+                mock.patch.object(remove_mod, "_run", side_effect=results),
+                mock.patch.object(remove_mod.shutil, "which", return_value=None),
+                mock.patch.object(
+                    remove_mod.socket,
+                    "create_connection",
+                    side_effect=ConnectionRefusedError,
+                ),
+            ):
+                remove_mod.quiesce_runtime(repo)
+
+    def test_no_docker_host_with_pg_stays_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            engine = repo / ".super-coder"
+            engine.mkdir()
+            (engine / "instance.json").write_text('{"pg": {}}\n')
+            result = subprocess.CompletedProcess(["sc", "down"], 1, "", "no docker")
+            with (
+                mock.patch.object(remove_mod, "stop_running_jobs"),
+                mock.patch.object(remove_mod, "_run", return_value=result),
+                mock.patch.object(remove_mod.shutil, "which", return_value=None),
+                self.assertRaises(remove_mod.RemoveError),
+            ):
+                remove_mod.quiesce_runtime(repo)
+
+
+class WiringTest(unittest.TestCase):
+    def test_dispatcher_and_make_alias_are_public(self) -> None:
+        dispatcher = (ROOT / "sc").read_text()
+        aliases = (ROOT / ".super-coder/aliases.mk").read_text()
+        self.assertIn('remove)       if sc_help_form "$@"; then', dispatcher)
+        self.assertIn('exec "$PY" "$S/remove.py" "$@"', dispatcher)
+        self.assertIn("dos-remove:           ; $(SC) remove $(ARGS)", aliases)
+        self.assertIn("dos-remove", aliases)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- add make dos-remove / ./sc remove with dry-run and typed confirmation
- quiesce repo-scoped runtime and refuse unsafe targets or dirty worktrees
- preserve a WAL-safe, integrity-checked DB backup and manifest under .sc-state/db_backups/removal/
- surgically unwind Makefile, gitignore, hooks, remotes, generated state, and remove the engine last

## Verification

- 35 focused teardown/lifecycle tests passed
- full managed suite: 1656 passed, 1 skipped, 819 subtests
- ruff, sh -n sc, diff --check, render-check, map, and standalone ./sc verify passed

Spec: feature #30 / document #45.