### PR TITLE
fix: close Sprint removal conformance gaps

### DIFF
--- a/.super-coder/aliases.mk
+++ b/.super-coder/aliases.mk
@@ -31,8 +31,7 @@
 #   make dos-h                   list the commands
 #   make dos-help                list + describe the commands
 #
-#   LONG-ONLY: Interface status/start/view/attach/take-control/stop/reconcile/
-#              recover; models/job; build/logs/serve/health/ports;
+#   LONG-ONLY: models/job; build/logs/serve/health/ports;
 #              verify/map/render/snapshot/deps/install/rollback/
 #              update-harnesses/harness-status/feature/eject/remove
 #              passthrough: make dos ARGS=health
@@ -41,15 +40,10 @@ SC := ./sc
 .PHONY: dos-e dos-enter dos-l dos-launch dos-r dos-restart dos-d dos-down dos-u dos-update \
         dos-t dos-test dos-h dos-help dos-url dos-build dos-logs dos-serve dos-health dos-ports \
         dos-verify dos-map dos-render dos-snapshot dos-deps dos-install dos-rollback \
-        dos-update-harnesses dos-harness-status dos-feat dos-feature dos-eject dos-remove dos-status \
-        dos-start dos-view dos-attach dos-take dos-take-control dos-stop \
-        dos-reconcile dos-recover dos-models dos-model-refresh dos-model-list \
+        dos-update-harnesses dos-harness-status dos-feat dos-feature dos-eject dos-remove \
+        dos-models dos-model-refresh dos-model-list \
         dos-model-resolve dos-job dos-setup dos
 
-# Interface actions other than enter/status require an exact shell. Fail in
-# Make before ./sc is invoked so a typo cannot silently widen an operation.
-require-shell = $(if $(strip $(s)),,$(error $@: requires s=<shell-shortname>))
-shell-arg = $(if $(strip $(s)),$(s))
 require-model-route = $(if $(and $(strip $(h)),$(strip $(m))),,$(error $@: requires h=<harness> m=<model> [s=<shell-shortname>]))
 model-shell-arg = $(if $(strip $(s)),--shell $(s))
 
@@ -69,18 +63,6 @@ dos-t: dos-test
 # The links an operator loses when the boot summary scrolls away — derived per
 # fork, never a fixed 8800 (decision #50).
 dos-url:              ; $(SC) url
-
-# Interface operator workflow. These are the accepted public API-backed verbs;
-# server-only primitives and direct DB operations intentionally stay out.
-dos-status:           ; $(SC) interface status $(shell-arg) $(ARGS)
-dos-start:            ; $(call require-shell)$(SC) interface start $(s) $(ARGS)
-dos-view:             ; $(call require-shell)$(SC) interface view $(s)
-dos-attach:           ; $(call require-shell)$(SC) interface attach $(s)
-dos-take:             ; $(call require-shell)$(SC) interface take-control $(s)
-dos-take-control:     ; $(call require-shell)$(SC) interface take-control $(s)
-dos-stop:             ; $(call require-shell)$(SC) interface stop $(s) $(ARGS)
-dos-reconcile:        ; $(call require-shell)$(SC) interface reconcile $(s) $(ARGS)
-dos-recover:          ; $(call require-shell)$(SC) interface recover $(s) $(ARGS)
 
 # Model catalogue and durable local jobs.
 dos-models:           ; $(SC) models $(ARGS)
@@ -151,17 +133,6 @@ dos-help:
 	@echo "    dos-u / dos-update          update and reconcile the engine (ARGS forwarded)"
 	@echo "    dos-t / dos-test            run backend + UI suites (ARGS forwarded)"
 	@echo "    dos-url                     print the review GUI + dev-server URLs for this fork"
