### PR TITLE
fix(conversations): harden adapter completion and persistence

### DIFF
--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -44,6 +44,7 @@ NORMALIZED_EVENTS = frozenset(
 TERMINAL_EVENTS = frozenset(
     {"run.completed", "run.failed", "run.interrupted"}
 )
+INTERRUPT_EVIDENCE = frozenset({"native", "operator"})
 RECONCILE_OUTCOMES = frozenset(
     {"running", "succeeded", "failed", "cancelled", "unknown"}
 )
@@ -143,10 +144,21 @@ class NormalizedEvent:
     type: str
     payload: Mapping[str, Any] = field(default_factory=dict)
     native_type: str | None = None
+    interrupt_evidence: str | None = None
 
     def __post_init__(self) -> None:
         if self.type not in NORMALIZED_EVENTS:
             raise ValueError(f"unknown normalized conversation event: {self.type}")
+        if self.type == "run.interrupted":
+            if self.interrupt_evidence not in INTERRUPT_EVIDENCE:
+                raise ValueError(
+                    "run.interrupted requires structured native or operator "
+                    "evidence"
+                )
+        elif self.interrupt_evidence is not None:
+            raise ValueError(
+                "interrupt evidence is valid only for run.interrupted"
+            )
 
 
 @dataclass(frozen=True)

--- a/.super-coder/scripts/conversation_adapters/claude.py
+++ b/.super-coder/scripts/conversation_adapters/claude.py
@@ -267,7 +267,7 @@ class ClaudeAdapter(ConversationAdapter):
             subtype = str(raw.get("subtype") or "")
             detail = str(raw.get("result") or raw.get("error") or "")
             interrupted = any(
-                token in f"{subtype} {detail}".lower()
+                token in subtype.lower()
                 for token in ("interrupt", "aborted")
             )
             failed = bool(raw.get("is_error")) or subtype.startswith("error")
@@ -298,6 +298,7 @@ class ClaudeAdapter(ConversationAdapter):
                         "result": detail if detail else None,
                     },
                     "result",
+                    "native" if interrupted else None,
                 )
             )
             return events

--- a/.super-coder/scripts/conversation_adapters/codex.py
+++ b/.super-coder/scripts/conversation_adapters/codex.py
@@ -515,6 +515,7 @@ class CodexAdapter(ConversationAdapter):
                     event_type,
                     {"status": status or "failed", "error": error},
                     method,
+                    "native" if event_type == "run.interrupted" else None,
                 )
             ]
         return []

--- a/.super-coder/scripts/conversation_adapters/kimi.py
+++ b/.super-coder/scripts/conversation_adapters/kimi.py
@@ -363,7 +363,7 @@ class KimiAdapter(ConversationAdapter):
                 records = self._run_slice(turn)
             except (AdapterError, OSError):
                 continue
-            if not self._usage(records):
+            if not self._completion_proven(records):
                 continue
             # Give final stdout metadata already in flight (especially the
             # resume hint) a bounded window to reach the validator.
@@ -819,6 +819,42 @@ class KimiAdapter(ConversationAdapter):
                     totals[normalized] = totals.get(normalized, 0) + value
         return totals
 
+    @classmethod
+    def _completion_proven(
+        cls,
+        records: list[Mapping[str, Any]],
+    ) -> bool:
+        """Return whether Kimi durably ended the exact run.
+
+        Kimi writes turn-scoped usage after every model step.  A tool-calling
+        step therefore has usage even though the next model step is already
+        starting.  Only the final ``end_turn`` step plus its usage proves that
+        a persistent child may be cleaned up safely.
+        """
+        latest_step: str | None = None
+        completed = False
+        for raw in records:
+            if raw.get("type") == "usage.record":
+                if raw.get("usageScope") == "turn" and cls._usage([raw]):
+                    completed = latest_step == "end_turn"
+                continue
+            if raw.get("type") != "context.append_loop_event":
+                continue
+            event = raw.get("event")
+            if not isinstance(event, dict):
+                continue
+            event_type = event.get("type")
+            if event_type == "step.begin":
+                latest_step = None
+                completed = False
+            elif event_type == "step.end":
+                finish_reason = event.get("finishReason")
+                latest_step = (
+                    finish_reason if isinstance(finish_reason, str) else None
+                )
+                completed = False
+        return completed
+
     @staticmethod
     def _stderr(process: Any) -> str:
         captured = getattr(process, "_sc_conversation_stderr", None)
@@ -995,13 +1031,8 @@ class KimiAdapter(ConversationAdapter):
             elif latest_slice:
                 latest_slice.append(raw)
         terminal = any(
-            raw.get("type") == "turn.cancel"
-            or (
-                raw.get("type") == "usage.record"
-                and raw.get("usageScope") == "turn"
-            )
-            for raw in latest_slice
-        )
+            raw.get("type") == "turn.cancel" for raw in latest_slice
+        ) or self._completion_proven(latest_slice)
         return SessionInspection(
             session_ref,
             True,
@@ -1058,11 +1089,11 @@ class KimiAdapter(ConversationAdapter):
                 True,
                 "Kimi exact run slice contains turn.cancel",
             )
