### PR TITLE
fix: chamfer browser diff tabs

### DIFF
--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -390,7 +390,24 @@ body.interface-view main {
 .review-freshness .warning { color: var(--warn); }
 .review-refresh.act { margin: 0; padding: .34rem .7rem; font-size: .7rem; }
 .review-group-switch {
-  margin: 0; flex: none; border-radius: 7px;
+  --review-tab-cut: 10px;
+  margin: 0; flex: none; border-radius: 0;
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - var(--review-tab-cut)),
+    calc(100% - var(--review-tab-cut)) 100%,
+    0 100%
+  );
+}
+.review-group-switch button:first-child.active {
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - var(--review-tab-cut)),
+    calc(100% - var(--review-tab-cut)) 100%,
+    0 100%
+  );
 }
 .review-change-switch { margin: 0; flex: none; }
 .review-scope-switch button { padding-inline: 1rem; }

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -659,7 +659,8 @@ export { mode };"""
         ) <= 1
         patch_header = page.locator(
             ".review-body, .review-patch-head, .review-patch-title, "
-            ".review-patch-title span, .review-group-switch"
+            ".review-patch-title span, .review-group-switch, "
+            ".review-group-switch button.active"
         ).evaluate_all(
             "nodes => { const body = nodes[0].getBoundingClientRect(); "
             "const header = nodes[1].getBoundingClientRect(); "
@@ -668,7 +669,10 @@ export { mode };"""
             "titleRight: nodes[2].getBoundingClientRect().right, "
             "subtitleOverflow: getComputedStyle(nodes[3]).textOverflow, "
             "tabsTop: tabs.top, tabsLeft: tabs.left, "
-            "tabsCenter: tabs.left + tabs.width / 2}; }"
+            "tabsCenter: tabs.left + tabs.width / 2, "
+            "tabsClip: getComputedStyle(nodes[4]).clipPath, "
+            "tabsRadius: getComputedStyle(nodes[4]).borderRadius, "
+            "activeClip: getComputedStyle(nodes[5]).clipPath}; }"
         )
         assert patch_header["tabsLeft"] - patch_header["titleRight"] >= 12
         assert patch_header["subtitleOverflow"] == "ellipsis"
@@ -677,6 +681,9 @@ export { mode };"""
         ) <= 1
         assert abs(summary_alignment["tabsCenter"] - patch_header["tabsCenter"]) <= 1
         assert abs(patch_header["headerTop"] - patch_header["tabsTop"]) <= 1
+        assert patch_header["tabsClip"].startswith("polygon(")
+        assert patch_header["activeClip"].startswith("polygon(")
+        assert patch_header["tabsRadius"] == "0px"
         initial_observations = sum(
             method == "POST" and path.endswith("/review-observations")
             for method, path, _query in requests

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -196,6 +196,8 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
     assert "grid-template-rows: auto minmax(0, 1fr)" in STYLE
     assert "grid-column: 1 / -1; grid-row: 1" in STYLE
     assert "align-self: start; margin-top: -.4rem" in STYLE
+    assert "--review-tab-cut: 10px" in STYLE
+    assert STYLE.count("calc(100% - var(--review-tab-cut))") == 4
     assert "flex: 1 1 auto" in STYLE
     assert "text-overflow: ellipsis" in STYLE
     source = current_workspace_source()


### PR DESCRIPTION
## Summary
- square the Diff section tab group and add the requested 10px lower-right chamfer
- apply the matching chamfer to the active Changes tab without changing tab sizing or centerline positioning
- extend static and browser coverage for the new shape while retaining the existing pixel-centering assertions

## Verification
- `./sc test tests/test_conversation_diff_ui.py tests/test_conversation_diff_browser.py::test_diff_workspace_preserves_live_chat_and_uses_get_only` (10 passed)
- isolated Playwright visual spot-check using the production stylesheet
- `./sc render-check`
- `git diff --check`

`./sc verify` was not run because it correctly refuses linked worktrees; the stale finish-gate guidance is tracked in #769 and this reproduction was added there.