-	@echo ""
-	@echo "  INTERFACE  (API-backed; actions marked s=x require a shell shortname)"
-	@echo "    dos-status [s=x]            rail status, optionally one shell"
-	@echo "    dos-start s=x               start a New chat"
-	@echo "    dos-view s=x                attach read-only"
-	@echo "    dos-attach s=x              attach as writer without takeover"
-	@echo "    dos-take s=x                explicitly transfer the writer role"
-	@echo "    dos-take-control s=x        descriptive alias of dos-take"
-	@echo "    dos-stop s=x                gracefully end; ARGS=--force after timeout"
-	@echo "    dos-reconcile s=x           revalidate; ARGS=--close after proved absence"
-	@echo "    dos-recover s=x             preview/recover; force/discard via explicit ARGS"
 	@echo ""
 	@echo "  MODELS + JOBS"
 	@echo "    dos-model-refresh           refresh the local model catalogue"

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -274,8 +274,7 @@ def require_current_schema(db_path=DB_PATH,
     A pre-fix updater can materialize the target engine and pin before its
     live-state refusal fires.  The newly installed server must therefore
     recognize that half-applied floor from the migration ledger before key
-    provisioning, Interface reconciliation, or request handling reaches a
-    column the old DB does not have.
+    provisioning or request handling reaches a column the old DB does not have.
     """
     expected = {path.name for path in migrations_dir.glob("*.sql")}
     con = db_driver.connect(db_path)
@@ -308,8 +307,8 @@ def require_current_schema(db_path=DB_PATH,
         "Refusing startup before first DB use; continuing would run new code "
         "against an old schema.\n"
         "Recovery: run `./sc rollback --engine-only` to restore the previous "
-        "engine/pin while preserving this unchanged DB, then drain/reconcile "
-        "live Interface state and retry `./sc update`.")
+        "engine/pin while preserving this unchanged DB, then retry "
+        "`./sc update`.")
 
 
 def rows(cur) -> list[dict]:

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -62,7 +62,6 @@ Run from the repo root, like every engine command:
     ./sc mem narrative "<line>"
     ./sc mem message check [N]                         # your unread inbox (read-only)
     ./sc mem message send <to-shortname> "<body>" [--kind shell|task|result]
-                            [--assignment ID --result-kind KIND --directive ID]
     ./sc mem message sent                              # outbound view — verify delivery
     ./sc mem message mark-read <message_id>
 

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -73,6 +73,7 @@ import db_driver  # noqa: E402
 import engine_manifest  # noqa: E402
 import install as install_mod  # noqa: E402  (ensure_harnesses)
 import migrate as migrate_mod  # noqa: E402
+import ports  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402
 import seed_skills  # noqa: E402
 import shell_factory  # noqa: E402
@@ -673,6 +674,66 @@ def migrate_or_rebuild() -> None:
     migrate_mod.migrate(str(DB_PATH))
 
 
+def stop_pm2_review_server() -> tuple[str, str] | None:
+    """Stop this fork's running legacy PM2 review server, if it has one.
+
+    A stopped process stays registered in PM2, so starting the same name after
+    migration loads the newly materialized server code.  An absent PM2 binary
+    or an unregistered/stopped process means this install has no PM2 service to
+    cut over.
+    """
+    pm2_bin = shutil.which("pm2")
+    if pm2_bin is None:
+        return None
+    process = f"sc-{ports.resolve(persist=False).get('repo', REPO_ROOT.name)}"
+    probe = subprocess.run(
+        [pm2_bin, "pid", process], capture_output=True, text=True, check=False
+    )
+    if probe.returncode != 0:
+        sys.exit(
+            f"update: could not inspect PM2 process {process}:\n"
+            + (probe.stderr or probe.stdout).strip()
+        )
+    pids = [line.strip() for line in probe.stdout.splitlines()]
+    if not any(pid.isdigit() and int(pid) > 0 for pid in pids):
+        return None
+    stopped = subprocess.run(
+        [pm2_bin, "stop", process], capture_output=True, text=True, check=False
+    )
+    if stopped.returncode != 0:
+        sys.exit(
+            f"update: could not stop old PM2 server {process}; "
+            "refusing to migrate the live DB:\n"
+            + (stopped.stderr or stopped.stdout).strip()
+        )
+    print(f"→ stopped old PM2 server {process} before DB migration")
+    return pm2_bin, process
+
+
+def start_pm2_review_server(service: tuple[str, str] | None) -> None:
+    if service is None:
+        return
+    pm2_bin, process = service
+    started = subprocess.run(
+        [pm2_bin, "start", process], capture_output=True, text=True, check=False
+    )
+    if started.returncode != 0:
+        sys.exit(
+            f"update: DB migration succeeded but new PM2 server {process} "
+            "could not start:\n" + (started.stderr or started.stdout).strip()
+        )
+    print(f"→ started new PM2 server {process} after DB migration")
+
+
+def migrate_with_service_cutover() -> None:
+    service = stop_pm2_review_server()
+    migrate_or_rebuild()
+    # Deliberately not in finally: a failed destructive migration must leave
+    # the old server stopped instead of restarting code against a changed or
+    # incompatible floor.
+    start_pm2_review_server(service)
+
+
 def sync_skills() -> None:
     """Re-apply the engine skills seed against the live DB.
 
@@ -847,7 +908,7 @@ def main(argv: list[str]) -> int:
         print(f"→ expire the sandbox's baked harness CLIs (epoch {epoch})")
         print("  they reinstall on the next image build — normal `./sc restart` / `make dos-r`")
 
-    migrate_or_rebuild()
+    migrate_with_service_cutover()
 
     print("→ sync skills catalogue (id-stable)")
     sync_skills()

--- a/tests/test_aliases_make.py
+++ b/tests/test_aliases_make.py
@@ -49,6 +49,18 @@ COMMANDS_THAT_MUST_EXPLAIN_THEMSELVES = (
     "dos-verify",
 )
 
+RETIRED_INTERFACE_TARGETS = (
+    "dos-status",
+    "dos-start",
+    "dos-view",
+    "dos-attach",
+    "dos-take",
+    "dos-take-control",
+    "dos-stop",
+    "dos-reconcile",
+    "dos-recover",
+)
+
 
 def described_targets(help_text: str) -> dict[str, str]:
     """Map every target in `help_text` to its description, alias pairs split.
@@ -98,6 +110,17 @@ class MakeAliasContractTest(unittest.TestCase):
         self.assertNotIn("dos-token", make("dos-help").stdout)
         self.assertNotIn("dos-token", make("dos-h").stdout)
 
+    def test_retired_interface_aliases_stay_gone(self):
+        help_text = make("dos-help").stdout
+        for target in RETIRED_INTERFACE_TARGETS:
+            with self.subTest(target=target):
+                result = make("-n", target, "s=DEV1")
+                self.assertNotEqual(
+                    result.returncode, 0, f"{target} still resolves as a make target"
+                )
+                self.assertNotIn(target, help_text)
+        self.assertNotIn("INTERFACE", help_text)
+
     def test_documented_targets_delegate_exactly_to_sc(self):
         cases = [
             (("dos-enter",), "./sc enter"),
@@ -115,22 +138,6 @@ class MakeAliasContractTest(unittest.TestCase):
              "./sc test tests/test_aliases_make.py"),
             (("dos-t",), "./sc test"),
             (("dos-url",), "./sc url"),
-            (("dos-status", "s=DEV1", "ARGS=--json"),
-             "./sc interface status DEV1 --json"),
-            (("dos-start", "s=DEV1", "ARGS=--harness codex"),
-             "./sc interface start DEV1 --harness codex"),
-            (("dos-view", "s=DEV1"), "./sc interface view DEV1"),
-            (("dos-attach", "s=DEV1"), "./sc interface attach DEV1"),
-            (("dos-take", "s=DEV1"),
-             "./sc interface take-control DEV1"),
-            (("dos-take-control", "s=DEV1"),
-             "./sc interface take-control DEV1"),
-            (("dos-stop", "s=DEV1", "ARGS=--force"),
-             "./sc interface stop DEV1 --force"),
-            (("dos-reconcile", "s=DEV1", "ARGS=--close"),
-             "./sc interface reconcile DEV1 --close"),
-            (("dos-recover", "s=DEV1", "ARGS=--force --yes"),
-             "./sc interface recover DEV1 --force --yes"),
             (("dos-models", "ARGS=list codex"), "./sc models list codex"),
             (("dos-model-refresh",), "./sc models refresh"),
             (("dos-model-list", "h=codex"), "./sc models list codex"),
@@ -162,25 +169,6 @@ class MakeAliasContractTest(unittest.TestCase):
                 self.assertEqual(result.returncode, 0, result.stderr)
                 self.assertEqual(result.stdout.strip(), expected)
 
-    def test_shell_actions_fail_before_dispatch_when_s_is_missing(self):
-        for target in (
-            "dos-start",
-            "dos-view",
-            "dos-attach",
-            "dos-take",
-            "dos-take-control",
-            "dos-stop",
-            "dos-reconcile",
-            "dos-recover",
-        ):
-            with self.subTest(target=target):
-                result = make("-n", target)
-                self.assertNotEqual(result.returncode, 0)
-                self.assertEqual(result.stdout, "")
-                self.assertIn(
-                    f"{target}: requires s=<shell-shortname>", result.stderr
-                )
-
     def test_model_resolve_requires_harness_and_model_before_dispatch(self):
         result = make("-n", "dos-model-resolve", "h=codex")
         self.assertNotEqual(result.returncode, 0)
@@ -195,17 +183,9 @@ class MakeAliasContractTest(unittest.TestCase):
         result = make("dos-help")
         self.assertEqual(result.returncode, 0, result.stderr)
         help_text = result.stdout
-        for heading in ("HOT", "INTERFACE", "MODELS + JOBS", "MAINTENANCE"):
+        for heading in ("HOT", "MODELS + JOBS", "MAINTENANCE"):
             self.assertIn(heading, help_text)
         for target in (
-            "dos-status",
-            "dos-start",
-            "dos-view",
-            "dos-attach",
-            "dos-take-control",
-            "dos-stop",
-            "dos-reconcile",
-            "dos-recover",
             "dos-models",
             "dos-model-refresh",
             "dos-model-list",

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -40,6 +40,35 @@ TOKEN = "test-token-deadbeef"
 PEER_TOKEN = "peer-token-cafebabe"   # second shell — cross-shell read coverage
 
 
+class MemMessageHelpContractTest(unittest.TestCase):
+    def test_authored_send_help_matches_parser_options(self):
+        parser = mem.build_parser()
+        message = next(
+            action for action in parser._actions
+            if isinstance(action, mem.argparse._SubParsersAction)
+        ).choices["message"]
+        send = next(
+            action for action in message._actions
+            if isinstance(action, mem.argparse._SubParsersAction)
+        ).choices["send"]
+        options = {
+            option
+            for action in send._actions
+            for option in action.option_strings
+        }
+        self.assertEqual(options, {"-h", "--help", "--kind"})
+
+        rendered = send.format_help()
+        synopsis = (
+            './sc mem message send <to-shortname> "<body>" '
+            '[--kind shell|task|result]'
+        )
+        self.assertIn(synopsis, mem.__doc__)
+        for retired in ("--assignment", "--result-kind", "--directive"):
+            self.assertNotIn(retired, mem.__doc__)
+            self.assertNotIn(retired, rendered)
+
+
 def build_engine_db(path: Path) -> None:
     """A throwaway file DB shaped like the shipped engine (schema + every
     migration), with one keyed shell that owns an active session archive."""

--- a/tests/test_update_service_cutover.py
+++ b/tests/test_update_service_cutover.py
@@ -1,0 +1,126 @@
+"""The updater quiesces a PM2 review server around DB migration."""
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import update  # noqa: E402
+
+
+class Stop(Exception):
+    """Sentinel proving main reached the service cutover seam."""
+
+
+class UpdateServiceCutoverTest(unittest.TestCase):
+    def test_main_routes_migration_through_the_service_cutover(self):
+        with mock.patch.object(update, "is_source_repo", return_value=True), \
+                mock.patch.object(update, "ensure_workflows", return_value=("source", [])), \
+                mock.patch.object(update.install_mod, "ensure_harnesses"), \
+                mock.patch.object(update, "expire_sandbox_harnesses", return_value=None), \
+                mock.patch.object(
+                    update, "migrate_with_service_cutover", side_effect=Stop
+                ) as cutover, mock.patch.object(
+                    update, "migrate_or_rebuild",
+                    side_effect=AssertionError("main bypassed service cutover"),
+                ), contextlib.redirect_stdout(io.StringIO()), \
+                self.assertRaises(Stop):
+            update.main(["--no-fetch"])
+        cutover.assert_called_once_with()
+
+    def test_running_pm2_server_stops_before_migration_and_starts_after(self):
+        order = []
+        service = ("/usr/bin/pm2", "sc-example")
+        with mock.patch.object(
+            update, "stop_pm2_review_server",
+            side_effect=lambda: order.append("stop-old") or service,
+        ), mock.patch.object(
+            update, "migrate_or_rebuild",
+            side_effect=lambda: order.append("migrate"),
+        ), mock.patch.object(
+            update, "start_pm2_review_server",
+            side_effect=lambda value: order.append(("start-new", value)),
+        ):
+            update.migrate_with_service_cutover()
+        self.assertEqual(
+            order,
+            ["stop-old", "migrate", ("start-new", service)],
+        )
+
+    def test_migration_failure_never_restarts_incompatible_old_code(self):
+        service = ("/usr/bin/pm2", "sc-example")
+        with mock.patch.object(
+            update, "stop_pm2_review_server", return_value=service
+        ) as stop, mock.patch.object(
+            update, "migrate_or_rebuild", side_effect=RuntimeError("migration failed")
+        ), mock.patch.object(update, "start_pm2_review_server") as start, \
+                self.assertRaisesRegex(RuntimeError, "migration failed"):
+            update.migrate_with_service_cutover()
+        stop.assert_called_once_with()
+        start.assert_not_called()
+
+    def test_pm2_lifecycle_targets_only_the_running_repo_server(self):
+        completed = [
+            mock.Mock(returncode=0, stdout="27182\n", stderr=""),
+            mock.Mock(returncode=0, stdout="stopped\n", stderr=""),
+            mock.Mock(returncode=0, stdout="started\n", stderr=""),
+        ]
+        with mock.patch.object(update.shutil, "which", return_value="/bin/pm2"), \
+                mock.patch.object(
+                    update.ports, "resolve", return_value={"repo": "example"}
+                ), mock.patch.object(
+                    update.subprocess, "run", side_effect=completed
+                ) as run, contextlib.redirect_stdout(io.StringIO()):
+            service = update.stop_pm2_review_server()
+            update.start_pm2_review_server(service)
+        self.assertEqual(service, ("/bin/pm2", "sc-example"))
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [
+                ["/bin/pm2", "pid", "sc-example"],
+                ["/bin/pm2", "stop", "sc-example"],
+                ["/bin/pm2", "start", "sc-example"],
+            ],
+        )
+
+    def test_stopped_or_unregistered_pm2_server_is_not_started(self):
+        probe = mock.Mock(returncode=0, stdout="0\n", stderr="")
+        with mock.patch.object(update.shutil, "which", return_value="/bin/pm2"), \
+                mock.patch.object(
+                    update.ports, "resolve", return_value={"repo": "example"}
+                ), mock.patch.object(
+                    update.subprocess, "run", return_value=probe
+                ) as run:
+            service = update.stop_pm2_review_server()
+            update.start_pm2_review_server(service)
+        self.assertIsNone(service)
+        run.assert_called_once_with(
+            ["/bin/pm2", "pid", "sc-example"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_stop_failure_refuses_migration(self):
+        completed = [
+            mock.Mock(returncode=0, stdout="27182\n", stderr=""),
+            mock.Mock(returncode=1, stdout="", stderr="stop denied"),
+        ]
+        with mock.patch.object(update.shutil, "which", return_value="/bin/pm2"), \
+                mock.patch.object(
+                    update.ports, "resolve", return_value={"repo": "example"}
+                ), mock.patch.object(
+                    update.subprocess, "run", side_effect=completed
+                ), mock.patch.object(update, "migrate_or_rebuild") as migrate, \
+                self.assertRaisesRegex(SystemExit, "refusing to migrate"):
+            update.migrate_with_service_cutover()
+        migrate.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the three final feature #29 conformance defects from spec #44 task #183.

- removes the nine dead Interface/TMUX Make aliases and the dos-help INTERFACE workflow, replacing positive alias contracts with negative retirement coverage while preserving unrelated aliases
- removes obsolete assignment/result-kind/directive synopsis flags from mem.py and pins authored help to the actual parser options
- enforces PM2 stop-old -> migrate/rebuild -> start-new ordering; migration or stop failure cannot restart incompatible old code
- removes stale Interface reconciliation recovery prose from server.py

Trade-off: PM2 cutover runs for any update when this fork's review server is online, rather than trying to classify individual migrations as destructive. This keeps the safety rule explicit with a small seam and leaves unregistered/stopped PM2 processes unchanged.

Verification:
- focused: 114 passed, 222 subtests passed
- full suite: 1270 passed, 1 skipped, 732 subtests passed
- ./sc render-check: passed
- isolated standalone ./sc verify: passed (93 migrations, fresh 10-shell init, render-only boot)
- git diff --check: passed