### PR TITLE
feat: add in-file diff navigation

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2762,6 +2762,7 @@ function reviewTypedState(title, detail = "", tone = "") {
 
 function reviewPatchRows(text) {
   const patch = el("div", { className: "review-patch" });
+  const rows = [];
   let oldLine = null;
   let newLine = null;
   for (const line of String(text || "").split("\n")) {
@@ -2799,7 +2800,52 @@ function reviewPatchRows(text) {
       el("span", { className: "review-line-code" }, line),
     );
     patch.append(row);
+    rows.push({ kind, row });
   }
+
+  const changeBlocks = [];
+  for (const entry of rows) {
+    if (entry.kind !== "add" && entry.kind !== "delete") continue;
+    const previous = changeBlocks.at(-1);
+    if (!previous || previous.last !== entry.row.previousElementSibling) {
+      changeBlocks.push({ first: entry.row, last: entry.row });
+    } else {
+      previous.last = entry.row;
+    }
+  }
+  const scrollToChange = (index) => {
+    const target = changeBlocks[index]?.first;
+    const scroller = target?.closest(".review-patch-wrap");
+    if (!target || !scroller) return;
+    const targetBox = target.getBoundingClientRect();
+    const scrollerBox = scroller.getBoundingClientRect();
+    const top = scroller.scrollTop + targetBox.top - scrollerBox.top
+      - (scroller.clientHeight - targetBox.height) / 2;
+    scroller.scrollTo({
+      top: Math.max(0, top),
+      left: scroller.scrollLeft,
+      behavior: window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches
+        ? "auto" : "smooth",
+    });
+  };
+  const changeStep = (direction, targetIndex) => {
+    const label = direction === "previous" ? "Previous change" : "Next change";
+    const button = el("button", {
+      type: "button",
+      className: `review-change-step review-change-step-${direction}`,
+      ariaLabel: label,
+      title: label,
+      disabled: targetIndex < 0 || targetIndex >= changeBlocks.length,
+    }, direction === "previous" ? "↑" : "↓");
+    button.onclick = () => scrollToChange(targetIndex);
+    return button;
+  };
+  changeBlocks.forEach((block, index) => {
+    block.first.classList.add("review-change-first");
+    block.last.classList.add("review-change-last");
+    block.first.append(changeStep("previous", index - 1));
+    block.last.append(changeStep("next", index + 1));
+  });
   return patch;
 }
 

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -464,13 +464,26 @@ body.interface-view main {
 }
 .review-line {
   display: grid; grid-template-columns: 3.7rem 3.7rem minmax(max-content, 1fr);
-  min-height: 1.55em; white-space: pre;
+  position: relative; min-height: 1.55em; white-space: pre;
 }
 .review-line-number {
   padding: 0 .45rem; color: rgba(255,255,255,.28); text-align: right;
   user-select: none; border-right: 1px solid var(--line-soft);
 }
 .review-line-code { padding: 0 .7rem; }
+.review-change-step {
+  position: absolute; left: .25rem; z-index: 1; width: 1.1rem; height: 1.1rem;
+  padding: 0; display: grid; place-items: center; border: 1px solid var(--line);
+  border-radius: 50%; background: var(--panel); color: var(--dim); cursor: pointer;
+  font: 700 .72rem/1 ui-monospace, monospace;
+}
+.review-change-step-previous { top: 0; transform: translateY(-55%); }
+.review-change-step-next { bottom: 0; transform: translateY(55%); }
+.review-change-step:hover:not(:disabled) {
+  color: var(--ink); border-color: var(--accent); background: var(--panel2);
+}
+.review-change-step:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.review-change-step:disabled { opacity: .28; cursor: default; }
 .review-line-add { background: rgba(76,175,125,.12); }
 .review-line-add .review-line-code { color: #a9dfbd; }
 .review-line-delete { background: rgba(239,125,134,.10); }

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -358,6 +358,10 @@ const mode = 'chat';
 +const safe = document.createTextNode('patch with a deliberately long line for horizontal scroll position preservation across refresh');
 export { mode };"""
     patch += "\n" + "\n".join(
+        f"const contextLine{index} = 'change navigation spacing {index}';"
+        for index in range(40)
+    )
+    patch += "\n" + "\n".join(
         f"+const addedLine{index} = 'scroll proof {index}';"
         for index in range(80)
     )
@@ -644,6 +648,23 @@ export { mode };"""
         assert page.locator(".review-line-add").count() >= 82
         assert page.locator(".review-line-delete").count() == 1
         assert page.locator(".status-conflict").count() == 1
+        previous_changes = page.get_by_role("button", name="Previous change")
+        next_changes = page.get_by_role("button", name="Next change")
+        assert previous_changes.count() == next_changes.count() == 2
+        assert previous_changes.first.is_disabled()
+        assert next_changes.last.is_disabled()
+        next_changes.first.click()
+        page.wait_for_function(
+            "document.querySelector('.review-patch-wrap').scrollTop > 0"
+        )
+        navigated_top = page.locator(".review-patch-wrap").evaluate(
+            "node => node.scrollTop"
+        )
+        previous_changes.last.click()
+        page.wait_for_function(
+            "top => document.querySelector('.review-patch-wrap').scrollTop < top",
+            arg=navigated_top,
+        )
         page.get_by_title("assets/logo.bin").click()
         page.get_by_text("Binary file", exact=True).wait_for()
         page.get_by_title("large.txt").click()

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -110,6 +110,26 @@ def test_workspace_has_current_changes_shell_files_and_manual_refresh():
     assert "innerHTML" not in patch_renderer
 
 
+def test_patch_change_arrows_scroll_between_adjacent_change_blocks():
+    renderer = APP[
+        APP.index("function reviewPatchRows"):
+        APP.index("function reviewFileTree")
+    ]
+
+    for text in (
+        'direction === "previous" ? "Previous change" : "Next change"',
+        'changeStep("previous", index - 1)',
+        'changeStep("next", index + 1)',
+        'target?.closest(".review-patch-wrap")',
+        "scroller.scrollTop",
+        "left: scroller.scrollLeft",
+        'behavior: window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches',
+    ):
+        assert text in renderer
+    assert ".review-change-step" in STYLE
+    assert ".review-change-step:disabled" in STYLE
+
+
 def test_diff_observes_once_then_only_refreshes_manually_single_flight():
     source = current_workspace_source()
 


### PR DESCRIPTION
## Summary
- add previous/next arrow controls around each contiguous change block in browser Diff
- smoothly center the adjacent change while preserving horizontal scroll
- keep boundary controls visible but disabled and respect reduced-motion preferences

## Verification
- `node --check .super-coder/ui/app.js`
- `pytest -q tests/test_conversation_diff_ui.py` (9 passed)
- real-browser Brave smoke for `test_diff_workspace_preserves_live_chat_and_uses_get_only` (passed)
- `./sc map`
- `./sc render-check`
- `git diff --check`

`./sc verify` safely refused the linked worktree; reproduced on #769. The unrelated chat scroll assertion in the optional full Brave suite was timing-sensitive (one pass, one failure), while the new Diff navigation interaction passed directly.