### PR TITLE
fix: finalize diff tab corners and layering

### DIFF
--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -391,9 +391,9 @@ body.interface-view main {
 .review-refresh.act { margin: 0; padding: .34rem .7rem; font-size: .7rem; }
 .review-group-switch {
   --review-tab-cut: 10px;
-  --review-tab-radius: 3px;
-  --review-tab-radius-diagonal: 2px;
-  margin: 0; flex: none; border-radius: 0;
+  --review-tab-radius: 6px;
+  --review-tab-radius-diagonal: 4.2px;
+  margin: 0; flex: none; border-radius: 4px 4px 0 4px;
 }
 .review-group-switch,
 .review-group-switch button:first-child.active {
@@ -419,13 +419,22 @@ body.interface-view main {
     close
   );
 }
+.review-group-switch button {
+  position: relative; z-index: 0;
+}
+.review-group-switch button.active { z-index: 1; }
+.review-group-switch button + button { border-left: 0; }
 .review-group-switch button:first-child.active + button {
-  position: relative; border-left: 0;
+  z-index: 0;
 }
 .review-group-switch button:first-child.active + button::before {
   content: ""; position: absolute; inset: 0 auto auto 0;
   height: calc(100% - var(--review-tab-cut) - var(--review-tab-radius));
   border-left: 1px solid var(--line); pointer-events: none;
+}
+.review-group-switch button:first-child:not(.active)::after {
+  content: ""; position: absolute; inset: 0 0 auto auto; height: 100%;
+  border-right: 1px solid var(--line); pointer-events: none;
 }
 .review-change-switch { margin: 0; flex: none; }
 .review-scope-switch button { padding-inline: 1rem; }

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -673,9 +673,14 @@ export { mode };"""
             "tabsTop: tabs.top, tabsLeft: tabs.left, "
             "tabsCenter: tabs.left + tabs.width / 2, "
             "tabsClip: getComputedStyle(nodes[4]).clipPath, "
-            "tabsRadius: getComputedStyle(nodes[4]).borderRadius, "
+            "tabsTopLeftRadius: getComputedStyle(nodes[4]).borderTopLeftRadius, "
+            "tabsTopRightRadius: getComputedStyle(nodes[4]).borderTopRightRadius, "
+            "tabsBottomRightRadius: getComputedStyle(nodes[4]).borderBottomRightRadius, "
+            "tabsBottomLeftRadius: getComputedStyle(nodes[4]).borderBottomLeftRadius, "
             "activeClip: getComputedStyle(nodes[5]).clipPath, "
             "activeHeight: active.height, "
+            "activeLayer: getComputedStyle(nodes[5]).zIndex, "
+            "inactiveLayer: getComputedStyle(nodes[6]).zIndex, "
             "dividerBorder: getComputedStyle(nodes[6], '::before').borderLeftWidth, "
             "dividerHeight: parseFloat(getComputedStyle(nodes[6], '::before').height), "
             "buttonBorder: getComputedStyle(nodes[6]).borderLeftWidth}; }"
@@ -689,11 +694,16 @@ export { mode };"""
         assert abs(patch_header["headerTop"] - patch_header["tabsTop"]) <= 1
         assert patch_header["tabsClip"].startswith("shape(")
         assert patch_header["activeClip"].startswith("shape(")
-        assert patch_header["tabsRadius"] == "0px"
+        assert patch_header["tabsTopLeftRadius"] == "4px"
+        assert patch_header["tabsTopRightRadius"] == "4px"
+        assert patch_header["tabsBottomRightRadius"] == "0px"
+        assert patch_header["tabsBottomLeftRadius"] == "4px"
+        assert patch_header["activeLayer"] == "1"
+        assert patch_header["inactiveLayer"] == "0"
         assert patch_header["dividerBorder"] == "1px"
         assert patch_header["buttonBorder"] == "0px"
         assert abs(
-            patch_header["activeHeight"] - patch_header["dividerHeight"] - 13
+            patch_header["activeHeight"] - patch_header["dividerHeight"] - 16
         ) <= 1
         initial_observations = sum(
             method == "POST" and path.endswith("/review-observations")
@@ -799,6 +809,18 @@ export { mode };"""
         page.get_by_role("tab", name="Commits").click()
         page.get_by_text("Build the current-worktree Diff", exact=True).wait_for()
         page.get_by_role("tab", name="Shell files").click()
+        shell_layers = page.locator(".review-group-switch button").evaluate_all(
+            "nodes => ({inactiveLayer: getComputedStyle(nodes[0]).zIndex, "
+            "activeLayer: getComputedStyle(nodes[1]).zIndex, "
+            "dividerBorder: getComputedStyle(nodes[0], '::after').borderRightWidth, "
+            "activeBorder: getComputedStyle(nodes[1]).borderLeftWidth})"
+        )
+        assert shell_layers == {
+            "inactiveLayer": "0",
+            "activeLayer": "1",
+            "dividerBorder": "1px",
+            "activeBorder": "0px",
+        }
         page.get_by_role("button", name="CLAUDE.md").click()
         page.locator(".review-shell-file").wait_for()
         assert "# Exact CLAUDE" in page.locator(".review-shell-file").text_content()

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -197,9 +197,12 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
     assert "grid-column: 1 / -1; grid-row: 1" in STYLE
     assert "align-self: start; margin-top: -.4rem" in STYLE
     assert "--review-tab-cut: 10px" in STYLE
-    assert "--review-tab-radius: 3px" in STYLE
+    assert "--review-tab-radius: 6px" in STYLE
+    assert "border-radius: 4px 4px 0 4px" in STYLE
     assert STYLE.count("clip-path: shape(") == 1
+    assert ".review-group-switch button.active { z-index: 1; }" in STYLE
     assert ".review-group-switch button:first-child.active + button::before" in STYLE
+    assert ".review-group-switch button:first-child:not(.active)::after" in STYLE
     assert "height: calc(100% - var(--review-tab-cut) - var(--review-tab-radius))" in STYLE
     assert "flex: 1 1 auto" in STYLE
     assert "text-overflow: ellipsis" in STYLE


### PR DESCRIPTION
## Summary
- use the approved 6px chamfer softness
- round the three ordinary outside corners (top-left, top-right, bottom-left) to 4px while leaving the chamfered bottom-right under shape control
- make the active blue tab an explicit foreground layer in both active states
- move each divider onto the inactive layer so gray never paints over blue
- preserve tab dimensions and centerline placement

## Verification
- direct focused pytest run: 10 passed
- production-stylesheet Playwright screenshot in both active states (`shared/tabs-final-corners-and-layering.png`)
- `./sc render-check`
- `git diff --check`

The direct pytest invocation works around `./sc test` incorrectly falling back to unittest when explicit pytest targets are supplied but provisioning fails; tracked in #851. `./sc verify` is not branch-safe from linked worktrees; tracked in #769.