### PR TITLE
fix: center browser diff tabs

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3060,13 +3060,15 @@ function chatReviewWorkspace(host, conversation) {
           textContent: warning,
           hidden: !warning,
         })));
+    const summaryActions = el("div", { className: "review-summary-actions" },
+      summaryStatus,
+      refreshButton);
     const summary = el("div", { className: "review-summary" },
       el("div", { className: "review-target-control" },
         el("label", { className: "k" }, "Current worktree"),
         el("strong", {}, facts[0])),
       ...(sectionSwitch ? [sectionSwitch] : []),
-      summaryStatus,
-      refreshButton);
+      summaryActions);
     const groupSwitch = el("div", {
       className: "review-scope-switch review-group-switch",
       role: "tablist",

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -349,11 +349,11 @@ body.interface-view main {
 }
 .review-summary {
   min-width: 0; padding: .55rem 1rem; border-bottom: 1px solid var(--line);
-  display: grid; grid-template-columns: minmax(220px, 1fr) auto auto auto;
+  display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center; gap: .8rem; background: var(--panel);
 }
 .review-workspace-shell .review-summary {
-  grid-template-columns: minmax(220px, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 .review-summary .k {
   display: block; margin: 0 0 .2rem; color: var(--dim); font-size: .63rem;
@@ -369,7 +369,10 @@ body.interface-view main {
 }
 .review-lifecycle-block { display: flex; flex-direction: column; gap: .18rem; }
 .review-status {
-  display: flex; align-items: center; justify-self: end; gap: .8rem;
+  display: flex; align-items: center; gap: .8rem;
+}
+.review-summary-actions {
+  min-width: 0; display: flex; align-items: center; justify-self: end; gap: .8rem;
 }
 .review-lifecycle {
   width: fit-content; border: 1px solid var(--line); border-radius: 99px;
@@ -387,7 +390,7 @@ body.interface-view main {
 .review-freshness .warning { color: var(--warn); }
 .review-refresh.act { margin: 0; padding: .34rem .7rem; font-size: .7rem; }
 .review-group-switch {
-  margin: 0 0 0 auto; flex: none; border-radius: 7px;
+  margin: 0; flex: none; border-radius: 7px;
 }
 .review-change-switch { margin: 0; flex: none; }
 .review-scope-switch button { padding-inline: 1rem; }
@@ -447,7 +450,8 @@ body.interface-view main {
 }
 .review-patch-head {
   flex: none; min-width: 0; min-height: 48px; padding: .4rem .75rem;
-  display: flex; align-items: center; gap: 1rem; border-bottom: 1px solid var(--line);
+  display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center; gap: 1rem; border-bottom: 1px solid var(--line);
   background: var(--panel); overflow: hidden;
 }
 .review-patch-title {
@@ -558,7 +562,8 @@ body.interface-view main {
   .review-summary, .review-workspace-shell .review-summary {
     grid-template-columns: minmax(0, 1fr); align-items: stretch;
   }
-  .review-status { justify-self: start; flex-wrap: wrap; }
+  .review-summary-actions { justify-self: start; flex-wrap: wrap; }
+  .review-status { flex-wrap: wrap; }
   .review-refresh.act { justify-self: start; }
   .review-body { grid-template-columns: minmax(0, 1fr); overflow-y: auto; }
   .review-navigator {

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -643,18 +643,36 @@ export { mode };"""
         assert page.get_by_text("ON DISK", exact=True).is_visible()
         assert page.get_by_text("7 dirty", exact=False).is_visible()
         assert page.locator(".review-summary > .review-change-switch").count() == 1
-        assert page.locator(".review-summary > .review-status").count() == 1
+        assert page.locator(".review-summary-actions > .review-status").count() == 1
         assert page.locator(".review-workspace > .review-group-switch").count() == 0
         assert page.locator(".review-patch-head > .review-group-switch").count() == 1
-        patch_header = page.locator(
-            ".review-patch-title, .review-patch-title span, .review-group-switch"
+        summary_alignment = page.locator(
+            ".review-summary, .review-summary > .review-change-switch"
         ).evaluate_all(
-            "nodes => ({titleRight: nodes[0].getBoundingClientRect().right, "
-            "subtitleOverflow: getComputedStyle(nodes[1]).textOverflow, "
-            "tabsLeft: nodes[2].getBoundingClientRect().left})"
+            "nodes => { const container = nodes[0].getBoundingClientRect(); "
+            "const tabs = nodes[1].getBoundingClientRect(); return "
+            "{containerCenter: container.left + container.width / 2, "
+            "tabsCenter: tabs.left + tabs.width / 2}; }"
+        )
+        assert abs(
+            summary_alignment["containerCenter"] - summary_alignment["tabsCenter"]
+        ) <= 1
+        patch_header = page.locator(
+            ".review-patch-head, .review-patch-title, "
+            ".review-patch-title span, .review-group-switch"
+        ).evaluate_all(
+            "nodes => { const header = nodes[0].getBoundingClientRect(); "
+            "const tabs = nodes[3].getBoundingClientRect(); return "
+            "{headerCenter: header.left + header.width / 2, "
+            "titleRight: nodes[1].getBoundingClientRect().right, "
+            "subtitleOverflow: getComputedStyle(nodes[2]).textOverflow, "
+            "tabsLeft: tabs.left, tabsCenter: tabs.left + tabs.width / 2}; }"
         )
         assert patch_header["tabsLeft"] - patch_header["titleRight"] >= 12
         assert patch_header["subtitleOverflow"] == "ellipsis"
+        assert abs(
+            patch_header["headerCenter"] - patch_header["tabsCenter"]
+        ) <= 1
         initial_observations = sum(
             method == "POST" and path.endswith("/review-observations")
             for method, path, _query in requests

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -177,6 +177,7 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
         ".chat-review-host",
         ".review-workspace",
         ".review-summary",
+        ".review-summary-actions",
         ".review-status",
         ".review-group-switch",
         ".review-change-switch",
@@ -191,6 +192,7 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
     ):
         assert selector in STYLE
     assert "grid-template-columns: minmax(220px, 300px) minmax(0, 1fr)" in STYLE
+    assert STYLE.count("grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr)") >= 2
     assert "grid-template-rows: auto minmax(0, 1fr)" in STYLE
     assert "flex: 1 1 auto" in STYLE
     assert "text-overflow: ellipsis" in STYLE
@@ -199,7 +201,8 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
         'const groupSwitch = el("div"'
     )]
     assert "...(sectionSwitch ? [sectionSwitch] : [])" in summary
-    assert "summaryStatus" in summary
+    assert "summaryStatus" in source
+    assert "summaryActions" in summary
     assert "patchHeader(" in source
     assert "}, summary);" in source
     assert 'el("span", { title: detail }, detail)' in source


### PR DESCRIPTION
## Summary
- center Dirty / Branch / Commits on the full diff summary bar using a balanced grid
- center Changes / Shell files on the full patch header while preserving subtitle truncation
- keep status and refresh controls grouped at the right, with the existing responsive stack on narrow screens
- add browser assertions that both tab groups are centered to within one pixel

## Verification
- `node --check .super-coder/ui/app.js`
- `pytest -q tests/test_conversation_diff_ui.py` (9 passed)
- Ruff on the changed test files
- real Brave run reached and passed both exact-centering assertions and all Diff interactions; the test later encountered the existing unrelated transcript-scroll assertion (`1901` vs `0`)
- `./sc map`
- `./sc render-check`
- `git diff --check`
- `./sc verify` safely refused the linked worktree without changing state (tracked in #769)