### PR TITLE
fix: soften diff tab chamfers

### DIFF
--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -391,15 +391,11 @@ body.interface-view main {
 .review-refresh.act { margin: 0; padding: .34rem .7rem; font-size: .7rem; }
 .review-group-switch {
   --review-tab-cut: 10px;
+  --review-tab-radius: 3px;
+  --review-tab-radius-diagonal: 2px;
   margin: 0; flex: none; border-radius: 0;
-  clip-path: polygon(
-    0 0,
-    100% 0,
-    100% calc(100% - var(--review-tab-cut)),
-    calc(100% - var(--review-tab-cut)) 100%,
-    0 100%
-  );
 }
+.review-group-switch,
 .review-group-switch button:first-child.active {
   clip-path: polygon(
     0 0,
@@ -408,6 +404,28 @@ body.interface-view main {
     calc(100% - var(--review-tab-cut)) 100%,
     0 100%
   );
+  clip-path: shape(
+    from 0 0,
+    line to 100% 0,
+    line to 100% calc(100% - var(--review-tab-cut) - var(--review-tab-radius)),
+    curve to calc(100% - var(--review-tab-radius-diagonal))
+      calc(100% - var(--review-tab-cut) + var(--review-tab-radius-diagonal))
+      with 100% calc(100% - var(--review-tab-cut)),
+    line to calc(100% - var(--review-tab-cut) + var(--review-tab-radius-diagonal))
+      calc(100% - var(--review-tab-radius-diagonal)),
+    curve to calc(100% - var(--review-tab-cut) - var(--review-tab-radius)) 100%
+      with calc(100% - var(--review-tab-cut)) 100%,
+    line to 0 100%,
+    close
+  );
+}
+.review-group-switch button:first-child.active + button {
+  position: relative; border-left: 0;
+}
+.review-group-switch button:first-child.active + button::before {
+  content: ""; position: absolute; inset: 0 auto auto 0;
+  height: calc(100% - var(--review-tab-cut) - var(--review-tab-radius));
+  border-left: 1px solid var(--line); pointer-events: none;
 }
 .review-change-switch { margin: 0; flex: none; }
 .review-scope-switch button { padding-inline: 1rem; }

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -660,11 +660,13 @@ export { mode };"""
         patch_header = page.locator(
             ".review-body, .review-patch-head, .review-patch-title, "
             ".review-patch-title span, .review-group-switch, "
-            ".review-group-switch button.active"
+            ".review-group-switch button.active, "
+            ".review-group-switch button:first-child.active + button"
         ).evaluate_all(
             "nodes => { const body = nodes[0].getBoundingClientRect(); "
             "const header = nodes[1].getBoundingClientRect(); "
-            "const tabs = nodes[4].getBoundingClientRect(); return "
+            "const tabs = nodes[4].getBoundingClientRect(); "
+            "const active = nodes[5].getBoundingClientRect(); return "
             "{bodyCenter: body.left + body.width / 2, headerTop: header.top, "
             "titleRight: nodes[2].getBoundingClientRect().right, "
             "subtitleOverflow: getComputedStyle(nodes[3]).textOverflow, "
@@ -672,7 +674,11 @@ export { mode };"""
             "tabsCenter: tabs.left + tabs.width / 2, "
             "tabsClip: getComputedStyle(nodes[4]).clipPath, "
             "tabsRadius: getComputedStyle(nodes[4]).borderRadius, "
-            "activeClip: getComputedStyle(nodes[5]).clipPath}; }"
+            "activeClip: getComputedStyle(nodes[5]).clipPath, "
+            "activeHeight: active.height, "
+            "dividerBorder: getComputedStyle(nodes[6], '::before').borderLeftWidth, "
+            "dividerHeight: parseFloat(getComputedStyle(nodes[6], '::before').height), "
+            "buttonBorder: getComputedStyle(nodes[6]).borderLeftWidth}; }"
         )
         assert patch_header["tabsLeft"] - patch_header["titleRight"] >= 12
         assert patch_header["subtitleOverflow"] == "ellipsis"
@@ -681,9 +687,14 @@ export { mode };"""
         ) <= 1
         assert abs(summary_alignment["tabsCenter"] - patch_header["tabsCenter"]) <= 1
         assert abs(patch_header["headerTop"] - patch_header["tabsTop"]) <= 1
-        assert patch_header["tabsClip"].startswith("polygon(")
-        assert patch_header["activeClip"].startswith("polygon(")
+        assert patch_header["tabsClip"].startswith("shape(")
+        assert patch_header["activeClip"].startswith("shape(")
         assert patch_header["tabsRadius"] == "0px"
+        assert patch_header["dividerBorder"] == "1px"
+        assert patch_header["buttonBorder"] == "0px"
+        assert abs(
+            patch_header["activeHeight"] - patch_header["dividerHeight"] - 13
+        ) <= 1
         initial_observations = sum(
             method == "POST" and path.endswith("/review-observations")
             for method, path, _query in requests

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -197,7 +197,10 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
     assert "grid-column: 1 / -1; grid-row: 1" in STYLE
     assert "align-self: start; margin-top: -.4rem" in STYLE
     assert "--review-tab-cut: 10px" in STYLE
-    assert STYLE.count("calc(100% - var(--review-tab-cut))") == 4
+    assert "--review-tab-radius: 3px" in STYLE
+    assert STYLE.count("clip-path: shape(") == 1
+    assert ".review-group-switch button:first-child.active + button::before" in STYLE
+    assert "height: calc(100% - var(--review-tab-cut) - var(--review-tab-radius))" in STYLE
     assert "flex: 1 1 auto" in STYLE
     assert "text-overflow: ellipsis" in STYLE
     source = current_workspace_source()


### PR DESCRIPTION
## Summary
- round only the two endpoints of each 10px Diff-tab chamfer with a subtle 3px curve
- retain the polygon chamfer as a compatibility fallback
- stop the Changes/Shell files divider at the beginning of the active Changes chamfer instead of extending it to the bottom edge
- preserve the existing tab dimensions and centerline geometry

## Verification
- `./sc test tests/test_conversation_diff_ui.py tests/test_conversation_diff_browser.py::test_diff_workspace_preserves_live_chat_and_uses_get_only` (10 passed)
- production-stylesheet Playwright visual check in both active states
- `./sc render-check`
- `git diff --check`

`./sc verify` is not branch-safe from linked worktrees; tracked in #769.