-        if self._usage(records):
+        if self._completion_proven(records):
             return ReconcileResult(
                 "succeeded",
                 True,
-                "Kimi exact run slice contains turn-scoped usage",
+                "Kimi exact run slice contains end_turn and turn-scoped usage",
             )
         return ReconcileResult(
             "unknown",

--- a/.super-coder/scripts/conversation_adapters/kimi.py
+++ b/.super-coder/scripts/conversation_adapters/kimi.py
@@ -937,6 +937,7 @@ class KimiAdapter(ConversationAdapter):
                 "run.interrupted",
                 {"status": "interrupted"},
                 "turn.cancel" if cancelled else "process.exit",
+                "native" if cancelled else "operator",
             )
             turn.metadata["terminal"] = event.type
             yield event

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -553,6 +553,7 @@ class OpenCodeAdapter(ConversationAdapter):
                     "run.interrupted" if interrupted else "run.failed",
                     {"error": name},
                     native_type,
+                    "native" if interrupted else None,
                 )
             ]
         if native_type == "message.part.delta":
@@ -681,6 +682,7 @@ class OpenCodeAdapter(ConversationAdapter):
                 "run.interrupted",
                 {"status": "cancelled"},
                 "operator.interrupt",
+                "operator",
             )
             return
         self._prompt(turn.session_ref, context, message)
@@ -703,6 +705,7 @@ class OpenCodeAdapter(ConversationAdapter):
                                 "run.interrupted",
                                 {"status": "cancelled"},
                                 event.native_type,
+                                "operator",
                             )
                 if event.type in {
                     "run.started",

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -23,6 +23,7 @@ import uuid
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +47,9 @@ DEFAULT_HEARTBEAT_SECONDS = 10
 DEFAULT_RECOVERY_SECONDS = 5
 DEFAULT_RECONCILE_ATTEMPTS = 3
 DEFAULT_MAX_WORKERS = 8
+DEFAULT_EVENT_BATCH_SIZE = 64
+DEFAULT_EVENT_BACKLOG_SIZE = 1024
+DEFAULT_EVENT_FLUSH_SECONDS = 0.1
 
 
 class BrokerError(RuntimeError):
@@ -544,17 +548,28 @@ class BrokerStore:
         run_id: int,
         event: NormalizedEvent,
     ) -> int:
-        if event.type in TERMINAL_EVENTS:
-            raise BrokerError(
-                "CONVERSATION_TERMINAL_EVENT_REQUIRES_FINISH",
-                event.type,
-            )
+        return self.append_events(run_id, [event])[0]
+
+    def append_events(
+        self,
+        run_id: int,
+        events: list[NormalizedEvent],
+    ) -> list[int]:
+        """Commit one ordered batch of non-terminal native events."""
+        if not events:
+            return []
+        for event in events:
+            if event.type in TERMINAL_EVENTS:
+                raise BrokerError(
+                    "CONVERSATION_TERMINAL_EVENT_REQUIRES_FINISH",
+                    event.type,
+                )
         con = self.connect()
         now, _ = self._times()
         try:
             with db_driver.write_transaction(
                 con,
-                "conversation.broker.append_event",
+                "conversation.broker.append_events",
             ):
                 row = con.execute(
                     "SELECT conversation_id,trigger_message_id,state "
@@ -568,17 +583,23 @@ class BrokerStore:
                         "CONVERSATION_RUN_TERMINAL",
                         f"run {run_id} is already {row['state']}",
                     )
-                payload = dict(event.payload)
-                if event.native_type:
-                    payload["native_type"] = event.native_type
-                sequence = self._append_event(
-                    con,
-                    conversation_id=row["conversation_id"],
-                    event_type=event.type,
-                    payload=payload,
-                    message_id=row["trigger_message_id"],
-                    run_id=run_id,
-                )
+                sequences = []
+                for event in events:
+                    payload = dict(event.payload)
+                    if event.native_type:
+                        payload["native_type"] = event.native_type
+                    if event.interrupt_evidence:
+                        payload["interrupt_evidence"] = event.interrupt_evidence
+                    sequences.append(
+                        self._append_event(
+                            con,
+                            conversation_id=row["conversation_id"],
+                            event_type=event.type,
+                            payload=payload,
+                            message_id=row["trigger_message_id"],
+                            run_id=run_id,
+                        )
+                    )
                 con.execute(
                     "UPDATE conversations SET last_activity_at=?,"
                     "version=version+1 WHERE conversation_id=?",
@@ -588,7 +609,7 @@ class BrokerStore:
         finally:
             con.close()
         conversation_events.notify(conversation_id)
-        return sequence
+        return sequences
 
     def finish_run(
         self,
@@ -884,6 +905,9 @@ class ConversationBroker(threading.Thread):
         heartbeat_seconds: int = DEFAULT_HEARTBEAT_SECONDS,
         recovery_seconds: int = DEFAULT_RECOVERY_SECONDS,
         reconcile_attempts: int = DEFAULT_RECONCILE_ATTEMPTS,
+        event_batch_size: int = DEFAULT_EVENT_BATCH_SIZE,
+        event_backlog_size: int = DEFAULT_EVENT_BACKLOG_SIZE,
+        event_flush_seconds: float = DEFAULT_EVENT_FLUSH_SECONDS,
     ) -> None:
         super().__init__(name="conversation-broker", daemon=True)
         self.store = store or BrokerStore(db_path)
@@ -896,6 +920,9 @@ class ConversationBroker(threading.Thread):
         self.heartbeat_seconds = heartbeat_seconds
         self.recovery_seconds = recovery_seconds
         self.reconcile_attempts = reconcile_attempts
+        self.event_batch_size = event_batch_size
+        self.event_backlog_size = event_backlog_size
+        self.event_flush_seconds = event_flush_seconds
         self._wake = threading.Event()
         self._stop_event = threading.Event()
         self._active: dict[int, _ActiveRun] = {}
@@ -1024,26 +1051,87 @@ class ConversationBroker(threading.Thread):
             "unknown": "run.unknown",
         }[outcome]
 
