### PR TITLE
feat: add Sprint v2 domain lifecycle

### DIFF
--- a/.super-coder/migrations/0146_sprint_v2_domain.sql
+++ b/.super-coder/migrations/0146_sprint_v2_domain.sql
@@ -1,0 +1,390 @@
+-- 0146 — Sprints v2 durable domain foundation.
+--
+-- Sprint v1 was deliberately removed by migration 0144.  These tables are a
+-- new domain: lifecycle is small and explicit, collaboration messages do not
+-- share generic shell_messages rows, and external work is represented by
+-- outbox/observation records rather than performed inside transactions.
+
+BEGIN;
+
+CREATE TABLE sprint_spec_approvals (
+    approval_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    document_id        INTEGER NOT NULL REFERENCES documents(document_id),
+    revision_sha256    TEXT NOT NULL
+                       CHECK (
+                         length(revision_sha256)=64
+                         AND revision_sha256 NOT GLOB '*[^0-9a-f]*'
+                       ),
+    reviewer_shell_id  INTEGER NOT NULL REFERENCES shells(shell_id),
+    verdict            TEXT NOT NULL CHECK (verdict IN ('pass','fail')),
+    findings_document_id INTEGER REFERENCES documents(document_id),
+    reviewed_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (document_id, revision_sha256, reviewer_shell_id)
+);
+
+CREATE TABLE sprints (
+    sprint_id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_id                   INTEGER NOT NULL REFERENCES roadmap(feature_id),
+    originating_planner_shell_id INTEGER NOT NULL REFERENCES shells(shell_id),
+    lifecycle                    TEXT NOT NULL DEFAULT 'prepared'
+                                 CHECK (lifecycle IN
+                                   ('prepared','armed','paused',
+                                    'completed','aborted')),
+    merge_grant_enabled          INTEGER NOT NULL DEFAULT 0
+                                 CHECK (merge_grant_enabled IN (0,1)),
+    terminal_outcome             TEXT,
+    created_at                   TEXT NOT NULL DEFAULT (datetime('now')),
+    armed_at                     TEXT,
+    paused_at                    TEXT,
+    completed_at                 TEXT,
+    aborted_at                   TEXT,
+    updated_at                   TEXT NOT NULL DEFAULT (datetime('now')),
+    version                      INTEGER NOT NULL DEFAULT 1 CHECK (version > 0),
+    CHECK (
+      (lifecycle IN ('completed','aborted') AND terminal_outcome IS NOT NULL)
+      OR
+      (lifecycle NOT IN ('completed','aborted') AND terminal_outcome IS NULL)
+    )
+);
+
+-- SQLite has one writer but can have many processes deciding concurrently.
+-- The invariant therefore belongs in the database, inside the arm transaction.
+CREATE UNIQUE INDEX idx_sprints_single_armed
+    ON sprints((1)) WHERE lifecycle='armed';
+CREATE INDEX idx_sprints_feature ON sprints(feature_id, sprint_id);
+
+CREATE TRIGGER trg_sprints_lifecycle
+BEFORE UPDATE OF lifecycle ON sprints
+WHEN NEW.lifecycle <> OLD.lifecycle AND NOT (
+    (OLD.lifecycle='prepared' AND NEW.lifecycle IN ('armed','aborted')) OR
+    (OLD.lifecycle='armed' AND NEW.lifecycle IN
+        ('paused','completed','aborted')) OR
+    (OLD.lifecycle='paused' AND NEW.lifecycle IN ('armed','aborted'))
+)
+BEGIN
+  SELECT RAISE(ABORT, 'illegal Sprint lifecycle transition');
+END;
+
+CREATE TRIGGER trg_sprints_arming_requires_grant
+BEFORE UPDATE OF lifecycle ON sprints
+WHEN NEW.lifecycle='armed' AND NEW.merge_grant_enabled<>1
+BEGIN
+  SELECT RAISE(ABORT, 'arming requires a committed Sprint merge grant');
+END;
+
+CREATE TABLE sprint_specs (
+    sprint_id              INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    document_id            INTEGER NOT NULL REFERENCES documents(document_id),
+    bound_revision_sha256  TEXT NOT NULL
+                           CHECK (
+                             length(bound_revision_sha256)=64
+                             AND bound_revision_sha256 NOT GLOB '*[^0-9a-f]*'
+                           ),
+    approval_id            INTEGER NOT NULL
+                           REFERENCES sprint_spec_approvals(approval_id),
+    included_at            TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (sprint_id, document_id)
+);
+
+CREATE TABLE sprint_participants (
+    participant_id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id               INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    shell_id                INTEGER NOT NULL REFERENCES shells(shell_id),
+    role                    TEXT NOT NULL
+                            CHECK (role IN ('planner','developer','reviewer')),
+    harness                 TEXT NOT NULL CHECK (trim(harness)<>''),
+    model                   TEXT,
+    effort                  TEXT,
+    route                   TEXT,
+    persistent_conversation_id TEXT REFERENCES conversations(conversation_id),
+    current_conversation_id TEXT REFERENCES conversations(conversation_id),
+    disposition             TEXT NOT NULL DEFAULT 'assigned'
+                            CHECK (disposition IN
+                              ('assigned','active','idle','declined','complete')),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (sprint_id, shell_id),
+    UNIQUE (sprint_id, participant_id)
+);
+CREATE INDEX idx_sprint_participants_shell
+    ON sprint_participants(shell_id, sprint_id);
+
+CREATE TABLE sprint_work_units (
+    work_unit_id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id                INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    assigned_shell_id        INTEGER NOT NULL REFERENCES shells(shell_id),
+    reviewer_shell_id        INTEGER NOT NULL REFERENCES shells(shell_id),
+    title                    TEXT NOT NULL CHECK (trim(title)<>''),
+    expected_output          TEXT NOT NULL CHECK (trim(expected_output)<>''),
+    planned_wave             INTEGER NOT NULL DEFAULT 0
+                             CHECK (planned_wave >= 0),
+    disposition             TEXT NOT NULL DEFAULT 'planned'
+                            CHECK (disposition IN
+                              ('planned','ready','active','blocked','in_review',
+                               'fixing','merge_ready','completed','cancelled')),
+    created_at               TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at               TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at             TEXT,
+    UNIQUE (sprint_id, work_unit_id)
+);
+CREATE INDEX idx_sprint_work_units_state
+    ON sprint_work_units(sprint_id, disposition, planned_wave, work_unit_id);
+CREATE UNIQUE INDEX idx_sprint_one_editing_lane
+    ON sprint_work_units(sprint_id, assigned_shell_id)
+    WHERE disposition IN ('active','in_review','fixing','merge_ready');
+
+CREATE TABLE sprint_work_unit_tasks (
+    sprint_id    INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    work_unit_id INTEGER NOT NULL,
+    task_id      INTEGER NOT NULL REFERENCES spec_tasks(task_id),
+    PRIMARY KEY (sprint_id, work_unit_id, task_id),
+    UNIQUE (task_id),
+    FOREIGN KEY (sprint_id, work_unit_id)
+      REFERENCES sprint_work_units(sprint_id, work_unit_id)
+);
+
+CREATE TABLE sprint_work_unit_dependencies (
+    sprint_id               INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    work_unit_id            INTEGER NOT NULL,
+    depends_on_work_unit_id INTEGER NOT NULL,
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (sprint_id, work_unit_id, depends_on_work_unit_id),
+    CHECK (work_unit_id <> depends_on_work_unit_id),
+    FOREIGN KEY (sprint_id, work_unit_id)
+      REFERENCES sprint_work_units(sprint_id, work_unit_id),
+    FOREIGN KEY (sprint_id, depends_on_work_unit_id)
+      REFERENCES sprint_work_units(sprint_id, work_unit_id)
+);
+CREATE INDEX idx_sprint_work_unit_dependencies_upstream
+    ON sprint_work_unit_dependencies(depends_on_work_unit_id, work_unit_id);
+
+CREATE TABLE sprint_messages (
+    message_id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id               INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    from_participant_id     INTEGER REFERENCES sprint_participants(participant_id),
+    to_participant_id       INTEGER NOT NULL
+                            REFERENCES sprint_participants(participant_id),
+    work_unit_id            INTEGER REFERENCES sprint_work_units(work_unit_id),
+    message_kind            TEXT NOT NULL
+                            CHECK (message_kind IN
+                              ('work_assignment','review_request','notification',
+                               'nudge','escalation','system')),
+    body                    TEXT NOT NULL CHECK (length(body)>0),
+    actionable              INTEGER NOT NULL DEFAULT 0
+                            CHECK (actionable IN (0,1)),
+    disposition             TEXT
+                            CHECK (disposition IN
+                              ('pending','accepted','declined')),
+    read_at                 TEXT,
+    decline_reason          TEXT,
+    idempotency_key         TEXT NOT NULL UNIQUE
+                            CHECK (length(idempotency_key) BETWEEN 1 AND 255),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK (
+      (actionable=1 AND disposition IS NOT NULL)
+      OR
+      (actionable=0 AND disposition IS NULL)
+    ),
+    CHECK (
+      disposition<>'declined' OR trim(COALESCE(decline_reason,''))<>''
+    ),
+    UNIQUE (sprint_id, message_id),
+    FOREIGN KEY (sprint_id, from_participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id),
+    FOREIGN KEY (sprint_id, to_participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id),
+    FOREIGN KEY (sprint_id, work_unit_id)
+      REFERENCES sprint_work_units(sprint_id, work_unit_id)
+);
+CREATE INDEX idx_sprint_messages_inbox
+    ON sprint_messages(to_participant_id, read_at, message_id);
+
+CREATE TABLE sprint_wake_outbox (
+    wake_id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id               INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    participant_id          INTEGER NOT NULL
+                            REFERENCES sprint_participants(participant_id),
+    state                   TEXT NOT NULL DEFAULT 'pending'
+                            CHECK (state IN
+                              ('pending','delivering','delivered','failed','cancelled')),
+    attempt_count           INTEGER NOT NULL DEFAULT 0
+                            CHECK (attempt_count BETWEEN 0 AND 3),
+    idempotency_key         TEXT NOT NULL UNIQUE
+                            CHECK (length(idempotency_key) BETWEEN 1 AND 255),
+    last_error              TEXT
+                            CHECK (last_error IS NULL OR length(last_error)<=16384),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    available_at            TEXT NOT NULL DEFAULT (datetime('now')),
+    delivered_at            TEXT,
+    failed_at               TEXT,
+    UNIQUE (sprint_id, wake_id),
+    FOREIGN KEY (sprint_id, participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id)
+);
+CREATE INDEX idx_sprint_wake_outbox_claim
+    ON sprint_wake_outbox(state, available_at, wake_id);
+
+CREATE TABLE sprint_wake_messages (
+    sprint_id   INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    wake_id     INTEGER NOT NULL,
+    message_id  INTEGER NOT NULL UNIQUE,
+    PRIMARY KEY (sprint_id, wake_id, message_id),
+    FOREIGN KEY (sprint_id, wake_id)
+      REFERENCES sprint_wake_outbox(sprint_id, wake_id),
+    FOREIGN KEY (sprint_id, message_id)
+      REFERENCES sprint_messages(sprint_id, message_id)
+);
+
+CREATE TABLE sprint_wake_attempts (
+    attempt_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    wake_id           INTEGER NOT NULL REFERENCES sprint_wake_outbox(wake_id),
+    attempt_number    INTEGER NOT NULL CHECK (attempt_number BETWEEN 1 AND 3),
+    target_conversation_id TEXT REFERENCES conversations(conversation_id),
+    native_run_ref    TEXT,
+    outcome           TEXT NOT NULL
+                      CHECK (outcome IN ('delivered','failed','coalesced')),
+    error_detail      TEXT
+                      CHECK (error_detail IS NULL OR length(error_detail)<=16384),
+    attempted_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (wake_id, attempt_number)
+);
+
+CREATE TABLE sprint_registered_prs (
+    registered_pr_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id        INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    owner_participant_id INTEGER NOT NULL
+                        REFERENCES sprint_participants(participant_id),
+    repository       TEXT NOT NULL CHECK (trim(repository)<>''),
+    pr_number        INTEGER NOT NULL CHECK (pr_number>0),
+    registered_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (repository, pr_number),
+    UNIQUE (sprint_id, registered_pr_id),
+    FOREIGN KEY (sprint_id, owner_participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id)
+);
+
+CREATE TABLE sprint_pr_work_units (
+    sprint_id        INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    registered_pr_id INTEGER NOT NULL,
+    work_unit_id     INTEGER NOT NULL,
+    PRIMARY KEY (sprint_id, registered_pr_id, work_unit_id),
+    FOREIGN KEY (sprint_id, registered_pr_id)
+      REFERENCES sprint_registered_prs(sprint_id, registered_pr_id),
+    FOREIGN KEY (sprint_id, work_unit_id)
+      REFERENCES sprint_work_units(sprint_id, work_unit_id)
+);
+
+CREATE TABLE sprint_pr_transitions (
+    transition_id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    registered_pr_id INTEGER NOT NULL
+                     REFERENCES sprint_registered_prs(registered_pr_id),
+    normalized_state TEXT NOT NULL
+                     CHECK (normalized_state IN
+                       ('created','pending','red','green','merged','closed')),
+    transition_key   TEXT NOT NULL UNIQUE,
+    observed_head_sha TEXT,
+    evidence         TEXT NOT NULL DEFAULT '{}'
+                     CHECK (json_valid(evidence) AND json_type(evidence)='object'),
+    observed_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_sprint_pr_transitions_latest
+    ON sprint_pr_transitions(registered_pr_id, transition_id DESC);
+
+CREATE TABLE sprint_judgments (
+    judgment_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id        INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    participant_id   INTEGER NOT NULL
+                     REFERENCES sprint_participants(participant_id),
+    work_unit_id     INTEGER REFERENCES sprint_work_units(work_unit_id),
+    kind             TEXT NOT NULL
+                     CHECK (kind IN ('ambiguity','decision','deviation','issue')),
+    body             TEXT NOT NULL CHECK (trim(body)<>''),
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (sprint_id, participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id),
+    FOREIGN KEY (sprint_id, work_unit_id)
+      REFERENCES sprint_work_units(sprint_id, work_unit_id)
+);
+
+CREATE TABLE sprint_reports (
+    report_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id        INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    report_kind      TEXT NOT NULL
+                     CHECK (report_kind IN
+                       ('pause','conformance','final','abort')),
+    author_shell_id  INTEGER REFERENCES shells(shell_id),
+    body             TEXT NOT NULL CHECK (trim(body)<>''),
+    created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE sprint_events (
+    event_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id        INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    event_type       TEXT NOT NULL CHECK (trim(event_type)<>''),
+    actor_kind       TEXT NOT NULL
+                     CHECK (actor_kind IN
+                       ('planner','fnb','participant','system')),
+    actor_shell_id   INTEGER REFERENCES shells(shell_id),
+    payload          TEXT NOT NULL DEFAULT '{}'
+                     CHECK (json_valid(payload) AND json_type(payload)='object'),
+    created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_sprint_events_timeline
+    ON sprint_events(sprint_id, event_id);
+
+-- Evidence is append-only.  Current projections have their own authoritative
+-- transition paths; history is never rewritten to make recovery look cleaner.
+CREATE TRIGGER trg_sprint_wake_attempts_append_only_update
+BEFORE UPDATE ON sprint_wake_attempts BEGIN
+  SELECT RAISE(ABORT, 'Sprint wake attempts are append-only');
+END;
+CREATE TRIGGER trg_sprint_wake_attempts_append_only_delete
+BEFORE DELETE ON sprint_wake_attempts BEGIN
+  SELECT RAISE(ABORT, 'Sprint wake attempts are append-only');
+END;
+CREATE TRIGGER trg_sprint_pr_transitions_append_only_update
+BEFORE UPDATE ON sprint_pr_transitions BEGIN
+  SELECT RAISE(ABORT, 'Sprint PR transitions are append-only');
+END;
+CREATE TRIGGER trg_sprint_pr_transitions_append_only_delete
+BEFORE DELETE ON sprint_pr_transitions BEGIN
+  SELECT RAISE(ABORT, 'Sprint PR transitions are append-only');
+END;
+CREATE TRIGGER trg_sprint_events_append_only_update
+BEFORE UPDATE ON sprint_events BEGIN
+  SELECT RAISE(ABORT, 'Sprint events are append-only');
+END;
+CREATE TRIGGER trg_sprint_events_append_only_delete
+BEFORE DELETE ON sprint_events BEGIN
+  SELECT RAISE(ABORT, 'Sprint events are append-only');
+END;
+CREATE TRIGGER trg_sprint_judgments_append_only_update
+BEFORE UPDATE ON sprint_judgments BEGIN
+  SELECT RAISE(ABORT, 'Sprint judgments are append-only');
+END;
+CREATE TRIGGER trg_sprint_judgments_append_only_delete
+BEFORE DELETE ON sprint_judgments BEGIN
+  SELECT RAISE(ABORT, 'Sprint judgments are append-only');
+END;
+CREATE TRIGGER trg_sprint_reports_append_only_update
+BEFORE UPDATE ON sprint_reports BEGIN
+  SELECT RAISE(ABORT, 'Sprint reports are append-only');
+END;
+CREATE TRIGGER trg_sprint_reports_append_only_delete
+BEFORE DELETE ON sprint_reports BEGIN
+  SELECT RAISE(ABORT, 'Sprint reports are append-only');
+END;
+CREATE TRIGGER trg_sprint_messages_content_immutable
+BEFORE UPDATE OF
+    message_id, sprint_id, from_participant_id, to_participant_id,
+    work_unit_id, message_kind, body, actionable, idempotency_key, created_at
+ON sprint_messages
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint message identity and content are immutable');
+END;
+CREATE TRIGGER trg_sprint_messages_no_delete
+BEFORE DELETE ON sprint_messages BEGIN
+  SELECT RAISE(ABORT, 'Sprint messages are durable facts');
+END;
+
+COMMIT;

--- a/.super-coder/migrations/0146_sprint_v2_domain.sql
+++ b/.super-coder/migrations/0146_sprint_v2_domain.sql
@@ -53,6 +53,23 @@ CREATE UNIQUE INDEX idx_sprints_single_armed
     ON sprints((1)) WHERE lifecycle='armed';
 CREATE INDEX idx_sprints_feature ON sprints(feature_id, sprint_id);
 
+-- Every Sprint must pass through the authoritative prepared -> armed path.
+-- Once that path commits the merge grant, later lifecycle states retain it.
+CREATE TRIGGER trg_sprints_insert_prepared_only
+BEFORE INSERT ON sprints
+WHEN NEW.lifecycle<>'prepared'
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint inserts must start prepared');
+END;
+
+CREATE TRIGGER trg_sprints_merge_grant_immutable_after_arm
+BEFORE UPDATE OF merge_grant_enabled ON sprints
+WHEN NEW.merge_grant_enabled<>OLD.merge_grant_enabled
+  AND OLD.lifecycle<>'prepared'
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint merge grant is immutable after arming');
+END;
+
 CREATE TRIGGER trg_sprints_lifecycle
 BEFORE UPDATE OF lifecycle ON sprints
 WHEN NEW.lifecycle <> OLD.lifecycle AND NOT (

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Sprints v2 lifecycle authority, arming transaction, and service gate.
+
+This module deliberately owns no GitHub or harness effects.  It commits the
+durable facts those services consume, and the ArmedServiceSwitch prevents
+registered poll/dispatch callbacks from running outside an armed Sprint.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass
+
+import db_driver
+
+
+SPRINT_TRANSITIONS = {
+    "prepared": frozenset({"armed", "aborted"}),
+    "armed": frozenset({"paused", "completed", "aborted"}),
+    "paused": frozenset({"armed", "aborted"}),
+    "completed": frozenset(),
+    "aborted": frozenset(),
+}
+
+
+class SprintLifecycleError(ValueError):
+    """Base class for a rejected Sprint lifecycle operation."""
+
+
+class SprintStateError(SprintLifecycleError):
+    """The requested lifecycle edge is unknown or illegal."""
+
+
+class SprintAuthorityError(SprintLifecycleError):
+    """The actor does not own the requested lifecycle transition."""
+
+
+class SprintInvariantError(SprintLifecycleError):
+    """The durable Sprint plan is not eligible for the requested transition."""
+
+
+@dataclass(frozen=True)
+class LifecycleActor:
+    kind: str
+    shell_id: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"planner", "fnb", "participant", "system"}:
+            raise ValueError(f"unknown Sprint actor kind: {self.kind}")
+        if self.kind in {"planner", "participant"} and self.shell_id is None:
+            raise ValueError(f"{self.kind} actor requires shell_id")
+
+
+def transition_allowed(current: str, target: str) -> bool:
+    return (
+        current in SPRINT_TRANSITIONS
+        and target in SPRINT_TRANSITIONS
+        and (target == current or target in SPRINT_TRANSITIONS[current])
+    )
+
+
+class SprintLifecycleStore:
+    """Transactional lifecycle operations over one engine DB connection."""
+
+    def __init__(self, con: sqlite3.Connection) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+
+    def armed_sprint_id(self) -> int | None:
+        row = self.con.execute(
+            "SELECT sprint_id FROM sprints WHERE lifecycle='armed'"
+        ).fetchone()
+        return int(row[0]) if row is not None else None
+
+    def arm(self, sprint_id: int, planner_shell_id: int) -> list[int]:
+        """Arm an eligible prepared Sprint and release initial work atomically.
+
+        The returned IDs name the committed wake intents.  A uniqueness failure
+        or any invalid plan rolls back the lifecycle update, messages, wakes,
+        and work-unit dispositions together.
+        """
+        actor = LifecycleActor("planner", planner_shell_id)
+        with db_driver.write_transaction(self.con, "sprint.arm"):
+            sprint = self._sprint(sprint_id)
+            if sprint["lifecycle"] != "prepared":
+                raise SprintStateError(
+                    f"arm() requires prepared; found {sprint['lifecycle']}"
+                )
+            self._require_edge(sprint["lifecycle"], "armed")
+            self._authorize(sprint, "armed", actor)
+            planner_participant = self._validate_arm_plan(sprint)
+            self._update_lifecycle(
+                sprint_id,
+                current="prepared",
+                target="armed",
+                outcome=None,
+            )
+            wake_ids = self._release_initial_work(
+                sprint_id,
+                planner_participant_id=planner_participant,
+            )
+            self._event(
+                sprint_id,
+                "lifecycle.armed",
+                actor,
+                {"initial_wake_ids": wake_ids},
+            )
+        return wake_ids
+
+    def transition(
+        self,
+        sprint_id: int,
+        target: str,
+        actor: LifecycleActor,
+        *,
+        reason: str | None = None,
+        terminal_outcome: str | None = None,
+    ) -> bool:
+        """Apply one authorized edge; same-state requests are idempotent."""
+        with db_driver.write_transaction(self.con, "sprint.transition"):
+            sprint = self._sprint(sprint_id)
+            current = str(sprint["lifecycle"])
+            if target == current:
+                return False
+            if current == "prepared" and target == "armed":
+                raise SprintInvariantError(
+                    "prepared Sprints must use arm() so plan release is atomic"
+                )
+            self._require_edge(current, target)
+            self._authorize(sprint, target, actor)
+            if target in {"completed", "aborted"} and not terminal_outcome:
+                raise SprintInvariantError(
+                    f"{target} transition requires terminal_outcome"
+                )
+            self._update_lifecycle(
+                sprint_id,
+                current=current,
+                target=target,
+                outcome=terminal_outcome,
+            )
+            self._event(
+                sprint_id,
+                f"lifecycle.{target}",
+                actor,
+                {"from": current, "reason": reason},
+            )
+        return True
+
+    def record_wake_failure(self, wake_id: int, error: str) -> int:
+        """Record one failed attempt; attempt three atomically auto-pauses."""
+        if not error.strip():
+            raise ValueError("wake failure requires an error")
+        with db_driver.write_transaction(self.con, "sprint.wake_failure"):
+            row = self.con.execute(
+                "SELECT wake_id,sprint_id,state,attempt_count "
+                "FROM sprint_wake_outbox WHERE wake_id=?",
+                (wake_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"unknown Sprint wake: {wake_id}")
+            if row["state"] in {"delivered", "failed", "cancelled"}:
+                raise SprintInvariantError(
+                    f"wake {wake_id} is terminal ({row['state']})"
+                )
+            attempt = int(row["attempt_count"]) + 1
+            if attempt > 3:
+                raise SprintInvariantError(f"wake {wake_id} exhausted attempts")
+            self.con.execute(
+                "INSERT INTO sprint_wake_attempts "
+                "(wake_id,attempt_number,outcome,error_detail) "
+                "VALUES (?,?,'failed',?)",
+                (wake_id, attempt, error),
+            )
+            terminal = attempt == 3
+            self.con.execute(
+                "UPDATE sprint_wake_outbox SET attempt_count=?,state=?,"
+                "last_error=?,failed_at=CASE WHEN ? THEN datetime('now') "
+                "ELSE NULL END WHERE wake_id=?",
+                (
+                    attempt,
+                    "failed" if terminal else "pending",
+                    error,
+                    1 if terminal else 0,
+                    wake_id,
+                ),
+            )
+            if terminal:
+                sprint = self._sprint(int(row["sprint_id"]))
+                if sprint["lifecycle"] == "armed":
+                    self._update_lifecycle(
+                        int(row["sprint_id"]),
+                        current="armed",
+                        target="paused",
+                        outcome=None,
+                    )
+                    body = json.dumps(
+                        {
+                            "reason": "wake_delivery_exhausted",
+                            "wake_id": wake_id,
+                            "attempts": 3,
+                            "last_error": error,
+                        },
+                        sort_keys=True,
+                    )
+                    self.con.execute(
+                        "INSERT INTO sprint_reports "
+                        "(sprint_id,report_kind,body) VALUES (?,'pause',?)",
+                        (int(row["sprint_id"]), body),
+                    )
+                    self._event(
+                        int(row["sprint_id"]),
+                        "lifecycle.paused",
+                        LifecycleActor("system"),
+                        {
+                            "reason": "wake_delivery_exhausted",
+                            "wake_id": wake_id,
+                        },
+                    )
+        return attempt
+
+    def _sprint(self, sprint_id: int) -> sqlite3.Row:
+        row = self.con.execute(
+            "SELECT * FROM sprints WHERE sprint_id=?", (sprint_id,)
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown Sprint: {sprint_id}")
+        return row
+
+    @staticmethod
+    def _require_edge(current: str, target: str) -> None:
+        if current not in SPRINT_TRANSITIONS or not transition_allowed(
+            current, target
+        ):
+            allowed = ", ".join(sorted(SPRINT_TRANSITIONS.get(current, ()))) or "none"
+            raise SprintStateError(
+                f"illegal Sprint lifecycle transition {current} -> {target}; "
+                f"allowed: {allowed}"
+            )
+
+    def _authorize(
+        self,
+        sprint: sqlite3.Row,
+        target: str,
+        actor: LifecycleActor,
+    ) -> None:
+        current = str(sprint["lifecycle"])
+        edge = (current, target)
+        if edge == ("prepared", "armed"):
+            allowed = {"planner"}
+        elif target == "paused":
+            allowed = {"planner", "fnb", "participant", "system"}
+        elif edge == ("paused", "armed"):
+            allowed = {"planner", "fnb"}
+        elif target in {"completed", "aborted"}:
+            allowed = {"planner", "fnb"}
+        else:
+            allowed = set()
+        if actor.kind not in allowed:
+            raise SprintAuthorityError(
+                f"{actor.kind} cannot transition Sprint {current} -> {target}"
+            )
+        if actor.kind == "planner" and actor.shell_id != sprint[
+            "originating_planner_shell_id"
+        ]:
+            raise SprintAuthorityError("only the originating Planner owns this edge")
+        if actor.kind == "participant":
+            exists = self.con.execute(
+                "SELECT 1 FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=?",
+                (sprint["sprint_id"], actor.shell_id),
+            ).fetchone()
+            if exists is None:
+                raise SprintAuthorityError(
+                    "only an assigned participant may pause this Sprint"
+                )
+
+    def _validate_arm_plan(self, sprint: sqlite3.Row) -> int:
+        sprint_id = int(sprint["sprint_id"])
+        if int(sprint["merge_grant_enabled"]) != 1:
+            raise SprintInvariantError("arming requires a committed merge grant")
+        invalid_specs = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_specs ss "
+            "JOIN sprint_spec_approvals a ON a.approval_id=ss.approval_id "
+            "JOIN documents d ON d.document_id=ss.document_id "
+            "WHERE ss.sprint_id=? AND "
+            "(a.verdict<>'pass' OR a.document_id<>ss.document_id "
+            "OR a.revision_sha256<>ss.bound_revision_sha256 "
+            "OR d.kind<>'spec' OR d.feature_id<>?)",
+            (sprint_id, sprint["feature_id"]),
+        ).fetchone()[0]
+        bound_specs = self.con.execute(
+            "SELECT ss.bound_revision_sha256,d.body FROM sprint_specs ss "
+            "JOIN documents d ON d.document_id=ss.document_id "
+            "WHERE ss.sprint_id=?",
+            (sprint_id,),
+        ).fetchall()
+        current_revision_mismatch = any(
+            row["body"] is None
+            or hashlib.sha256(row["body"].encode()).hexdigest()
+            != row["bound_revision_sha256"]
+            for row in bound_specs
+        )
+        if not bound_specs or invalid_specs or current_revision_mismatch:
+            raise SprintInvariantError(
+                "arming requires at least one exact, passing spec approval"
+            )
+        roles = {
+            row[0]
+            for row in self.con.execute(
+                "SELECT DISTINCT role FROM sprint_participants WHERE sprint_id=?",
+                (sprint_id,),
+            )
+        }
+        if roles != {"planner", "developer", "reviewer"}:
+            raise SprintInvariantError(
+                "arming requires Planner, Developer, and Reviewer capacity"
+            )
+        unavailable = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_participants p "
+            "JOIN shells sh ON sh.shell_id=p.shell_id "
+            "WHERE p.sprint_id=? AND sh.is_deleted<>0",
+            (sprint_id,),
+        ).fetchone()[0]
+        if unavailable:
+            raise SprintInvariantError("arming requires active participant shells")
+        planner = self.con.execute(
+            "SELECT participant_id FROM sprint_participants "
+            "WHERE sprint_id=? AND shell_id=? AND role='planner'",
+            (sprint_id, sprint["originating_planner_shell_id"]),
+        ).fetchone()
+        if planner is None:
+            raise SprintInvariantError(
+                "originating Planner must be an assigned Sprint participant"
+            )
+        unit_count = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_work_units WHERE sprint_id=?",
+            (sprint_id,),
+        ).fetchone()[0]
+        invalid_units = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_work_units u "
+            "LEFT JOIN sprint_participants d "
+            "ON d.sprint_id=u.sprint_id AND d.shell_id=u.assigned_shell_id "
+            "AND d.role='developer' "
+            "LEFT JOIN sprint_participants r "
+            "ON r.sprint_id=u.sprint_id AND r.shell_id=u.reviewer_shell_id "
+            "AND r.role='reviewer' "
+            "WHERE u.sprint_id=? "
+            "AND (d.participant_id IS NULL OR r.participant_id IS NULL)",
+            (sprint_id,),
+        ).fetchone()[0]
+        if unit_count == 0 or invalid_units:
+            raise SprintInvariantError(
+                "arming requires routed work units with assigned reviewers"
+            )
+        return int(planner[0])
+
+    def _release_initial_work(
+        self,
+        sprint_id: int,
+        *,
+        planner_participant_id: int,
+    ) -> list[int]:
+        units = self.con.execute(
+            "SELECT u.work_unit_id,u.assigned_shell_id,u.title,u.expected_output,"
+            "p.participant_id FROM sprint_work_units u "
+            "JOIN sprint_participants p ON p.sprint_id=u.sprint_id "
+            "AND p.shell_id=u.assigned_shell_id AND p.role='developer' "
+            "WHERE u.sprint_id=? AND u.disposition='planned' "
+            "AND NOT EXISTS (SELECT 1 FROM sprint_work_unit_dependencies d "
+            "WHERE d.work_unit_id=u.work_unit_id) "
+            "ORDER BY u.planned_wave,u.work_unit_id",
+            (sprint_id,),
+        ).fetchall()
+        wake_ids: list[int] = []
+        for unit in units:
+            unit_id = int(unit["work_unit_id"])
+            key = f"sprint:{sprint_id}:work-unit:{unit_id}:assignment"
+            message_id = self.con.execute(
+                "INSERT INTO sprint_messages "
+                "(sprint_id,from_participant_id,to_participant_id,work_unit_id,"
+                "message_kind,body,actionable,disposition,idempotency_key) "
+                "VALUES (?,?,?,?,?,?,1,'pending',?)",
+                (
+                    sprint_id,
+                    planner_participant_id,
+                    unit["participant_id"],
+                    unit_id,
+                    "work_assignment",
+                    f"{unit['title']}\n\n{unit['expected_output']}",
+                    key,
+                ),
+            ).lastrowid
+            wake_id = self.con.execute(
+                "INSERT INTO sprint_wake_outbox "
+                "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
+                (sprint_id, unit["participant_id"], f"wake:{key}"),
+            ).lastrowid
+            self.con.execute(
+                "INSERT INTO sprint_wake_messages "
+                "(sprint_id,wake_id,message_id) VALUES (?,?,?)",
+                (sprint_id, wake_id, message_id),
+            )
+            self.con.execute(
+                "UPDATE sprint_work_units SET disposition='ready',"
+                "updated_at=datetime('now') WHERE work_unit_id=?",
+                (unit_id,),
+            )
+            wake_ids.append(int(wake_id))
+        return wake_ids
+
+    def _update_lifecycle(
+        self,
+        sprint_id: int,
+        *,
+        current: str,
+        target: str,
+        outcome: str | None,
+    ) -> None:
+        timestamp_column = {
+            "armed": "armed_at",
+            "paused": "paused_at",
+            "completed": "completed_at",
+            "aborted": "aborted_at",
+        }[target]
+        result = self.con.execute(
+            f"UPDATE sprints SET lifecycle=?,terminal_outcome=?,"
+            f"{timestamp_column}=datetime('now'),updated_at=datetime('now'),"
+            "version=version+1 WHERE sprint_id=? AND lifecycle=?",
+            (target, outcome, sprint_id, current),
+        )
+        if result.rowcount != 1:
+            raise SprintStateError("Sprint lifecycle changed concurrently")
+
+    def _event(
+        self,
+        sprint_id: int,
+        event_type: str,
+        actor: LifecycleActor,
+        payload: dict,
+    ) -> None:
+        self.con.execute(
+            "INSERT INTO sprint_events "
+            "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+            "VALUES (?,?,?,?,?)",
+            (
+                sprint_id,
+                event_type,
+                actor.kind,
+                actor.shell_id,
+                json.dumps(payload, sort_keys=True),
+            ),
+        )
+
+
+class ArmedServiceSwitch:
+    """Run Sprint external-service callbacks only while a Sprint is armed.
+
+    ``recover_on_startup`` is the restart seam: it reads durable lifecycle once
+    and immediately services an armed Sprint.  A supervisor may call ``tick``
+    on its normal pulse; prepared, paused, completed, aborted, and empty states
+    invoke zero callbacks.
+    """
+
+    def __init__(
+        self,
+        store: SprintLifecycleStore,
+        callbacks: Iterable[Callable[[int, str], None]],
+    ) -> None:
+        self.store = store
+        self.callbacks = tuple(callbacks)
+
+    def recover_on_startup(self) -> bool:
+        return self._run("startup")
+
+    def tick(self) -> bool:
+        return self._run("pulse")
+
+    def _run(self, trigger: str) -> bool:
+        sprint_id = self.store.armed_sprint_id()
+        if sprint_id is None:
+            return False
+        for callback in self.callbacks:
+            callback(sprint_id, trigger)
+        return True

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -1,11 +1,14 @@
 {
   "allowed_reference_files": [
+    ".super-coder/migrations/0146_sprint_v2_domain.sql",
+    ".super-coder/scripts/sprint_domain.py",
     ".super-coder/migrations/0144_remove_sprint_v1.sql",
     "tests/fixtures/sprint_removal/build_pre_removal_fixture.py",
     "tests/fixtures/sprint_removal/manifest.json",
     "tests/fixtures/sprint_removal/pre_removal.sql",
     "tests/test_sprint_entrypoint_removal.py",
-    "tests/test_sprint_removal_manifest.py"
+    "tests/test_sprint_removal_manifest.py",
+    "tests/test_sprint_v2_domain.py"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -383,7 +383,7 @@ class ConversationBrokerCase(unittest.TestCase):
 
 
 class StoreContractTest(ConversationBrokerCase):
-    def test_normal_run_finishes_without_sprint_runtime_tables(self) -> None:
+    def test_normal_run_finishes_without_sprint_domain_writes(self) -> None:
         conversation_id = self.add_conversation()
         self.add_message(conversation_id)
         con = self.connect()
@@ -391,7 +391,6 @@ class StoreContractTest(ConversationBrokerCase):
             "sprint_assignment_results",
             "sprint_cancellations",
             "sprint_conversation_bindings",
-            "sprints",
         )
         present = {
             row[0]
@@ -400,6 +399,11 @@ class StoreContractTest(ConversationBrokerCase):
             ).fetchall()
         }
         self.assertTrue(set(absent_tables).isdisjoint(present))
+        self.assertTrue({"sprints", "sprint_events"}.issubset(present))
+        self.assertEqual(0, con.execute("SELECT COUNT(*) FROM sprints").fetchone()[0])
+        self.assertEqual(
+            0, con.execute("SELECT COUNT(*) FROM sprint_events").fetchone()[0]
+        )
         con.close()
 
         store = BrokerStore(self.db_path)
@@ -432,6 +436,13 @@ class StoreContractTest(ConversationBrokerCase):
                     (run.run_id,),
                 ).fetchone()[0],
                 "succeeded",
