### PR TITLE
feat: add Sprint message wake delivery

### DIFF
--- a/.super-coder/migrations/0148_sprint_message_delivery.sql
+++ b/.super-coder/migrations/0148_sprint_message_delivery.sql
@@ -1,0 +1,108 @@
+-- 0148 — Sprint v2 message acceptance and wake-delivery backstops.
+--
+-- Migration 0146 created the durable domain.  This delta adds the claim lease
+-- needed for at-least-once external delivery and database guards for the
+-- read-equals-acceptance contract.  Remote harness work remains outside the
+-- transaction that creates a Sprint message and its wake intent.
+
+BEGIN;
+
+ALTER TABLE sprint_wake_outbox ADD COLUMN claim_owner TEXT;
+ALTER TABLE sprint_wake_outbox ADD COLUMN claimed_at TEXT;
+ALTER TABLE sprint_wake_outbox ADD COLUMN lease_expires_at TEXT;
+
+-- One pending follow-up wake absorbs every active message that arrives while a
+-- participant already has queued or running work.  A currently delivering wake
+-- is distinct: messages arriving behind it coalesce into the next pending row.
+CREATE UNIQUE INDEX idx_sprint_wake_one_pending_participant
+    ON sprint_wake_outbox(sprint_id, participant_id)
+    WHERE state='pending';
+
+CREATE TRIGGER trg_sprint_messages_acceptance_insert
+BEFORE INSERT ON sprint_messages
+WHEN NOT (
+    (NEW.actionable=0 AND NEW.disposition IS NULL
+     AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='pending'
+     AND NEW.read_at IS NULL AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='accepted'
+     AND NEW.read_at IS NOT NULL AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='declined'
+     AND NEW.read_at IS NOT NULL
+     AND trim(COALESCE(NEW.decline_reason,''))<>'')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid Sprint message acceptance state');
+END;
+
+CREATE TRIGGER trg_sprint_messages_acceptance_update
+BEFORE UPDATE OF actionable, disposition, read_at, decline_reason
+ON sprint_messages
+WHEN NOT (
+    (NEW.actionable=0 AND NEW.disposition IS NULL
+     AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='pending'
+     AND NEW.read_at IS NULL AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='accepted'
+     AND NEW.read_at IS NOT NULL AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='declined'
+     AND NEW.read_at IS NOT NULL
+     AND trim(COALESCE(NEW.decline_reason,''))<>'')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid Sprint message acceptance state');
+END;
+
+CREATE TRIGGER trg_sprint_wake_delivery_state_insert
+BEFORE INSERT ON sprint_wake_outbox
+WHEN NOT (
+    (NEW.state='pending' AND NEW.claim_owner IS NULL
+     AND NEW.claimed_at IS NULL AND NEW.lease_expires_at IS NULL
+     AND NEW.delivered_at IS NULL AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='delivering' AND trim(COALESCE(NEW.claim_owner,''))<>''
+     AND NEW.claimed_at IS NOT NULL AND NEW.lease_expires_at IS NOT NULL
+     AND NEW.delivered_at IS NULL AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='delivered' AND NEW.delivered_at IS NOT NULL
+     AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='failed' AND NEW.failed_at IS NOT NULL)
+    OR
+    (NEW.state='cancelled' AND NEW.delivered_at IS NULL)
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid Sprint wake delivery state');
+END;
+
+CREATE TRIGGER trg_sprint_wake_delivery_state_update
+BEFORE UPDATE OF
+    state, claim_owner, claimed_at, lease_expires_at, delivered_at, failed_at
+ON sprint_wake_outbox
+WHEN NOT (
+    (NEW.state='pending' AND NEW.claim_owner IS NULL
+     AND NEW.claimed_at IS NULL AND NEW.lease_expires_at IS NULL
+     AND NEW.delivered_at IS NULL AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='delivering' AND trim(COALESCE(NEW.claim_owner,''))<>''
+     AND NEW.claimed_at IS NOT NULL AND NEW.lease_expires_at IS NOT NULL
+     AND NEW.delivered_at IS NULL AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='delivered' AND NEW.delivered_at IS NOT NULL
+     AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='failed' AND NEW.failed_at IS NOT NULL)
+    OR
+    (NEW.state='cancelled' AND NEW.delivered_at IS NULL)
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid Sprint wake delivery state');
+END;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -148,13 +148,22 @@ class SprintLifecycleStore:
             )
         return True
 
-    def record_wake_failure(self, wake_id: int, error: str) -> int:
+    def record_wake_failure(
+        self,
+        wake_id: int,
+        error: str,
+        *,
+        target_conversation_id: str | None = None,
+        expected_claim_owner: str | None = None,
+    ) -> int:
         """Record one failed attempt; attempt three atomically auto-pauses."""
-        if not error.strip():
+        error = error.strip()
+        if not error:
             raise ValueError("wake failure requires an error")
+        error = error[:16384]
         with db_driver.write_transaction(self.con, "sprint.wake_failure"):
             row = self.con.execute(
-                "SELECT wake_id,sprint_id,state,attempt_count "
+                "SELECT wake_id,sprint_id,state,attempt_count,claim_owner "
                 "FROM sprint_wake_outbox WHERE wake_id=?",
                 (wake_id,),
             ).fetchone()
@@ -164,20 +173,26 @@ class SprintLifecycleStore:
                 raise SprintInvariantError(
                     f"wake {wake_id} is terminal ({row['state']})"
                 )
+            if expected_claim_owner is not None and (
+                row["state"] != "delivering"
+                or row["claim_owner"] != expected_claim_owner
+            ):
+                raise SprintInvariantError("wake delivery claim is not owned")
             attempt = int(row["attempt_count"]) + 1
             if attempt > 3:
                 raise SprintInvariantError(f"wake {wake_id} exhausted attempts")
             self.con.execute(
                 "INSERT INTO sprint_wake_attempts "
-                "(wake_id,attempt_number,outcome,error_detail) "
-                "VALUES (?,?,'failed',?)",
-                (wake_id, attempt, error),
+                "(wake_id,attempt_number,target_conversation_id,outcome,error_detail) "
+                "VALUES (?,?,?,'failed',?)",
+                (wake_id, attempt, target_conversation_id, error),
             )
             terminal = attempt == 3
             self.con.execute(
                 "UPDATE sprint_wake_outbox SET attempt_count=?,state=?,"
                 "last_error=?,failed_at=CASE WHEN ? THEN datetime('now') "
-                "ELSE NULL END WHERE wake_id=?",
+                "ELSE NULL END,claim_owner=NULL,claimed_at=NULL,"
+                "lease_expires_at=NULL WHERE wake_id=?",
                 (
                     attempt,
                     "failed" if terminal else "pending",
@@ -392,11 +407,23 @@ class SprintLifecycleStore:
                     key,
                 ),
             ).lastrowid
-            wake_id = self.con.execute(
-                "INSERT INTO sprint_wake_outbox "
-                "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
-                (sprint_id, unit["participant_id"], f"wake:{key}"),
-            ).lastrowid
+            pending_wake = self.con.execute(
+                "SELECT wake_id FROM sprint_wake_outbox "
+                "WHERE sprint_id=? AND participant_id=? AND state='pending'",
+                (sprint_id, unit["participant_id"]),
+            ).fetchone()
+            wake_id = (
+                int(pending_wake["wake_id"])
+                if pending_wake is not None
+                else int(
+                    self.con.execute(
+                        "INSERT INTO sprint_wake_outbox "
+                        "(sprint_id,participant_id,idempotency_key) "
+                        "VALUES (?,?,?)",
+                        (sprint_id, unit["participant_id"], f"wake:{key}"),
+                    ).lastrowid
+                )
+            )
             self.con.execute(
                 "INSERT INTO sprint_wake_messages "
                 "(sprint_id,wake_id,message_id) VALUES (?,?,?)",
@@ -407,7 +434,8 @@ class SprintLifecycleStore:
                 "updated_at=datetime('now') WHERE work_unit_id=?",
                 (unit_id,),
             )
-            wake_ids.append(int(wake_id))
+            if wake_id not in wake_ids:
+                wake_ids.append(wake_id)
         return wake_ids
 
     def _update_lifecycle(

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Dedicated Sprint v2 messages and retryable wake delivery.
+
+Sprint messages are durable collaboration facts.  An active message commits
+its wake intent in the same SQLite transaction; a later delivery worker claims
+that intent, resolves the participant's current conversation, and performs the
+external harness enqueue outside the database transaction.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import sqlite3
+
+import db_driver
+from sprint_domain import SprintInvariantError, SprintLifecycleStore
+
+
+FIXED_WAKE_PROMPT = (
+    "Check your inbox. If you accept the task(s), mark the message as read "
+    "and act on the message using your assigned sprint skill."
+)
+ACTIONABLE_KINDS = frozenset({"work_assignment", "review_request"})
+
+
+@dataclass(frozen=True)
+class MessageReceipt:
+    message_id: int
+    wake_id: int | None
+    created: bool
+
+
+@dataclass(frozen=True)
+class WakeLease:
+    wake_id: int
+    sprint_id: int
+    participant_id: int
+    target_conversation_id: str | None
+    idempotency_key: str
+    attempt_number: int
+    claim_owner: str
+
+
+@dataclass(frozen=True)
+class DeliveryOutcome:
+    wake_id: int
+    state: str
+    attempt_number: int
+
+
+def _stamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+class SprintMessageStore:
+    """Transactional inbox, acceptance, decline, and wake coalescing."""
+
+    def __init__(self, con: sqlite3.Connection) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+
+    def send(
+        self,
+        sprint_id: int,
+        *,
+        to_participant_id: int,
+        message_kind: str,
+        body: str,
+        idempotency_key: str,
+        from_participant_id: int | None = None,
+        work_unit_id: int | None = None,
+        actionable: bool = False,
+        active: bool = True,
+    ) -> MessageReceipt:
+        body = body.strip()
+        key = idempotency_key.strip()
+        if not body:
+            raise ValueError("Sprint message body is empty")
+        if not key:
+            raise ValueError("Sprint message idempotency key is empty")
+        if actionable and message_kind not in ACTIONABLE_KINDS:
+            raise SprintInvariantError(
+                "only work assignments and review requests are actionable"
+            )
+        with db_driver.write_transaction(self.con, "sprint.message.send"):
+            return self._send(
+                sprint_id,
+                to_participant_id=to_participant_id,
+                message_kind=message_kind,
+                body=body,
+                idempotency_key=key,
+                from_participant_id=from_participant_id,
+                work_unit_id=work_unit_id,
+                actionable=actionable,
+                active=active,
+            )
+
+    def inbox(self, sprint_id: int, shell_id: int) -> list[sqlite3.Row]:
+        return self.con.execute(
+            "SELECT m.* FROM sprint_messages m "
+            "JOIN sprint_participants p "
+            "ON p.sprint_id=m.sprint_id AND p.participant_id=m.to_participant_id "
+            "WHERE m.sprint_id=? AND p.shell_id=? AND m.read_at IS NULL "
+            "ORDER BY m.message_id",
+            (sprint_id, shell_id),
+        ).fetchall()
+
+    def mark_read(self, message_id: int, shell_id: int) -> str | None:
+        """Read one message; actionable reads atomically accept it."""
+        with db_driver.write_transaction(self.con, "sprint.message.read"):
+            message = self._recipient_message(message_id, shell_id)
+            if message["actionable"]:
+                if message["disposition"] == "declined":
+                    return "declined"
+                if message["disposition"] == "pending":
+                    self.con.execute(
+                        "UPDATE sprint_messages SET disposition='accepted',"
+                        "read_at=datetime('now') WHERE message_id=?",
+                        (message_id,),
+                    )
+                disposition = "accepted"
+            else:
+                self.con.execute(
+                    "UPDATE sprint_messages SET read_at=COALESCE(read_at,datetime('now')) "
+                    "WHERE message_id=?",
+                    (message_id,),
+                )
+                disposition = None
+            self._cancel_resolved_wakes(message_id)
+            return disposition
+
+    def decline(self, message_id: int, shell_id: int, reason: str) -> int:
+        """Resolve an actionable message and actively route the result to Planner."""
+        reason = reason.strip()
+        if not reason:
+            raise ValueError("decline requires a reason")
+        with db_driver.write_transaction(self.con, "sprint.message.decline"):
+            message = self._recipient_message(message_id, shell_id)
+            if not message["actionable"]:
+                raise SprintInvariantError("informational messages cannot be declined")
+            if message["disposition"] == "accepted":
+                raise SprintInvariantError("accepted Sprint messages cannot be declined")
+            if message["disposition"] == "pending":
+                self.con.execute(
+                    "UPDATE sprint_messages SET disposition='declined',"
+                    "read_at=datetime('now'),decline_reason=? WHERE message_id=?",
+                    (reason, message_id),
+                )
+                if message["message_kind"] == "work_assignment" and message[
+                    "work_unit_id"
+                ] is not None:
+                    self.con.execute(
+                        "UPDATE sprint_work_units SET disposition='planned',"
+                        "updated_at=datetime('now') WHERE work_unit_id=?",
+                        (message["work_unit_id"],),
+                    )
+            elif message["decline_reason"] != reason:
+                raise SprintInvariantError(
+                    "decline was already recorded with a different reason"
+                )
+
+            planner = self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND role='planner'",
+                (message["sprint_id"],),
+            ).fetchone()
+            if planner is None:
+                raise SprintInvariantError("Sprint has no Planner participant")
+            lifecycle = self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                (message["sprint_id"],),
+            ).fetchone()[0]
+            routed = self._send(
+                int(message["sprint_id"]),
+                to_participant_id=int(planner["participant_id"]),
+                message_kind="notification",
+                body=(
+                    f"Participant declined {message['message_kind']} message "
+                    f"#{message_id}: {reason}"
+                ),
+                idempotency_key=f"decline-result:{message_id}",
+                from_participant_id=int(message["to_participant_id"]),
+                work_unit_id=(
+                    int(message["work_unit_id"])
+                    if message["work_unit_id"] is not None
+                    else None
+                ),
+                actionable=False,
+                active=lifecycle == "armed",
+            )
+            self._cancel_resolved_wakes(message_id)
+            return routed.message_id
+
+    def _send(
+        self,
+        sprint_id: int,
+        *,
+        to_participant_id: int,
+        message_kind: str,
+        body: str,
+        idempotency_key: str,
+        from_participant_id: int | None,
+        work_unit_id: int | None,
+        actionable: bool,
+        active: bool,
+    ) -> MessageReceipt:
+        sprint = self.con.execute(
+            "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+        ).fetchone()
+        if sprint is None:
+            raise KeyError(f"unknown Sprint: {sprint_id}")
+        if active and sprint["lifecycle"] != "armed":
+            raise SprintInvariantError("active Sprint messages require an armed Sprint")
+        recipient = self.con.execute(
+            "SELECT 1 FROM sprint_participants "
+            "WHERE sprint_id=? AND participant_id=?",
+            (sprint_id, to_participant_id),
+        ).fetchone()
+        if recipient is None:
+            raise SprintInvariantError("recipient is not a Sprint participant")
+
+        existing = self.con.execute(
+            "SELECT * FROM sprint_messages WHERE idempotency_key=?",
+            (idempotency_key,),
+        ).fetchone()
+        if existing is not None:
+            actual = (
+                int(existing["sprint_id"]),
+                existing["from_participant_id"],
+                int(existing["to_participant_id"]),
+                existing["work_unit_id"],
+                str(existing["message_kind"]),
+                str(existing["body"]),
+                bool(existing["actionable"]),
+            )
+            expected = (
+                sprint_id,
+                from_participant_id,
+                to_participant_id,
+                work_unit_id,
+                message_kind,
+                body,
+                actionable,
+            )
+            wake = self.con.execute(
+                "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
+                (existing["message_id"],),
+            ).fetchone()
+            if actual != expected or (wake is not None) != active:
+                raise SprintInvariantError(
+                    "Sprint message idempotency key was reused with different input"
+                )
+            return MessageReceipt(
+                int(existing["message_id"]),
+                int(wake["wake_id"]) if wake is not None else None,
+                False,
+            )
+
+        disposition = "pending" if actionable else None
+        message_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_messages "
+                "(sprint_id,from_participant_id,to_participant_id,work_unit_id,"
+                "message_kind,body,actionable,disposition,idempotency_key) "
+                "VALUES (?,?,?,?,?,?,?,?,?)",
+                (
+                    sprint_id,
+                    from_participant_id,
+                    to_participant_id,
+                    work_unit_id,
+                    message_kind,
+                    body,
+                    1 if actionable else 0,
+                    disposition,
+                    idempotency_key,
+                ),
+            ).lastrowid
+        )
+        wake_id = (
+            self._coalesce_wake(sprint_id, to_participant_id, message_id)
+            if active
+            else None
+        )
+        return MessageReceipt(message_id, wake_id, True)
+
+    def _coalesce_wake(
+        self, sprint_id: int, participant_id: int, message_id: int
+    ) -> int:
+        wake = self.con.execute(
+            "SELECT wake_id FROM sprint_wake_outbox "
+            "WHERE sprint_id=? AND participant_id=? AND state='pending'",
+            (sprint_id, participant_id),
+        ).fetchone()
+        if wake is None:
+            wake_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_wake_outbox "
+                    "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
+                    (
+                        sprint_id,
+                        participant_id,
+                        f"sprint:{sprint_id}:participant:{participant_id}:"
+                        f"wake-for-message:{message_id}",
+                    ),
+                ).lastrowid
+            )
+        else:
+            wake_id = int(wake["wake_id"])
+        self.con.execute(
+            "INSERT INTO sprint_wake_messages (sprint_id,wake_id,message_id) "
+            "VALUES (?,?,?)",
+            (sprint_id, wake_id, message_id),
+        )
+        return wake_id
+
+    def _recipient_message(self, message_id: int, shell_id: int) -> sqlite3.Row:
+        row = self.con.execute(
+            "SELECT m.* FROM sprint_messages m "
+            "JOIN sprint_participants p "
+            "ON p.sprint_id=m.sprint_id AND p.participant_id=m.to_participant_id "
+            "WHERE m.message_id=? AND p.shell_id=?",
+            (message_id, shell_id),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"Sprint message {message_id} is not addressed to shell")
+        return row
+
+    def _cancel_resolved_wakes(self, message_id: int) -> None:
+        wake_ids = self.con.execute(
+            "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
+            (message_id,),
+        ).fetchall()
+        for wake in wake_ids:
+            unresolved = self.con.execute(
+                "SELECT 1 FROM sprint_wake_messages wm "
+                "JOIN sprint_messages m USING (message_id) "
+                "WHERE wm.wake_id=? AND m.read_at IS NULL LIMIT 1",
+                (wake["wake_id"],),
+            ).fetchone()
+            if unresolved is None:
+                self.con.execute(
+                    "UPDATE sprint_wake_outbox SET state='cancelled',"
+                    "claim_owner=NULL,claimed_at=NULL,lease_expires_at=NULL "
+                    "WHERE wake_id=? AND state='pending'",
+                    (wake["wake_id"],),
+                )
+
+
+class SprintWakeDeliveryService:
+    """Lease and deliver committed wake intents with a three-attempt budget."""
+
+    def __init__(
+        self,
+        con: sqlite3.Connection,
+        *,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+        self.now = now or (lambda: datetime.now(timezone.utc))
+        self.lifecycle = SprintLifecycleStore(con)
+
+    def requeue_expired(self) -> int:
+        now = _stamp(self.now())
+        with db_driver.write_transaction(self.con, "sprint.wake.recover"):
+            result = self.con.execute(
+                "UPDATE sprint_wake_outbox SET state='pending',claim_owner=NULL,"
+                "claimed_at=NULL,lease_expires_at=NULL "
+                "WHERE state='delivering' AND lease_expires_at<=? "
+                "AND NOT EXISTS (SELECT 1 FROM sprint_wake_outbox followup "
+                "WHERE followup.sprint_id=sprint_wake_outbox.sprint_id "
+                "AND followup.participant_id=sprint_wake_outbox.participant_id "
+                "AND followup.state='pending')",
+                (now,),
+            )
+        return int(result.rowcount)
+
+    def claim_next(self, owner: str, *, lease_seconds: int = 60) -> WakeLease | None:
+        owner = owner.strip()
+        if not owner:
+            raise ValueError("wake claim owner is empty")
+        if lease_seconds <= 0:
+            raise ValueError("wake lease must be positive")
+        now_value = self.now()
+        now = _stamp(now_value)
+        expires = _stamp(now_value + timedelta(seconds=lease_seconds))
+        with db_driver.write_transaction(self.con, "sprint.wake.claim"):
+            self.con.execute(
+                "UPDATE sprint_wake_outbox SET state='pending',claim_owner=NULL,"
+                "claimed_at=NULL,lease_expires_at=NULL "
+                "WHERE state='delivering' AND lease_expires_at<=? "
+                "AND NOT EXISTS (SELECT 1 FROM sprint_wake_outbox followup "
+                "WHERE followup.sprint_id=sprint_wake_outbox.sprint_id "
+                "AND followup.participant_id=sprint_wake_outbox.participant_id "
+                "AND followup.state='pending')",
+                (now,),
+            )
+            row = self.con.execute(
+                "SELECT w.*,p.current_conversation_id "
+                "FROM sprint_wake_outbox w "
+                "JOIN sprints s USING (sprint_id) "
+                "JOIN sprint_participants p "
+                "ON p.sprint_id=w.sprint_id AND p.participant_id=w.participant_id "
+                "WHERE ((w.state='delivering' AND w.lease_expires_at<=?) "
+                "OR (w.state='pending' AND w.available_at<=?)) "
+                "AND s.lifecycle='armed' "
+                "AND EXISTS (SELECT 1 FROM sprint_wake_messages wm "
+                "JOIN sprint_messages m USING (message_id) "
+                "WHERE wm.wake_id=w.wake_id AND m.read_at IS NULL) "
+                "ORDER BY w.wake_id LIMIT 1",
+                (now, now),
+            ).fetchone()
+            if row is None:
+                return None
+            if row["state"] == "pending":
+                result = self.con.execute(
+                    "UPDATE sprint_wake_outbox SET state='delivering',claim_owner=?,"
+                    "claimed_at=?,lease_expires_at=? "
+                    "WHERE wake_id=? AND state='pending'",
+                    (owner, now, expires, row["wake_id"]),
+                )
+            else:
+                result = self.con.execute(
+                    "UPDATE sprint_wake_outbox SET claim_owner=?,claimed_at=?,"
+                    "lease_expires_at=? WHERE wake_id=? AND state='delivering' "
+                    "AND lease_expires_at<=?",
+                    (owner, now, expires, row["wake_id"], now),
+                )
+            if result.rowcount != 1:
+                return None
+            return WakeLease(
+                wake_id=int(row["wake_id"]),
+                sprint_id=int(row["sprint_id"]),
+                participant_id=int(row["participant_id"]),
+                target_conversation_id=row["current_conversation_id"],
+                idempotency_key=str(row["idempotency_key"]),
+                attempt_number=int(row["attempt_count"]) + 1,
+                claim_owner=owner,
+            )
+
+    def deliver_once(
+        self,
+        owner: str,
+        deliver: Callable[[str, str, str], str | None],
+    ) -> DeliveryOutcome | None:
+        lease = self.claim_next(owner)
+        if lease is None:
+            return None
+        try:
+            if lease.target_conversation_id is None:
+                raise RuntimeError("participant has no current Sprint conversation")
+            native_run_ref = deliver(
+                lease.target_conversation_id,
+                FIXED_WAKE_PROMPT,
+                lease.idempotency_key,
+            )
+        except Exception as exc:  # external delivery faults become durable evidence
+            attempt = self.lifecycle.record_wake_failure(
+                lease.wake_id,
+                str(exc) or exc.__class__.__name__,
+                target_conversation_id=lease.target_conversation_id,
+                expected_claim_owner=owner,
+            )
+            state = "failed" if attempt == 3 else "pending"
+            return DeliveryOutcome(lease.wake_id, state, attempt)
+
+        with db_driver.write_transaction(self.con, "sprint.wake.delivered"):
+            row = self.con.execute(
+                "SELECT state,claim_owner,attempt_count FROM sprint_wake_outbox "
+                "WHERE wake_id=?",
+                (lease.wake_id,),
+            ).fetchone()
+            if row is None or row["state"] != "delivering":
+                raise SprintInvariantError("wake lease is no longer deliverable")
+            if row["claim_owner"] != owner:
+                raise SprintInvariantError("wake lease is owned by another worker")
+            attempt = int(row["attempt_count"]) + 1
+            self.con.execute(
+                "INSERT INTO sprint_wake_attempts "
+                "(wake_id,attempt_number,target_conversation_id,native_run_ref,"
+                "outcome) VALUES (?,?,?,?,'delivered')",
+                (
+                    lease.wake_id,
+                    attempt,
+                    lease.target_conversation_id,
+                    native_run_ref,
+                ),
+            )
+            self.con.execute(
+                "UPDATE sprint_wake_outbox SET state='delivered',attempt_count=?,"
+                "delivered_at=datetime('now'),claim_owner=NULL,claimed_at=NULL,"
+                "lease_expires_at=NULL,last_error=NULL WHERE wake_id=?",
+                (attempt, lease.wake_id),
+            )
+        return DeliveryOutcome(lease.wake_id, "delivered", attempt)

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -1,14 +1,17 @@
 {
   "allowed_reference_files": [
     ".super-coder/migrations/0146_sprint_v2_domain.sql",
+    ".super-coder/migrations/0148_sprint_message_delivery.sql",
     ".super-coder/scripts/sprint_domain.py",
+    ".super-coder/scripts/sprint_message_delivery.py",
     ".super-coder/migrations/0144_remove_sprint_v1.sql",
     "tests/fixtures/sprint_removal/build_pre_removal_fixture.py",
     "tests/fixtures/sprint_removal/manifest.json",
     "tests/fixtures/sprint_removal/pre_removal.sql",
     "tests/test_sprint_entrypoint_removal.py",
     "tests/test_sprint_removal_manifest.py",
-    "tests/test_sprint_v2_domain.py"
+    "tests/test_sprint_v2_domain.py",
+    "tests/test_sprint_message_delivery.py"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Stage 3 gates for dedicated Sprint messages and wake delivery."""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import sprint_domain  # noqa: E402
+import sprint_message_delivery as delivery  # noqa: E402
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+class SprintMessageCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = sqlite3.connect(":memory:")
+        self.addCleanup(self.con.close)
+        self.con.row_factory = sqlite3.Row
+        apply_schema(self.con)
+        self.con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        self.con.executemany(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (?,?,?,?,?,1)",
+            (
+                (1, "Developer", "DEV1", "dev", "prompt"),
+                (2, "Reviewer", "REV1", "reviewer", "prompt"),
+                (3, "Planner", "PLN1", "planner", "prompt"),
+            ),
+        )
+        self.con.executemany(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,owner_user_id,harness,worktree,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES (?,?,1,'codex',?,?,?)",
+            (
+                ("cv_dev", 1, "/tmp/dev", "conversation-dev", "hash-dev"),
+                ("cv_review", 2, "/tmp/review", "conversation-review", "hash-review"),
+                ("cv_plan", 3, "/tmp/plan", "conversation-plan", "hash-plan"),
+            ),
+        )
+        feature_id = self.con.execute(
+            "INSERT INTO roadmap (title,roadmap_status) "
+            "VALUES ('Feature','in_progress')"
+        ).lastrowid
+        body = "governing spec"
+        document_id = self.con.execute(
+            "INSERT INTO documents (feature_id,kind,seq,title,body) "
+            "VALUES (?,'spec',1,'Spec',?)",
+            (feature_id, body),
+        ).lastrowid
+        revision = hashlib.sha256(body.encode()).hexdigest()
+        approval_id = self.con.execute(
+            "INSERT INTO sprint_spec_approvals "
+            "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+            "VALUES (?,?,2,'pass')",
+            (document_id, revision),
+        ).lastrowid
+        self.sprint_id = int(
+            self.con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_specs "
+            "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+            "VALUES (?,?,?,?)",
+            (self.sprint_id, document_id, revision, approval_id),
+        )
+        self.con.executemany(
+            "INSERT INTO sprint_participants "
+            "(sprint_id,shell_id,role,harness,current_conversation_id) "
+            "VALUES (?,?,?,?,?)",
+            (
+                (self.sprint_id, 3, "planner", "codex", "cv_plan"),
+                (self.sprint_id, 1, "developer", "codex", "cv_dev"),
+                (self.sprint_id, 2, "reviewer", "codex", "cv_review"),
+            ),
+        )
+        participants = {
+            row["role"]: int(row["participant_id"])
+            for row in self.con.execute(
+                "SELECT role,participant_id FROM sprint_participants "
+                "WHERE sprint_id=?",
+                (self.sprint_id,),
+            )
+        }
+        self.planner_id = participants["planner"]
+        self.developer_id = participants["developer"]
+        self.reviewer_id = participants["reviewer"]
+        self.unit_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,expected_output) "
+                "VALUES (?,1,2,'Unit','Ship it')",
+                (self.sprint_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+        self.lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        initial_wake = self.lifecycle.arm(self.sprint_id, 3)[0]
+        initial_message = self.con.execute(
+            "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",
+            (initial_wake,),
+        ).fetchone()[0]
+        self.messages = delivery.SprintMessageStore(self.con)
+        self.assertEqual("accepted", self.messages.mark_read(initial_message, 1))
+
+    def send(
+        self,
+        key: str,
+        *,
+        kind: str = "notification",
+        actionable: bool = False,
+        to_participant_id: int | None = None,
+        active: bool = True,
+    ) -> delivery.MessageReceipt:
+        return self.messages.send(
+            self.sprint_id,
+            to_participant_id=to_participant_id or self.developer_id,
+            from_participant_id=self.planner_id,
+            work_unit_id=self.unit_id,
+            message_kind=kind,
+            body=f"body for {key}",
+            actionable=actionable,
+            active=active,
+            idempotency_key=key,
+        )
+
+
+class MessageTransactionTest(SprintMessageCase):
+    def test_message_and_active_wake_commit_or_roll_back_together(self) -> None:
+        before = tuple(
+            self.con.execute(
+                "SELECT (SELECT COUNT(*) FROM sprint_messages),"
+                "(SELECT COUNT(*) FROM sprint_wake_outbox)"
+            ).fetchone()
+        )
+        self.con.execute(
+            "CREATE TEMP TRIGGER fail_wake BEFORE INSERT ON sprint_wake_outbox "
+            "BEGIN SELECT RAISE(ABORT,'simulated crash window'); END"
+        )
+
+        with self.assertRaisesRegex(sqlite3.IntegrityError, "simulated crash"):
+            self.send("atomic")
+
+        self.assertEqual(
+            before,
+            tuple(
+                self.con.execute(
+                    "SELECT (SELECT COUNT(*) FROM sprint_messages),"
+                    "(SELECT COUNT(*) FROM sprint_wake_outbox)"
+                ).fetchone()
+            ),
+        )
+
+    def test_idempotency_replays_exact_input_and_rejects_conflicts(self) -> None:
+        first = self.send("same-key")
+        replay = self.send("same-key")
+        self.assertEqual(first.message_id, replay.message_id)
+        self.assertEqual(first.wake_id, replay.wake_id)
+        self.assertFalse(replay.created)
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "different input"
+        ):
+            self.messages.send(
+                self.sprint_id,
+                to_participant_id=self.developer_id,
+                message_kind="notification",
+                body="different body",
+                idempotency_key="same-key",
+                active=True,
+            )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_messages WHERE idempotency_key='same-key'"
+            ).fetchone()[0],
+        )
+
+    def test_only_task_messages_are_actionable_and_passive_has_no_wake(self) -> None:
+        before = self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0]
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "only work assignments"
+        ):
+            self.send("bad-action", actionable=True)
+        self.assertEqual(
+            before,
+            self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0],
+        )
+
+        passive = self.send("passive", active=False)
+        self.assertIsNone(passive.wake_id)
+        self.assertEqual(
+            [],
+            self.con.execute(
+                "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
+                (passive.message_id,),
+            ).fetchall(),
+        )
+
+
+class AcceptanceAndDeclineTest(SprintMessageCase):
+    def test_actionable_read_accepts_but_informational_read_does_not(self) -> None:
+        task = self.send(
+            "accept-task", kind="review_request", actionable=True
+        )
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "invalid Sprint message acceptance state"
+        ):
+            self.con.execute(
+                "UPDATE sprint_messages SET read_at=datetime('now') "
+                "WHERE message_id=?",
+                (task.message_id,),
+            )
+        self.con.rollback()
+        self.assertEqual("accepted", self.messages.mark_read(task.message_id, 1))
+        task_row = self.con.execute(
+            "SELECT disposition,read_at,decline_reason FROM sprint_messages "
+            "WHERE message_id=?",
+            (task.message_id,),
+        ).fetchone()
+        self.assertEqual("accepted", task_row["disposition"])
+        self.assertIsNotNone(task_row["read_at"])
+        self.assertIsNone(task_row["decline_reason"])
+
+        info = self.send("read-info")
+        self.assertIsNone(self.messages.mark_read(info.message_id, 1))
+        info_row = self.con.execute(
+            "SELECT disposition,read_at FROM sprint_messages WHERE message_id=?",
+            (info.message_id,),
+        ).fetchone()
+        self.assertIsNone(info_row["disposition"])
+        self.assertIsNotNone(info_row["read_at"])
+
+    def test_declines_resolve_source_and_route_once_to_planner(self) -> None:
+        assignment = self.send(
+            "decline-assignment", kind="work_assignment", actionable=True
+        )
+        assignment_result = self.messages.decline(
+            assignment.message_id, 1, "wrong editing lane"
+        )
+        review = self.send(
+            "decline-review",
+            kind="review_request",
+            actionable=True,
+            to_participant_id=self.reviewer_id,
+        )
+        review_result = self.messages.decline(
+            review.message_id, 2, "review capacity unavailable"
+        )
+        self.assertEqual(
+            assignment_result,
+            self.messages.decline(assignment.message_id, 1, "wrong editing lane"),
+        )
+
+        declined = [
+            tuple(row)
+            for row in self.con.execute(
+                "SELECT disposition,read_at IS NOT NULL,decline_reason "
+                "FROM sprint_messages WHERE message_id IN (?,?) ORDER BY message_id",
+                (assignment.message_id, review.message_id),
+            )
+        ]
+        self.assertEqual(
+            [
+                ("declined", 1, "wrong editing lane"),
+                ("declined", 1, "review capacity unavailable"),
+            ],
+            declined,
+        )
+        self.assertEqual(
+            "planned",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+        planner_results = [
+            tuple(row)
+            for row in self.con.execute(
+                "SELECT message_id,to_participant_id,body FROM sprint_messages "
+                "WHERE message_id IN (?,?) ORDER BY message_id",
+                (assignment_result, review_result),
+            )
+        ]
+        self.assertEqual(2, len(planner_results))
+        self.assertEqual(
+            [self.planner_id, self.planner_id],
+            [row[1] for row in planner_results],
+        )
+        self.assertIn("wrong editing lane", planner_results[0][2])
+        self.assertIn("review capacity unavailable", planner_results[1][2])
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(DISTINCT wm.wake_id) "
+                "FROM sprint_wake_messages wm "
+                "WHERE wm.message_id IN (?,?)",
+                (assignment_result, review_result),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            ["cancelled", "cancelled"],
+            [
+                row[0]
+                for row in self.con.execute(
+                    "SELECT w.state FROM sprint_wake_outbox w "
+                    "JOIN sprint_wake_messages wm USING (wake_id) "
+                    "WHERE wm.message_id IN (?,?) ORDER BY wm.message_id",
+                    (assignment.message_id, review.message_id),
+                )
+            ],
+        )
+
+    def test_decline_while_paused_records_passive_planner_result(self) -> None:
+        assignment = self.send(
+            "paused-decline", kind="work_assignment", actionable=True
+        )
+        self.lifecycle.transition(
+            self.sprint_id,
+            "paused",
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="integrity hold",
+        )
+
+        result_id = self.messages.decline(
+            assignment.message_id, 1, "cannot safely continue"
+        )
+
+        result = self.con.execute(
+            "SELECT to_participant_id,body FROM sprint_messages WHERE message_id=?",
+            (result_id,),
+        ).fetchone()
+        self.assertEqual(self.planner_id, result["to_participant_id"])
+        self.assertIn("cannot safely continue", result["body"])
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_wake_messages WHERE message_id=?",
+                (result_id,),
+            ).fetchone()[0],
+        )
+
+
+class WakeDeliveryTest(SprintMessageCase):
+    def test_fixed_prompt_and_target_are_durable_delivery_evidence(self) -> None:
+        sent = self.send("deliver")
+        observed: list[tuple[str, str, str]] = []
+        service = delivery.SprintWakeDeliveryService(self.con)
+
+        outcome = service.deliver_once(
+            "worker-a",
+            lambda conversation, prompt, key: (
+                observed.append((conversation, prompt, key)) or "native-run-7"
+            ),
+        )
+
+        self.assertEqual(
+            [("cv_dev", delivery.FIXED_WAKE_PROMPT, self._wake_key(sent.wake_id))],
+            observed,
+        )
+        self.assertEqual(
+            (sent.wake_id, "delivered", 1),
+            (outcome.wake_id, outcome.state, outcome.attempt_number),
+        )
+        attempt = self.con.execute(
+            "SELECT attempt_number,target_conversation_id,native_run_ref,outcome "
+            "FROM sprint_wake_attempts WHERE wake_id=?",
+            (sent.wake_id,),
+        ).fetchone()
+        self.assertEqual((1, "cv_dev", "native-run-7", "delivered"), tuple(attempt))
+
+    def test_messages_behind_delivering_wake_coalesce_once(self) -> None:
+        first = self.send("first")
+        service = delivery.SprintWakeDeliveryService(self.con)
+        lease = service.claim_next("worker-a")
+        self.assertEqual(first.wake_id, lease.wake_id)
+
+        second = self.send("second")
+        third = self.send("third")
+
+        self.assertNotEqual(first.wake_id, second.wake_id)
+        self.assertEqual(second.wake_id, third.wake_id)
+        self.assertEqual(
+            [(first.wake_id, "delivering", 1), (second.wake_id, "pending", 2)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT w.wake_id,w.state,COUNT(wm.message_id) "
+                    "FROM sprint_wake_outbox w "
+                    "JOIN sprint_wake_messages wm USING (wake_id) "
+                    "WHERE w.wake_id IN (?,?) GROUP BY w.wake_id ORDER BY w.wake_id",
+                    (first.wake_id, second.wake_id),
+                )
+            ],
+        )
+
+    def test_expired_claim_retries_same_identity_without_logical_duplicate(self) -> None:
+        sent = self.send("crash-retry")
+        clock = [datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc)]
+        service = delivery.SprintWakeDeliveryService(self.con, now=lambda: clock[0])
+        first = service.claim_next("worker-a", lease_seconds=5)
+        invocations: list[str] = []
+
+        # Remote enqueue succeeds, then the worker crashes before recording it.
+        invocations.append(first.idempotency_key)
+        clock[0] += timedelta(seconds=6)
+        self.assertEqual(1, service.requeue_expired())
+        outcome = service.deliver_once(
+            "worker-b",
+            lambda _conversation, _prompt, key: (
+                invocations.append(key) or "same-native-run"
+            ),
+        )
+
+        self.assertEqual([self._wake_key(sent.wake_id)] * 2, invocations)
+        self.assertEqual(1, len(set(invocations)))
+        self.assertEqual("delivered", outcome.state)
+        self.assertEqual(
+            [(1, "same-native-run", "delivered")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT attempt_number,native_run_ref,outcome "
+                    "FROM sprint_wake_attempts WHERE wake_id=?",
+                    (sent.wake_id,),
+                )
+            ],
+        )
+
+    def test_expired_wake_is_reclaimed_before_its_pending_followup(self) -> None:
+        first = self.send("expired-first")
+        clock = [datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc)]
+        service = delivery.SprintWakeDeliveryService(self.con, now=lambda: clock[0])
+        first_lease = service.claim_next("worker-a", lease_seconds=5)
+        second = self.send("pending-second")
+        clock[0] += timedelta(seconds=6)
+
+        self.assertEqual(0, service.requeue_expired())
+        reclaimed = service.claim_next("worker-b", lease_seconds=5)
+
+        self.assertEqual(first.wake_id, reclaimed.wake_id)
+        self.assertEqual(self._wake_key(first.wake_id), reclaimed.idempotency_key)
+        self.assertEqual(
+            ("delivering", "pending"),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT state FROM sprint_wake_outbox WHERE wake_id=?),"
+                    "(SELECT state FROM sprint_wake_outbox WHERE wake_id=?)",
+                    (first.wake_id, second.wake_id),
+                ).fetchone()
+            ),
+        )
+
+    def test_third_delivery_failure_auto_pauses_and_stops_claiming(self) -> None:
+        sent = self.send("always-fails")
+        service = delivery.SprintWakeDeliveryService(self.con)
+
+        outcomes = [
+            service.deliver_once(
+                "worker-a",
+                lambda _conversation, _prompt, _key: (_ for _ in ()).throw(
+                    RuntimeError("provider unavailable")
+                ),
+            )
+            for _ in range(3)
+        ]
+
+        self.assertEqual(
+            [(1, "pending"), (2, "pending"), (3, "failed")],
+            [(item.attempt_number, item.state) for item in outcomes],
+        )
+        self.assertIsNone(service.claim_next("worker-a"))
+        self.assertEqual(
+            ("paused", "failed", 3, None),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,w.state,w.attempt_count,w.claim_owner "
+                    "FROM sprints s JOIN sprint_wake_outbox w USING (sprint_id) "
+                    "WHERE w.wake_id=?",
+                    (sent.wake_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            [(1, "failed"), (2, "failed"), (3, "failed")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT attempt_number,outcome FROM sprint_wake_attempts "
+                    "WHERE wake_id=? ORDER BY attempt_number",
+                    (sent.wake_id,),
+                )
+            ],
+        )
+
+    def _wake_key(self, wake_id: int | None) -> str:
+        return self.con.execute(
+            "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
+            (wake_id,),
+        ).fetchone()[0]
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -311,6 +311,32 @@ class LifecycleTest(SprintDomainCase):
             ).fetchone()[0],
         )
 
+    def test_arm_coalesces_ready_messages_for_the_same_participant(self) -> None:
+        sprint_id, first_unit = self.create_sprint()
+        second_unit = self.con.execute(
+            "INSERT INTO sprint_work_units "
+            "(sprint_id,assigned_shell_id,reviewer_shell_id,title,expected_output) "
+            "VALUES (?,1,2,'Second','Ship second')",
+            (sprint_id,),
+        ).lastrowid
+        self.con.commit()
+
+        wake_ids = self.store.arm(sprint_id, 3)
+
+        self.assertEqual(1, len(wake_ids))
+        self.assertEqual(
+            [(first_unit,), (second_unit,)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT m.work_unit_id FROM sprint_wake_messages wm "
+                    "JOIN sprint_messages m USING (message_id) "
+                    "WHERE wm.wake_id=? ORDER BY m.message_id",
+                    (wake_ids[0],),
+                )
+            ],
+        )
+
     def test_arm_rejects_wrong_planner_and_unapproved_spec_without_effect(self) -> None:
         sprint_id, unit_id = self.create_sprint(approval_verdict="fail")
         with self.assertRaises(sprint_domain.SprintAuthorityError):


### PR DESCRIPTION
## Summary
- add the dedicated Sprint message store with actionable read-equals-acceptance, durable decline routing, and atomic active message + wake creation
- add lease-based wake delivery with the fixed prompt, stable idempotency identity, pending-follow-up coalescing, crash recovery, and three-attempt auto-pause
- add migration backstops, initial-arm coalescing, adversarial tests, and the R1 v1-removal allowlist extension

## Trade-off
Sprint semantics remain isolated in `sprint_messages`; generic conversations are reused only as the external delivery target resolved from the participant current-pointer at claim time. Expired in-flight wakes are reclaimed in place ahead of pending follow-ups so both logical identities remain intact.

## Verification
- `python3 tests/test_sprint_message_delivery.py` (11/11)
- `python3 tests/test_sprint_v2_domain.py` (13/13)
- `python3 tests/test_sprint_removal_manifest.py` (14/14)
- `./sc render-check`
- `git diff --check`
- full stdlib discovery executed 1,217 tests; four pytest-only modules could not import because pytest is unavailable on this host, with no executed-test failures