### PR TITLE
fix: refine diff change navigation

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2828,23 +2828,30 @@ function reviewPatchRows(text) {
         ? "auto" : "smooth",
     });
   };
-  const changeStep = (direction, targetIndex) => {
-    const label = direction === "previous" ? "Previous change" : "Next change";
+  const changeStep = (direction, targetIndex, customLabel = "") => {
+    const label = customLabel
+      || (direction === "previous" ? "Previous change" : "Next change");
     const button = el("button", {
       type: "button",
       className: `review-change-step review-change-step-${direction}`,
       ariaLabel: label,
       title: label,
-      disabled: targetIndex < 0 || targetIndex >= changeBlocks.length,
-    }, direction === "previous" ? "↑" : "↓");
+    });
     button.onclick = () => scrollToChange(targetIndex);
     return button;
   };
+  if (changeBlocks.length && changeBlocks[0].first !== rows[0]?.row) {
+    const firstChange = changeStep("next", 0, "Jump to first change");
+    firstChange.classList.add("review-change-step-first");
+    rows[0].row.append(firstChange);
+  }
   changeBlocks.forEach((block, index) => {
     block.first.classList.add("review-change-first");
     block.last.classList.add("review-change-last");
-    block.first.append(changeStep("previous", index - 1));
-    block.last.append(changeStep("next", index + 1));
+    if (index > 0) block.first.append(changeStep("previous", index - 1));
+    if (index < changeBlocks.length - 1) {
+      block.last.append(changeStep("next", index + 1));
+    }
   });
   return patch;
 }

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -480,18 +480,21 @@ body.interface-view main {
 }
 .review-line-code { padding: 0 .7rem; }
 .review-change-step {
-  position: absolute; left: .25rem; z-index: 1; width: 1.1rem; height: 1.1rem;
-  padding: 0; display: grid; place-items: center; border: 1px solid var(--line);
-  border-radius: 50%; background: var(--panel); color: var(--dim); cursor: pointer;
-  font: 700 .72rem/1 ui-monospace, monospace;
+  position: absolute; left: .2rem; z-index: 1; width: 1.3rem; height: 1.3rem;
+  padding: 0; display: grid; place-items: center; border: 0;
+  background: transparent; color: var(--ink); cursor: pointer;
 }
+.review-change-step::before {
+  content: ""; width: .58rem; height: .58rem;
+  border-right: 2.5px solid currentColor; border-bottom: 2.5px solid currentColor;
+}
+.review-change-step-previous::before { transform: rotate(-135deg); }
+.review-change-step-next::before { transform: rotate(45deg); }
 .review-change-step-previous { top: 0; transform: translateY(-55%); }
 .review-change-step-next { bottom: 0; transform: translateY(55%); }
-.review-change-step:hover:not(:disabled) {
-  color: var(--ink); border-color: var(--accent); background: var(--panel2);
-}
+.review-change-step-first { top: .1rem; bottom: auto; transform: none; }
+.review-change-step:hover { color: var(--accent); }
 .review-change-step:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
