### PR TITLE
feat: review current shell worktree in browser Diff

### DIFF
--- a/.super-coder/api/review_routes.py
+++ b/.super-coder/api/review_routes.py
@@ -11,11 +11,16 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import os
 import re
 import sqlite3
+import stat
+import threading
 import time
+from collections import OrderedDict
 from dataclasses import asdict
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -43,6 +48,12 @@ _CONVERSATION_TARGETS = re.compile(
 _TARGET_RESOURCE = re.compile(
     r"^/api/review-targets/(gt_[0-9a-f]{32})/(files|diff|commits)$"
 )
+_CONVERSATION_OBSERVATIONS = re.compile(
+    r"^/api/conversations/(cv_[0-9a-f]{32})/review-observations$"
+)
+_OBSERVATION_RESOURCE = re.compile(
+    r"^/api/review-observations/([0-9a-f]{64})/(patch|shell-file)$"
+)
 _REMOTE_ATTEMPTS: dict[str, float] = {}
 _REMOTE_RESULTS: dict[
     str,
@@ -51,6 +62,17 @@ _REMOTE_RESULTS: dict[
 _FILE_STATUSES = frozenset(
     ("added", "modified", "deleted", "renamed", "untracked", "conflict")
 )
+OBSERVATION_CACHE_LIMIT = 64
+OBSERVATION_KEY_CACHE_LIMIT = 512
+MAX_SHELL_FILES = 256
+MAX_SHELL_FILE_BYTES = 512 * 1024
+MAX_SHELL_TOTAL_BYTES = 2 * 1024 * 1024
+FETCHER = git_review.fetch_origin_main
+_OBSERVATION_LOCK = threading.Lock()
+_OBSERVATIONS: OrderedDict[str, dict[str, Any]] = OrderedDict()
+_OBSERVATION_KEYS: OrderedDict[
+    tuple[int, str, str], dict[str, Any]
+] = OrderedDict()
 
 ApiError = conversation_routes.ApiError
 
@@ -135,7 +157,7 @@ def _etag_response(headers, etag_value: str, body: dict[str, Any]):
 
 def _conversation(con, conversation_id: str, owner_user_id: int):
     row = con.execute(
-        "SELECT conversation_id,worktree FROM conversations "
+        "SELECT conversation_id,shell_id,harness,worktree FROM conversations "
         "WHERE conversation_id=? AND owner_user_id=?",
         (conversation_id, owner_user_id),
     ).fetchone()
@@ -1000,6 +1022,464 @@ def _commits(
     return _etag_response(headers, response_etag, body)
 
 
+def _skill_names(con, shell_id: int) -> list[str]:
+    return [
+        str(row["name"])
+        for row in con.execute(
+            "SELECT sk.name FROM shell_skills ss "
+            "JOIN skills sk ON sk.skill_id=ss.skill_id "
+            "WHERE ss.shell_id=? AND sk.is_deleted=0 ORDER BY sk.name",
+            (shell_id,),
+        ).fetchall()
+    ]
+
+
+def _skill_roots(harness: str) -> list[str]:
+    adapter = Path(__file__).resolve().parents[1] / "adapters" / harness / "adapter.json"
+    roots = [".claude/skills"]
+    try:
+        payload = json.loads(adapter.read_text())
+    except (OSError, json.JSONDecodeError):
+        return roots
+    declared = payload.get("skill_dirs")
+    if isinstance(declared, list) and all(isinstance(item, str) for item in declared):
+        roots = declared
+    return list(dict.fromkeys(roots))
+
+
+def _shell_source(worktree: Path, relative_path: str) -> dict[str, Any]:
+    try:
+        safe_path = git_review.validate_review_path(relative_path)
+    except git_review.ReviewError:
+        return {"available": False, "error": "REVIEW_PATH_INVALID"}
+    candidate = worktree / safe_path
+    try:
+        direct = candidate.lstat()
+    except OSError:
+        return {"available": False, "error": "REVIEW_SHELL_FILE_UNAVAILABLE"}
+    if stat.S_ISLNK(direct.st_mode):
+        return {"available": False, "error": "REVIEW_SHELL_FILE_UNAVAILABLE"}
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(candidate, flags)
+    except OSError:
+        return {"available": False, "error": "REVIEW_SHELL_FILE_UNAVAILABLE"}
+    try:
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            return {"available": False, "error": "REVIEW_SHELL_FILE_UNAVAILABLE"}
+        try:
+            opened = Path(os.readlink(f"/proc/self/fd/{descriptor}")).resolve(strict=True)
+            opened.relative_to(worktree)
+        except (OSError, RuntimeError, ValueError):
+            return {"available": False, "error": "REVIEW_SHELL_FILE_UNAVAILABLE"}
+        if info.st_size > MAX_SHELL_FILE_BYTES:
+            return {
+                "available": False,
+                "error": "REVIEW_SHELL_FILE_TOO_LARGE",
+                "bytes": info.st_size,
+            }
+        chunks: list[bytes] = []
+        remaining = MAX_SHELL_FILE_BYTES + 1
+        while remaining > 0:
+            chunk = os.read(descriptor, min(64 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+    except OSError:
+        return {"available": False, "error": "REVIEW_SHELL_FILE_UNAVAILABLE"}
+    finally:
+        os.close(descriptor)
+    if len(raw) > MAX_SHELL_FILE_BYTES:
+        return {
+            "available": False,
+            "error": "REVIEW_SHELL_FILE_TOO_LARGE",
+            "bytes": len(raw),
+        }
+    try:
+        body = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return {"available": False, "error": "REVIEW_SHELL_FILE_NOT_TEXT"}
+    if "\0" in body:
+        return {"available": False, "error": "REVIEW_SHELL_FILE_NOT_TEXT"}
+    return {
+        "available": True,
+        "bytes": len(raw),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+        "body": body,
+    }
+
+
+def _shell_projection(
+    worktree_raw: str,
+    harness: str,
+    skill_names: list[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    try:
+        worktree = Path(worktree_raw).resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise git_review.ReviewError(
+            "REVIEW_WORKTREE_MISSING",
+            "Conversation worktree is unavailable",
+        ) from exc
+    sources: list[dict[str, Any]] = []
+    for name in ("CLAUDE.md", "AGENTS.md"):
+        sources.append(
+            {
+                "kind": "boot",
+                "name": name,
+                "path": name,
+                **_shell_source(worktree, name),
+            }
+        )
+    skill_pattern = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+    roots = _skill_roots(harness)
+    for skill_name in skill_names:
+        if not skill_pattern.fullmatch(skill_name):
+            continue
+        for root in roots:
+            relative = f"{root}/{skill_name}/SKILL.md"
+            sources.append(
+                {
+                    "kind": "skill",
+                    "name": skill_name,
+                    "path": relative,
+                    **_shell_source(worktree, relative),
+                }
+            )
+    sources = sources[:MAX_SHELL_FILES]
+    total = 0
+    for source in sources:
+        if not source.get("available"):
+            continue
+        total += int(source["bytes"])
+        if total > MAX_SHELL_TOTAL_BYTES:
+            source.pop("body", None)
+            source.pop("sha256", None)
+            source["available"] = False
+            source["error"] = "REVIEW_SHELL_FILES_TOO_LARGE"
+
+    public: list[dict[str, Any]] = []
+    internal: list[dict[str, Any]] = []
+    for source in (item for item in sources if item["kind"] == "boot"):
+        descriptor = {
+            key: source.get(key)
+            for key in ("kind", "name", "available", "bytes", "sha256", "error")
+            if source.get(key) is not None
+        }
+        descriptor["paths"] = [source["path"]]
+        public.append(descriptor)
+        internal.append({**descriptor, "bodies": [source.get("body")]})
+
+    for skill_name in skill_names:
+        items = [
+            item for item in sources
+            if item["kind"] == "skill" and item["name"] == skill_name
+        ]
+        available = [item for item in items if item.get("available")]
+        digests = {item["sha256"] for item in available}
+        mismatch = len(digests) > 1
+        groups: dict[str, list[dict[str, Any]]] = {}
+        for item in available:
+            groups.setdefault(item["sha256"], []).append(item)
+        for digest, group in groups.items():
+            descriptor = {
+                "kind": "skill",
+                "name": skill_name,
+                "available": True,
+                "bytes": group[0]["bytes"],
+                "sha256": digest,
+                "paths": [item["path"] for item in group],
+                "mismatch": mismatch,
+            }
+            public.append(descriptor)
+            internal.append(
+                {**descriptor, "bodies": [item["body"] for item in group]}
+            )
+        for item in (entry for entry in items if not entry.get("available")):
+            descriptor = {
+                "kind": "skill",
+                "name": skill_name,
+                "available": False,
+                "paths": [item["path"]],
+                "error": item.get("error", "REVIEW_SHELL_FILE_UNAVAILABLE"),
+                "mismatch": mismatch,
+            }
+            public.append(descriptor)
+            internal.append({**descriptor, "bodies": [None]})
+    return public, internal
+
+
+def _observation_fingerprint(
+    conversation_id: str,
+    projection: git_review.WorktreeProjection,
+    shell_files: list[dict[str, Any]],
+) -> str:
+    return git_review.fingerprint(
+        {
+            "conversation_id": conversation_id,
+            "projection": projection.fingerprint,
+            "shell_files": shell_files,
+        }
+    )
+
+
+def _file_descriptor(
+    fingerprint_value: str,
+    section: str,
+    item: git_review.FileProjection,
+) -> dict[str, Any]:
+    file_id = "rf_" + git_review.fingerprint(
+        {"fingerprint": fingerprint_value, "section": section, "path": item.path}
+    )[:32]
+    return {**asdict(item), "file_id": file_id}
+
+
+def _build_observation(
+    conversation: dict[str, Any],
+    owner_user_id: int,
+    *,
+    fetch: git_review.FetchProjection,
+) -> dict[str, Any]:
+    worktree = str(conversation["worktree"])
+    projection = git_review.project_current_worktree(worktree)
+    con = _db()
+    try:
+        skill_names = _skill_names(con, int(conversation["shell_id"]))
+    finally:
+        con.close()
+    shell_public, shell_internal = _shell_projection(
+        worktree,
+        str(conversation["harness"]),
+        skill_names,
+    )
+    digest = _observation_fingerprint(
+        str(conversation["conversation_id"]),
+        projection,
+        shell_public,
+    )
+    dirty = [_file_descriptor(digest, "dirty", item) for item in projection.dirty]
+    branch_files = [
+        _file_descriptor(digest, "branch", item) for item in projection.branch_files
+    ]
+    file_map = {
+        item["file_id"]: {"section": section, "path": item["path"]}
+        for section, items in (("dirty", dirty), ("branch", branch_files))
+        for item in items
+    }
+    shell_map: dict[str, dict[str, Any]] = {}
+    for index, (public, internal) in enumerate(zip(shell_public, shell_internal)):
+        shell_id = "sf_" + git_review.fingerprint(
+            {"fingerprint": digest, "index": index, "paths": public["paths"]}
+        )[:32]
+        public["file_id"] = shell_id
+        internal["file_id"] = shell_id
+        if public.get("available"):
+            shell_map[shell_id] = internal
+    observed_at = datetime.now(timezone.utc).isoformat()
+    body = {
+        "conversation_id": conversation["conversation_id"],
+        "fingerprint": digest,
+        "observed_at": observed_at,
+        "fetch": {
+            "fresh": fetch.fresh,
+            "error": fetch.error,
+            "base_stale": not fetch.fresh and projection.base_available,
+        },
+        "status": {
+            "branch": projection.branch,
+            "head_sha": projection.head_sha,
+            "base_sha": projection.base_sha,
+            "base_available": projection.base_available,
+            "dirty_count": len(dirty),
+            "ahead_count": projection.visible_ahead,
+            "behind": projection.behind,
+        },
+        "changes": {
+            "dirty": dirty,
+            "branch": branch_files,
+            "commits": [asdict(item) for item in projection.commits],
+            "files_truncated": projection.files_truncated,
+            "commits_truncated": projection.commits_truncated,
+        },
+        "shell_files": shell_public,
+        "no_code_changes": not dirty and not branch_files and not projection.commits,
+    }
+    return {
+        "conversation_id": conversation["conversation_id"],
+        "owner_user_id": owner_user_id,
+        "shell_id": int(conversation["shell_id"]),
+        "harness": str(conversation["harness"]),
+        "worktree": worktree,
+        "projection": projection,
+        "fingerprint": digest,
+        "file_map": file_map,
+        "shell_map": shell_map,
+        "body": body,
+    }
+
+
+def _remember_observation(snapshot: dict[str, Any]) -> None:
+    digest = snapshot["fingerprint"]
+    _OBSERVATIONS.setdefault(digest, snapshot)
+    _OBSERVATIONS.move_to_end(digest)
+    while len(_OBSERVATIONS) > OBSERVATION_CACHE_LIMIT:
+        old_digest, _old = _OBSERVATIONS.popitem(last=False)
+        for key, value in list(_OBSERVATION_KEYS.items()):
+            if value["fingerprint"] == old_digest:
+                _OBSERVATION_KEYS.pop(key, None)
+
+
+def _create_observation(
+    conversation_id: str,
+    owner_user_id: int,
+    idempotency_key: str,
+):
+    key = (owner_user_id, conversation_id, idempotency_key)
+    with _OBSERVATION_LOCK:
+        cached = _OBSERVATION_KEYS.get(key)
+        if cached is not None:
+            _OBSERVATION_KEYS.move_to_end(key)
+            return conversation_routes._json(200, cached["body"])
+        con = _db()
+        try:
+            row = _conversation(con, conversation_id, owner_user_id)
+            conversation = dict(row)
+        finally:
+            con.close()
+        fetch = FETCHER(str(conversation["worktree"]))
+        snapshot = _build_observation(conversation, owner_user_id, fetch=fetch)
+        _remember_observation(snapshot)
+        _OBSERVATION_KEYS[key] = {
+            "fingerprint": snapshot["fingerprint"],
+            "body": snapshot["body"],
+        }
+        _OBSERVATION_KEYS.move_to_end(key)
+        while len(_OBSERVATION_KEYS) > OBSERVATION_KEY_CACHE_LIMIT:
+            _OBSERVATION_KEYS.popitem(last=False)
+        return conversation_routes._json(201, snapshot["body"])
+
+
+def _observation(digest: str, owner_user_id: int) -> dict[str, Any]:
+    snapshot = _OBSERVATIONS.get(digest)
+    if snapshot is None or snapshot["owner_user_id"] != owner_user_id:
+        raise ApiError(
+            404,
+            "REVIEW_OBSERVATION_NOT_FOUND",
+            "review observation does not exist",
+        )
+    _OBSERVATIONS.move_to_end(digest)
+    return snapshot
+
+
+def _observation_source(snapshot: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    con = _db()
+    try:
+        row = _conversation(
+            con,
+            str(snapshot["conversation_id"]),
+            int(snapshot["owner_user_id"]),
+        )
+        conversation = dict(row)
+        skill_names = _skill_names(con, int(conversation["shell_id"]))
+    finally:
+        con.close()
+    if (
+        str(conversation["worktree"]) != snapshot["worktree"]
+        or int(conversation["shell_id"]) != snapshot["shell_id"]
+        or str(conversation["harness"]) != snapshot["harness"]
+    ):
+        raise ApiError(
+            409,
+            "REVIEW_SNAPSHOT_CHANGED",
+            "review source changed after the observation",
+        )
+    return conversation, skill_names
+
+
+def _ensure_observation_current(snapshot: dict[str, Any]) -> None:
+    _conversation_row, skill_names = _observation_source(snapshot)
+    projection = git_review.project_current_worktree(snapshot["worktree"])
+    shell_public, _internal = _shell_projection(
+        snapshot["worktree"],
+        snapshot["harness"],
+        skill_names,
+    )
+    current = _observation_fingerprint(
+        snapshot["conversation_id"],
+        projection,
+        shell_public,
+    )
+    if current != snapshot["fingerprint"]:
+        raise ApiError(
+            409,
+            "REVIEW_SNAPSHOT_CHANGED",
+            "worktree changed after the observation",
+        )
+
+
+def _observation_patch(snapshot: dict[str, Any], query: dict[str, str], headers):
+    file_id = query.get("file") or ""
+    selected = snapshot["file_map"].get(file_id)
+    if selected is None:
+        raise ApiError(422, "REVIEW_PATH_INVALID", "review file is not in the snapshot")
+    _ensure_observation_current(snapshot)
+    projection = snapshot["projection"]
+    if selected["section"] == "dirty":
+        patch = git_review.read_file_patch(
+            snapshot["worktree"],
+            projection.head_sha,
+            selected["path"],
+        )
+    else:
+        patch = git_review.read_file_patch(
+            snapshot["worktree"],
+            projection.merge_base_sha,
+            selected["path"],
+            new_ref=projection.head_sha,
+        )
+    _ensure_observation_current(snapshot)
+    body = {
+        "fingerprint": snapshot["fingerprint"],
+        "file_id": file_id,
+        "section": selected["section"],
+        "patch": patch.text,
+        "sha256": patch.sha256,
+        "truncated": patch.truncated,
+        "binary": patch.binary,
+        "unavailable_reason": patch.unavailable_reason,
+    }
+    return _etag_response(headers, patch.etag, body)
+
+
+def _observation_shell_file(snapshot: dict[str, Any], query: dict[str, str], headers):
+    file_id = query.get("file") or ""
+    selected = snapshot["shell_map"].get(file_id)
+    if selected is None:
+        raise ApiError(
+            422,
+            "REVIEW_PATH_INVALID",
+            "shell file is not in the snapshot",
+        )
+    _observation_source(snapshot)
+    bodies = selected["bodies"]
+    _observation_source(snapshot)
+    response_etag = git_review.etag(selected["sha256"])
+    return _etag_response(
+        headers,
+        response_etag,
+        {
+            "fingerprint": snapshot["fingerprint"],
+            "file_id": file_id,
+            "paths": selected["paths"],
+            "body": bodies[0],
+            "mismatch": selected.get("mismatch", False),
+        },
+    )
+
+
 _REVIEW_ERROR_STATUS = {
     "REVIEW_TARGET_NOT_FOUND": 404,
     "REVIEW_WORKTREE_MISSING": 409,
@@ -1010,25 +1490,41 @@ _REVIEW_ERROR_STATUS = {
     "REVIEW_DIFF_TOO_LARGE": 413,
     "REVIEW_TARGET_CHANGED": 409,
     "REVIEW_TARGET_UNAVAILABLE": 503,
+    "REVIEW_SNAPSHOT_CHANGED": 409,
+    "REVIEW_OBSERVATION_NOT_FOUND": 404,
+    "REVIEW_SHELL_FILE_TOO_LARGE": 413,
+    "REVIEW_SHELL_FILES_TOO_LARGE": 413,
+    "REVIEW_SHELL_FILE_NOT_TEXT": 415,
 }
 
 
 def handle(method: str, path: str, headers_raw: str, raw_body: bytes):
-    """Dispatch one authenticated review GET request."""
+    """Dispatch authenticated historical and current-worktree review reads."""
     headers = conversation_routes._parse_headers(headers_raw)
     if not conversation_routes._host_ok(headers):
         return conversation_routes._err(403, "HOST_FORBIDDEN", "Host is not allowed")
     parsed = urlparse(path)
     conversation_match = _CONVERSATION_TARGETS.fullmatch(parsed.path)
     target_match = _TARGET_RESOURCE.fullmatch(parsed.path)
-    if conversation_match is None and target_match is None:
+    observation_match = _CONVERSATION_OBSERVATIONS.fullmatch(parsed.path)
+    observation_resource_match = _OBSERVATION_RESOURCE.fullmatch(parsed.path)
+    if all(
+        match is None
+        for match in (
+            conversation_match,
+            target_match,
+            observation_match,
+            observation_resource_match,
+        )
+    ):
         return conversation_routes._err(404, "NOT_FOUND", "route does not exist")
-    if method != "GET":
+    expected_method = "POST" if observation_match is not None else "GET"
+    if method != expected_method:
         return conversation_routes._err(
             405,
             "METHOD_NOT_ALLOWED",
-            "review resources are read-only",
-            headers=[("Allow", "GET")],
+            "review method is not allowed",
+            headers=[("Allow", expected_method)],
         )
     if not conversation_routes._mutation_site_ok(headers):
         return conversation_routes._err(
@@ -1040,16 +1536,36 @@ def handle(method: str, path: str, headers_raw: str, raw_body: bytes):
         con = _db()
         try:
             operator = conversation_routes._operator(con, headers)
-            if conversation_match is not None:
+            if conversation_match is not None or observation_match is not None:
+                matched_conversation = conversation_match or observation_match
                 _conversation(
                     con,
-                    conversation_match.group(1),
+                    matched_conversation.group(1),
                     operator["user_id"],
                 )
-            else:
+            elif target_match is not None:
                 row = _target(con, target_match.group(1), operator["user_id"])
         finally:
             con.close()
+        if observation_match is not None:
+            _query(parsed.query, set())
+            if raw_body:
+                raise ApiError(422, "VALIDATION_ERROR", "request body must be empty")
+            idempotency_key = conversation_routes._idempotency_key(headers)
+            return _create_observation(
+                observation_match.group(1),
+                operator["user_id"],
+                idempotency_key,
+            )
+        if observation_resource_match is not None:
+            snapshot = _observation(
+                observation_resource_match.group(1),
+                operator["user_id"],
+            )
+            query = _query(parsed.query, {"file"})
+            if observation_resource_match.group(2) == "patch":
+                return _observation_patch(snapshot, query, headers)
+            return _observation_shell_file(snapshot, query, headers)
         if conversation_match is not None:
             query = _query(parsed.query, {"refresh"})
             return _list_targets(

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -3098,9 +3098,10 @@ def dispatch_http(method: str, path: str, headers_raw: str,
     parsed = urlparse(path)
     if (
         parsed.path.startswith("/api/review-targets/")
+        or parsed.path.startswith("/api/review-observations/")
         or (
             parsed.path.startswith("/api/conversations/")
-            and parsed.path.endswith("/review-targets")
+            and parsed.path.endswith(("/review-targets", "/review-observations"))
         )
     ):
         return review_routes.handle(method, path, headers_raw, body)

--- a/.super-coder/scripts/git_review.py
+++ b/.super-coder/scripts/git_review.py
@@ -39,6 +39,10 @@ _READ_ONLY_ENV = {
     "GIT_PAGER": "cat",
     "GIT_TERMINAL_PROMPT": "0",
 }
+_FETCH_ENV = {
+    **_READ_ONLY_ENV,
+    "GIT_OPTIONAL_LOCKS": "1",
+}
 _HEX = frozenset("0123456789abcdef")
 
 
@@ -127,6 +131,30 @@ class CommitSetProjection:
 
 
 @dataclass(frozen=True)
+class WorktreeProjection:
+    branch: str | None
+    head_sha: str
+    base_sha: str | None
+    merge_base_sha: str | None
+    dirty: tuple[FileProjection, ...]
+    branch_files: tuple[FileProjection, ...]
+    commits: tuple[CommitProjection, ...]
+    files_truncated: bool
+    commits_truncated: bool
+    visible_ahead: int
+    behind: int | None
+    base_available: bool
+    fingerprint: str
+    etag: str
+
+
+@dataclass(frozen=True)
+class FetchProjection:
+    fresh: bool
+    error: str | None
+
+
+@dataclass(frozen=True)
 class PatchProjection:
     text: str | None
     sha256: str | None
@@ -210,12 +238,13 @@ def _run_read_process(
     check: bool,
     env: dict[str, str],
     start_new_session: bool,
+    input: bytes | None = None,
 ) -> subprocess.CompletedProcess:
     """Run one Git read in its own group and reap the group on timeout."""
     process = subprocess.Popen(
         args,
         cwd=cwd,
-        stdin=stdin,
+        stdin=subprocess.PIPE if input is not None else stdin,
         stdout=stdout,
         stderr=stderr,
         text=text,
@@ -223,7 +252,10 @@ def _run_read_process(
         start_new_session=start_new_session,
     )
     try:
-        result_stdout, result_stderr = process.communicate(timeout=timeout)
+        result_stdout, result_stderr = process.communicate(
+            input=input,
+            timeout=timeout,
+        )
     except subprocess.TimeoutExpired:
         try:
             os.killpg(process.pid, signal.SIGKILL)
@@ -260,28 +292,32 @@ def _run_git(
     timeout: float = GIT_TIMEOUT_SECONDS,
     output_limit: int = _STATUS_OUTPUT_LIMIT,
     allow_truncate: bool = False,
+    ok_returncodes: tuple[int, ...] = (0,),
+    input_bytes: bytes | None = None,
 ) -> tuple[bytes, bool]:
     command = ["git", "-C", str(worktree), "--no-pager", *args]
     try:
-        result = runner(
-            command,
-            cwd=str(worktree),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=False,
-            timeout=timeout,
-            check=False,
-            env=_READ_ONLY_ENV,
-            start_new_session=True,
-        )
+        kwargs = {
+            "cwd": str(worktree),
+            "stdin": subprocess.DEVNULL,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "text": False,
+            "timeout": timeout,
+            "check": False,
+            "env": _READ_ONLY_ENV,
+            "start_new_session": True,
+        }
+        if input_bytes is not None:
+            kwargs["input"] = input_bytes
+        result = runner(command, **kwargs)
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise GitReadError(
             "REVIEW_TARGET_UNAVAILABLE",
             f"Git read failed: {exc}",
         ) from exc
     stdout = _completed_bytes(result.stdout)
-    if result.returncode != 0:
+    if result.returncode not in ok_returncodes:
         stderr = _completed_bytes(result.stderr).decode("utf-8", errors="replace")
         detail = stderr.strip().splitlines()
         raise GitReadError(
@@ -580,6 +616,53 @@ def _merge_stats(
 def _batches(values: Sequence[str], size: int = 100) -> Iterable[Sequence[str]]:
     for index in range(0, len(values), size):
         yield values[index : index + size]
+
+
+def _ignored_paths(
+    worktree: Path,
+    paths: Sequence[str],
+    *,
+    limits: ReviewLimits,
+    runner: Callable[..., Any],
+) -> set[str]:
+    """Resolve the worktree's effective ignore rules, including tracked paths."""
+    ignored: set[str] = set()
+    candidates = sorted(set(filter(None, paths)))
+    for batch in _batches(candidates):
+        encoded = b"\0".join(
+            path.encode("utf-8", errors="surrogateescape") for path in batch
+        ) + b"\0"
+        payload, _ = _run_git(
+            worktree,
+            ("check-ignore", "--no-index", "-z", "--stdin"),
+            runner=runner,
+            ok_returncodes=(0, 1),
+            input_bytes=encoded,
+        )
+        ignored.update(
+            _decode_path(raw, limits)
+            for raw in payload.split(b"\0")
+            if raw
+        )
+    return ignored
+
+
+def _visible_files(
+    worktree: Path,
+    files: Sequence[FileProjection],
+    *,
+    limits: ReviewLimits,
+    runner: Callable[..., Any],
+) -> list[FileProjection]:
+    candidates = [item.path for item in files]
+    candidates.extend(item.old_path for item in files if item.old_path)
+    ignored = _ignored_paths(worktree, candidates, limits=limits, runner=runner)
+    return [
+        item
+        for item in files
+        if item.path not in ignored
+        and (item.old_path is None or item.old_path not in ignored)
+    ]
 
 
 def _generated_paths(
@@ -932,6 +1015,259 @@ def review_commits(
         commits_truncated=truncated,
         fingerprint=digest,
         etag=etag(digest),
+    )
+
+
+def _commit_paths(
+    worktree: Path,
+    commit_sha: str,
+    *,
+    limits: ReviewLimits,
+    runner: Callable[..., Any],
+) -> tuple[str, ...]:
+    payload, _ = _run_git(
+        worktree,
+        (
+            "diff-tree",
+            "--root",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            "-z",
+            commit_sha,
+            "--",
+        ),
+        runner=runner,
+    )
+    return tuple(
+        _decode_path(raw, limits) for raw in payload.split(b"\0") if raw
+    )
+
+
+def _path_states(
+    worktree: Path,
+    files: Sequence[FileProjection],
+    *,
+    limits: ReviewLimits,
+    runner: Callable[..., Any],
+) -> list[dict[str, Any]]:
+    """Fingerprint bounded on-disk and index state without exposing contents."""
+    paths = sorted({item.path for item in files})
+    index_payload = b""
+    if paths:
+        index_payload, _ = _run_git(
+            worktree,
+            ("ls-files", "--stage", "-z", "--", *paths),
+            runner=runner,
+        )
+    index_rows: dict[str, list[str]] = {path: [] for path in paths}
+    for raw in index_payload.split(b"\0"):
+        metadata, separator, path_raw = raw.partition(b"\t")
+        if not separator:
+            continue
+        path = _decode_path(path_raw, limits)
+        index_rows.setdefault(path, []).append(
+            metadata.decode("ascii", errors="replace")
+        )
+    states: list[dict[str, Any]] = []
+    for path in paths:
+        candidate = worktree / path
+        try:
+            info = candidate.lstat()
+        except OSError:
+            states.append(
+                {"path": path, "worktree": "missing", "index": index_rows[path]}
+            )
+            continue
+        state: dict[str, Any] = {
+            "path": path,
+            "mode": stat.S_IFMT(info.st_mode),
+            "size": info.st_size,
+            "mtime_ns": info.st_mtime_ns,
+            "index": index_rows[path],
+        }
+        if stat.S_ISLNK(info.st_mode):
+            try:
+                state["link"] = os.readlink(candidate)
+            except OSError:
+                state["link"] = "unavailable"
+        elif stat.S_ISREG(info.st_mode) and info.st_size <= limits.max_patch_bytes:
+            digest = hashlib.sha256()
+            try:
+                with candidate.open("rb") as handle:
+                    for chunk in iter(lambda: handle.read(64 * 1024), b""):
+                        digest.update(chunk)
+                state["sha256"] = digest.hexdigest()
+            except OSError:
+                state["sha256"] = "unavailable"
+        states.append(state)
+    return states
+
+
+def project_current_worktree(
+    worktree: str | Path,
+    *,
+    base_ref: str = "refs/remotes/origin/main",
+    limits: ReviewLimits = DEFAULT_LIMITS,
+    runner: Callable[..., Any] = _run_read_process,
+) -> WorktreeProjection:
+    """Project only visible current-worktree changes against remote main."""
+    resolved = _resolve_worktree(worktree)
+    workspace = collect_workspace(resolved, limits=limits, runner=runner)
+    dirty = _visible_files(
+        resolved,
+        workspace.files,
+        limits=limits,
+        runner=runner,
+    )
+    base_sha = _optional_sha(resolved, base_ref, runner=runner)
+    branch_files: list[FileProjection] = []
+    commits: list[CommitProjection] = []
+    merge_base: str | None = None
+    behind: int | None = None
+    files_truncated = workspace.files_truncated
+    commits_truncated = False
+    if base_sha is not None:
+        merge_raw, _ = _run_git(
+            resolved,
+            ("merge-base", base_sha, workspace.head_sha),
+            runner=runner,
+            output_limit=128,
+        )
+        merge_base = merge_raw.decode("ascii", errors="replace").strip().lower()
+        branch_projection = _file_set(
+            resolved,
+            base_sha=base_sha,
+            head_sha=workspace.head_sha,
+            merge_base_sha=merge_base,
+            diff_args=(merge_base, workspace.head_sha),
+            include_untracked=False,
+            limits=limits,
+            runner=runner,
+        )
+        branch_files = _visible_files(
+            resolved,
+            branch_projection.files,
+            limits=limits,
+            runner=runner,
+        )
+        files_truncated = files_truncated or branch_projection.files_truncated
+        all_commits = review_commits(
+            resolved,
+            base_sha,
+            head_ref=workspace.head_sha,
+            limits=limits,
+            runner=runner,
+        )
+        commit_paths = {
+            commit.sha: _commit_paths(
+                resolved,
+                commit.sha,
+                limits=limits,
+                runner=runner,
+            )
+            for commit in all_commits.commits
+        }
+        ignored = _ignored_paths(
+            resolved,
+            [path for paths in commit_paths.values() for path in paths],
+            limits=limits,
+            runner=runner,
+        )
+        commits = [
+            commit
+            for commit in all_commits.commits
+            if any(path not in ignored for path in commit_paths[commit.sha])
+        ]
+        commits_truncated = all_commits.commits_truncated
+        counts_raw, _ = _run_git(
+            resolved,
+            ("rev-list", "--left-right", "--count", f"{workspace.head_sha}...{base_sha}"),
+            runner=runner,
+            output_limit=128,
+        )
+        count_fields = counts_raw.decode("ascii", errors="replace").split()
+        if len(count_fields) == 2:
+            behind = int(count_fields[1])
+    dirty = sorted(dirty, key=lambda item: item.path)[: limits.max_files]
+    branch_files = sorted(branch_files, key=lambda item: item.path)[: limits.max_files]
+    core = {
+        "branch": workspace.branch,
+        "head_sha": workspace.head_sha,
+        "base_sha": base_sha,
+        "merge_base_sha": merge_base,
+        "dirty": [asdict(item) for item in dirty],
+        "branch_files": [asdict(item) for item in branch_files],
+        "commits": [asdict(item) for item in commits],
+        "files_truncated": files_truncated,
+        "commits_truncated": commits_truncated,
+        "behind": behind,
+        "path_states": _path_states(
+            resolved,
+            [*dirty, *branch_files],
+            limits=limits,
+            runner=runner,
+        ),
+    }
+    digest = fingerprint(core)
+    return WorktreeProjection(
+        branch=workspace.branch,
+        head_sha=workspace.head_sha,
+        base_sha=base_sha,
+        merge_base_sha=merge_base,
+        dirty=tuple(dirty),
+        branch_files=tuple(branch_files),
+        commits=tuple(commits),
+        files_truncated=files_truncated,
+        commits_truncated=commits_truncated,
+        visible_ahead=len(commits),
+        behind=behind,
+        base_available=base_sha is not None,
+        fingerprint=digest,
+        etag=etag(digest),
+    )
+
+
+def fetch_origin_main(
+    worktree: str | Path,
+    *,
+    runner: Callable[..., Any] = _run_read_process,
+    timeout: float = 20.0,
+) -> FetchProjection:
+    """Advance only the fixed origin/main tracking ref with a bounded fetch."""
+    resolved = _resolve_worktree(worktree)
+    command = [
+        "git",
+        "-C",
+        str(resolved),
+        "--no-pager",
+        "fetch",
+        "--no-tags",
+        "origin",
+        "+refs/heads/main:refs/remotes/origin/main",
+    ]
+    try:
+        result = runner(
+            command,
+            cwd=str(resolved),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+            timeout=timeout,
+            check=False,
+            env=_FETCH_ENV,
+            start_new_session=True,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return FetchProjection(False, f"origin/main fetch failed: {exc}"[:240])
+    if result.returncode == 0:
+        return FetchProjection(True, None)
+    stderr = _completed_bytes(result.stderr).decode("utf-8", errors="replace")
+    detail = stderr.strip().splitlines()
+    return FetchProjection(
+        False,
+        (detail[0][:240] if detail else "origin/main fetch failed"),
     )
 
 

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2441,7 +2441,6 @@ const CHAT_FLAVOR_ORDER = [
 ];
 const CHAT_CONFIGURE_ROUTE = "configure";
 const CHAT_HISTORY_POLL_MS = 2000;
-const CHAT_REVIEW_POLL_MS = 2000;
 const CHAT_MODES = ["chat", "diff"];
 let chatRouteShell = "";
 let chatRouteConversation = "";
@@ -2454,7 +2453,6 @@ let chatModeController = null;
 let chatReviewCleanup = null;
 let chatConfiguration = null;
 let chatConfigurationPromise = null;
-const chatReviewViewed = new Map();
 
 function chatLoadConfiguration() {
   if (chatConfiguration) return Promise.resolve(chatConfiguration);
@@ -2723,23 +2721,16 @@ function chatCreateConversation(shell, fields = {}) {
   );
 }
 
-async function reviewApi(path, etagValue = "") {
-  const headers = etagValue ? { "If-None-Match": etagValue } : {};
+async function reviewObservationApi(path, { method = "GET", key = "" } = {}) {
+  const headers = key ? { "Idempotency-Key": key } : {};
   let response;
   try {
-    response = await fetch("/api" + path, { method: "GET", headers });
+    response = await fetch("/api" + path, { method, headers });
   } catch (cause) {
-    const error = new Error("Review data could not be reached.");
-    error.code = "REVIEW_REMOTE_UNAVAILABLE";
+    const error = new Error("Diff observation could not be reached.");
+    error.code = "REVIEW_TARGET_UNAVAILABLE";
     error.cause = cause;
     throw error;
-  }
-  if (response.status === 304) {
-    return {
-      notModified: true,
-      etag: response.headers.get("ETag") || etagValue,
-      data: null,
-    };
   }
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
@@ -2750,34 +2741,7 @@ async function reviewApi(path, etagValue = "") {
     error.status = response.status;
     throw error;
   }
-  return {
-    notModified: false,
-    etag: response.headers.get("ETag") || "",
-    data,
-  };
-}
-
-function reviewLifecycleLabel(lifecycle) {
-  return {
-    local: "LOCAL BRANCH",
-    local_branch: "LOCAL BRANCH",
-    pushed: "PUSHED",
-    pr_open: "PR OPEN",
-    checks_failed: "CHECKS FAILED",
-    pr_merged: "PR MERGED",
-    pr_closed: "PR CLOSED",
-    remote_unknown: "REMOTE UNKNOWN",
-  }[lifecycle] || String(lifecycle || "LOCAL BRANCH").replaceAll("_", " ").toUpperCase();
-}
-
-function reviewTargetLabel(target) {
-  if (target.pr_number)
-    return `PR #${target.pr_number} · ${target.branch || "branch unavailable"} · `
-      + reviewLifecycleLabel(target.lifecycle).toLowerCase();
-  if (target.kind === "workspace")
-    return `Live workspace · ${target.branch || "detached HEAD"}`;
-  return `Branch ${target.branch || "detached HEAD"} · `
-    + reviewLifecycleLabel(target.lifecycle).toLowerCase();
+  return data;
 }
 
 function reviewObservedLabel(value) {
@@ -2786,10 +2750,6 @@ function reviewObservedLabel(value) {
   return Number.isNaN(parsed.getTime())
     ? `observed ${value}`
     : `observed ${parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
-}
-
-function reviewViewedKey(targetId, fingerprint) {
-  return `${targetId}:${fingerprint || "unknown"}`;
 }
 
 function reviewTypedState(title, detail = "", tone = "") {
@@ -2903,577 +2863,426 @@ function reviewFileTree(files, selectedPath, viewed, onSelect) {
 function chatReviewWorkspace(host, conversation) {
   const state = {
     mode: "chat",
+    snapshot: null,
     loaded: false,
-    loadingTargets: false,
-    loadingContent: false,
-    pollInFlight: false,
-    pollTimer: null,
+    loading: false,
+    refreshInFlight: false,
     requestGeneration: 0,
-    responseCache: new Map(),
-    targetsEtag: "",
-    gitFingerprint: "",
-    targets: [],
-    targetId: "",
-    targetFingerprint: "",
-    freshness: null,
-    scope: "review",
-    files: [],
-    fileFingerprint: "",
-    filesTruncated: false,
+    group: "changes",
+    section: "dirty",
     selectedPath: "",
-    patch: null,
-    patchError: null,
-    patchLoading: false,
-    commits: [],
-    commitsTruncated: false,
     pathFilter: "",
     statusFilter: "",
-    hideViewed: false,
-    hideGenerated: false,
-    hideBinary: false,
-    hideDeleted: false,
+    patch: null,
+    shellFile: null,
+    contentLoading: false,
+    contentError: null,
     error: null,
+    refreshWarning: "",
   };
+  let refreshButton = null;
 
-  const selectedTarget = () =>
-    state.targets.find((target) => target.target_id === state.targetId) || null;
-  const selectedFile = () =>
-    state.files.find((file) => file.path === state.selectedPath) || null;
-  const viewedFiles = () => {
-    const key = reviewViewedKey(state.targetId, state.fileFingerprint);
-    if (!chatReviewViewed.has(key)) chatReviewViewed.set(key, new Set());
-    return chatReviewViewed.get(key);
+  const sectionFiles = (snapshot = state.snapshot) => {
+    if (!snapshot || state.group !== "changes") return [];
+    if (state.section === "dirty") return snapshot.changes.dirty || [];
+    if (state.section === "branch") return snapshot.changes.branch || [];
+    return [];
   };
-
-  const targetFacts = (target) => {
-    if (!target) return [];
-    const facts = [];
-    if (target.facts?.dirty) facts.push("dirty workspace");
-    if (target.facts?.ahead) facts.push(`${target.facts.ahead} unpushed commit${target.facts.ahead === 1 ? "" : "s"}`);
-    if (target.facts?.behind) facts.push(`${target.facts.behind} behind base`);
-    if (target.facts?.cleanup_pending) facts.push("cleanup pending");
-    if (target.facts?.pushed === false && target.kind !== "pull_request")
-      facts.push("not pushed");
-    if (target.freshness?.remote === "cached") facts.push("cached remote");
-    return facts;
+  const shellFiles = (snapshot = state.snapshot) => snapshot?.shell_files || [];
+  const itemPath = (item) => state.group === "shell"
+    ? (item.paths || []).join("\n")
+    : item.path;
+  const selectedItem = () => {
+    const items = state.group === "shell" ? shellFiles() : sectionFiles();
+    return items.find((item) => itemPath(item) === state.selectedPath) || null;
   };
-
-  const patchBody = () => {
-    const file = selectedFile();
-    if (!file) return reviewTypedState(
-      "Select a file",
-      "Choose a path from the navigator to read its bounded patch.",
-    );
-    if (state.patchLoading) return reviewTypedState("Loading patch…", file.path);
-    if (state.patchError) {
-      const code = state.patchError.code || "REVIEW_TARGET_UNAVAILABLE";
-      return reviewTypedState(code, state.patchError.message, "error");
-    }
-    if (!state.patch) return reviewTypedState("Patch unavailable", file.path);
-    if (state.patch.binary || file.binary)
-      return reviewTypedState("Binary file", "Raw binary bytes are never transported.");
-    if (!state.patch.patch) {
-      const reason = state.patch.unavailable_reason || "unavailable";
-      return reviewTypedState(
-        reason === "oversized" ? "Patch too large" : "Patch unavailable",
-        reason === "oversized"
-          ? "The file remains listed, but its patch exceeds the review limit."
-          : `No textual patch is available (${reason}).`,
-      );
-    }
-    const wrapper = el("div", { className: "review-patch-wrap" });
-    if (state.patch.truncated)
-      wrapper.append(reviewTypedState(
-        "Patch truncated",
-        "Showing the bounded portion returned by the server.",
-        "warning",
-      ));
-    wrapper.append(reviewPatchRows(state.patch.patch));
-    return wrapper;
-  };
-
-  const commitBody = () => {
-    if (state.error)
-      return reviewTypedState(
-        state.error.code || "REVIEW_TARGET_UNAVAILABLE",
-        state.error.message,
-        "error",
-      );
-    if (state.loadingContent)
-      return reviewTypedState("Loading commits…", "Reading the bounded change history.");
-    if (!state.commits.length)
-      return reviewTypedState("No commits in this change set.");
-    const list = el("div", { className: "review-commit-list" });
-    for (const commit of state.commits) {
-      list.append(el("article", { className: "review-commit" },
-        el("code", {}, commit.short_sha),
-        el("div", { className: "review-commit-main" },
-          el("strong", {}, commit.subject),
-          el("span", {}, `${commit.author} · ${commit.authored_at}`))));
-    }
-    if (state.commitsTruncated)
-      list.append(reviewTypedState(
-        "Commit list truncated",
-        "The server returned its bounded commit projection.",
-        "warning",
-      ));
-    return list;
-  };
-
-  const filteredFiles = () => {
-    const needle = state.pathFilter.trim().toLowerCase();
-    const viewed = viewedFiles();
-    return state.files.filter((file) =>
-      (!needle || file.path.toLowerCase().includes(needle))
-      && (!state.statusFilter || file.status === state.statusFilter)
-      && (!state.hideViewed || !viewed.has(file.path))
-      && (!state.hideGenerated || !file.generated)
-      && (!state.hideBinary || !file.binary)
-      && (!state.hideDeleted || file.status !== "deleted"));
-  };
-
-  const toggleFilter = (label, key) => {
-    const button = el("button", {
-      className: `review-filter-toggle${state[key] ? " active" : ""}`,
-      type: "button",
-      textContent: label,
-      ariaPressed: String(state[key]),
-    });
-    button.onclick = () => {
-      state[key] = !state[key];
-      paint();
+  const visibleFiles = () => sectionFiles().filter((file) => {
+    if (state.pathFilter
+      && !file.path.toLowerCase().includes(state.pathFilter.toLowerCase())) return false;
+    if (state.statusFilter && file.status !== state.statusFilter) return false;
+    return true;
+  });
+  const capturePosition = () => {
+    const navigator = $(".review-file-tree", host);
+    const patch = $(".review-patch-wrap", host);
+    return {
+      navigatorTop: navigator?.scrollTop || 0,
+      navigatorLeft: navigator?.scrollLeft || 0,
+      patchTop: patch?.scrollTop || 0,
+      patchLeft: patch?.scrollLeft || 0,
     };
+  };
+  const restorePosition = (position, preservePatch) => queueMicrotask(() => {
+    const navigator = $(".review-file-tree", host);
+    if (navigator) {
+      navigator.scrollTop = position?.navigatorTop || 0;
+      navigator.scrollLeft = position?.navigatorLeft || 0;
+    }
+    const patch = $(".review-patch-wrap", host);
+    if (patch && preservePatch) {
+      patch.scrollTop = position?.patchTop || 0;
+      patch.scrollLeft = position?.patchLeft || 0;
+    }
+  });
+  const typedError = (error) => reviewTypedState(
+    error?.code || "REVIEW_TARGET_UNAVAILABLE",
+    error?.message || "Diff is unavailable.",
+    "error",
+  );
+  const tabButton = (value, label, active, onclick) => {
+    const button = el("button", {
+      type: "button",
+      role: "tab",
+      className: active === value ? "active" : "",
+      ariaSelected: String(active === value),
+      textContent: label,
+    });
+    button.onclick = onclick;
     return button;
   };
 
-  const selectReviewFile = (file) => {
-    if (!file) return;
-    state.selectedPath = file.path;
-    viewedFiles().add(file.path);
-    loadPatch(file);
-    paint();
-  };
-
   const paint = () => {
-    if (state.mode !== "diff") return;
-    if (state.loadingTargets && !state.loaded) {
+    if (!state.loaded && state.loading) {
       host.replaceChildren(reviewTypedState(
-        "Loading review workspace…",
-        "Reading local Git state and cached pull-request evidence.",
+        "Observing current worktree…",
+        "Fetching origin/main once and reading the selected shell.",
       ));
       return;
     }
-    if (state.error && !state.targets.length) {
-      const retry = el("button", {
-        className: "act",
-        type: "button",
-        textContent: "Retry",
-      });
-      retry.onclick = () => loadTargets();
-      host.replaceChildren(reviewTypedState(
-        state.error.code || "REVIEW_TARGET_UNAVAILABLE",
-        state.error.message,
-        "error",
-      ), retry);
+    if (!state.snapshot) {
+      host.replaceChildren(state.error ? typedError(state.error) : reviewTypedState(
+        "Diff unavailable",
+        "Select Refresh Diff to try the current shell again.",
+      ));
       return;
     }
-    if (!state.targets.length) {
-      const refresh = el("button", {
-        className: "act",
-        type: "button",
-        textContent: "Refresh remote",
-      });
-      refresh.onclick = () => loadTargets({ remote: true });
-      host.replaceChildren(reviewTypedState(
-        "No review targets yet.",
-        "The selected conversation has no observed branch, workspace change, or pull request.",
-      ), refresh);
-      return;
-    }
-
-    const target = selectedTarget();
-    const targetSelect = el("select", {
-      className: "review-target-select",
-      ariaLabel: "Review target",
-    });
-    for (const item of state.targets)
-      targetSelect.append(el("option", {
-        value: item.target_id,
-        selected: item.target_id === state.targetId,
-        textContent: reviewTargetLabel(item),
-      }));
-    targetSelect.onchange = () => {
-      state.targetId = targetSelect.value;
-      state.targetFingerprint = selectedTarget()?.fingerprint || "";
-      state.scope = "review";
-      state.selectedPath = "";
-      state.patch = null;
-      state.commits = [];
-      loadContent();
-    };
-    const status = el("span", {
-      className: `review-lifecycle lifecycle-${target?.lifecycle || "local"}`,
-    }, reviewLifecycleLabel(target?.lifecycle));
-    const refresh = el("button", {
-      className: "act review-refresh",
+    const snapshot = state.snapshot;
+    const status = snapshot.status || {};
+    const facts = [
+      status.branch || `detached ${String(status.head_sha || "").slice(0, 8)}`,
+      `${status.dirty_count || 0} dirty`,
+      `${status.ahead_count || 0} ahead`,
+    ];
+    if (status.behind) facts.push(`${status.behind} behind origin/main`);
+    const warning = state.refreshWarning
+      || (!snapshot.fetch?.fresh && snapshot.fetch?.base_stale
+        ? "Fetch failed; this observation uses stale origin/main."
+        : !status.base_available
+          ? "Remote main unavailable; only Dirty can be inspected."
+          : "");
+    refreshButton = el("button", {
       type: "button",
-      textContent: state.loadingTargets ? "Refreshing…" : "Refresh remote",
-      disabled: state.loadingTargets,
+      className: "act review-refresh",
+      textContent: state.refreshInFlight ? "Refreshing…" : "Refresh Diff",
+      disabled: state.refreshInFlight,
     });
-    refresh.onclick = () => loadTargets({ remote: true });
-    const facts = targetFacts(target);
-    if (state.scope !== "commits" && !state.loadingContent) {
-      const additions = state.files.reduce(
-        (total, file) => total + (file.additions || 0), 0);
-      const deletions = state.files.reduce(
-        (total, file) => total + (file.deletions || 0), 0);
-      facts.push(`${state.files.length} file${state.files.length === 1 ? "" : "s"}`);
-      if (additions || deletions) facts.push(`+${additions} −${deletions}`);
-    }
-    const remoteWarning = state.freshness?.remote === "unavailable"
-      ? `Remote unavailable${state.freshness.remote_error
-        ? ` — ${state.freshness.remote_error}` : ""}. Local and cached evidence remain readable.`
-      : "";
+    refreshButton.onclick = () => observe(true);
     const summary = el("div", { className: "review-summary" },
       el("div", { className: "review-target-control" },
-        el("label", { className: "k" }, "Change set"),
-        targetSelect),
+        el("label", { className: "k" }, "Current worktree"),
+        el("strong", {}, facts[0])),
       el("div", { className: "review-lifecycle-block" },
-        status,
-        el("span", { className: "review-facts" }, facts.join(" · ") || "clean local state")),
+        el("span", { className: "review-lifecycle lifecycle-local" }, "ON DISK"),
+        el("span", { className: "review-facts" }, facts.slice(1).join(" · "))),
       el("div", { className: "review-freshness" },
-        el("span", {}, reviewObservedLabel(target?.last_seen_at)),
-        remoteWarning ? el("span", { className: "warning" }, remoteWarning) : null),
-      refresh);
-
-    const scopeSwitch = el("div", {
-      className: "review-scope-switch",
+        el("span", {}, reviewObservedLabel(snapshot.observed_at)),
+        el("span", {
+          className: "warning review-refresh-warning",
+          textContent: warning,
+          hidden: !warning,
+        })),
+      refreshButton);
+    const groupSwitch = el("div", {
+      className: "review-scope-switch review-group-switch",
       role: "tablist",
-      ariaLabel: "Comparison scope",
-    });
-    for (const [value, label] of [
-      ["review", "Review changes"],
-      ["local", "Local only"],
-      ["commits", "Commits"],
-    ]) {
-      const button = el("button", {
-        className: value === state.scope ? "active" : "",
-        type: "button",
-        role: "tab",
-        ariaSelected: String(value === state.scope),
-        textContent: label,
-      });
-      button.onclick = () => {
-        if (state.scope === value) return;
-        state.scope = value;
-        state.selectedPath = "";
-        state.patch = null;
-        state.error = null;
-        loadContent();
-      };
-      scopeSwitch.append(button);
-    }
-
-    const workspace = el("div", { className: "review-workspace" }, summary, scopeSwitch);
-    if (state.scope === "commits") {
-      workspace.append(el("div", { className: "review-commits-pane" }, commitBody()));
-      host.replaceChildren(workspace);
-      return;
-    }
-
-    const pathInput = el("input", {
-      type: "search",
-      className: "review-path-filter",
-      placeholder: "Filter paths",
-      value: state.pathFilter,
-    });
-    pathInput.oninput = () => {
-      const start = pathInput.selectionStart;
-      state.pathFilter = pathInput.value;
+      ariaLabel: "Diff section",
+    },
+    tabButton("changes", "Changes", state.group, () => {
+      if (state.group === "changes") return;
+      state.group = "changes";
+      state.section = "dirty";
+      state.selectedPath = sectionFiles()[0]?.path || "";
+      state.patch = null;
+      state.shellFile = null;
+      state.contentError = null;
       paint();
-      const next = $(".review-path-filter", host);
-      next?.focus();
-      next?.setSelectionRange(start, start);
-    };
-    const statuses = [...new Set(state.files.map((file) => file.status))].sort();
-    const statusSelect = el("select", {
-      className: "review-status-filter",
-      ariaLabel: "File status",
-    }, el("option", { value: "", textContent: "All statuses" }));
-    for (const value of statuses)
-      statusSelect.append(el("option", {
+      loadSelected();
+    }),
+    tabButton("shell", "Shell files", state.group, () => {
+      if (state.group === "shell") return;
+      state.group = "shell";
+      state.selectedPath = itemPath(
+        shellFiles().find((file) => file.available) || {},
+      );
+      state.patch = null;
+      state.shellFile = null;
+      state.contentError = null;
+      paint();
+      loadSelected();
+    }));
+    const workspace = el("div", {
+      className: `review-workspace review-workspace-${state.group}`,
+    }, summary, groupSwitch);
+
+    if (state.group === "changes") {
+      const sectionSwitch = el("div", {
+        className: "review-scope-switch review-change-switch",
+        role: "tablist",
+        ariaLabel: "Changes view",
+      });
+      for (const [value, label] of [
+        ["dirty", "Dirty"], ["branch", "Branch"], ["commits", "Commits"],
+      ]) sectionSwitch.append(tabButton(value, label, state.section, () => {
+        if (state.section === value) return;
+        state.section = value;
+        state.selectedPath = value === "commits" ? "" : sectionFiles()[0]?.path || "";
+        state.patch = null;
+        state.contentError = null;
+        paint();
+        loadSelected();
+      }));
+      workspace.append(sectionSwitch);
+      if (state.section === "commits") {
+        const commits = snapshot.changes.commits || [];
+        const body = el("div", { className: "review-commits-pane" });
+        if (!commits.length) body.append(reviewTypedState("No visible ahead commits."));
+        else {
+          const list = el("div", { className: "review-commit-list" });
+          for (const commit of commits) list.append(el("article", { className: "review-commit" },
+            el("code", {}, commit.short_sha),
+            el("div", { className: "review-commit-main" },
+              el("strong", {}, commit.subject),
+              el("span", {}, `${commit.author} · ${reviewObservedLabel(commit.authored_at)}`))));
+          body.append(list);
+        }
+        workspace.append(body);
+        host.replaceChildren(workspace);
+        return;
+      }
+      const pathInput = el("input", {
+        type: "search",
+        className: "review-path-filter",
+        placeholder: "Filter paths",
+        value: state.pathFilter,
+      });
+      pathInput.oninput = () => {
+        const start = pathInput.selectionStart;
+        state.pathFilter = pathInput.value;
+        paint();
+        const next = $(".review-path-filter", host);
+        next?.focus();
+        next?.setSelectionRange(start, start);
+      };
+      const statuses = [...new Set(sectionFiles().map((file) => file.status))].sort();
+      const statusSelect = el("select", {
+        className: "review-status-filter",
+        ariaLabel: "File status",
+      }, el("option", { value: "", textContent: "All statuses" }));
+      for (const value of statuses) statusSelect.append(el("option", {
         value,
         selected: value === state.statusFilter,
         textContent: value,
       }));
-    statusSelect.onchange = () => {
-      state.statusFilter = statusSelect.value;
-      paint();
-    };
-    const filters = el("div", { className: "review-filters" },
-      pathInput,
-      statusSelect,
-      toggleFilter("Hide viewed", "hideViewed"),
-      toggleFilter("Hide generated", "hideGenerated"),
-      toggleFilter("Hide binary", "hideBinary"),
-      toggleFilter("Hide deleted", "hideDeleted"));
-    const visibleFiles = filteredFiles();
-    const viewed = viewedFiles();
-    const navigator = el("aside", { className: "review-navigator" }, filters);
-    if (state.error) {
-      navigator.append(reviewTypedState(
-        state.error.code || "REVIEW_TARGET_UNAVAILABLE",
-        state.error.message,
-        "error",
+      statusSelect.onchange = () => {
+        state.statusFilter = statusSelect.value;
+        paint();
+      };
+      const navigator = el("aside", { className: "review-navigator" },
+        el("div", { className: "review-filters" }, pathInput, statusSelect));
+      const files = visibleFiles();
+      if (!files.length) navigator.append(reviewTypedState(
+        snapshot.no_code_changes ? "No code changes" : `No ${state.section} changes.`,
       ));
-    } else if (state.loadingContent) {
-      navigator.append(reviewTypedState("Loading files…"));
-    } else if (!visibleFiles.length) {
-      navigator.append(reviewTypedState("No files match this scope and filter."));
-    } else {
-      navigator.append(reviewFileTree(
-        visibleFiles,
+      else navigator.append(reviewFileTree(
+        files,
         state.selectedPath,
-        viewed,
-        selectReviewFile,
+        new Set(),
+        (file) => selectItem(file),
       ));
-    }
-    if (state.filesTruncated)
-      navigator.append(reviewTypedState(
-        "File list truncated",
-        "The server returned its bounded file projection.",
+      const selected = selectedItem();
+      const patchHead = el("div", { className: "review-patch-head" },
+        el("strong", {}, selected?.path || "Patch"),
+        el("span", {}, state.section === "dirty"
+          ? "staged, unstaged, conflicted, or untracked relative to HEAD"
+          : "merge-base(origin/main, HEAD) through HEAD"));
+      let patchBody;
+      if (state.contentError) patchBody = typedError(state.contentError);
+      else if (state.contentLoading) patchBody = reviewTypedState("Loading patch…");
+      else if (!selected) patchBody = reviewTypedState("Select a changed file.");
+      else if (!state.patch) patchBody = reviewTypedState("Patch unavailable.");
+      else if (state.patch.binary) patchBody = reviewTypedState("Binary file", "Binary bytes are never transported.");
+      else if (state.patch.truncated) patchBody = reviewTypedState(
+        "Patch exceeds review limits",
+        state.patch.unavailable_reason || "The bounded patch cannot be displayed.",
         "warning",
-      ));
-    const selected = selectedFile();
-    const selectedIndex = visibleFiles.findIndex(
-      (file) => file.path === state.selectedPath);
-    const previousFile = selectedIndex > 0 ? visibleFiles[selectedIndex - 1] : null;
-    const nextFile = selectedIndex >= 0 && selectedIndex < visibleFiles.length - 1
-      ? visibleFiles[selectedIndex + 1] : null;
-    const previous = el("button", {
-      type: "button",
-      className: "review-file-step",
-      textContent: "↑",
-      title: "Previous file",
-      ariaLabel: "Previous file",
-      disabled: !previousFile,
-    });
-    previous.onclick = () => selectReviewFile(previousFile);
-    const next = el("button", {
-      type: "button",
-      className: "review-file-step",
-      textContent: "↓",
-      title: "Next file",
-      ariaLabel: "Next file",
-      disabled: !nextFile,
-    });
-    next.onclick = () => selectReviewFile(nextFile);
-    const patchHead = el("div", { className: "review-patch-head" },
-      el("strong", {}, selected?.path || "Patch"),
-      selected?.old_path
-        ? el("span", {}, `renamed from ${selected.old_path}`)
-        : el("span", {}, state.scope === "local"
-          ? "local changes absent from selected head"
-          : "merge-base / canonical review patch"),
-      el("div", { className: "review-file-steps" }, previous, next));
-    const patchPane = el("section", { className: "review-patch-pane" },
-      patchHead, patchBody());
-    workspace.append(el("div", { className: "review-body" }, navigator, patchPane));
+      );
+      else {
+        patchBody = el("div", { className: "review-patch-wrap" });
+        patchBody.append(reviewPatchRows(state.patch.patch || ""));
+      }
+      workspace.append(el("div", { className: "review-body" }, navigator,
+        el("section", { className: "review-patch-pane" }, patchHead, patchBody)));
+    } else {
+      const navigator = el("aside", { className: "review-navigator" });
+      const list = el("div", { className: "review-file-tree review-shell-tree" });
+      for (const file of shellFiles()) {
+        const key = itemPath(file);
+        const row = el("button", {
+          type: "button",
+          className: `review-file-row${key === state.selectedPath ? " selected" : ""}`,
+          disabled: !file.available,
+          title: (file.paths || []).join("\n"),
+        },
+        el("span", { className: "review-file-status" }, file.available ? "R" : "!"),
+        el("span", { className: "review-file-path" }, file.name),
+        el("span", { className: "review-file-counts" },
+          file.mismatch ? "mirror mismatch" : (file.paths || []).join(" · ")));
+        row.onclick = () => selectItem(file);
+        list.append(row);
+        if (!file.available) list.append(reviewTypedState(
+          file.error || "Unavailable",
+          (file.paths || []).join(" · "),
+          "warning",
+        ));
+      }
+      navigator.append(list);
+      const selected = selectedItem();
+      const head = el("div", { className: "review-patch-head" },
+        el("strong", {}, selected?.name || "Shell file"),
+        el("span", {}, selected ? (selected.paths || []).join(" · ") : "Read-only exact text"));
+      let body;
+      if (state.contentError) body = typedError(state.contentError);
+      else if (state.contentLoading) body = reviewTypedState("Loading shell file…");
+      else if (!selected) body = reviewTypedState("Select an available Shell file.");
+      else if (!state.shellFile) body = reviewTypedState("Shell file unavailable.");
+      else body = el("pre", {
+        className: "review-shell-file review-patch-wrap",
+        textContent: state.shellFile.body,
+      });
+      workspace.append(el("div", { className: "review-body" }, navigator,
+        el("section", { className: "review-patch-pane" }, head, body)));
+    }
     host.replaceChildren(workspace);
   };
 
-  const readReviewResource = async (path) => {
-    const cached = state.responseCache.get(path);
-    const result = await reviewApi(path, cached?.etag || "");
-    if (result.notModified) {
-      if (!cached) {
-        const error = new Error("Review cache entry is unavailable.");
-        error.code = "REVIEW_TARGET_UNAVAILABLE";
-        throw error;
-      }
-      return cached.data;
+  const loadSelected = async ({ position = null, preservePatch = false } = {}) => {
+    const selected = selectedItem();
+    if (!selected || (state.group === "changes" && state.section === "commits")) {
+      paint();
+      restorePosition(position, false);
+      return;
     }
-    state.responseCache.set(path, { etag: result.etag, data: result.data });
-    return result.data;
-  };
-
-  const loadPatch = async (file) => {
-    if (!file || state.scope === "commits") return;
     const request = ++state.requestGeneration;
-    state.patchLoading = true;
-    state.patchError = null;
+    state.contentLoading = true;
+    state.contentError = null;
+    state.patch = null;
+    state.shellFile = null;
     paint();
     try {
-      const data = await readReviewResource(
-        `/review-targets/${encodeURIComponent(state.targetId)}/diff`
-        + `?scope=${encodeURIComponent(state.scope)}`
-        + `&path=${encodeURIComponent(file.path)}`,
+      const resource = state.group === "shell" ? "shell-file" : "patch";
+      const data = await reviewObservationApi(
+        `/review-observations/${state.snapshot.fingerprint}/${resource}`
+        + `?file=${encodeURIComponent(selected.file_id)}`,
       );
       if (request !== state.requestGeneration) return;
-      state.patch = data;
+      if (state.group === "shell") state.shellFile = data;
+      else state.patch = data;
     } catch (error) {
       if (request !== state.requestGeneration) return;
-      state.patchError = error;
-      if (error.code === "REVIEW_TARGET_CHANGED") loadTargets();
+      state.contentError = error;
     } finally {
       if (request === state.requestGeneration) {
-        state.patchLoading = false;
+        state.contentLoading = false;
         paint();
+        restorePosition(position, preservePatch && !state.contentError);
       }
     }
   };
 
-  const loadFiles = async () => {
-    const request = ++state.requestGeneration;
-    state.loadingContent = true;
+  const selectItem = (item) => {
+    const nextPath = itemPath(item);
+    if (!nextPath || nextPath === state.selectedPath) return;
+    state.selectedPath = nextPath;
+    state.contentError = null;
+    loadSelected();
+  };
+
+  const observe = async (manual = false) => {
+    if (state.refreshInFlight) return;
+    state.refreshInFlight = true;
+    state.loading = !state.snapshot;
     state.error = null;
-    paint();
-    try {
-      const items = [];
-      let cursor = "";
-      let page;
-      do {
-        const suffix = cursor ? `&cursor=${encodeURIComponent(cursor)}` : "";
-        page = await readReviewResource(
-          `/review-targets/${encodeURIComponent(state.targetId)}/files`
-          + `?scope=${encodeURIComponent(state.scope)}&limit=200${suffix}`,
-        );
-        items.push(...page.items);
-        cursor = page.next_cursor || "";
-      } while (cursor && items.length < 2000);
-      if (request !== state.requestGeneration) return;
-      const fingerprintChanged = state.fileFingerprint
-        && state.fileFingerprint !== page.fingerprint;
-      state.files = items;
-      state.fileFingerprint = page.fingerprint;
-      state.filesTruncated = Boolean(page.files_truncated || cursor);
-      if (fingerprintChanged || !items.some((file) => file.path === state.selectedPath))
-        state.selectedPath = items[0]?.path || "";
-      state.patch = null;
-      state.patchError = null;
-      state.loadingContent = false;
-      paint();
-      const file = selectedFile();
-      if (file) {
-        viewedFiles().add(file.path);
-        await loadPatch(file);
-      }
-    } catch (error) {
-      if (request !== state.requestGeneration) return;
-      state.loadingContent = false;
-      state.error = error;
-      state.files = [];
-      state.patch = null;
-      paint();
+    const position = capturePosition();
+    const oldSnapshot = state.snapshot;
+    const oldItems = state.group === "shell"
+      ? shellFiles(oldSnapshot).filter((file) => file.available)
+      : sectionFiles(oldSnapshot);
+    const oldIndex = oldItems.findIndex((item) => itemPath(item) === state.selectedPath);
+    const oldPath = state.selectedPath;
+    if (!oldSnapshot) paint();
+    if (refreshButton) {
+      refreshButton.disabled = true;
+      refreshButton.textContent = "Refreshing…";
     }
-  };
-
-  const loadCommits = async () => {
-    const request = ++state.requestGeneration;
-    state.loadingContent = true;
-    state.error = null;
-    paint();
     try {
-      const items = [];
-      let cursor = "";
-      let page;
-      do {
-        const suffix = cursor ? `?limit=200&cursor=${encodeURIComponent(cursor)}` : "?limit=200";
-        page = await readReviewResource(
-          `/review-targets/${encodeURIComponent(state.targetId)}/commits${suffix}`,
-        );
-        items.push(...page.items);
-        cursor = page.next_cursor || "";
-      } while (cursor && items.length < 500);
-      if (request !== state.requestGeneration) return;
-      state.commits = items;
-      state.commitsTruncated = Boolean(page.commits_truncated || cursor);
-    } catch (error) {
-      if (request !== state.requestGeneration) return;
-      state.error = error;
-      state.commits = [];
-    } finally {
-      if (request === state.requestGeneration) {
-        state.loadingContent = false;
-        paint();
-      }
-    }
-  };
-
-  const loadContent = () =>
-    state.scope === "commits" ? loadCommits() : loadFiles();
-
-  const loadTargets = async ({ remote = false, polling = false } = {}) => {
-    if (state.loadingTargets) return;
-    state.loadingTargets = true;
-    if (!polling) paint();
-    const oldTargetId = state.targetId;
-    const oldTargetFingerprint = selectedTarget()?.fingerprint || "";
-    try {
-      const query = remote ? "?refresh=remote" : "";
-      const result = await reviewApi(
-        `/conversations/${conversation.conversation_id}/review-targets${query}`,
-        polling && !remote ? state.targetsEtag : "",
+      const next = await reviewObservationApi(
+        `/conversations/${conversation.conversation_id}/review-observations`,
+        { method: "POST", key: requestKey() },
       );
-      if (result.notModified) return;
-      const page = result.data;
-      state.targetsEtag = result.etag;
-      state.gitFingerprint = page.git_fingerprint;
-      state.targets = page.items;
-      state.freshness = page.freshness;
       state.loaded = true;
-      state.error = null;
-      if (!state.targets.some((target) => target.target_id === state.targetId))
-        state.targetId = page.selected_target_id || state.targets[0]?.target_id || "";
-      const nextTargetFingerprint = selectedTarget()?.fingerprint || "";
-      state.targetFingerprint = nextTargetFingerprint;
-      if (state.targetId && (
-        state.targetId !== oldTargetId
-        || nextTargetFingerprint !== oldTargetFingerprint
-        || (!state.files.length && !state.commits.length)
-      )) {
-        await loadContent();
-      } else {
-        paint();
+      if (manual && oldSnapshot && !next.fetch?.fresh) {
+        state.refreshWarning = next.fetch?.error
+          ? `Refresh failed: ${next.fetch.error}`
+          : "Refresh failed; the current observation is retained.";
+        const warning = $(".review-refresh-warning", host);
+        if (warning) {
+          warning.hidden = false;
+          warning.textContent = state.refreshWarning;
+        }
+        return;
       }
+      state.refreshWarning = "";
+      if (oldSnapshot && oldSnapshot.fingerprint === next.fingerprint) return;
+      state.snapshot = next;
+      const nextItems = state.group === "shell"
+        ? shellFiles(next).filter((file) => file.available)
+        : sectionFiles(next);
+      const stillPresent = nextItems.find((item) => itemPath(item) === oldPath);
+      const nearest = nextItems[Math.min(Math.max(oldIndex, 0), nextItems.length - 1)];
+      state.selectedPath = itemPath(stillPresent || nearest || {});
+      state.patch = null;
+      state.shellFile = null;
+      state.contentError = null;
+      paint();
+      await loadSelected({ position, preservePatch: Boolean(stillPresent) });
     } catch (error) {
       state.error = error;
       state.loaded = true;
-      paint();
+      if (!oldSnapshot) paint();
+      else {
+        state.refreshWarning = error.message || "Refresh failed.";
+        const warning = $(".review-refresh-warning", host);
+        if (warning) {
+          warning.hidden = false;
+          warning.textContent = state.refreshWarning;
+        }
+      }
     } finally {
-      state.loadingTargets = false;
-      paint();
+      state.loading = false;
+      state.refreshInFlight = false;
+      if (refreshButton) {
+        refreshButton.disabled = false;
+        refreshButton.textContent = "Refresh Diff";
+      }
     }
   };
-
-  const pollReview = async () => {
-    if (document.hidden || state.mode !== "diff" || state.pollInFlight) return;
-    state.pollInFlight = true;
-    try { await loadTargets({ polling: true }); }
-    finally { state.pollInFlight = false; }
-  };
-  const visibilityRefresh = () => {
-    if (!document.hidden && state.mode === "diff") pollReview();
-  };
-  document.addEventListener("visibilitychange", visibilityRefresh);
 
   const setMode = (mode) => {
     state.mode = mode;
-    if (mode === "diff") {
-      if (!state.loaded) loadTargets();
-      if (state.pollTimer === null)
-        state.pollTimer = setInterval(pollReview, CHAT_REVIEW_POLL_MS);
-      paint();
-    } else if (state.pollTimer !== null) {
-      clearInterval(state.pollTimer);
-      state.pollTimer = null;
-    }
+    if (mode === "diff" && !state.loaded && !state.loading) observe(false);
   };
   const cleanup = () => {
     state.requestGeneration += 1;
-    if (state.pollTimer !== null) clearInterval(state.pollTimer);
-    state.pollTimer = null;
-    document.removeEventListener("visibilitychange", visibilityRefresh);
   };
   chatReviewCleanup = cleanup;
   return { setMode, cleanup };

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -345,8 +345,9 @@ body.interface-view main {
 }
 .review-workspace {
   min-width: 0; min-height: 0; height: 100%; display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr); overflow: hidden;
+  grid-template-rows: auto auto auto minmax(0, 1fr); overflow: hidden;
 }
+.review-workspace-shell { grid-template-rows: auto auto minmax(0, 1fr); }
 .review-summary {
   min-width: 0; padding: .7rem 1rem; border-bottom: 1px solid var(--line);
   display: grid; grid-template-columns: minmax(220px, 1.3fr) auto minmax(130px, .7fr) auto;
@@ -418,6 +419,7 @@ body.interface-view main {
   color: var(--dim); cursor: pointer; text-align: left; font: inherit;
 }
 .review-file-row:hover { color: var(--ink); background: var(--accent2); }
+.review-file-row:disabled { cursor: not-allowed; opacity: .58; }
 .review-file-row.selected {
   color: var(--ink); background: var(--panel2); border-left-color: var(--accent);
 }
@@ -476,6 +478,15 @@ body.interface-view main {
 .review-line-hunk { color: #9ec2ff; background: rgba(110,168,254,.10); }
 .review-line-header { color: var(--dim); background: var(--panel); }
 .review-line-notice { color: var(--warn); }
+.review-shell-file {
+  margin: 0;
+  padding: .85rem 1rem 1.5rem;
+  color: var(--ink);
+  background: var(--bg);
+  font: .72rem/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: pre;
+  tab-size: 2;
+}
 .review-typed-state {
   min-width: 0; margin: 1rem; padding: .85rem; border: 1px dashed var(--line);
   border-radius: 9px; color: var(--dim); display: flex; flex-direction: column;

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -203,6 +203,85 @@ def file_items() -> list[dict]:
     ]
 
 
+def observation_page(*, fresh: bool = True, fingerprint: str = "a" * 64) -> dict:
+    files = file_items()
+    return {
+        "conversation_id": CONVERSATION_ID,
+        "fingerprint": fingerprint,
+        "observed_at": "2026-07-31T12:00:00+00:00",
+        "fetch": {
+            "fresh": fresh,
+            "error": None if fresh else "fixture origin is offline",
+            "base_stale": not fresh,
+        },
+        "status": {
+            "branch": "feat/current-worktree-diff",
+            "head_sha": "b" * 40,
+            "base_sha": "c" * 40,
+            "base_available": True,
+            "dirty_count": len(files),
+            "ahead_count": 1,
+            "behind": 3,
+        },
+        "changes": {
+            "dirty": files,
+            "branch": [files[0], files[1]],
+            "commits": [
+                {
+                    "sha": "d" * 40,
+                    "short_sha": "ddddddd",
+                    "author": "CC",
+                    "authored_at": "2026-07-30T20:30:00Z",
+                    "subject": "Build the current-worktree Diff",
+                }
+            ],
+            "files_truncated": False,
+            "commits_truncated": False,
+        },
+        "shell_files": [
+            {
+                "file_id": "sf_claude",
+                "kind": "boot",
+                "name": "CLAUDE.md",
+                "available": True,
+                "bytes": 24,
+                "sha256": "e" * 64,
+                "paths": ["CLAUDE.md"],
+            },
+            {
+                "file_id": "sf_agents",
+                "kind": "boot",
+                "name": "AGENTS.md",
+                "available": True,
+                "bytes": 22,
+                "sha256": "f" * 64,
+                "paths": ["AGENTS.md"],
+            },
+            {
+                "file_id": "sf_skill_a",
+                "kind": "skill",
+                "name": "git",
+                "available": True,
+                "bytes": 18,
+                "sha256": "1" * 64,
+                "paths": [".claude/skills/git/SKILL.md"],
+                "mismatch": True,
+            },
+            {
+                "file_id": "sf_skill_b",
+                "kind": "skill",
+                "name": "git",
+                "available": True,
+                "bytes": 20,
+                "sha256": "2" * 64,
+                "paths": [".opencode/skills/git/SKILL.md"],
+                "mismatch": True,
+            },
+        ],
+        "no_code_changes": False,
+    }
+
+
 def test_diff_workspace_preserves_live_chat_and_uses_get_only(
     static_ui,
     tmp_path,
@@ -210,7 +289,11 @@ def test_diff_workspace_preserves_live_chat_and_uses_get_only(
     requests: list[tuple[str, str, str]] = []
     conditional_requests: list[str] = []
     browser_errors: list[str] = []
-    remote_state = {"available": True}
+    observation_state = {
+        "fresh": True,
+        "fingerprint": "a" * 64,
+        "remove_path": None,
+    }
     current = conversation()
     messages = [
         {
@@ -221,17 +304,63 @@ def test_diff_workspace_preserves_live_chat_and_uses_get_only(
         }
         for index in range(1, 22)
     ]
+    transcript_page = {
+        "conversation_id": CONVERSATION_ID,
+        "projection_version": 1,
+        "through_sequence": 22,
+        "controls": {
+            "conversation_version": 4,
+            "conversation_state": "running",
+            "queued_count": 0,
+            "active_run_id": 77,
+            "close_requested_at": None,
+        },
+        "items": [
+            {
+                "item_id": f"message:{item['message_id']}",
+                "kind": "user",
+                "order_sequence": item["message_id"],
+                "message_id": item["message_id"],
+                "run_id": None,
+                "created_at": "2026-07-30 20:00:00",
+                "text": item["body"],
+                "state": "completed",
+                "completed_at": "2026-07-30 20:00:01",
+                "text_truncated": False,
+            }
+            for item in messages
+        ] + [
+            {
+                "item_id": "run:77:assistant",
+                "kind": "assistant",
+                "order_sequence": 22,
+                "message_id": 1,
+                "run_id": 77,
+                "created_at": "2026-07-30 20:00:02",
+                "text": "initial",
+                "outcome": None,
+                "first_sequence": 22,
+                "last_sequence": 22,
+                "text_truncated": False,
+            }
+        ],
+        "truncation": None,
+    }
     files = file_items()
     patch = """diff --git a/src/app.js b/src/app.js
 index 1111111..2222222 100644
 --- a/src/app.js
 +++ b/src/app.js
 @@ -1,3 +1,4 @@
- const mode = 'chat';
+const mode = 'chat';
 -const oldValue = false;
 +const reviewOnly = true;
-+const safe = document.createTextNode('patch');
- export { mode };"""
++const safe = document.createTextNode('patch with a deliberately long line for horizontal scroll position preservation across refresh');
+export { mode };"""
+    patch += "\n" + "\n".join(
+        f"+const addedLine{index} = 'scroll proof {index}';"
+        for index in range(80)
+    )
 
     def fulfill(route, payload, *, status=200, headers=None):
         route.fulfill(
@@ -290,6 +419,66 @@ index 1111111..2222222 100644
             return fulfill(route, current)
         if path == f"/api/conversations/{CONVERSATION_ID}/messages":
             return fulfill(route, {"items": messages})
+        if path == f"/api/conversations/{CONVERSATION_ID}/transcript":
+            return fulfill(route, transcript_page)
+        if path == f"/api/conversations/{CONVERSATION_ID}/review-observations":
+            assert request.method == "POST"
+            assert request.headers.get("idempotency-key")
+            observed = observation_page(
+                fresh=observation_state["fresh"],
+                fingerprint=observation_state["fingerprint"],
+            )
+            remove_path = observation_state["remove_path"]
+            if remove_path:
+                for section in ("dirty", "branch"):
+                    observed["changes"][section] = [
+                        item for item in observed["changes"][section]
+                        if item["path"] != remove_path
+                    ]
+                observed["status"]["dirty_count"] = len(
+                    observed["changes"]["dirty"]
+                )
+            return fulfill(route, observed, status=201)
+        if path.endswith("/patch") and "/api/review-observations/" in path:
+            selected_id = query.get("file", [""])[0]
+            selected = next(
+                item for item in file_items() if item["file_id"] == selected_id
+            )
+            binary = selected["binary"]
+            oversized = selected["oversized"]
+            return fulfill(
+                route,
+                {
+                    "fingerprint": observation_state["fingerprint"],
+                    "file_id": selected_id,
+                    "section": "dirty",
+                    "patch": None if binary or oversized else patch,
+                    "sha256": "c" * 64,
+                    "truncated": oversized,
+                    "binary": binary,
+                    "unavailable_reason": "binary" if binary
+                    else "oversized" if oversized
+                    else None,
+                },
+            )
+        if path.endswith("/shell-file") and "/api/review-observations/" in path:
+            selected_id = query.get("file", [""])[0]
+            bodies = {
+                "sf_claude": "# Exact CLAUDE\nplain text\n",
+                "sf_agents": "# Exact AGENTS\nplain text\n",
+                "sf_skill_a": "# Claude git skill\n",
+                "sf_skill_b": "# OpenCode git skill\n",
+            }
+            return fulfill(
+                route,
+                {
+                    "fingerprint": observation_state["fingerprint"],
+                    "file_id": selected_id,
+                    "paths": [selected_id],
+                    "body": bodies[selected_id],
+                    "mismatch": selected_id.startswith("sf_skill"),
+                },
+            )
         if path == f"/api/conversations/{CONVERSATION_ID}/review-targets":
             if (
                 request.headers.get("if-none-match") == '"targets-1"'
@@ -301,7 +490,7 @@ index 1111111..2222222 100644
                     body="",
                 )
             body = target_page()
-            if not remote_state["available"]:
+            if not observation_state["fresh"]:
                 body["freshness"] = {
                     "local": "fresh",
                     "remote": "unavailable",
@@ -422,6 +611,11 @@ index 1111111..2222222 100644
             wait_until="networkidle",
         )
         composer = page.locator(".chat-composer-input")
+        page.wait_for_timeout(500)
+        assert composer.count() == 1, json.dumps(
+            {"requests": requests, "browser_errors": browser_errors},
+            indent=2,
+        )
         composer.fill("unsent draft survives mode changes")
         transcript = page.locator(".chat-transcript")
         page.wait_for_timeout(100)
@@ -438,23 +632,66 @@ index 1111111..2222222 100644
         assert composer.input_value() == "unsent draft survives mode changes"
         assert page.locator(".chat-stop-header").is_visible()
         assert page.locator(".chat-stop-header").is_enabled()
-        assert page.get_by_text("LOCAL BRANCH", exact=True).is_visible()
-        assert page.get_by_text("7 files", exact=False).is_visible()
-        assert page.locator(".review-line-add").count() == 2
+        assert page.get_by_text("ON DISK", exact=True).is_visible()
+        assert page.get_by_text("7 dirty", exact=False).is_visible()
+        initial_observations = sum(
+            method == "POST" and path.endswith("/review-observations")
+            for method, path, _query in requests
+        )
+        page.wait_for_timeout(2200)
+        assert sum(
+            method == "POST" and path.endswith("/review-observations")
+            for method, path, _query in requests
+        ) == initial_observations == 1
+        assert page.locator(".review-line-add").count() >= 82
         assert page.locator(".review-line-delete").count() == 1
         assert page.locator(".status-conflict").count() == 1
         page.get_by_title("assets/logo.bin").click()
         page.get_by_text("Binary file", exact=True).wait_for()
         page.get_by_title("large.txt").click()
-        page.get_by_text("Patch too large", exact=True).wait_for()
+        page.get_by_text("Patch exceeds review limits", exact=True).wait_for()
         page.get_by_title("src/old.js → src/renamed.js").click()
-        page.get_by_text("renamed from src/old.js", exact=True).wait_for()
+        page.get_by_text("src/renamed.js", exact=True).wait_for()
+        page.get_by_title("src/app.js").click()
+        page.locator(".review-patch-wrap").wait_for()
+        scroll_proof = page.locator(".review-patch-wrap").evaluate(
+            "node => { node.scrollTop = 240; node.scrollLeft = 120; "
+            "return {top: node.scrollTop, left: node.scrollLeft}; }"
+        )
+        page.evaluate(
+            "window.__unchangedWorkspace = document.querySelector('.review-workspace')"
+        )
+        before_refresh_observations = sum(
+            method == "POST" and path.endswith("/review-observations")
+            for method, path, _query in requests
+        )
+        page.get_by_role("button", name="Refresh Diff").click()
+        page.wait_for_timeout(150)
+        assert sum(
+            method == "POST" and path.endswith("/review-observations")
+            for method, path, _query in requests
+        ) == before_refresh_observations + 1
+        assert page.evaluate(
+            "window.__unchangedWorkspace === "
+            "document.querySelector('.review-workspace')"
+        )
+        assert page.locator(".review-patch-wrap").evaluate(
+            "node => ({top: node.scrollTop, left: node.scrollLeft})"
+        ) == scroll_proof
+
+        observation_state["fingerprint"] = "b" * 64
+        observation_state["remove_path"] = "src/app.js"
+        page.get_by_role("button", name="Refresh Diff").click()
+        page.get_by_text("src/renamed.js", exact=True).wait_for()
+        assert page.locator(".review-patch-wrap").evaluate(
+            "node => node.scrollTop"
+        ) == 0
         page.screenshot(path=tmp_path / "diff-desktop.png", full_page=True)
 
         page.evaluate(
             """
             window.__fakeEventSources[0].emit('assistant.delta', {
-              sequence: 9001,
+              sequence: 23,
               event_type: 'assistant.delta',
               message_id: 1,
               run_id: 77,
@@ -464,29 +701,25 @@ index 1111111..2222222 100644
             """
         )
         page.get_by_role("tab", name="Commits").click()
-        page.get_by_text("Build the Diff workspace", exact=True).wait_for()
-        page.get_by_role("tab", name="Local only").click()
-        page.locator(".review-file-row").first.wait_for()
-        page.get_by_role("button", name="Hide binary").click()
-        page.locator(".review-target-select").select_option(
-            "gt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-        )
-        page.get_by_text("PR MERGED", exact=True).wait_for()
-        assert page.get_by_text("cleanup pending", exact=False).is_visible()
-        assert page.get_by_text("40 behind base", exact=False).is_visible()
-        page.locator(".review-target-select").select_option(TARGET_ID)
-        remote_state["available"] = False
-        page.get_by_role("button", name="Refresh remote").click()
-        page.get_by_text("Remote unavailable", exact=False).wait_for()
+        page.get_by_text("Build the current-worktree Diff", exact=True).wait_for()
+        page.get_by_role("tab", name="Shell files").click()
+        page.get_by_role("button", name="CLAUDE.md").click()
+        page.locator(".review-shell-file").wait_for()
+        assert "# Exact CLAUDE" in page.locator(".review-shell-file").text_content()
+        assert page.get_by_text("mirror mismatch", exact=True).count() == 2
+
+        observation_state["fresh"] = False
+        page.get_by_role("button", name="Refresh Diff").click()
+        page.get_by_text("Refresh failed: fixture origin is offline", exact=True).wait_for()
+        assert "# Exact CLAUDE" in page.locator(".review-shell-file").text_content()
 
         page.go_back()
         transcript.wait_for()
         page.wait_for_timeout(100)
         assert composer.input_value() == "unsent draft survives mode changes"
-        assert page.get_by_text(
-            "background completion arrived",
-            exact=True,
-        ).is_visible()
+        assert "background completion arrived" in (
+            page.locator(".chat-assistant-body").last.text_content() or ""
+        )
         assert abs(transcript.evaluate("node => node.scrollTop") - scroll_before) <= 1
         assert page.evaluate("window.__fakeEventSources.length") == 1
 
@@ -496,18 +729,18 @@ index 1111111..2222222 100644
         page.screenshot(path=tmp_path / "diff-mobile.png", full_page=True)
 
         current["state"] = "closed"
+        transcript_page["controls"]["conversation_state"] = "closed"
+        transcript_page["controls"]["active_run_id"] = None
         page.reload(wait_until="networkidle")
         page.locator(".review-workspace").wait_for()
         assert page.get_by_role("button", name="Close").is_disabled()
-        assert page.get_by_text("LOCAL BRANCH", exact=True).is_visible()
+        assert page.get_by_text("ON DISK", exact=True).is_visible()
         browser.close()
 
-    review_requests = [
-        item for item in requests if "/review-targets" in item[1]
-    ]
+    review_requests = [item for item in requests if "/review-observations" in item[1]]
     assert review_requests
-    assert {method for method, _path, _query in review_requests} == {"GET"}
-    assert any(path.endswith("/files") for path in conditional_requests)
+    assert {method for method, _path, _query in review_requests} == {"GET", "POST"}
+    assert not conditional_requests
     assert not browser_errors
     assert (tmp_path / "diff-desktop.png").stat().st_size > 10_000
     assert (tmp_path / "diff-mobile.png").stat().st_size > 10_000
@@ -644,6 +877,25 @@ def test_chat_performance_uses_bounded_requests_and_keyed_frames(static_ui):
                             "state": "completed",
                         }
                     ]
+                },
+            )
+        if parsed.path == f"/api/conversations/{CONVERSATION_ID}/review-observations":
+            return fulfill(route, observation_page(), status=201)
+        if (
+            parsed.path.endswith("/patch")
+            and "/api/review-observations/" in parsed.path
+        ):
+            return fulfill(
+                route,
+                {
+                    "fingerprint": "a" * 64,
+                    "file_id": "rf_1",
+                    "section": "dirty",
+                    "patch": "diff --git a/src/app.js b/src/app.js\n+proof\n",
+                    "sha256": "c" * 64,
+                    "truncated": False,
+                    "binary": False,
+                    "unavailable_reason": None,
                 },
             )
         if parsed.path == f"/api/conversations/{CONVERSATION_ID}/review-targets":

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -11,15 +11,21 @@ STYLE = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
 
 def diff_source() -> str:
     return APP[
-        APP.index("const CHAT_REVIEW_POLL_MS"):
+        APP.index("const CHAT_MODES"):
         APP.index("async function renderInterface")
+    ]
+
+
+def current_workspace_source() -> str:
+    return APP[
+        APP.index("function chatReviewWorkspace"):
+        APP.index("async function chatRenderNew")
     ]
 
 
 def test_diff_is_a_deep_linked_coequal_mode_without_rebuilding_chat():
     source = diff_source()
 
-    assert "const CHAT_REVIEW_POLL_MS = 2000" in source
     assert 'const CHAT_MODES = ["chat", "diff"]' in source
     assert "function chatModeHash(" in source
     assert 'mode === "diff" ? "/diff" : ""' in source
@@ -54,79 +60,94 @@ def test_diff_keeps_truthful_header_controls_and_chat_state_alive():
     ]
 
 
-def test_review_client_is_get_only_and_uses_server_issued_identities():
-    source = diff_source()
-    client = source[
-        source.index("async function reviewApi"):
-        source.index("function reviewLifecycleLabel")
-    ]
+def test_review_client_posts_observations_and_reads_only_server_issued_files():
+    source = current_workspace_source()
 
-    assert 'method: "GET"' in client
-    assert '"If-None-Match"' in client
-    assert "response.status === 304" in client
-    assert "Cache-Control" not in client
-    for verb in ("POST", "PATCH", "PUT", "DELETE"):
-        assert f'"{verb}"' not in client
-    assert "/review-targets/${" in source
-    assert "encodeURIComponent(file.path)" in source
+    assert "/review-observations`" in source
+    assert '{ method: "POST", key: requestKey() }' in source
+    assert "selected.file_id" in source
+    assert "encodeURIComponent(selected.file_id)" in source
+    assert "/review-targets/${" not in source
+    assert "encodeURIComponent(file.path)" not in source
     assert "cwd=" not in source
     assert "ref=" not in source
 
 
-def test_workspace_has_targets_scopes_filters_tree_patch_and_commits():
-    source = diff_source()
+def test_workspace_has_current_changes_shell_files_and_manual_refresh():
+    source = current_workspace_source()
 
     for text in (
-        "Review changes",
-        "Local only",
+        "Changes",
+        "Shell files",
+        "Dirty",
+        "Branch",
         "Commits",
         "Filter paths",
-        "Hide viewed",
-        "Hide generated",
-        "Hide binary",
-        "Hide deleted",
-        "Refresh remote",
-        "No review targets yet.",
-        "No files match this scope and filter.",
-        "No commits in this change set.",
+        "Refresh Diff",
+        "No code changes",
+        "No visible ahead commits.",
+        "Remote main unavailable",
+        "mirror mismatch",
     ):
         assert text in source
     for class_name in (
         "review-summary",
-        "review-target-select",
         "review-scope-switch",
         "review-file-tree",
         "review-file-row",
         "review-patch",
         "review-commit-list",
-        "review-typed-state",
     ):
         assert class_name in source
-    assert "function reviewPatchRows" in source
+    assert "reviewTypedState(" in source
+    assert "reviewPatchRows(" in source
+    assert "function reviewPatchRows" in APP
     assert 'document.createTextNode' in APP
-    assert "innerHTML" not in source[source.index("function reviewPatchRows"):]
+    patch_renderer = APP[
+        APP.index("function reviewPatchRows"):
+        APP.index("function reviewFileTree")
+    ]
+    assert "innerHTML" not in patch_renderer
 
 
-def test_viewed_state_is_ephemeral_and_scoped_to_target_fingerprint():
-    source = diff_source()
+def test_diff_observes_once_then_only_refreshes_manually_single_flight():
+    source = current_workspace_source()
 
-    assert "const chatReviewViewed = new Map()" in source
-    assert "function reviewViewedKey(targetId, fingerprint)" in source
-    assert "reviewViewedKey(state.targetId, state.fileFingerprint)" in source
-    assert "viewedFiles().add(file.path)" in source
-    assert "chatReviewViewed.get(key)" in source
+    assert 'mode === "diff" && !state.loaded && !state.loading' in source
+    assert "if (state.refreshInFlight) return" in source
+    assert "state.refreshInFlight = true" in source
+    assert "state.refreshInFlight = false" in source
+    assert "setInterval(" not in source
+    assert "visibilitychange" not in source
+    assert "poll" not in source.lower()
 
 
-def test_local_polling_is_visible_single_flight_and_stops_in_chat():
-    source = diff_source()
+def test_refresh_reconciliation_preserves_selection_and_both_scroll_axes():
+    source = current_workspace_source()
 
-    assert "document.hidden || state.mode !== \"diff\" || state.pollInFlight" in source
-    assert "state.pollInFlight = true" in source
-    assert "finally { state.pollInFlight = false; }" in source
-    assert "setInterval(pollReview, CHAT_REVIEW_POLL_MS)" in source
-    assert "clearInterval(state.pollTimer)" in source
-    assert 'document.addEventListener("visibilitychange", visibilityRefresh)' in source
-    assert 'document.removeEventListener("visibilitychange", visibilityRefresh)' in source
+    for text in (
+        "navigator.scrollTop",
+        "navigator.scrollLeft",
+        "patch.scrollTop",
+        "patch.scrollLeft",
+        "oldSnapshot.fingerprint === next.fingerprint",
+        "stillPresent || nearest",
+        "preservePatch: Boolean(stillPresent)",
+    ):
+        assert text in source
+    unchanged = source[
+        source.index("oldSnapshot.fingerprint === next.fingerprint") - 40:
+        source.index("oldSnapshot.fingerprint === next.fingerprint") + 100
+    ]
+    assert "paint()" not in unchanged
+
+
+def test_shell_file_body_is_exact_text_not_markdown():
+    source = current_workspace_source()
+
+    assert 'textContent: state.shellFile.body' in source
+    assert 'className: "review-shell-file review-patch-wrap"' in source
+    assert "marked.parse" not in source
 
 
 def test_diff_layout_is_full_width_bounded_and_responsive():

--- a/tests/test_conversation_review_api.py
+++ b/tests/test_conversation_review_api.py
@@ -70,23 +70,25 @@ class ReviewDispatchTest(unittest.TestCase):
     def test_real_server_dispatches_both_review_resource_families(self) -> None:
         expected = (299, [("X-Review", "yes")], b"review")
         conversation_id = "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        paths = (
-            f"/api/conversations/{conversation_id}/review-targets?refresh=remote",
-            "/api/review-targets/gt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/files",
+        routes = (
+            ("GET", f"/api/conversations/{conversation_id}/review-targets?refresh=remote"),
+            ("GET", "/api/review-targets/gt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/files"),
+            ("POST", f"/api/conversations/{conversation_id}/review-observations"),
+            ("GET", "/api/review-observations/" + "a" * 64 + "/patch?file=rf_a"),
         )
         with patch.object(server.review_routes, "handle", return_value=expected) as call:
-            for path in paths:
+            for method, path in routes:
                 with self.subTest(path=path):
                     self.assertEqual(
                         server.dispatch_http(
-                            "GET",
+                            method,
                             path,
                             "Host: 127.0.0.1\r\n\r\n",
                             b"",
                         ),
                         expected,
                     )
-            self.assertEqual(call.call_count, 2)
+            self.assertEqual(call.call_count, 4)
 
 
 class ConversationReviewApiTest(unittest.TestCase):
@@ -121,6 +123,7 @@ class ConversationReviewApiTest(unittest.TestCase):
         self.original_db_path = review_routes.DB_PATH
         self.original_reader = review_routes.READER_FACTORY
         self.original_cache = review_routes.CACHE_FACTORY
+        self.original_fetcher = review_routes.FETCHER
         review_routes.DB_PATH = self.db_path
         review_routes.READER_FACTORY = FakeReader
         review_routes.CACHE_FACTORY = partial(
@@ -129,6 +132,8 @@ class ConversationReviewApiTest(unittest.TestCase):
         )
         review_routes._REMOTE_ATTEMPTS.clear()
         review_routes._REMOTE_RESULTS.clear()
+        review_routes._OBSERVATIONS.clear()
+        review_routes._OBSERVATION_KEYS.clear()
         FakeReader.pull_requests = []
         FakeReader.available = True
         self.addCleanup(self._restore)
@@ -137,17 +142,27 @@ class ConversationReviewApiTest(unittest.TestCase):
         review_routes.DB_PATH = self.original_db_path
         review_routes.READER_FACTORY = self.original_reader
         review_routes.CACHE_FACTORY = self.original_cache
+        review_routes.FETCHER = self.original_fetcher
         review_routes._REMOTE_ATTEMPTS.clear()
         review_routes._REMOTE_RESULTS.clear()
+        review_routes._OBSERVATIONS.clear()
+        review_routes._OBSERVATION_KEYS.clear()
         FakeReader.pull_requests = []
         FakeReader.available = True
 
-    def request(self, path: str, *, headers: str | None = None):
+    def request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        headers: str | None = None,
+        body: bytes = b"",
+    ):
         status, response_headers, body = review_routes.handle(
-            "GET",
+            method,
             path,
             headers or self.headers,
-            b"",
+            body,
         )
         value = json.loads(body) if body else None
         return status, dict(response_headers), value
@@ -161,6 +176,16 @@ class ConversationReviewApiTest(unittest.TestCase):
             item["target_id"]
             for item in body["items"]
             if item["kind"] == "workspace"
+        )
+
+    def observe(self, key: str = "observe-1"):
+        return self.request(
+            f"/api/conversations/{self.conversation_id}/review-observations",
+            method="POST",
+            headers=(
+                "Host: 127.0.0.1\r\n"
+                f"Idempotency-Key: {key}\r\n\r\n"
+            ),
         )
 
     def test_owned_targets_hide_worktree_and_expose_fresh_selection(self) -> None:
@@ -280,6 +305,227 @@ class ConversationReviewApiTest(unittest.TestCase):
         )
         self.assertEqual(not_modified, 304)
         self.assertIsNone(response_body)
+
+    def test_current_worktree_observation_is_retry_safe_and_fingerprinted(self) -> None:
+        calls = []
+        real_fetcher = review_routes.FETCHER
+
+        def fetcher(worktree):
+            calls.append(worktree)
+            return real_fetcher(worktree)
+
+        review_routes.FETCHER = fetcher
+        self.fixture.write("CLAUDE.md", "claude boot\n")
+        self.fixture.write("AGENTS.md", "agents boot\n")
+
+        status, _headers, observed = self.observe()
+        retry_status, _retry_headers, retried = self.observe()
+
+        self.assertEqual(status, 201, observed)
+        self.assertEqual(retry_status, 200, retried)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(retried, observed)
+        self.assertEqual(len(observed["fingerprint"]), 64)
+        self.assertEqual(observed["status"]["branch"], "feature/review-api")
+        self.assertEqual(observed["status"]["ahead_count"], 1)
+        self.assertEqual(observed["status"]["behind"], 0)
+        self.assertEqual(
+            {item["path"] for item in observed["changes"]["branch"]},
+            {"api.txt", "second.txt"},
+        )
+        self.assertEqual(
+            {item["name"] for item in observed["shell_files"][:2]},
+            {"CLAUDE.md", "AGENTS.md"},
+        )
+        self.assertNotIn(str(self.fixture.repo), json.dumps(observed))
+
+        review_routes.FETCHER = lambda _worktree: git_review.FetchProjection(
+            False,
+            "offline",
+        )
+        second_status, _second_headers, second = self.observe("observe-2")
+        retry_status, _retry_headers, retried_again = self.observe()
+        self.assertEqual(second_status, 201, second)
+        self.assertEqual(second["fingerprint"], observed["fingerprint"])
+        self.assertFalse(second["fetch"]["fresh"])
+        self.assertEqual(retry_status, 200, retried_again)
+        self.assertEqual(retried_again, observed)
+
+    def test_observation_patch_accepts_only_snapshot_files_and_detects_change(self) -> None:
+        status, _headers, observed = self.observe()
+        self.assertEqual(status, 201, observed)
+        api_file = next(
+            item for item in observed["changes"]["branch"]
+            if item["path"] == "api.txt"
+        )
+
+        status, _headers, patch_body = self.request(
+            f"/api/review-observations/{observed['fingerprint']}/patch"
+            f"?file={api_file['file_id']}"
+        )
+        self.assertEqual(status, 200, patch_body)
+        self.assertEqual(patch_body["section"], "branch")
+        self.assertIn("+review api", patch_body["patch"])
+
+        status, _headers, refused = self.request(
+            f"/api/review-observations/{observed['fingerprint']}/patch"
+            "?file=rf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        )
+        self.assertEqual(status, 422, refused)
+        self.assertEqual(refused["error"]["code"], "REVIEW_PATH_INVALID")
+
+        self.fixture.write("api.txt", "changed after observation\n")
+        status, _headers, changed = self.request(
+            f"/api/review-observations/{observed['fingerprint']}/patch"
+            f"?file={api_file['file_id']}"
+        )
+        self.assertEqual(status, 409, changed)
+        self.assertEqual(changed["error"]["code"], "REVIEW_SNAPSHOT_CHANGED")
+
+    def test_fetch_failure_uses_stale_base_or_typed_unavailable_base(self) -> None:
+        review_routes.FETCHER = lambda _worktree: git_review.FetchProjection(
+            False,
+            "offline",
+        )
+
+        status, _headers, stale = self.observe("stale-base")
+        self.assertEqual(status, 201, stale)
+        self.assertFalse(stale["fetch"]["fresh"])
+        self.assertTrue(stale["fetch"]["base_stale"])
+        self.assertTrue(stale["status"]["base_available"])
+        self.assertEqual(stale["fetch"]["error"], "offline")
+
+        self.fixture.git("update-ref", "-d", "refs/remotes/origin/main")
+        self.fixture.write("dirty.txt", "dirty without base\n")
+        status, _headers, unavailable = self.observe("missing-base")
+        self.assertEqual(status, 201, unavailable)
+        self.assertFalse(unavailable["status"]["base_available"])
+        self.assertIsNone(unavailable["status"]["base_sha"])
+        self.assertEqual(unavailable["changes"]["branch"], [])
+        self.assertEqual(unavailable["changes"]["commits"], [])
+        self.assertIn(
+            "dirty.txt",
+            {item["path"] for item in unavailable["changes"]["dirty"]},
+        )
+
+    def test_shell_files_are_exact_deduplicated_and_mismatch_aware(self) -> None:
+        con = sqlite3.connect(self.db_path)
+        self.conversation_id = "cv_cccccccccccccccccccccccccccccccc"
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (2,'OpenCode Dev','ocdev','dev','prompt',1)"
+        )
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,owner_user_id,harness,worktree,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES (?,2,1,'opencode',?,'opencode-create','hash')",
+            (self.conversation_id, str(self.fixture.repo)),
+        )
+        con.execute(
+            "INSERT INTO skills (name,description,content) "
+            "VALUES ('sample','sample skill','body')"
+        )
+        skill_id = con.execute(
+            "SELECT skill_id FROM skills WHERE name='sample'"
+        ).fetchone()[0]
+        con.execute(
+            "INSERT INTO shell_skills (shell_id,skill_id) VALUES (2,?)",
+            (skill_id,),
+        )
+        con.commit()
+        con.close()
+        self.fixture.write("CLAUDE.md", "claude boot\n")
+        self.fixture.write("AGENTS.md", "agents boot\n")
+        mirrored = "---\nname: sample\n---\nexact body\n"
+        self.fixture.write(".claude/skills/sample/SKILL.md", mirrored)
+        self.fixture.write(".opencode/skills/sample/SKILL.md", mirrored)
+
+        status, _headers, observed = self.observe("shell-identical")
+        self.assertEqual(status, 201, observed)
+        skill_files = [
+            item for item in observed["shell_files"] if item["name"] == "sample"
+        ]
+        self.assertEqual(len(skill_files), 1)
+        self.assertEqual(
+            skill_files[0]["paths"],
+            [
+                ".claude/skills/sample/SKILL.md",
+                ".opencode/skills/sample/SKILL.md",
+            ],
+        )
+        self.assertFalse(skill_files[0]["mismatch"])
+
+        status, _headers, content = self.request(
+            f"/api/review-observations/{observed['fingerprint']}/shell-file"
+            f"?file={skill_files[0]['file_id']}"
+        )
+        self.assertEqual(status, 200, content)
+        self.assertEqual(content["body"], mirrored)
+        self.assertEqual(content["paths"], skill_files[0]["paths"])
+
+        self.fixture.write(
+            ".opencode/skills/sample/SKILL.md",
+            "---\nname: sample\n---\ndifferent mirror\n",
+        )
+        status, _headers, stable = self.request(
+            f"/api/review-observations/{observed['fingerprint']}/shell-file"
+            f"?file={skill_files[0]['file_id']}"
+        )
+        self.assertEqual(status, 200, stable)
+        self.assertEqual(stable["body"], mirrored)
+        status, _headers, mismatched = self.observe("shell-mismatch")
+        self.assertEqual(status, 201, mismatched)
+        skill_files = [
+            item for item in mismatched["shell_files"] if item["name"] == "sample"
+        ]
+        self.assertEqual(len(skill_files), 2)
+        self.assertTrue(all(item["mismatch"] for item in skill_files))
+
+    def test_shell_file_symlink_binary_and_size_limits_fail_closed(self) -> None:
+        con = sqlite3.connect(self.db_path)
+        con.execute(
+            "INSERT INTO skills (name,description,content) "
+            "VALUES ('sample','sample skill','body')"
+        )
+        skill_id = con.execute(
+            "SELECT skill_id FROM skills WHERE name='sample'"
+        ).fetchone()[0]
+        con.execute(
+            "INSERT INTO shell_skills (shell_id,skill_id) VALUES (1,?)",
+            (skill_id,),
+        )
+        con.commit()
+        con.close()
+        self.fixture.write("CLAUDE.md", b"binary\x00body")
+        self.fixture.write("AGENTS.md", "x" * (512 * 1024 + 1))
+        secret = self.fixture.root / "outside-secret.txt"
+        secret.write_text("must not escape\n")
+        skill_dir = self.fixture.repo / ".claude" / "skills" / "sample"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").symlink_to(secret)
+
+        status, _headers, observed = self.observe("unsafe-shell-files")
+
+        self.assertEqual(status, 201, observed)
+        by_name = {item["name"]: item for item in observed["shell_files"][:2]}
+        self.assertFalse(by_name["CLAUDE.md"]["available"])
+        self.assertEqual(
+            by_name["CLAUDE.md"]["error"],
+            "REVIEW_SHELL_FILE_NOT_TEXT",
+        )
+        self.assertFalse(by_name["AGENTS.md"]["available"])
+        self.assertEqual(
+            by_name["AGENTS.md"]["error"],
+            "REVIEW_SHELL_FILE_TOO_LARGE",
+        )
+        sample = next(
+            item for item in observed["shell_files"] if item["name"] == "sample"
+        )
+        self.assertFalse(sample["available"])
+        self.assertEqual(sample["error"], "REVIEW_SHELL_FILE_UNAVAILABLE")
+        self.assertNotIn("must not escape", json.dumps(observed))
 
     def test_target_ownership_and_operator_auth_do_not_leak(self) -> None:
         con = sqlite3.connect(self.db_path)

--- a/tests/test_git_review.py
+++ b/tests/test_git_review.py
@@ -120,6 +120,131 @@ class LocalReviewProjectionTest(unittest.TestCase):
         )
         self.assertEqual(projection.etag, f'"{projection.fingerprint}"')
 
+    def test_current_worktree_projection_separates_dirty_branch_and_commits(self) -> None:
+        self.fixture.write("tracked-ignored.txt", "tracked base\n")
+        self.fixture.write("tracked-visible.txt", "visible base\n")
+        self.fixture.commit("tracked ignored base")
+        self.fixture.git("push", "origin", "main")
+        self.fixture.branch("feature/current-worktree")
+        self.fixture.write(
+            ".gitignore",
+            "ignored-untracked.txt\ntracked-ignored.txt\nignored-commit.txt\n",
+        )
+        self.fixture.commit("add current ignore rules")
+        self.fixture.write("ignored-commit.txt", "hidden commit\n")
+        self.fixture.git("add", "-f", "ignored-commit.txt")
+        hidden_sha = self.fixture.commit("ignored only commit")
+        self.fixture.write("visible-commit.txt", "visible commit\n")
+        visible_sha = self.fixture.commit("visible commit")
+        self.fixture.write("tracked-ignored.txt", "hidden dirty\n")
+        self.fixture.write("tracked-visible.txt", "visible unstaged\n")
+        self.fixture.write("ignored-untracked.txt", "hidden untracked\n")
+        self.fixture.write("dirty-staged.txt", "staged\n")
+        self.fixture.git("add", "dirty-staged.txt")
+        self.fixture.write("dirty-untracked.txt", "untracked\n")
+
+        projection = git_review.project_current_worktree(self.fixture.repo)
+
+        self.assertEqual(
+            {item.path for item in projection.dirty},
+            {"dirty-staged.txt", "dirty-untracked.txt", "tracked-visible.txt"},
+        )
+        self.assertEqual(
+            {item.path for item in projection.branch_files},
+            {".gitignore", "visible-commit.txt"},
+        )
+        self.assertEqual(
+            [item.sha for item in projection.commits],
+            [visible_sha, self.fixture.git("rev-parse", "HEAD~2")],
+        )
+        self.assertNotIn(hidden_sha, {item.sha for item in projection.commits})
+        self.assertEqual(projection.visible_ahead, 2)
+        self.assertEqual(projection.behind, 0)
+        self.assertTrue(projection.base_available)
+
+    def test_current_worktree_projection_keeps_conflicted_paths_dirty(self) -> None:
+        self.fixture.build_conflict_case()
+
+        projection = git_review.project_current_worktree(self.fixture.repo)
+        conflict = next(
+            item for item in projection.dirty if item.path == "conflict.txt"
+        )
+
+        self.assertEqual(conflict.status, "conflict")
+        self.assertTrue(conflict.staged)
+        self.assertTrue(conflict.unstaged)
+        self.assertTrue(conflict.conflict)
+
+    def test_ignored_only_commit_and_dirty_state_are_no_code_changes(self) -> None:
+        self.fixture.write("tracked.txt", "base\n")
+        self.fixture.commit("tracked base")
+        self.fixture.write(".gitignore", "tracked.txt\nhidden.txt\n")
+        self.fixture.commit("ignore policy")
+        self.fixture.git("push", "origin", "main")
+        self.fixture.branch("feature/ignored-only")
+        self.fixture.write("hidden.txt", "committed but hidden\n")
+        self.fixture.git("add", "-f", "hidden.txt")
+        self.fixture.commit("hidden commit")
+        self.fixture.write("tracked.txt", "dirty but hidden\n")
+
+        projection = git_review.project_current_worktree(self.fixture.repo)
+
+        self.assertEqual(projection.dirty, ())
+        self.assertEqual(projection.branch_files, ())
+        self.assertEqual(projection.commits, ())
+        self.assertEqual(projection.visible_ahead, 0)
+        self.assertEqual(projection.behind, 0)
+
+    def test_projection_uses_merge_base_for_diverged_and_detached_heads(self) -> None:
+        self.fixture.branch("feature/diverged")
+        self.fixture.write("topic.txt", "topic\n")
+        topic_sha = self.fixture.commit("topic")
+        self.fixture.checkout("main")
+        self.fixture.write("remote-main.txt", "remote\n")
+        self.fixture.commit("advance remote main")
+        self.fixture.git("push", "origin", "main")
+        self.fixture.checkout("feature/diverged")
+        self.fixture.git("fetch", "origin", "main")
+        self.fixture.git("checkout", "--detach", topic_sha)
+
+        projection = git_review.project_current_worktree(self.fixture.repo)
+
+        self.assertIsNone(projection.branch)
+        self.assertEqual(projection.behind, 1)
+        self.assertEqual(projection.visible_ahead, 1)
+        self.assertEqual(
+            {item.path for item in projection.branch_files},
+            {"topic.txt"},
+        )
+        self.assertNotIn(
+            "remote-main.txt",
+            {item.path for item in projection.branch_files},
+        )
+
+    def test_origin_main_fetch_is_fixed_bounded_and_failure_tolerant(self) -> None:
+        calls = []
+
+        def runner(args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess(args, 1, b"", b"offline\n")
+
+        result = git_review.fetch_origin_main(self.fixture.repo, runner=runner)
+
+        self.assertFalse(result.fresh)
+        self.assertEqual(result.error, "offline")
+        self.assertEqual(
+            calls[0][0][-4:],
+            [
+                "fetch",
+                "--no-tags",
+                "origin",
+                "+refs/heads/main:refs/remotes/origin/main",
+            ],
+        )
+        self.assertEqual(calls[0][1]["timeout"], 20.0)
+        self.assertEqual(calls[0][1]["env"]["GIT_TERMINAL_PROMPT"], "0")
+        self.assertEqual(calls[0][1]["env"]["GIT_OPTIONAL_LOCKS"], "1")
+
     def test_workspace_projects_all_bounded_file_states(self) -> None:
         self.fixture.build_file_state_case()
 


### PR DESCRIPTION
## Summary
- replace the browser Diff target and PR history flow with one current-shell worktree observation against freshly fetched origin/main
- separate Dirty, Branch, and visible ahead Commits with effective Git ignore filtering, merge-base semantics, detached and behind status, and fingerprinted patch reads
- expose bounded exact CLAUDE.md, AGENTS.md, and granted skill snapshots with mirror deduplication, mismatch warnings, and fail-closed path, symlink, binary, and size checks
- remove Diff polling and preserve selection, navigator scroll, patch scroll, Chat draft, and Chat scroll across navigation and manual refresh

## Tests
- ./sc test: 1272 passed, including 2 real Chromium browser gates
- focused review projection, observation API, UI contract, and browser suite: 46 passed
- ruff check, node --check, git diff --check, ./sc map, and ./sc render-check passed
- ./sc verify cannot run from a linked feature worktree; the command refuses and would target the unrelated shared live checkout. Reproduced on issue #769.

## Spec deviations
None. Historical conversation_git_targets data and endpoints remain for compatibility, as allowed by spec #48, but the active Diff UI neither reads nor writes them.

## Trade-off
Observations use a bounded in-memory snapshot and idempotency cache instead of adding durable schema. That keeps page-session review stable and makes server restart a typed refresh condition without creating historical review state.