### PR TITLE
fix: unblock Sprint removal dirty upgrades

### DIFF
--- a/.super-coder/migrations/0144_remove_sprint_v1.sql
+++ b/.super-coder/migrations/0144_remove_sprint_v1.sql
@@ -88,6 +88,10 @@ DELETE FROM conversation_outbox
 WHERE conversation_id IN (
     SELECT conversation_id FROM _sprint_v1_conversations
 );
+-- Conversation events remain append-only for every retained runtime path. Lift
+-- only the delete guard, inside this transaction, for the destructive Sprint
+-- cutover; the retained trigger is recreated below after the parent swap.
+DROP TRIGGER IF EXISTS trg_conversation_events_append_only_delete;
 DELETE FROM conversation_events
 WHERE conversation_id IN (
     SELECT conversation_id FROM _sprint_v1_conversations

--- a/tests/fixtures/sprint_removal/build_pre_removal_fixture.py
+++ b/tests/fixtures/sprint_removal/build_pre_removal_fixture.py
@@ -273,7 +273,9 @@ def build_database() -> sqlite3.Connection:
              message_id, run_id)
         VALUES
             (220, 'cv_normal', 1, 'assistant.delta',
-             '{"text":"retained event"}', 200, 210);
+             '{"text":"retained event"}', 200, 210),
+            (221, 'cv_sprint_dev', 1, 'assignment.notice',
+             '{"text":"disposable Sprint event"}', 201, NULL);
 
         INSERT INTO conversation_outbox
             (outbox_id, conversation_id, message_id, state, claim_owner,

--- a/tests/fixtures/sprint_removal/pre_removal.sql
+++ b/tests/fixtures/sprint_removal/pre_removal.sql
@@ -29,6 +29,7 @@ CREATE TABLE conversation_events (
     UNIQUE (conversation_id, sequence)
 );
 INSERT INTO "conversation_events" VALUES(220,'cv_normal',1,'assistant.delta',1,'{"text":"retained event"}',200,210,'2026-07-31 00:00:00');
+INSERT INTO "conversation_events" VALUES(221,'cv_sprint_dev',1,'assignment.notice',1,'{"text":"disposable Sprint event"}',201,NULL,'2026-07-31 00:00:00');
 CREATE TABLE conversation_git_targets (
     target_id              TEXT PRIMARY KEY
                            DEFAULT ('gt_' || lower(hex(randomblob(16))))

--- a/tests/test_sprint_removal_manifest.py
+++ b/tests/test_sprint_removal_manifest.py
@@ -152,6 +152,26 @@ class SprintRemovalManifestTest(unittest.TestCase):
             self.assertEqual(expected_ledger["count"], len(migration_ledger))
             self.assertEqual(expected_ledger["first"], migration_ledger[0])
             self.assertEqual(expected_ledger["last"], migration_ledger[-1])
+            self.assertEqual(
+                [
+                    (220, "cv_normal", "assistant.delta"),
+                    (221, "cv_sprint_dev", "assignment.notice"),
+                ],
+                [
+                    tuple(row)
+                    for row in con.execute(
+                        "SELECT event_id,conversation_id,event_type "
+                        "FROM conversation_events ORDER BY event_id"
+                    )
+                ],
+            )
+            self.assertIsNotNone(
+                con.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='trigger' "
+                    "AND name='trg_conversation_events_append_only_delete'"
+                ).fetchone(),
+                "dirty fixture must install the retained append-only guard",
+            )
 
     def test_frozen_fixture_pins_retained_data_and_sprint_negative_space(self):
         with closing(build_pre_removal_database()) as con:
@@ -595,6 +615,28 @@ for name in sys.argv[2:]:
                     )
                 ],
             )
+            with self.assertRaisesRegex(
+                sqlite3.IntegrityError,
+                "conversation events are append-only",
+            ):
+                con.execute("DELETE FROM conversation_events WHERE event_id=220")
+            with self.assertRaisesRegex(
+                sqlite3.IntegrityError,
+                "conversation events are append-only",
+            ):
+                con.execute(
+                    "UPDATE conversation_events SET event_type='mutated' "
+                    "WHERE event_id=220"
+                )
+            self.assertEqual(
+                (220, "cv_normal", "assistant.delta"),
+                tuple(
+                    con.execute(
+                        "SELECT event_id,conversation_id,event_type "
+                        "FROM conversation_events WHERE event_id=220"
+                    ).fetchone()
+                ),
+            )
             self.assertEqual(
                 [(230, "dispatched")],
                 [
@@ -738,6 +780,21 @@ for name in sys.argv[2:]:
                 4,
                 con.execute("SELECT COUNT(*) FROM shell_messages").fetchone()[0],
             )
+            self.assertEqual(
+                [(220, "cv_normal"), (221, "cv_sprint_dev")],
+                [
+                    tuple(row)
+                    for row in con.execute(
+                        "SELECT event_id,conversation_id "
+                        "FROM conversation_events ORDER BY event_id"
+                    )
+                ],
+            )
+            with self.assertRaisesRegex(
+                sqlite3.IntegrityError,
+                "conversation events are append-only",
+            ):
+                con.execute("DELETE FROM conversation_events WHERE event_id=221")
             self.assertIsNone(
                 con.execute(
                     "SELECT 1 FROM schema_migrations WHERE filename=?",


### PR DESCRIPTION
## Outcome

Fixes SC-028 and completes the implementation-owned feature #29/spec #44 task #172 gate. Migration 0144 now temporarily removes only the conversation-event delete guard inside its atomic destructive cutover, then recreates the retained append-only trigger after rebuilding conversations.

## Regression hardening

- Dirty pre-removal fixture now contains retained normal event 220 and disposable Sprint event 221 while the append-only delete trigger is installed.
- Cutover must remove only the Sprint event and preserve normal conversation/message/run/event/outbox/Git-target children.
- Retained event update and delete remain rejected after commit.
- The real migration runner must apply and stamp 0144 exactly once; the second run must report nothing pending.
- Injected later failure rolls back all cleanup, restores both events and the trigger, and leaves migration 0144 unstamped.
- Repeated SQL cleanup, partially absent legacy tables, and fresh-schema convergence remain covered.
- Final source denylist found no new residue, so the checked manifest required no new allowlist entry.

## Verification

- Focused removal/entrypoint: 18 passed, 62 subtests.
- Retained API/browser/roster surface: 101 passed, 74 subtests.
- Chat/Diff/current-worktree Diff/broker: 143 passed, 1 skipped, 162 subtests.
- Messages/jobs/models/quota/headless: 331 passed, 57 subtests.
- Install/update/restart/snapshot/rebuild/seed/render lifecycle: 121 passed, 182 subtests.
- Full suite after the runner-level addendum: 1262 passed, 1 skipped, 740 subtests.
- Isolated fresh rebuild applied all 93 migrations; fresh init produced 10 shells with no CON1/conductor, no Sprint skill/schema object, and clean foreign keys.
- Isolated snapshot, flat render, hermetic render-check, and rebuild-from-snapshot preserved all 10 API keys.
- Disposable loopback server returned the standard 404 for /api/sprints; process inspection found no PR poller, sentinel, Conductor, Sprint, or watcher process.
- Ruff and git diff --check pass.

Independent review is intentionally left to PLN1; this PR does not freeze spec #44 or mark feature #29 shipped. subfloor#836 is outside feature #29 and is intentionally untouched.