+            )
+            self.assertEqual(
+                (0, 0),
+                (
+                    con.execute("SELECT COUNT(*) FROM sprints").fetchone()[0],
+                    con.execute("SELECT COUNT(*) FROM sprint_events").fetchone()[0],
+                ),
             )
         finally:
             con.close()

--- a/tests/test_sprint_removal_manifest.py
+++ b/tests/test_sprint_removal_manifest.py
@@ -32,11 +32,13 @@ def build_pre_removal_database() -> sqlite3.Connection:
     return con
 
 
-def build_current_database() -> sqlite3.Connection:
+def build_current_database(*, through: str | None = None) -> sqlite3.Connection:
     con = sqlite3.connect(":memory:")
     con.row_factory = sqlite3.Row
     con.executescript((ENGINE / "schema.sql").read_text())
     for migration in sorted(MIGRATIONS.glob("*.sql")):
+        if through is not None and migration.name > through:
+            break
         con.executescript(migration.read_text())
     con.execute("PRAGMA foreign_keys=ON")
     return con
@@ -349,6 +351,8 @@ for name in sys.argv[2:]:
         with closing(sqlite3.connect(":memory:")) as con:
             con.executescript((ENGINE / "schema.sql").read_text())
             for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name > "0145_reseed_generic_guidance.sql":
