### PR TITLE
fix: align browser diff tab centerline

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3189,8 +3189,8 @@ function chatReviewWorkspace(host, conversation) {
         patchBody = el("div", { className: "review-patch-wrap" });
         patchBody.append(reviewPatchRows(state.patch.patch || ""));
       }
-      workspace.append(el("div", { className: "review-body" }, navigator,
-        el("section", { className: "review-patch-pane" }, patchHead, patchBody)));
+      workspace.append(el("div", { className: "review-body" }, navigator, patchHead,
+        el("section", { className: "review-patch-pane" }, patchBody)));
     } else {
       const navigator = el("aside", { className: "review-navigator" });
       const list = el("div", { className: "review-file-tree review-shell-tree" });
@@ -3229,8 +3229,8 @@ function chatReviewWorkspace(host, conversation) {
         className: "review-shell-file review-patch-wrap",
         textContent: state.shellFile.body,
       });
-      workspace.append(el("div", { className: "review-body" }, navigator,
-        el("section", { className: "review-patch-pane" }, head, body)));
+      workspace.append(el("div", { className: "review-body" }, navigator, head,
+        el("section", { className: "review-patch-pane" }, body)));
     }
     host.replaceChildren(workspace);
   };

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -396,12 +396,14 @@ body.interface-view main {
 .review-scope-switch button { padding-inline: 1rem; }
 .review-body {
   min-width: 0; min-height: 0; overflow: hidden; display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
   border-top: 1px solid var(--line);
 }
 .review-navigator {
   min-width: 0; min-height: 0; overflow: hidden; display: flex;
-  flex-direction: column; border-right: 1px solid var(--line); background: var(--panel);
+  grid-column: 1; grid-row: 1 / -1; z-index: 1; flex-direction: column;
+  border-right: 1px solid var(--line); background: var(--panel);
 }
 .review-filters {
   flex: none; display: grid; grid-template-columns: minmax(0, 1fr) auto;
@@ -447,12 +449,22 @@ body.interface-view main {
 .review-file-counts { color: var(--dim); font: .61rem ui-monospace, monospace; white-space: nowrap; }
 .review-patch-pane {
   min-width: 0; min-height: 0; overflow: hidden; display: flex; flex-direction: column;
+  grid-column: 2; grid-row: 2;
 }
 .review-patch-head {
   flex: none; min-width: 0; min-height: 48px; padding: .4rem .75rem;
   display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center; gap: 1rem; border-bottom: 1px solid var(--line);
   background: var(--panel); overflow: hidden;
+}
+.review-body > .review-patch-head {
+  position: relative; grid-column: 1 / -1; grid-row: 1;
+}
+.review-body > .review-patch-head > .review-patch-title {
+  padding-left: 300px;
+}
+.review-body > .review-patch-head > .review-group-switch {
+  align-self: start; margin-top: -.4rem;
 }
 .review-patch-title {
   min-width: 0; flex: 1 1 auto; display: flex; flex-direction: column;
@@ -565,12 +577,19 @@ body.interface-view main {
   .review-summary-actions { justify-self: start; flex-wrap: wrap; }
   .review-status { flex-wrap: wrap; }
   .review-refresh.act { justify-self: start; }
-  .review-body { grid-template-columns: minmax(0, 1fr); overflow-y: auto; }
+  .review-body {
+    grid-template-columns: minmax(0, 1fr); grid-template-rows: auto auto minmax(0, 1fr);
+    overflow-y: auto;
+  }
   .review-navigator {
+    grid-column: 1; grid-row: 1;
     max-height: 42%; min-height: 180px; border-right: 0;
     border-bottom: 1px solid var(--line);
   }
-  .review-patch-pane { min-height: 420px; }
+  .review-body > .review-patch-head { grid-column: 1; grid-row: 2; }
+  .review-body > .review-patch-head > .review-patch-title { padding-left: 0; }
+  .review-body > .review-patch-head > .review-group-switch { margin-top: -.4rem; }
+  .review-patch-pane { grid-column: 1; grid-row: 3; min-height: 420px; }
 }
 @media (max-width: 680px) {
   .chat-layout { grid-template-columns: 101px minmax(0, 1fr); }

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -658,21 +658,25 @@ export { mode };"""
             summary_alignment["containerCenter"] - summary_alignment["tabsCenter"]
         ) <= 1
         patch_header = page.locator(
-            ".review-patch-head, .review-patch-title, "
+            ".review-body, .review-patch-head, .review-patch-title, "
             ".review-patch-title span, .review-group-switch"
         ).evaluate_all(
-            "nodes => { const header = nodes[0].getBoundingClientRect(); "
-            "const tabs = nodes[3].getBoundingClientRect(); return "
-            "{headerCenter: header.left + header.width / 2, "
-            "titleRight: nodes[1].getBoundingClientRect().right, "
-            "subtitleOverflow: getComputedStyle(nodes[2]).textOverflow, "
-            "tabsLeft: tabs.left, tabsCenter: tabs.left + tabs.width / 2}; }"
+            "nodes => { const body = nodes[0].getBoundingClientRect(); "
+            "const header = nodes[1].getBoundingClientRect(); "
+            "const tabs = nodes[4].getBoundingClientRect(); return "
+            "{bodyCenter: body.left + body.width / 2, headerTop: header.top, "
+            "titleRight: nodes[2].getBoundingClientRect().right, "
+            "subtitleOverflow: getComputedStyle(nodes[3]).textOverflow, "
+            "tabsTop: tabs.top, tabsLeft: tabs.left, "
+            "tabsCenter: tabs.left + tabs.width / 2}; }"
         )
         assert patch_header["tabsLeft"] - patch_header["titleRight"] >= 12
         assert patch_header["subtitleOverflow"] == "ellipsis"
         assert abs(
-            patch_header["headerCenter"] - patch_header["tabsCenter"]
+            patch_header["bodyCenter"] - patch_header["tabsCenter"]
         ) <= 1
+        assert abs(summary_alignment["tabsCenter"] - patch_header["tabsCenter"]) <= 1
+        assert abs(patch_header["headerTop"] - patch_header["tabsTop"]) <= 1
         initial_observations = sum(
             method == "POST" and path.endswith("/review-observations")
             for method, path, _query in requests

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -194,6 +194,8 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
     assert "grid-template-columns: minmax(220px, 300px) minmax(0, 1fr)" in STYLE
     assert STYLE.count("grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr)") >= 2
     assert "grid-template-rows: auto minmax(0, 1fr)" in STYLE
+    assert "grid-column: 1 / -1; grid-row: 1" in STYLE
+    assert "align-self: start; margin-top: -.4rem" in STYLE
     assert "flex: 1 1 auto" in STYLE
     assert "text-overflow: ellipsis" in STYLE
     source = current_workspace_source()
@@ -204,6 +206,8 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
     assert "summaryStatus" in source
     assert "summaryActions" in summary
     assert "patchHeader(" in source
+    assert '}, navigator, patchHead,' in source
+    assert '}, navigator, head,' in source
     assert "}, summary);" in source
     assert 'el("span", { title: detail }, detail)' in source
     assert "@media (max-width: 900px)" in STYLE


### PR DESCRIPTION
## Summary
- align `Changes / Shell files` to the same full-workspace centerline as `Dirty / Branch / Commits`
- make the patch header span the navigator and patch columns so left-side text cannot shift the tabs
- pull the lower tabs flush against the divider above while keeping filename/subtitle truncation clear of the controls
- preserve the stacked responsive layout below 900px

## Verification
- `node --check .super-coder/ui/app.js`
- `pytest -q tests/test_conversation_diff_ui.py` (9 passed)
- Ruff on both changed test files
- real Brave run passed exact shared-centerline, flush-top, truncation-gap, and all Diff interaction assertions; it later reached the known unrelated transcript-scroll assertion (`1901` vs `0`)
- `./sc map`
- `./sc render-check`
- `git diff --check`
- `./sc verify` safely refused the linked worktree without changing state (tracked in #769)