### PR TITLE
fix: fold diff tabs into file header

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3095,14 +3095,22 @@ function chatReviewWorkspace(host, conversation) {
       paint();
       loadSelected();
     }));
+    const patchHeader = (title, detail, extraClass = "") => el("div", {
+      className: `review-patch-head${extraClass ? ` ${extraClass}` : ""}`,
+    },
+    el("div", { className: "review-patch-title" },
+      el("strong", {}, title),
+      el("span", { title: detail }, detail)),
+    groupSwitch);
     const workspace = el("div", {
       className: `review-workspace review-workspace-${state.group}`,
-    }, summary, groupSwitch);
+    }, summary);
 
     if (state.group === "changes") {
       if (state.section === "commits") {
         const commits = snapshot.changes.commits || [];
-        const body = el("div", { className: "review-commits-pane" });
+        const body = el("div", { className: "review-commits-pane" },
+          patchHeader("Commits", "Ahead commits relative to origin/main", "review-commits-head"));
         if (!commits.length) body.append(reviewTypedState("No visible ahead commits."));
         else {
           const list = el("div", { className: "review-commit-list" });
@@ -3158,11 +3166,12 @@ function chatReviewWorkspace(host, conversation) {
         (file) => selectItem(file),
       ));
       const selected = selectedItem();
-      const patchHead = el("div", { className: "review-patch-head" },
-        el("strong", {}, selected?.path || "Patch"),
-        el("span", {}, state.section === "dirty"
+      const patchHead = patchHeader(
+        selected?.path || "Patch",
+        state.section === "dirty"
           ? "staged, unstaged, conflicted, or untracked relative to HEAD"
-          : "merge-base(origin/main, HEAD) through HEAD"));
+          : "merge-base(origin/main, HEAD) through HEAD",
+      );
       let patchBody;
       if (state.contentError) patchBody = typedError(state.contentError);
       else if (state.contentLoading) patchBody = reviewTypedState("Loading patch…");
@@ -3205,9 +3214,10 @@ function chatReviewWorkspace(host, conversation) {
       }
       navigator.append(list);
       const selected = selectedItem();
-      const head = el("div", { className: "review-patch-head" },
-        el("strong", {}, selected?.name || "Shell file"),
-        el("span", {}, selected ? (selected.paths || []).join(" · ") : "Read-only exact text"));
+      const head = patchHeader(
+        selected?.name || "Shell file",
+        selected ? (selected.paths || []).join(" · ") : "Read-only exact text",
+      );
       let body;
       if (state.contentError) body = typedError(state.contentError);
       else if (state.contentLoading) body = reviewTypedState("Loading shell file…");

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -345,7 +345,7 @@ body.interface-view main {
 }
 .review-workspace {
   min-width: 0; min-height: 0; height: 100%; display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr); overflow: hidden;
+  grid-template-rows: auto minmax(0, 1fr); overflow: hidden;
 }
 .review-summary {
   min-width: 0; padding: .55rem 1rem; border-bottom: 1px solid var(--line);
@@ -387,7 +387,7 @@ body.interface-view main {
 .review-freshness .warning { color: var(--warn); }
 .review-refresh.act { margin: 0; padding: .34rem .7rem; font-size: .7rem; }
 .review-group-switch {
-  margin: 0 auto; flex: none; border-top: 0; border-radius: 0 0 7px 7px;
+  margin: 0 0 0 auto; flex: none; border-radius: 7px;
 }
 .review-change-switch { margin: 0; flex: none; }
 .review-scope-switch button { padding-inline: 1rem; }
@@ -446,15 +446,20 @@ body.interface-view main {
   min-width: 0; min-height: 0; overflow: hidden; display: flex; flex-direction: column;
 }
 .review-patch-head {
-  flex: none; min-width: 0; min-height: 40px; padding: .55rem .75rem;
-  display: flex; align-items: baseline; gap: .7rem; border-bottom: 1px solid var(--line);
+  flex: none; min-width: 0; min-height: 48px; padding: .4rem .75rem;
+  display: flex; align-items: center; gap: 1rem; border-bottom: 1px solid var(--line);
   background: var(--panel); overflow: hidden;
 }
+.review-patch-title {
+  min-width: 0; flex: 1 1 auto; display: flex; flex-direction: column;
+  gap: .05rem; overflow: hidden;
+}
 .review-patch-head strong {
-  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  display: block; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   font: .74rem ui-monospace, monospace;
 }
 .review-patch-head span {
+  display: block; max-width: 100%; overflow: hidden; text-overflow: ellipsis;
   color: var(--dim); font-size: .64rem; white-space: nowrap;
 }
 .review-file-steps { display: flex; gap: .25rem; margin-left: auto; }

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -644,14 +644,17 @@ export { mode };"""
         assert page.get_by_text("7 dirty", exact=False).is_visible()
         assert page.locator(".review-summary > .review-change-switch").count() == 1
         assert page.locator(".review-summary > .review-status").count() == 1
-        header_edges = page.locator(".review-summary, .review-group-switch").evaluate_all(
-            "nodes => ({summaryTop: nodes[0].getBoundingClientRect().top, "
-            "summaryBottom: nodes[0].getBoundingClientRect().bottom, "
-            "tabsTop: nodes[1].getBoundingClientRect().top, "
-            "tabsBottom: nodes[1].getBoundingClientRect().bottom})"
+        assert page.locator(".review-workspace > .review-group-switch").count() == 0
+        assert page.locator(".review-patch-head > .review-group-switch").count() == 1
+        patch_header = page.locator(
+            ".review-patch-title, .review-patch-title span, .review-group-switch"
+        ).evaluate_all(
+            "nodes => ({titleRight: nodes[0].getBoundingClientRect().right, "
+            "subtitleOverflow: getComputedStyle(nodes[1]).textOverflow, "
+            "tabsLeft: nodes[2].getBoundingClientRect().left})"
         )
-        assert abs(header_edges["summaryBottom"] - header_edges["tabsTop"]) <= 1
-        assert header_edges["tabsBottom"] - header_edges["summaryTop"] <= 90
+        assert patch_header["tabsLeft"] - patch_header["titleRight"] >= 12
+        assert patch_header["subtitleOverflow"] == "ellipsis"
         initial_observations = sum(
             method == "POST" and path.endswith("/review-observations")
             for method, path, _query in requests

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -180,6 +180,7 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
         ".review-status",
         ".review-group-switch",
         ".review-change-switch",
+        ".review-patch-title",
         ".review-body",
         ".review-file-tree",
         ".review-patch",
@@ -190,14 +191,18 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
     ):
         assert selector in STYLE
     assert "grid-template-columns: minmax(220px, 300px) minmax(0, 1fr)" in STYLE
-    assert "grid-template-rows: auto auto minmax(0, 1fr)" in STYLE
-    assert "border-radius: 0 0 7px 7px" in STYLE
+    assert "grid-template-rows: auto minmax(0, 1fr)" in STYLE
+    assert "flex: 1 1 auto" in STYLE
+    assert "text-overflow: ellipsis" in STYLE
     source = current_workspace_source()
     summary = source[source.index('const summary = el("div"'):source.index(
         'const groupSwitch = el("div"'
     )]
     assert "...(sectionSwitch ? [sectionSwitch] : [])" in summary
     assert "summaryStatus" in summary
+    assert "patchHeader(" in source
+    assert "}, summary);" in source
+    assert 'el("span", { title: detail }, detail)' in source
     assert "@media (max-width: 900px)" in STYLE
     responsive = STYLE[STYLE.index("@media (max-width: 900px)"):]
     assert "grid-template-columns: minmax(0, 1fr)" in responsive


### PR DESCRIPTION
## Summary
- remove the standalone Changes / Shell files row and its empty horizontal space
- place those tabs inside the patch header
- stack patch context beneath the filename
- let context consume available width, then ellipsize responsively before a protected 1rem tab gap
- preserve the full context in the native title tooltip

## Verification
- `node --check .super-coder/ui/app.js`
- `pytest -q tests/test_conversation_diff_ui.py` (9 passed)
- `ruff check tests/test_conversation_diff_ui.py tests/test_conversation_diff_browser.py`
- real Brave render passed tab-placement, spacing, and ellipsis-style assertions; screenshot visually inspected against `shared/UI-tweaks2..png`
- `./sc map`
- `./sc render-check`
- `git diff --check`

The optional Brave smoke later reaches the known unrelated chat transcript scroll timing assertion. `./sc verify` safely refuses linked worktrees per #769.