-    def _finish_adapter_event(
+    def _retry_busy(
+        self,
+        action: Callable[[], Any],
+        *,
+        wait: bool,
+    ) -> tuple[bool, Any]:
+        """Retry only exhausted SQLite writer acquisition, never native work."""
+        while not self._stop_event.is_set():
+            try:
+                return True, action()
+            except Exception as exc:
+                if not db_driver.is_busy_error(exc):
+                    raise
+                if not wait:
+                    return False, None
+                self._stop_event.wait(min(1.0, self.recovery_seconds))
+        return False, None
+
+    def _flush_events(
         self,
         run_id: int,
+        pending: list[NormalizedEvent],
+        *,
+        wait: bool,
+    ) -> bool:
+        if not pending:
+            return True
+        batch = list(pending)
+        persisted, _result = self._retry_busy(
+            partial(self.store.append_events, run_id, batch),
+            wait=wait,
+        )
+        if persisted:
+            del pending[: len(batch)]
+        return persisted
+
+    def _finish_adapter_event(
+        self,
+        active: _ActiveRun,
         event: NormalizedEvent,
-    ) -> None:
+    ) -> bool:
+        if event.type == "run.failed" and active.interrupt_requested:
+            event = NormalizedEvent(
+                "run.interrupted",
+                {
+                    **dict(event.payload),
+                    "status": "cancelled",
+                    "adapter_terminal": "run.failed",
+                },
+                event.native_type,
+                "operator",
+            )
         outcome = terminal_outcome(event.type)
         error = event.payload.get("error")
         exit_code = event.payload.get("exit_code")