-.review-change-step:disabled { opacity: .28; cursor: default; }
 .review-line-add { background: rgba(76,175,125,.12); }
 .review-line-add .review-line-code { color: #a9dfbd; }
 .review-line-delete { background: rgba(239,125,134,.10); }

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -353,6 +353,12 @@ index 1111111..2222222 100644
 +++ b/src/app.js
 @@ -1,3 +1,4 @@
 const mode = 'chat';
+"""
+    patch += "\n" + "\n".join(
+        f"const openingContext{index} = 'first change navigation spacing {index}';"
+        for index in range(30)
+    )
+    patch += """
 -const oldValue = false;
 +const reviewOnly = true;
 +const safe = document.createTextNode('patch with a deliberately long line for horizontal scroll position preservation across refresh');
@@ -658,25 +664,43 @@ export { mode };"""
         assert page.locator(".review-line-add").count() >= 82
         assert page.locator(".review-line-delete").count() == 1
         assert page.locator(".status-conflict").count() == 1
+        first_change = page.get_by_role("button", name="Jump to first change")
         previous_changes = page.get_by_role("button", name="Previous change")
         next_changes = page.get_by_role("button", name="Next change")
-        assert previous_changes.count() == next_changes.count() == 2
-        assert previous_changes.first.is_disabled()
-        assert next_changes.last.is_disabled()
-        next_changes.first.click()
-        page.wait_for_function(
-            "document.querySelector('.review-patch-wrap').scrollTop > 0"
+        assert first_change.count() == 1
+        assert previous_changes.count() == next_changes.count() == 1
+        assert page.locator(".review-change-step:disabled").count() == 0
+
+        def wait_for_change(index):
+            page.wait_for_function(
+                "index => { const target = document.querySelectorAll("
+                "'.review-change-first')[index]; const scroller = target?.closest("
+                "'.review-patch-wrap'); if (!target || !scroller) return false; "
+                "const targetBox = target.getBoundingClientRect(); const scrollerBox = "
+                "scroller.getBoundingClientRect(); return Math.abs(targetBox.top + "
+                "targetBox.height / 2 - scrollerBox.top - scroller.clientHeight / 2) < 3; }",
+                arg=index,
+            )
+
+        first_change.click()
+        wait_for_change(0)
+        first_top = page.locator(".review-patch-wrap").evaluate(
+            "node => node.scrollTop"
         )
+        next_changes.first.click()
+        wait_for_change(1)
         navigated_top = page.locator(".review-patch-wrap").evaluate(
             "node => node.scrollTop"
         )
-        previous_changes.last.click()
-        page.wait_for_function(
-            "top => document.querySelector('.review-patch-wrap').scrollTop < top",
-            arg=navigated_top,
-        )
+        assert navigated_top > first_top
+        previous_changes.first.click()
+        wait_for_change(0)
+        assert page.locator(".review-patch-wrap").evaluate(
+            "node => node.scrollTop"
+        ) < navigated_top
         page.get_by_title("assets/logo.bin").click()
         page.get_by_text("Binary file", exact=True).wait_for()
+        assert page.locator(".review-change-step").count() == 0
         page.get_by_title("large.txt").click()
         page.get_by_text("Patch exceeds review limits", exact=True).wait_for()
         page.get_by_title("src/old.js → src/renamed.js").click()

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -110,24 +110,26 @@ def test_workspace_has_current_changes_shell_files_and_manual_refresh():
     assert "innerHTML" not in patch_renderer
 
 
-def test_patch_change_arrows_scroll_between_adjacent_change_blocks():
+def test_patch_chevrons_only_render_for_real_change_targets():
     renderer = APP[
         APP.index("function reviewPatchRows"):
         APP.index("function reviewFileTree")
     ]
 
     for text in (
-        'direction === "previous" ? "Previous change" : "Next change"',
-        'changeStep("previous", index - 1)',
-        'changeStep("next", index + 1)',
+        'changeStep("next", 0, "Jump to first change")',
+        "if (index > 0)",
+        "if (index < changeBlocks.length - 1)",
         'target?.closest(".review-patch-wrap")',
         "scroller.scrollTop",
         "left: scroller.scrollLeft",
         'behavior: window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches',
     ):
         assert text in renderer
+    assert "disabled:" not in renderer
     assert ".review-change-step" in STYLE
-    assert ".review-change-step:disabled" in STYLE
+    assert ".review-change-step::before" in STYLE
+    assert ".review-change-step:disabled" not in STYLE
 
 
 def test_diff_observes_once_then_only_refreshes_manually_single_flight():


### PR DESCRIPTION
## Summary
- add a top-of-file chevron that jumps to the first change block
- render Previous / Next chevrons only when an adjacent change exists
- remove disabled boundary controls entirely
- replace circular arrow glyphs with roughly 15% larger borderless chevrons matching `shared/arrow.png`

## Verification
- `node --check .super-coder/ui/app.js`
- `pytest -q tests/test_conversation_diff_ui.py` (9 passed)
- `ruff check tests/test_conversation_diff_browser.py tests/test_conversation_diff_ui.py`
- real Brave interaction passed top jump, next, previous, and zero-disabled-control assertions; rendered screenshot visually inspected
- `./sc map`
- `./sc render-check`
- `git diff --check`

The optional Brave smoke later reaches the already-tracked unrelated chat transcript scroll timing assertion. `./sc verify` safely refuses linked worktrees per #769.