### PR TITLE
fix: compact browser diff controls

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2977,10 +2977,26 @@ function chatReviewWorkspace(host, conversation) {
       disabled: state.refreshInFlight,
     });
     refreshButton.onclick = () => observe(true);
-    const summary = el("div", { className: "review-summary" },
-      el("div", { className: "review-target-control" },
-        el("label", { className: "k" }, "Current worktree"),
-        el("strong", {}, facts[0])),
+    let sectionSwitch = null;
+    if (state.group === "changes") {
+      sectionSwitch = el("div", {
+        className: "review-scope-switch review-change-switch",
+        role: "tablist",
+        ariaLabel: "Changes view",
+      });
+      for (const [value, label] of [
+        ["dirty", "Dirty"], ["branch", "Branch"], ["commits", "Commits"],
+      ]) sectionSwitch.append(tabButton(value, label, state.section, () => {
+        if (state.section === value) return;
+        state.section = value;
+        state.selectedPath = value === "commits" ? "" : sectionFiles()[0]?.path || "";
+        state.patch = null;
+        state.contentError = null;
+        paint();
+        loadSelected();
+      }));
+    }
+    const summaryStatus = el("div", { className: "review-status" },
       el("div", { className: "review-lifecycle-block" },
         el("span", { className: "review-lifecycle lifecycle-local" }, "ON DISK"),
         el("span", { className: "review-facts" }, facts.slice(1).join(" · "))),
@@ -2990,7 +3006,13 @@ function chatReviewWorkspace(host, conversation) {
           className: "warning review-refresh-warning",
           textContent: warning,
           hidden: !warning,
-        })),
+        })));
+    const summary = el("div", { className: "review-summary" },
+      el("div", { className: "review-target-control" },
+        el("label", { className: "k" }, "Current worktree"),
+        el("strong", {}, facts[0])),
+      ...(sectionSwitch ? [sectionSwitch] : []),
+      summaryStatus,
       refreshButton);
     const groupSwitch = el("div", {
       className: "review-scope-switch review-group-switch",
@@ -3025,23 +3047,6 @@ function chatReviewWorkspace(host, conversation) {
     }, summary, groupSwitch);
 
     if (state.group === "changes") {
-      const sectionSwitch = el("div", {
-        className: "review-scope-switch review-change-switch",
-        role: "tablist",
-        ariaLabel: "Changes view",
-      });
-      for (const [value, label] of [
-        ["dirty", "Dirty"], ["branch", "Branch"], ["commits", "Commits"],
-      ]) sectionSwitch.append(tabButton(value, label, state.section, () => {
-        if (state.section === value) return;
-        state.section = value;
-        state.selectedPath = value === "commits" ? "" : sectionFiles()[0]?.path || "";
-        state.patch = null;
-        state.contentError = null;
-        paint();
-        loadSelected();
-      }));
-      workspace.append(sectionSwitch);
       if (state.section === "commits") {
         const commits = snapshot.changes.commits || [];
         const body = el("div", { className: "review-commits-pane" });

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -345,19 +345,21 @@ body.interface-view main {
 }
 .review-workspace {
   min-width: 0; min-height: 0; height: 100%; display: grid;
-  grid-template-rows: auto auto auto minmax(0, 1fr); overflow: hidden;
+  grid-template-rows: auto auto minmax(0, 1fr); overflow: hidden;
 }
-.review-workspace-shell { grid-template-rows: auto auto minmax(0, 1fr); }
 .review-summary {
-  min-width: 0; padding: .7rem 1rem; border-bottom: 1px solid var(--line);
-  display: grid; grid-template-columns: minmax(220px, 1.3fr) auto minmax(130px, .7fr) auto;
-  align-items: end; gap: .8rem; background: var(--panel);
+  min-width: 0; padding: .55rem 1rem; border-bottom: 1px solid var(--line);
+  display: grid; grid-template-columns: minmax(220px, 1fr) auto auto auto;
+  align-items: center; gap: .8rem; background: var(--panel);
+}
+.review-workspace-shell .review-summary {
+  grid-template-columns: minmax(220px, 1fr) auto auto;
 }
 .review-summary .k {
   display: block; margin: 0 0 .2rem; color: var(--dim); font-size: .63rem;
   text-transform: uppercase; letter-spacing: .12em;
 }
-.review-target-control, .review-lifecycle-block, .review-freshness {
+.review-target-control, .review-status, .review-lifecycle-block, .review-freshness {
   min-width: 0;
 }
 .review-target-select, .review-status-filter, .review-path-filter {
@@ -366,6 +368,9 @@ body.interface-view main {
   font: inherit; font-size: .76rem;
 }
 .review-lifecycle-block { display: flex; flex-direction: column; gap: .18rem; }
+.review-status {
+  display: flex; align-items: center; justify-self: end; gap: .8rem;
+}
 .review-lifecycle {
   width: fit-content; border: 1px solid var(--line); border-radius: 99px;
   padding: .08rem .45rem; color: var(--dim); font-size: .62rem;
@@ -381,7 +386,10 @@ body.interface-view main {
 .review-freshness { display: flex; flex-direction: column; gap: .12rem; }
 .review-freshness .warning { color: var(--warn); }
 .review-refresh.act { margin: 0; padding: .34rem .7rem; font-size: .7rem; }
-.review-scope-switch { margin: .65rem auto; flex: none; }
+.review-group-switch {
+  margin: 0 auto; flex: none; border-top: 0; border-radius: 0 0 7px 7px;
+}
+.review-change-switch { margin: 0; flex: none; }
 .review-scope-switch button { padding-inline: 1rem; }
 .review-body {
   min-width: 0; min-height: 0; overflow: hidden; display: grid;
@@ -526,9 +534,10 @@ body.interface-view main {
     position: static; grid-column: 1 / -1; grid-row: 2;
     justify-self: center; transform: none;
   }
-  .review-summary {
+  .review-summary, .review-workspace-shell .review-summary {
     grid-template-columns: minmax(0, 1fr); align-items: stretch;
   }
+  .review-status { justify-self: start; flex-wrap: wrap; }
   .review-refresh.act { justify-self: start; }
   .review-body { grid-template-columns: minmax(0, 1fr); overflow-y: auto; }
   .review-navigator {

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -632,6 +632,16 @@ export { mode };"""
         assert page.locator(".chat-stop-header").is_enabled()
         assert page.get_by_text("ON DISK", exact=True).is_visible()
         assert page.get_by_text("7 dirty", exact=False).is_visible()
+        assert page.locator(".review-summary > .review-change-switch").count() == 1
+        assert page.locator(".review-summary > .review-status").count() == 1
+        header_edges = page.locator(".review-summary, .review-group-switch").evaluate_all(
+            "nodes => ({summaryTop: nodes[0].getBoundingClientRect().top, "
+            "summaryBottom: nodes[0].getBoundingClientRect().bottom, "
+            "tabsTop: nodes[1].getBoundingClientRect().top, "
+            "tabsBottom: nodes[1].getBoundingClientRect().bottom})"
+        )
+        assert abs(header_edges["summaryBottom"] - header_edges["tabsTop"]) <= 1
+        assert header_edges["tabsBottom"] - header_edges["summaryTop"] <= 90
         initial_observations = sum(
             method == "POST" and path.endswith("/review-observations")
             for method, path, _query in requests

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -155,6 +155,9 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
         ".chat-review-host",
         ".review-workspace",
         ".review-summary",
+        ".review-status",
+        ".review-group-switch",
+        ".review-change-switch",
         ".review-body",
         ".review-file-tree",
         ".review-patch",
@@ -165,6 +168,14 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
     ):
         assert selector in STYLE
     assert "grid-template-columns: minmax(220px, 300px) minmax(0, 1fr)" in STYLE
+    assert "grid-template-rows: auto auto minmax(0, 1fr)" in STYLE
+    assert "border-radius: 0 0 7px 7px" in STYLE
+    source = current_workspace_source()
+    summary = source[source.index('const summary = el("div"'):source.index(
+        'const groupSwitch = el("div"'
+    )]
+    assert "...(sectionSwitch ? [sectionSwitch] : [])" in summary
+    assert "summaryStatus" in summary
     assert "@media (max-width: 900px)" in STYLE
     responsive = STYLE[STYLE.index("@media (max-width: 900px)"):]
     assert "grid-template-columns: minmax(0, 1fr)" in responsive


### PR DESCRIPTION
## Summary
- move Dirty / Branch / Commits into the worktree summary row
- group lifecycle, counts, and observation freshness beside Refresh Diff
- attach Changes / Shell files directly beneath the summary as a compact tab
- collapse the Diff control band from three rows to two without changing review behavior

This is independent of #839 and can merge in either order.

## Verification
- `node --check .super-coder/ui/app.js`
- `pytest -q tests/test_conversation_diff_ui.py` (8 passed)
- real Brave render reached and passed the new DOM placement, no-gap, and compact-height assertions; screenshot inspected against `shared/layout-diff.png`
- `./sc map`
- `./sc render-check`
- `git diff --check`

The optional full Brave smoke later encountered the already-observed timing-sensitive chat transcript scroll assertion, outside this layout surface. `./sc verify` safely refused the linked worktree per #769.