-        self.store.finish_run(
-            run_id,
-            outcome,
-            event_type=event.type,
-            payload={
-                **dict(event.payload),
-                **({"native_type": event.native_type} if event.native_type else {}),
-            },
-            error_code=str(error)[:255] if error else None,
-            error_detail=str(error) if error else None,
-            exit_code=exit_code if isinstance(exit_code, int) else None,
+        persisted, _result = self._retry_busy(
+            partial(
+                self.store.finish_run,
+                active.run.run_id,
+                outcome,
+                event_type=event.type,
+                payload={
+                    **dict(event.payload),
+                    **(
+                        {"native_type": event.native_type}
+                        if event.native_type
+                        else {}
+                    ),
+                    **(
+                        {"interrupt_evidence": event.interrupt_evidence}
+                        if event.interrupt_evidence
+                        else {}
+                    ),
+                },
+                error_code=str(error)[:255] if error else None,
+                error_detail=str(error) if error else None,
+                exit_code=exit_code if isinstance(exit_code, int) else None,
+            ),
+            wait=True,
         )
+        return persisted
 
     def _finish_error(
         self,
@@ -1055,13 +1143,17 @@ class ConversationBroker(threading.Thread):
         code = getattr(exc, "code", "BROKER_RUN_ERROR")
         detail = getattr(exc, "detail", str(exc))
         outcome = "failed" if proven else "unknown"
-        self.store.finish_run(
-            run_id,
-            outcome,
-            event_type=self._terminal_event(outcome),
-            payload={"error": str(code), "detail": str(detail)},
-            error_code=str(code)[:255],
-            error_detail=str(detail),
+        self._retry_busy(
+            partial(
+                self.store.finish_run,
+                run_id,
+                outcome,
+                event_type=self._terminal_event(outcome),
+                payload={"error": str(code), "detail": str(detail)},
+                error_code=str(code)[:255],
+                error_detail=str(detail),
+            ),
+            wait=True,
         )
 
     def _reconcile_loop(
@@ -1090,10 +1182,15 @@ class ConversationBroker(threading.Thread):
                 result = adapter.reconcile(turn, context)
             except Exception as exc:
                 failures += 1
-                self.store.note_reconcile_error(
-                    active.run.run_id,
-                    self.owner,
-                    f"reconcile attempt {failures}: {exc}",
+                reconcile_detail = f"reconcile attempt {failures}: {exc}"
+                self._retry_busy(
+                    partial(
+                        self.store.note_reconcile_error,
+                        active.run.run_id,
+                        self.owner,
+                        reconcile_detail,
+                    ),
+                    wait=True,
                 )
                 if failures >= self.reconcile_attempts:
                     self._finish_error(active.run.run_id, exc, proven=False)
@@ -1103,25 +1200,39 @@ class ConversationBroker(threading.Thread):
 
             if result.outcome == "running" and result.proven:
                 failures = 0
-                self.store.renew_runs(self.owner, [active.run.run_id])
+                self._retry_busy(
+                    partial(
+                        self.store.renew_runs,
+                        self.owner,
+                        [active.run.run_id],
+                    ),
+                    wait=True,
+                )
                 self._stop_event.wait(self.recovery_seconds)
                 continue
             outcome = result.outcome if result.proven else "unknown"
-            self.store.finish_run(
-                active.run.run_id,
-                outcome,
-                event_type=self._terminal_event(outcome),
-                payload={
-                    "reconciled": True,
-                    "proven": result.proven,
-                    "detail": result.detail,
-                },
-                error_code=(
-                    "HARNESS_OUTCOME_UNKNOWN" if outcome == "unknown" else None
+            terminal_payload = {
+                "reconciled": True,
+                "proven": result.proven,
+                "detail": result.detail,
+            }
+            error_code = (
+                "HARNESS_OUTCOME_UNKNOWN" if outcome == "unknown" else None
+            )
+            error_detail = (
+                result.detail if outcome in {"failed", "unknown"} else None
+            )
+            self._retry_busy(
+                partial(
+                    self.store.finish_run,
+                    active.run.run_id,
+                    outcome,
+                    event_type=self._terminal_event(outcome),
+                    payload=terminal_payload,
+                    error_code=error_code,
+                    error_detail=error_detail,
                 ),
-                error_detail=result.detail
-                if outcome in {"failed", "unknown"}
-                else None,
+                wait=True,
             )
             return
 
@@ -1164,18 +1275,54 @@ class ConversationBroker(threading.Thread):
                 self._deliver_interrupt(active)
 
                 terminal = False
+                pending: list[NormalizedEvent] = []
+                last_flush = time.monotonic()
+                retry_after = 0.0
                 try:
                     for event in adapter.stream(turn):
                         if event.type in TERMINAL_EVENTS:
-                            self._finish_adapter_event(run.run_id, event)
-                            terminal = True
+                            if not self._flush_events(
+                                run.run_id,
+                                pending,
+                                wait=True,
+                            ):
+                                return
+                            terminal = self._finish_adapter_event(active, event)
                             break
-                        self.store.append_event(run.run_id, event)
+                        pending.append(event)
+                        now = time.monotonic()
+                        should_flush = (
+                            event.type != "assistant.delta"
+                            or len(pending) >= self.event_batch_size
+                            or now - last_flush >= self.event_flush_seconds
+                        )
+                        force_backpressure = (
+                            len(pending) >= self.event_backlog_size
+                        )
+                        if not should_flush and not force_backpressure:
+                            continue
+                        if now < retry_after and not force_backpressure:
+                            continue
+                        if self._flush_events(
+                            run.run_id,
+                            pending,
+                            wait=force_backpressure,
+                        ):
+                            last_flush = time.monotonic()
+                            retry_after = 0.0
+                        else:
+                            retry_after = now + self.recovery_seconds
                 except Exception:
                     # Exact identities are durable; inspect them rather than
                     # replaying a message after a broken stream.
                     pass
                 if terminal:
+                    return
+                if not self._flush_events(
+                    run.run_id,
+                    pending,
+                    wait=True,
+                ):
                     return
                 self._reconcile_loop(active, context)
                 return

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -34,6 +34,17 @@ from conversation_adapters import (  # noqa: E402
 KIMI_FIXTURES = ROOT / "tests" / "fixtures" / "conversations" / "kimi"
 
 
+def kimi_step_event(
+    event_type: str,
+    *,
+    finish_reason: str | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {"type": event_type}
+    if finish_reason is not None:
+        event["finishReason"] = finish_reason
+    return {"type": "context.append_loop_event", "event": event}
+
+
 class FakeOpenCode:
     def __init__(self) -> None:
         self.requests: list[tuple[str, str, dict, Any]] = []
@@ -1241,6 +1252,7 @@ class ConversationAdapterTest(unittest.TestCase):
                 *captured,
             ],
             after_prompt=[
+                kimi_step_event("step.end", finish_reason="end_turn"),
                 {
                     "type": "usage.record",
                     "usageScope": "turn",
@@ -1340,6 +1352,7 @@ class ConversationAdapterTest(unittest.TestCase):
                 {"role": "assistant", "content": "server started"},
             ],
             after_prompt=[
+                kimi_step_event("step.end", finish_reason="end_turn"),
                 {
                     "type": "usage.record",
                     "usageScope": "turn",
@@ -1365,6 +1378,107 @@ class ConversationAdapterTest(unittest.TestCase):
             ],
         )
         self.assertEqual(events[-1].native_type, "usage.record")
+
+    def test_kimi_tool_usage_does_not_complete_before_follow_up_answer(
+        self,
+    ) -> None:
+        adapter, runner = self.build("kimi")
+        runner.queue(
+            stdout_lines=[
+                {
+                    "role": "assistant",
+                    "content": "Running the repo-map queries now.",
+                    "tool_calls": [
+                        {
+                            "id": "tool-map",
+                            "function": {"name": "Bash"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "tool-map"},
+                {"role": "assistant", "content": "Map loaded."},
+            ],
+            after_prompt=[
+                kimi_step_event("step.end", finish_reason="tool_use"),
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {"inputOther": 10, "output": 2},
+                },
+                kimi_step_event("step.begin"),
+            ],
+            block_after_stdout=True,
+        )
+
+        turn = adapter.start(self.context, "continue")
+        events: list[Any] = []
+        errors: list[BaseException] = []
+
+        def consume() -> None:
+            try:
+                events.extend(adapter.stream(turn))
+            except BaseException as exc:  # noqa: BLE001 - cross-thread test capture
+                errors.append(exc)
+
+        worker = threading.Thread(target=consume)
+        worker.start()
+        self.assertTrue(turn.opaque.stdout_blocked.wait(1.0))
+        self.assertFalse(
+            turn.opaque.stdout_released.wait(0.25),
+            "tool-use usage must not terminate the persistent Kimi child",
+        )
+        self.assertFalse(turn.opaque.terminated)
+        self.assertEqual(
+            adapter.inspect(turn.session_ref, self.context).state,
+            "unknown",
+        )
+
+        wire = Path(turn.metadata["wire_path"])
+        with wire.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(
+                kimi_step_event("step.end", finish_reason="end_turn")
+            ) + "\n")
+        self.assertFalse(
+            turn.opaque.stdout_released.wait(0.25),
+            "end_turn without its usage must not terminate Kimi",
+        )
+        with wire.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps({
+                "type": "usage.record",
+                "usageScope": "turn",
+                "usage": {"inputOther": 5, "output": 3},
+            }) + "\n")
+
+        worker.join(2.0)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(errors, [])
+        self.assertTrue(turn.opaque.terminated)
+        self.assertEqual(
+            [event.type for event in events],
+            [
+                "session.started",
+                "run.started",
+                "assistant.delta",
+                "tool.started",
+                "tool.completed",
+                "assistant.delta",
+                "usage",
+                "run.completed",
+            ],
+        )
+        self.assertEqual(
+            next(event for event in events if event.type == "usage").payload,
+            {
+                "tokens": {
+                    "input_tokens": 15,
+                    "output_tokens": 5,
+                }
+            },
+        )
+        self.assertEqual(
+            adapter.inspect(turn.session_ref, self.context).state,
+            "idle",
+        )
 
     def test_kimi_default_runner_owns_and_cleans_up_process_group(self) -> None:
         adapter = KimiAdapter()
@@ -1419,6 +1533,7 @@ class ConversationAdapterTest(unittest.TestCase):
             "recovered",
             prompt_time=8000,
             after_prompt=[
+                kimi_step_event("step.end", finish_reason="end_turn"),
                 {
                     "type": "usage.record",
                     "usageScope": "turn",
@@ -1453,6 +1568,43 @@ class ConversationAdapterTest(unittest.TestCase):
             result.outcome,
             "cancelled",
             "a later turn.cancel must not terminate the recovered run",
+        )
+
+    def test_kimi_recovered_tool_step_is_not_terminal_completion(self) -> None:
+        adapter, runner = self.build("kimi")
+        session_ref = "session_abababab-abab-4bab-8bab-abababababab"
+        _session, _wire = runner.write_session(
+            runner.sessions_root,
+            session_ref,
+            self.root,
+            "recover tool step",
+            prompt_time=8050,
+            after_prompt=[
+                kimi_step_event("step.end", finish_reason="tool_use"),
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {"inputOther": 4, "output": 2},
+                },
+                kimi_step_event("step.begin"),
+            ],
+            directory="wd_recovered_tool_step",
+        )
+        recovered = NativeTurn(
+            "kimi",
+            session_ref,
+            "kimi-8050-0",
+            self.root,
+            metadata={"recovered": True},
+        )
+
+        result = adapter.reconcile(recovered, self.context)
+
+        self.assertEqual(result.outcome, "unknown")
+        self.assertFalse(result.proven)
+        self.assertEqual(
+            adapter.inspect(session_ref, self.context).state,
+            "unknown",
         )
 
     def test_kimi_recovered_turn_rebuilds_exact_cancel_slice(self) -> None:
@@ -1518,6 +1670,7 @@ class ConversationAdapterTest(unittest.TestCase):
                     "input": [{"type": "text", "text": "later"}],
                     "time": 7001,
                 },
+                kimi_step_event("step.end", finish_reason="end_turn"),
                 {
                     "type": "usage.record",
                     "usageScope": "turn",

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -27,6 +27,7 @@ from conversation_adapters import (  # noqa: E402
     ConversationContext,
     KimiAdapter,
     NativeTurn,
+    NormalizedEvent,
     OpenCodeAdapter,
     adapter_for,
 )
@@ -724,6 +725,24 @@ class ConversationAdapterTest(unittest.TestCase):
             / "-home-j3d1-Repos-dos-app--sc-worktrees-pln1"
             / "b6321ad5-9363-4529-980d-93a959000968.jsonl",
         )
+
+    def test_claude_success_result_prose_cannot_assert_interruption(self) -> None:
+        adapter, _runner = self.build("claude")
+
+        events = adapter._normalize(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": "I was mid-orientation when you first interrupted.",
+            }
+        )
+
+        self.assertEqual(events[-1].type, "run.completed")
+        self.assertEqual(events[-1].payload["status"], "completed")
+
+    def test_interrupted_events_require_structured_evidence(self) -> None:
+        with self.assertRaisesRegex(ValueError, "structured native or operator"):
+            NormalizedEvent("run.interrupted", {"status": "interrupted"})
 
     def test_identical_contract_start_stream_interrupt_resume_reconcile(
         self,

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -57,6 +57,7 @@ class FakeAdapter:
         harness: str = "codex",
         native_session_ref: str = "native-session",
         native_run_ref: str | None = None,
+        interrupt_terminal: str = "run.interrupted",
     ) -> None:
         self.harness = harness
         self.terminal = terminal
@@ -66,6 +67,7 @@ class FakeAdapter:
         self.block = block
         self.native_session_ref = native_session_ref
         self.native_run_ref = native_run_ref
+        self.interrupt_terminal = interrupt_terminal
         self.interrupted = threading.Event()
         self.started = 0
         self.resumed = 0
@@ -105,8 +107,18 @@ class FakeAdapter:
         yield NormalizedEvent("assistant.delta", {"text": "hello"})
         if self.block:
             self.interrupted.wait(5)
-        event_type = "run.interrupted" if self.interrupted.is_set() else self.terminal
-        yield NormalizedEvent(event_type, {"status": event_type.split(".")[1]})
+        event_type = (
+            self.interrupt_terminal
+            if self.interrupted.is_set()
+            else self.terminal
+        )
+        yield NormalizedEvent(
+            event_type,
+            {"status": event_type.split(".")[1]},
+            interrupt_evidence=(
+                "operator" if event_type == "run.interrupted" else None
+            ),
+        )
 
     def interrupt(self, turn: NativeTurn) -> InterruptResult:
         self.interrupted.set()
@@ -122,6 +134,48 @@ class FakeAdapter:
 
     def close(self) -> None:
         self.closed += 1
+
+
+class BarrierAdapter(FakeAdapter):
+    """Prove separate instances of one harness can stream concurrently."""
+
+    def __init__(self, barrier: threading.Barrier, serial: int) -> None:
+        super().__init__(native_session_ref=f"native-session-{serial}")
+        self.barrier = barrier
+        self.crossed = False
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        yield NormalizedEvent("session.started", {"session_ref": turn.session_ref})
+        yield NormalizedEvent("run.started", {"status": "running"})
+        self.barrier.wait(2)
+        self.crossed = True
+        yield NormalizedEvent("assistant.delta", {"text": "hello"})
+        yield NormalizedEvent("run.completed", {"status": "completed"})
+
+
+class ReconcileSequenceAdapter(FakeAdapter):
+    """End the stream uncertain, then prove running and terminal states."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.results = iter(
+            [
+                ReconcileResult("running", True, "native run is live"),
+                ReconcileResult("succeeded", True, "native run completed"),
+            ]
+        )
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        yield NormalizedEvent("session.started", {"session_ref": turn.session_ref})
+        yield NormalizedEvent("assistant.delta", {"text": "before recovery"})
+
+    def reconcile(
+        self,
+        turn: NativeTurn,
+        context: ConversationContext,
+    ) -> ReconcileResult:
+        self.reconciled += 1
+        return next(self.results)
 
 
 class BlockingOpenCodeTransport:
@@ -522,6 +576,45 @@ class StoreContractTest(ConversationBrokerCase):
         self.assertEqual(first_state, "completed")
         self.assertEqual(sequences, [1, 2])
 
+    def test_noisy_events_are_appended_in_one_ordered_batch(self) -> None:
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        store = BrokerStore(self.db_path)
+        run = store.claim_next("broker")
+        store.mark_starting(run.run_id, "broker")
+        store.mark_native_started(
+            run.run_id,
+            "broker",
+            NativeTurn("codex", "session", "runner", self.worktree),
+        )
+
+        sequences = store.append_events(
+            run.run_id,
+            [
+                NormalizedEvent("run.started", {"status": "running"}),
+                NormalizedEvent("assistant.delta", {"text": "one"}),
+                NormalizedEvent("assistant.delta", {"text": "two"}),
+            ],
+        )
+
+        self.assertEqual(sequences, [1, 2, 3])
+        con = self.connect()
+        rows = con.execute(
+            "SELECT sequence,event_type,payload FROM conversation_events "
+            "WHERE run_id=? ORDER BY sequence",
+            (run.run_id,),
+        ).fetchall()
+        con.close()
+        self.assertEqual(
+            [(row["sequence"], row["event_type"]) for row in rows],
+            [
+                (1, "run.started"),
+                (2, "assistant.delta"),
+                (3, "assistant.delta"),
+            ],
+        )
+        self.assertEqual(json.loads(rows[-1]["payload"])["text"], "two")
+
     def test_terminal_observation_is_post_commit_and_cannot_fail_run(self) -> None:
         conversation_id = self.add_conversation()
         self.add_message(conversation_id)
@@ -800,6 +893,158 @@ class ServiceContractTest(ConversationBrokerCase):
         self.assertEqual(len(adapters), 1)
         self.assertEqual(adapters[0].started, 1)
 
+    def test_transient_event_write_contention_does_not_abandon_stream(
+        self,
+    ) -> None:
+        adapter = FakeAdapter()
+        broker = self.start_broker(
+            lambda _harness: adapter,
+            recovery_seconds=0.01,
+        )
+        append_events = broker.store.append_events
+        attempts = 0
+
+        def contend_once(run_id, events):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise sqlite3.OperationalError("database is locked")
+            return append_events(run_id, events)
+
+        broker.store.append_events = contend_once
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        deadline = time.monotonic() + 3
+        row = None
+        while time.monotonic() < deadline:
+            con = self.connect()
+            row = con.execute(
+                "SELECT run_id,state FROM conversation_runs "
+                "WHERE trigger_message_id=?",
+                (message_id,),
+            ).fetchone()
+            con.close()
+            if row is not None and row["state"] == "succeeded":
+                break
+            time.sleep(0.01)
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row["state"], "succeeded")
+        self.assertGreaterEqual(attempts, 2)
+        con = self.connect()
+        event_types = [
+            item[0]
+            for item in con.execute(
+                "SELECT event_type FROM conversation_events "
+                "WHERE run_id=? ORDER BY sequence",
+                (row["run_id"],),
+            )
+        ]
+        con.close()
+        self.assertEqual(
+            event_types,
+            [
+                "session.started",
+                "run.started",
+                "assistant.delta",
+                "run.completed",
+            ],
+        )
+        self.assertEqual(adapter.reconciled, 0)
+
+    def test_same_harness_runs_stream_concurrently_on_different_shells(
+        self,
+    ) -> None:
+        barrier = threading.Barrier(2)
+        adapters: list[BarrierAdapter] = []
+
+        def factory(_harness: str) -> BarrierAdapter:
+            adapter = BarrierAdapter(barrier, len(adapters) + 1)
+            adapters.append(adapter)
+            return adapter
+
+        broker = self.start_broker(factory)
+        first = self.add_conversation(shell_id=1, harness="codex")
+        second = self.add_conversation(shell_id=2, harness="codex")
+        first_message = self.add_message(first)
+        second_message = self.add_message(second)
+        broker.notify()
+
+        deadline = time.monotonic() + 3
+        states: dict[int, str] = {}
+        while time.monotonic() < deadline:
+            con = self.connect()
+            states = {
+                int(row["trigger_message_id"]): row["state"]
+                for row in con.execute(
+                    "SELECT trigger_message_id,state FROM conversation_runs "
+                    "WHERE trigger_message_id IN (?,?)",
+                    (first_message, second_message),
+                )
+            }
+            con.close()
+            if states == {
+                first_message: "succeeded",
+                second_message: "succeeded",
+            }:
+                break
+            time.sleep(0.01)
+
+        self.assertEqual(
+            states,
+            {
+                first_message: "succeeded",
+                second_message: "succeeded",
+            },
+        )
+        self.assertEqual(len(adapters), 2)
+        self.assertTrue(all(adapter.started == 1 for adapter in adapters))
+        self.assertTrue(all(adapter.crossed for adapter in adapters))
+
+    def test_transient_lease_renewal_contention_stays_recoverable(
+        self,
+    ) -> None:
+        adapter = ReconcileSequenceAdapter()
+        broker = self.start_broker(
+            lambda _harness: adapter,
+            recovery_seconds=0.01,
+        )
+        renew_runs = broker.store.renew_runs
+        attempts = 0
+
+        def contend_once(owner, run_ids):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise sqlite3.OperationalError("database is locked")
+            return renew_runs(owner, run_ids)
+
+        broker.store.renew_runs = contend_once
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        deadline = time.monotonic() + 3
+        row = None
+        while time.monotonic() < deadline:
+            con = self.connect()
+            row = con.execute(
+                "SELECT run_id,state FROM conversation_runs "
+                "WHERE trigger_message_id=?",
+                (message_id,),
+            ).fetchone()
+            con.close()
+            if row is not None and row["state"] == "succeeded":
+                break
+            time.sleep(0.01)
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row["state"], "succeeded")
+        self.assertGreaterEqual(attempts, 2)
+        self.assertEqual(adapter.reconciled, 2)
+
     def test_kimi_native_identities_are_persisted_before_first_event(
         self,
     ) -> None:
@@ -817,18 +1062,18 @@ class ServiceContractTest(ConversationBrokerCase):
         ))
         order: list[tuple[str, str, str | None]] = []
         mark_native_started = broker.store.mark_native_started
-        append_event = broker.store.append_event
+        append_events = broker.store.append_events
 
         def record_native(run_id, owner, turn):
             order.append(("native", turn.session_ref, turn.run_ref))
             return mark_native_started(run_id, owner, turn)
 
-        def record_event(run_id, event):
-            order.append(("event", event.type, None))
-            return append_event(run_id, event)
+        def record_events(run_id, events):
+            order.extend(("event", event.type, None) for event in events)
+            return append_events(run_id, events)
 
         broker.store.mark_native_started = record_native
-        broker.store.append_event = record_event
+        broker.store.append_events = record_events
         conversation_id = self.add_conversation(harness="kimi")
         message_id = self.add_message(conversation_id)
         broker.notify()
@@ -897,6 +1142,43 @@ class ServiceContractTest(ConversationBrokerCase):
             events.index("run.interrupt.requested"),
             events.index("run.interrupted"),
         )
+
+    def test_interrupt_intent_normalizes_adapter_failure_to_cancelled(
+        self,
+    ) -> None:
+        adapter = FakeAdapter(
+            block=True,
+            interrupt_terminal="run.failed",
+        )
+        broker = self.start_broker(lambda _harness: adapter)
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        broker.notify()
+
+        deadline = time.monotonic() + 3
+        run_id = None
+        while time.monotonic() < deadline:
+            active = broker.active_run_ids()
+            if active:
+                run_id = active[0]
+                break
+            time.sleep(0.01)
+        self.assertIsNotNone(run_id)
+
+        self.assertTrue(broker.interrupt(run_id))
+        self.wait_run_state(run_id, "cancelled")
+        con = self.connect()
+        terminal = con.execute(
+            "SELECT event_type,payload FROM conversation_events "
+            "WHERE run_id=? AND event_type LIKE 'run.%' "
+            "ORDER BY sequence DESC LIMIT 1",
+            (run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(terminal["event_type"], "run.interrupted")
+        payload = json.loads(terminal["payload"])
+        self.assertEqual(payload["adapter_terminal"], "run.failed")
+        self.assertEqual(payload["interrupt_evidence"], "operator")
 
     def test_opencode_blocking_message_is_interruptible_after_identity(
         self,

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -1051,6 +1051,18 @@ class ServiceContractTest(ConversationBrokerCase):
             stream.write(
                 json.dumps(
                     {
+                        "type": "context.append_loop_event",
+                        "event": {
+                            "type": "step.end",
+                            "finishReason": "end_turn",
+                        },
+                    }
+                )
+                + "\n"
+            )
+            stream.write(
+                json.dumps(
+                    {
                         "type": "usage.record",
                         "usageScope": "turn",
                         "usage": {"inputOther": 4, "output": 2},
@@ -1089,7 +1101,10 @@ class ServiceContractTest(ConversationBrokerCase):
         self.assertEqual(
             json.loads(events[0]["payload"]),
             {
-                "detail": "Kimi exact run slice contains turn-scoped usage",
+                "detail": (
+                    "Kimi exact run slice contains end_turn and "
+                    "turn-scoped usage"
+                ),
                 "outcome": "succeeded",
                 "proven": True,
                 "reconciled": True,


### PR DESCRIPTION
## Summary

- keep Kimi tool-calling turns alive until the exact run slice proves `step.end` with `finishReason=end_turn` plus turn-scoped usage
- require structured native/operator evidence for normalized interrupted terminals; Claude no longer derives cancellation from free-form answer prose
- normalize an adapter failure following an explicit durable operator interrupt to cancellation at the shared broker boundary
- batch noisy assistant events in short transactions and retain a bounded per-run backlog while SQLite is busy
- retry transient event, lease-renewal, reconciliation-note, and terminal writes without abandoning the still-running native stream
- prove two conversations using the same harness can stream concurrently on different shells

## Verification

- full suite: `1291 passed, 1 skipped, 733 subtests passed`
- conversation suites: `167 passed, 162 subtests passed`
- focused adapter/broker suites: `51 passed, 4 subtests passed`
- change-scoped Ruff fatal/B023 checks and Python compilation passed
- `./sc render-check` and `git diff --check` passed
- linked-worktree `./sc verify` remains blocked by #769
- linked-worktree `./sc lint` cannot see the primary checkout Ruff environment (#789); clean-main Ruff baseline remains #854

Closes #856
Closes #857