+                    break
                 con.executescript(migration.read_text())
             con.execute("PRAGMA foreign_keys=ON")
 
@@ -490,6 +494,8 @@ for name in sys.argv[2:]:
 
         removed = set(load_manifest()["removed_tables"])
         for migration in sorted(MIGRATIONS.glob("*.sql")):
+            if migration.name > Path(removal["cleanup_migration"]).name:
+                continue
             if migration.name == Path(removal["cleanup_migration"]).name:
                 continue
             sql = migration.read_text().lower()
@@ -511,9 +517,11 @@ for name in sys.argv[2:]:
             self.assertNotIn("'sprint_rev'", sql, migration.name)
             self.assertNotIn("'sprint_cond'", sql, migration.name)
 
-    def test_task_170_fresh_build_contains_only_retained_schema(self):
+    def test_task_170_cutover_floor_contains_only_retained_schema(self):
         manifest = load_manifest()
-        with closing(build_current_database()) as con:
+        with closing(
+            build_current_database(through="0145_reseed_generic_guidance.sql")
+        ) as con:
             tables = {
                 row[0]
                 for row in con.execute(
@@ -739,7 +747,9 @@ for name in sys.argv[2:]:
             dirty.execute("PRAGMA foreign_keys=ON")
             dirty.executescript(cleanup.read_text())
             dirty.executescript(cleanup.read_text())
-            with closing(build_current_database()) as fresh:
+            with closing(
+                build_current_database(through="0145_reseed_generic_guidance.sql")
+            ) as fresh:
                 self.assertEqual(schema_signature(fresh), schema_signature(dirty))
                 self.assertEqual(
                     fresh.execute("PRAGMA foreign_key_check").fetchall(),

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Stage 1 gates for the Sprints v2 domain and lifecycle switch."""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+import tempfile
+import unittest
+from contextlib import closing
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+FOUNDATION = MIGRATIONS / "0146_sprint_v2_domain.sql"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import db_driver  # noqa: E402
+import sprint_domain  # noqa: E402
+
+
+def apply_schema(con: sqlite3.Connection, *, through: str | None = None) -> None:
+    con.executescript(SCHEMA.read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        if through is not None and migration.name > through:
+            break
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+class SprintDomainCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = sqlite3.connect(":memory:")
+        self.addCleanup(self.con.close)
+        self.con.row_factory = sqlite3.Row
+        apply_schema(self.con)
+        self.con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        self.con.executemany(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (?,?,?,?,?,1)",
+            (
+                (1, "Developer", "DEV1", "dev", "prompt"),
+                (2, "Reviewer", "REV1", "reviewer", "prompt"),
+                (3, "Planner", "PLN1", "planner", "prompt"),
+                (4, "Other planner", "PLN2", "planner", "prompt"),
+            ),
+        )
+        self.con.commit()
+        self.store = sprint_domain.SprintLifecycleStore(self.con)
+        self.serial = 0
+
+    def create_sprint(
+        self,
+        *,
+        merge_grant: bool = True,
+        approval_verdict: str = "pass",
+    ) -> tuple[int, int]:
+        self.serial += 1
+        serial = self.serial
+        feature_id = self.con.execute(
+            "INSERT INTO roadmap (title,roadmap_status) VALUES (?,'in_progress')",
+            (f"Feature {serial}",),
+        ).lastrowid
+        body = f"governing spec revision {serial}"
+        document_id = self.con.execute(
+            "INSERT INTO documents (feature_id,kind,seq,title,body) "
+            "VALUES (?,'spec',1,?,?)",
+            (feature_id, f"Spec {serial}", body),
+        ).lastrowid
+        revision = hashlib.sha256(body.encode()).hexdigest()
+        approval_id = self.con.execute(
+            "INSERT INTO sprint_spec_approvals "
+            "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+            "VALUES (?,?,2,?)",
+            (document_id, revision, approval_verdict),
+        ).lastrowid
+        sprint_id = self.con.execute(
+            "INSERT INTO sprints "
+            "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+            "VALUES (?,3,?)",
+            (feature_id, 1 if merge_grant else 0),
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO sprint_specs "
+            "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+            "VALUES (?,?,?,?)",
+            (sprint_id, document_id, revision, approval_id),
+        )
+        self.con.executemany(
+            "INSERT INTO sprint_participants "
+            "(sprint_id,shell_id,role,harness,model,effort) "
+            "VALUES (?,?,?,?,?,?)",
+            (
+                (sprint_id, 3, "planner", "codex", "planner-model", "high"),
+                (sprint_id, 1, "developer", "codex", "dev-model", "high"),
+                (sprint_id, 2, "reviewer", "kimi", "review-model", "high"),
+            ),
+        )
+        work_unit_id = self.con.execute(
+            "INSERT INTO sprint_work_units "
+            "(sprint_id,assigned_shell_id,reviewer_shell_id,title,expected_output) "
+            "VALUES (?,1,2,'Foundation','Ship the durable foundation')",
+            (sprint_id,),
+        ).lastrowid
+        self.con.commit()
+        return int(sprint_id), int(work_unit_id)
+
+
+class MigrationAndShapeTest(SprintDomainCase):
+    def test_upgrade_from_zero_sprint_baseline_creates_v2_domain(self) -> None:
+        with closing(sqlite3.connect(":memory:")) as con:
+            apply_schema(con, through="0145_reseed_generic_guidance.sql")
+            self.assertEqual(
+                [],
+                con.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name LIKE 'sprint%'"
+                ).fetchall(),
+            )
+            con.executescript(FOUNDATION.read_text())
+            tables = {
+                row[0]
+                for row in con.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+            self.assertTrue(
+                {
+                    "sprints",
+                    "sprint_specs",
+                    "sprint_participants",
+                    "sprint_work_units",
+                    "sprint_messages",
+                    "sprint_wake_outbox",
+                    "sprint_wake_attempts",
+                    "sprint_registered_prs",
+                    "sprint_pr_transitions",
+                    "sprint_judgments",
+                    "sprint_reports",
+                    "sprint_events",
+                }.issubset(tables)
+            )
+            self.assertEqual([], con.execute("PRAGMA foreign_key_check").fetchall())
+
+    def test_append_only_evidence_rejects_mutation_and_preserves_row(self) -> None:
+        sprint_id, _ = self.create_sprint()
+        self.store.arm(sprint_id, 3)
+        event = self.con.execute(
+            "SELECT event_id,event_type FROM sprint_events WHERE sprint_id=?",
+            (sprint_id,),
+        ).fetchone()
+        self.assertEqual("lifecycle.armed", event["event_type"])
+        with self.assertRaisesRegex(sqlite3.IntegrityError, "append-only"):
+            self.con.execute(
+                "UPDATE sprint_events SET event_type='rewritten' WHERE event_id=?",
+                (event["event_id"],),
+            )
+        self.assertEqual(
+            "lifecycle.armed",
+            self.con.execute(
+                "SELECT event_type FROM sprint_events WHERE event_id=?",
+                (event["event_id"],),
+            ).fetchone()[0],
+        )
+
+
+class LifecycleTest(SprintDomainCase):
+    def test_arm_atomically_releases_only_dependency_free_work(self) -> None:
+        sprint_id, first_unit = self.create_sprint()
+        blocked_unit = self.con.execute(
+            "INSERT INTO sprint_work_units "
+            "(sprint_id,assigned_shell_id,reviewer_shell_id,title,expected_output,"
+            "planned_wave) VALUES (?,1,2,'Blocked','Wait for foundation',1)",
+            (sprint_id,),
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO sprint_work_unit_dependencies "
+            "(sprint_id,work_unit_id,depends_on_work_unit_id) VALUES (?,?,?)",
+            (sprint_id, blocked_unit, first_unit),
+        )
+        self.con.commit()
+
+        wake_ids = self.store.arm(sprint_id, 3)
+
+        self.assertEqual(1, len(wake_ids))
+        self.assertEqual(
+            ("armed", 2),
+            tuple(
+                self.con.execute(
+                    "SELECT lifecycle,version FROM sprints WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            [(first_unit, "ready"), (blocked_unit, "planned")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT work_unit_id,disposition FROM sprint_work_units "
+                    "WHERE sprint_id=? ORDER BY work_unit_id",
+                    (sprint_id,),
+                )
+            ],
+        )
+        message = self.con.execute(
+            "SELECT work_unit_id,message_kind,actionable,disposition,body "
+            "FROM sprint_messages WHERE sprint_id=?",
+            (sprint_id,),
+        ).fetchone()
+        self.assertEqual(first_unit, message["work_unit_id"])
+        self.assertEqual("work_assignment", message["message_kind"])
+        self.assertEqual(1, message["actionable"])
+        self.assertEqual("pending", message["disposition"])
+        self.assertEqual(
+            "Foundation\n\nShip the durable foundation", message["body"]
+        )
+        self.assertEqual(
+            [(wake_ids[0], message["work_unit_id"])],
+            [
+                (row["wake_id"], first_unit)
+                for row in self.con.execute(
+                    "SELECT w.wake_id FROM sprint_wake_outbox w "
+                    "JOIN sprint_wake_messages wm USING (wake_id) "
+                    "JOIN sprint_messages m USING (message_id) "
+                    "WHERE w.sprint_id=? AND m.work_unit_id=?",
+                    (sprint_id, first_unit),
+                )
+            ],
+        )
+
+    def test_single_armed_invariant_rolls_back_second_release(self) -> None:
+        first, _ = self.create_sprint()
+        second, second_unit = self.create_sprint()
+        self.store.arm(first, 3)
+
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.store.arm(second, 3)
+
+        self.assertEqual(
+            "prepared",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (second,)
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            "planned",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (second_unit,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_messages WHERE sprint_id=?", (second,)
+            ).fetchone()[0],
+        )
+
+    def test_arm_rejects_wrong_planner_and_unapproved_spec_without_effect(self) -> None:
+        sprint_id, unit_id = self.create_sprint(approval_verdict="fail")
+        with self.assertRaises(sprint_domain.SprintAuthorityError):
+            self.store.arm(sprint_id, 4)
+        with self.assertRaises(sprint_domain.SprintInvariantError):
+            self.store.arm(sprint_id, 3)
+        self.assertEqual(
+            ("prepared", "planned", 0),
+            (
+                self.con.execute(
+                    "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                    (unit_id,),
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT COUNT(*) FROM sprint_wake_outbox WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone()[0],
+            ),
+        )
+
+    def test_arm_rejects_spec_edited_after_approval_without_effect(self) -> None:
+        sprint_id, unit_id = self.create_sprint()
+        self.con.execute(
+            "UPDATE documents SET body='edited after QAQC' "
+            "WHERE document_id=(SELECT document_id FROM sprint_specs "
+            "WHERE sprint_id=?)",
+            (sprint_id,),
+        )
+        self.con.commit()
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "exact, passing spec approval"
+        ):
+            self.store.arm(sprint_id, 3)
+
+        self.assertEqual(
+            ("prepared", "planned", 0),
+            (
+                self.con.execute(
+                    "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                    (unit_id,),
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT COUNT(*) FROM sprint_messages WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone()[0],
+            ),
+        )
+
+    def test_transition_authority_and_database_backstop(self) -> None:
+        sprint_id, _ = self.create_sprint()
+        self.store.arm(sprint_id, 3)
+        with self.assertRaises(sprint_domain.SprintAuthorityError):
+            self.store.transition(
+                sprint_id,
+                "paused",
+                sprint_domain.LifecycleActor("participant", 4),
+                reason="not assigned",
+            )
+        self.assertTrue(
+            self.store.transition(
+                sprint_id,
+                "paused",
+                sprint_domain.LifecycleActor("participant", 1),
+                reason="integrity threat",
+            )
+        )
+        with self.assertRaises(sprint_domain.SprintAuthorityError):
+            self.store.transition(
+                sprint_id,
+                "armed",
+                sprint_domain.LifecycleActor("participant", 1),
+            )
+        self.assertTrue(
+            self.store.transition(
+                sprint_id,
+                "armed",
+                sprint_domain.LifecycleActor("fnb"),
+            )
+        )
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "illegal Sprint lifecycle transition"
+        ):
+            self.con.execute(
+                "UPDATE sprints SET lifecycle='prepared' WHERE sprint_id=?",
+                (sprint_id,),
+            )
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()[0],
+        )
+
+    def test_terminal_wake_failure_auto_pauses_with_evidence(self) -> None:
+        sprint_id, _ = self.create_sprint()
+        wake_id = self.store.arm(sprint_id, 3)[0]
+
+        self.assertEqual(1, self.store.record_wake_failure(wake_id, "fault one"))
+        self.assertEqual(2, self.store.record_wake_failure(wake_id, "fault two"))
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()[0],
+        )
+        self.assertEqual(3, self.store.record_wake_failure(wake_id, "fault three"))
+
+        self.assertEqual(
+            ("paused", "failed", 3),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,w.state,w.attempt_count FROM sprints s "
+                    "JOIN sprint_wake_outbox w USING (sprint_id) "
+                    "WHERE w.wake_id=?",
+                    (wake_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            [(1, "fault one"), (2, "fault two"), (3, "fault three")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT attempt_number,error_detail FROM sprint_wake_attempts "
+                    "WHERE wake_id=? ORDER BY attempt_number",
+                    (wake_id,),
+                )
+            ],
+        )
+        report = self.con.execute(
+            "SELECT report_kind,body FROM sprint_reports WHERE sprint_id=?",
+            (sprint_id,),
+        ).fetchone()
+        self.assertEqual("pause", report["report_kind"])
+        self.assertIn('"reason": "wake_delivery_exhausted"', report["body"])
+        self.assertEqual(
+            "lifecycle.paused",
+            self.con.execute(
+                "SELECT event_type FROM sprint_events WHERE sprint_id=? "
+                "ORDER BY event_id DESC LIMIT 1",
+                (sprint_id,),
+            ).fetchone()[0],
+        )
+
+
+class ArmedServiceSwitchTest(SprintDomainCase):
+    def test_non_armed_states_invoke_zero_poll_or_dispatch_callbacks(self) -> None:
+        sprint_id, _ = self.create_sprint()
+        calls: list[tuple[int, str]] = []
+        switch = sprint_domain.ArmedServiceSwitch(
+            self.store,
+            (lambda active, trigger: calls.append((active, trigger)),),
+        )
+
+        self.assertFalse(switch.recover_on_startup())
+        self.assertFalse(switch.tick())
+        self.assertEqual([], calls)
+        self.store.arm(sprint_id, 3)
+        self.assertTrue(switch.tick())
+        self.assertEqual([(sprint_id, "pulse")], calls)
+        self.store.transition(
+            sprint_id,
+            "paused",
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="hold",
+        )
+        self.assertFalse(switch.tick())
+        self.assertEqual([(sprint_id, "pulse")], calls)
+
+    def test_restart_recovers_armed_sprint_from_durable_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "sprint.db"
+            with closing(db_driver.connect(path)) as seed:
+                apply_schema(seed)
+                seed.execute(
+                    "INSERT INTO users (user_id,username) VALUES (1,'operator')"
+                )
+                seed.executemany(
+                    "INSERT INTO shells "
+                    "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                    "VALUES (?,?,?,?,?,1)",
+                    (
+                        (1, "Developer", "DEV1", "dev", "prompt"),
+                        (2, "Reviewer", "REV1", "reviewer", "prompt"),
+                        (3, "Planner", "PLN1", "planner", "prompt"),
+                    ),
+                )
+                seed.execute(
+                    "INSERT INTO roadmap (feature_id,title,roadmap_status) "
+                    "VALUES (1,'Feature','in_progress')"
+                )
+                body = "spec"
+                revision = hashlib.sha256(body.encode()).hexdigest()
+                seed.execute(
+                    "INSERT INTO documents "
+                    "(document_id,feature_id,kind,seq,title,body) "
+                    "VALUES (1,1,'spec',1,'Spec',?)",
+                    (body,),
+                )
+                seed.execute(
+                    "INSERT INTO sprint_spec_approvals "
+                    "(approval_id,document_id,revision_sha256,reviewer_shell_id,verdict) "
+                    "VALUES (1,1,?,2,'pass')",
+                    (revision,),
+                )
+                seed.execute(
+                    "INSERT INTO sprints "
+                    "(sprint_id,feature_id,originating_planner_shell_id,"
+                    "merge_grant_enabled) VALUES (1,1,3,1)"
+                )
+                seed.execute(
+                    "INSERT INTO sprint_specs VALUES (1,1,?,1,datetime('now'))",
+                    (revision,),
+                )
+                seed.executemany(
+                    "INSERT INTO sprint_participants "
+                    "(sprint_id,shell_id,role,harness) VALUES (1,?,?,?)",
+                    ((3, "planner", "codex"), (1, "developer", "codex"),
+                     (2, "reviewer", "kimi")),
+                )
+                seed.execute(
+                    "INSERT INTO sprint_work_units "
+                    "(sprint_id,assigned_shell_id,reviewer_shell_id,title,expected_output) "
+                    "VALUES (1,1,2,'Unit','Output')"
+                )
+                seed.commit()
+                sprint_domain.SprintLifecycleStore(seed).arm(1, 3)
+
+            calls: list[tuple[int, str]] = []
+            with closing(db_driver.connect(path)) as restarted:
+                switch = sprint_domain.ArmedServiceSwitch(
+                    sprint_domain.SprintLifecycleStore(restarted),
+                    (lambda active, trigger: calls.append((active, trigger)),),
+                )
+                self.assertTrue(switch.recover_on_startup())
+            self.assertEqual([(1, "startup")], calls)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -169,6 +169,56 @@ class MigrationAndShapeTest(SprintDomainCase):
 
 
 class LifecycleTest(SprintDomainCase):
+    def test_sprint_insert_must_start_prepared(self) -> None:
+        sprint_id, _ = self.create_sprint()
+        feature_id = self.con.execute(
+            "SELECT feature_id FROM sprints WHERE sprint_id=?", (sprint_id,)
+        ).fetchone()[0]
+
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "Sprint inserts must start prepared"
+        ):
+            self.con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,lifecycle,"
+                "merge_grant_enabled) VALUES (?,3,'armed',1)",
+                (feature_id,),
+            )
+
+        self.assertEqual(
+            [(sprint_id, "prepared")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT sprint_id,lifecycle FROM sprints ORDER BY sprint_id"
+                )
+            ],
+        )
+
+    def test_armed_sprint_merge_grant_is_immutable(self) -> None:
+        sprint_id, _ = self.create_sprint()
+        self.store.arm(sprint_id, 3)
+
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "Sprint merge grant is immutable after arming",
+        ):
+            self.con.execute(
+                "UPDATE sprints SET merge_grant_enabled=0 WHERE sprint_id=?",
+                (sprint_id,),
+            )
+
+        self.assertEqual(
+            ("armed", 1),
+            tuple(
+                self.con.execute(
+                    "SELECT lifecycle,merge_grant_enabled FROM sprints "
+                    "WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone()
+            ),
+        )
+
     def test_arm_atomically_releases_only_dependency_free_work(self) -> None:
         sprint_id, first_unit = self.create_sprint()
         blocked_unit = self.con.execute(


### PR DESCRIPTION
## Summary

- add the zero-baseline Sprint v2 domain migration: bound QAQC revisions, participants, work units and dependencies, dedicated messages/wake outbox, registered PR transitions, judgments/reports, and append-only timeline evidence
- add the authorized lifecycle store with one atomic arming path, exact current-spec approval checks, initial assignment+wake release, database-enforced single-armed uniqueness, and third-wake-failure auto-pause
- add the armed-only external-service switch and restart recovery seam, with adversarial schema/lifecycle tests
- keep Sprint v1 removal guarantees explicit by bounding historical cutover assertions at migration 0145 and allowlisting only the new v2 files

## Judgment and trade-off

The v1 removal guard is extended deliberately rather than weakened: the new module is sprint_domain.py, not a retired v1 module name, and the historical cutover tests still prove the pre-v2 floor is clean. The service switch is callback-based and not wired to a no-op server daemon in Stage 1; later watcher/dispatcher units register real external effects, while this unit proves those effects cannot run outside armed state.

## Verification

- 1216 tests passed: /home/j3d1/Repos/subfloor/.venv/bin/pytest tests/ -q
- 10 Stage 1 domain/lifecycle tests passed after rebase
- 14 Sprint v1 removal compatibility tests passed after rebase
- render-check passed
- git diff --check passed