### PR TITLE
feat: dispatch Sprint work units

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -65,6 +65,7 @@ import conversation_launch  # noqa: E402  (canonical shell launch preparation)
 import db_driver  # noqa: E402
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, spec #30 req 11)
+import sprint_runtime  # noqa: E402  (armed-only Sprint dispatch + wake delivery)
 sys.path.insert(0, str(ENGINE / "api"))
 import conversation_routes  # noqa: E402  (Feature #24 browser conversations)
 import review_routes  # noqa: E402  (Feature #26 browser Diff review)
@@ -3225,6 +3226,15 @@ def require_loopback_bind(bind: str) -> None:
     )
 
 
+def start_runtime_services() -> None:
+    """Start commit-woken conversations, then the armed Sprint pulse."""
+    conversation_broker.start_service(
+        DB_PATH,
+        launch_preparer=conversation_launch.ConversationLaunchPreparer(DB_PATH),
+    )
+    sprint_runtime.start_service(DB_PATH)
+
+
 def main(argv):
     port = None
     if "--port" in argv:
@@ -3272,12 +3282,7 @@ def main(argv):
             port,
             dispatch_http,
             _ws_unavailable,
-            on_started=lambda: conversation_broker.start_service(
-                DB_PATH,
-                launch_preparer=conversation_launch.ConversationLaunchPreparer(
-                    DB_PATH
-                ),
-            ),
+            on_started=start_runtime_services,
             stream_handler=conversation_routes.stream_events,
         )
 

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -7,15 +7,14 @@ registered poll/dispatch callbacks from running outside an armed Sprint.
 """
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 import hashlib
 import json
 import sqlite3
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
 import db_driver
 import sprint_participant_chats
-
 
 SPRINT_TRANSITIONS = {
     "prepared": frozenset({"armed", "aborted"}),
@@ -24,6 +23,10 @@ SPRINT_TRANSITIONS = {
     "completed": frozenset(),
     "aborted": frozenset(),
 }
+
+EDITING_UNIT_DISPOSITIONS = frozenset(
+    {"active", "in_review", "fixing", "merge_ready"}
+)
 
 
 class SprintLifecycleError(ValueError):
@@ -384,66 +387,10 @@ class SprintLifecycleStore:
         *,
         planner_participant_id: int,
     ) -> list[int]:
-        units = self.con.execute(
-            "SELECT u.work_unit_id,u.assigned_shell_id,u.title,u.expected_output,"
-            "p.participant_id FROM sprint_work_units u "
-            "JOIN sprint_participants p ON p.sprint_id=u.sprint_id "
-            "AND p.shell_id=u.assigned_shell_id AND p.role='developer' "
-            "WHERE u.sprint_id=? AND u.disposition='planned' "
-            "AND NOT EXISTS (SELECT 1 FROM sprint_work_unit_dependencies d "
-            "WHERE d.work_unit_id=u.work_unit_id) "
-            "ORDER BY u.planned_wave,u.work_unit_id",
-            (sprint_id,),
-        ).fetchall()
-        wake_ids: list[int] = []
-        for unit in units:
-            unit_id = int(unit["work_unit_id"])
-            key = f"sprint:{sprint_id}:work-unit:{unit_id}:assignment"
-            message_id = self.con.execute(
-                "INSERT INTO sprint_messages "
-                "(sprint_id,from_participant_id,to_participant_id,work_unit_id,"
-                "message_kind,body,actionable,disposition,idempotency_key) "
-                "VALUES (?,?,?,?,?,?,1,'pending',?)",
-                (
-                    sprint_id,
-                    planner_participant_id,
-                    unit["participant_id"],
-                    unit_id,
-                    "work_assignment",
-                    f"{unit['title']}\n\n{unit['expected_output']}",
-                    key,
-                ),
-            ).lastrowid
-            pending_wake = self.con.execute(
-                "SELECT wake_id FROM sprint_wake_outbox "
-                "WHERE sprint_id=? AND participant_id=? AND state='pending'",
-                (sprint_id, unit["participant_id"]),
-            ).fetchone()
-            wake_id = (
-                int(pending_wake["wake_id"])
-                if pending_wake is not None
-                else int(
-                    self.con.execute(
-                        "INSERT INTO sprint_wake_outbox "
-                        "(sprint_id,participant_id,idempotency_key) "
-                        "VALUES (?,?,?)",
-                        (sprint_id, unit["participant_id"], f"wake:{key}"),
-                    ).lastrowid
-                )
-            )
-            self.con.execute(
-                "INSERT INTO sprint_wake_messages "
-                "(sprint_id,wake_id,message_id) VALUES (?,?,?)",
-                (sprint_id, wake_id, message_id),
-            )
-            self.con.execute(
-                "UPDATE sprint_work_units SET disposition='ready',"
-                "updated_at=datetime('now') WHERE work_unit_id=?",
-                (unit_id,),
-            )
-            if wake_id not in wake_ids:
-                wake_ids.append(wake_id)
-        return wake_ids
+        return SprintWorkUnitStore(self.con)._dispatch_ready_locked(
+            sprint_id,
+            planner_participant_id=planner_participant_id,
+        )
 
     def _update_lifecycle(
         self,
@@ -484,6 +431,496 @@ class SprintLifecycleStore:
                 event_type,
                 actor.kind,
                 actor.shell_id,
+                json.dumps(payload, sort_keys=True),
+            ),
+        )
+
+
+class SprintWorkUnitStore:
+    """Planner-owned work-unit planning and dependency-aware dispatch."""
+
+    def __init__(self, con: sqlite3.Connection) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+
+    def create(
+        self,
+        sprint_id: int,
+        planner_shell_id: int,
+        *,
+        assigned_shell_id: int,
+        reviewer_shell_id: int,
+        title: str,
+        expected_output: str,
+        task_ids: Iterable[int],
+        planned_wave: int = 0,
+        dependency_ids: Iterable[int] = (),
+    ) -> int:
+        """Create one planned editing lane from existing governing-spec tasks."""
+        title = title.strip()
+        expected_output = expected_output.strip()
+        tasks = tuple(dict.fromkeys(int(task_id) for task_id in task_ids))
+        dependencies = tuple(
+            dict.fromkeys(int(unit_id) for unit_id in dependency_ids)
+        )
+        if not title or not expected_output:
+            raise ValueError("work unit title and expected output are required")
+        if not tasks:
+            raise SprintInvariantError("work units require at least one spec task")
+        if planned_wave < 0:
+            raise ValueError("planned wave must be non-negative")
+
+        with db_driver.write_transaction(self.con, "sprint.work_unit.create"):
+            lifecycle, _ = self._require_planner(sprint_id, planner_shell_id)
+            if lifecycle in {"completed", "aborted"}:
+                raise SprintInvariantError("terminal Sprints reject new work units")
+            self._require_participant(sprint_id, assigned_shell_id, "developer")
+            self._require_participant(sprint_id, reviewer_shell_id, "reviewer")
+            self._require_tasks(sprint_id, tasks)
+            unit_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_work_units "
+                    "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                    "expected_output,planned_wave) VALUES (?,?,?,?,?,?)",
+                    (
+                        sprint_id,
+                        assigned_shell_id,
+                        reviewer_shell_id,
+                        title,
+                        expected_output,
+                        planned_wave,
+                    ),
+                ).lastrowid
+            )
+            self.con.executemany(
+                "INSERT INTO sprint_work_unit_tasks "
+                "(sprint_id,work_unit_id,task_id) VALUES (?,?,?)",
+                ((sprint_id, unit_id, task_id) for task_id in tasks),
+            )
+            self._replace_dependencies(sprint_id, unit_id, dependencies)
+            self._event(
+                sprint_id,
+                "work_unit.created",
+                planner_shell_id,
+                {
+                    "work_unit_id": unit_id,
+                    "assigned_shell_id": assigned_shell_id,
+                    "reviewer_shell_id": reviewer_shell_id,
+                    "planned_wave": planned_wave,
+                    "task_ids": list(tasks),
+                    "dependency_ids": list(dependencies),
+                },
+            )
+        return unit_id
+
+    def replan(
+        self,
+        sprint_id: int,
+        work_unit_id: int,
+        planner_shell_id: int,
+        *,
+        assigned_shell_id: int,
+        reviewer_shell_id: int,
+        planned_wave: int,
+        dependency_ids: Iterable[int],
+    ) -> bool:
+        """Replace the editable plan projection and append its before/after fact."""
+        if planned_wave < 0:
+            raise ValueError("planned wave must be non-negative")
+        dependencies = tuple(
+            dict.fromkeys(int(unit_id) for unit_id in dependency_ids)
+        )
+        with db_driver.write_transaction(self.con, "sprint.work_unit.replan"):
+            self._require_planner(sprint_id, planner_shell_id)
+            unit = self._unit(sprint_id, work_unit_id)
+            if unit["disposition"] != "planned":
+                raise SprintInvariantError(
+                    "only planned work units may be replanned; return assigned "
+                    "work to the ready pool first"
+                )
+            self._require_participant(sprint_id, assigned_shell_id, "developer")
+            self._require_participant(sprint_id, reviewer_shell_id, "reviewer")
+            before = self._plan_projection(unit)
+            after = {
+                "assigned_shell_id": assigned_shell_id,
+                "reviewer_shell_id": reviewer_shell_id,
+                "planned_wave": planned_wave,
+                "dependency_ids": sorted(dependencies),
+            }
+            if before == after:
+                return False
+            self.con.execute(
+                "UPDATE sprint_work_units SET assigned_shell_id=?,"
+                "reviewer_shell_id=?,planned_wave=?,updated_at=datetime('now') "
+                "WHERE work_unit_id=?",
+                (
+                    assigned_shell_id,
+                    reviewer_shell_id,
+                    planned_wave,
+                    work_unit_id,
+                ),
+            )
+            self._replace_dependencies(sprint_id, work_unit_id, dependencies)
+            self._event(
+                sprint_id,
+                "work_unit.replanned",
+                planner_shell_id,
+                {
+                    "work_unit_id": work_unit_id,
+                    "before": before,
+                    "after": after,
+                },
+            )
+        return True
+
+    def dispatch_ready(self, sprint_id: int) -> list[int]:
+        """Release every dependency-ready unit that has shell capacity."""
+        with db_driver.write_transaction(self.con, "sprint.work_unit.dispatch"):
+            sprint = self.con.execute(
+                "SELECT lifecycle,originating_planner_shell_id FROM sprints "
+                "WHERE sprint_id=?",
+                (sprint_id,),
+            ).fetchone()
+            if sprint is None:
+                raise KeyError(f"unknown Sprint: {sprint_id}")
+            if sprint["lifecycle"] != "armed":
+                return []
+            planner = self._require_participant(
+                sprint_id,
+                int(sprint["originating_planner_shell_id"]),
+                "planner",
+            )
+            return self._dispatch_ready_locked(
+                sprint_id,
+                planner_participant_id=planner,
+            )
+
+    def complete(
+        self,
+        sprint_id: int,
+        work_unit_id: int,
+        shell_id: int,
+    ) -> list[int]:
+        """Record Developer completion and release newly unblocked work."""
+        with db_driver.write_transaction(self.con, "sprint.work_unit.complete"):
+            unit = self._unit(sprint_id, work_unit_id)
+            if int(unit["assigned_shell_id"]) != shell_id:
+                raise SprintAuthorityError("only the assigned Developer owns completion")
+            if unit["disposition"] == "completed":
+                return []
+            if unit["disposition"] not in EDITING_UNIT_DISPOSITIONS:
+                raise SprintInvariantError(
+                    f"cannot complete work unit from {unit['disposition']}"
+                )
+            self.con.execute(
+                "UPDATE sprint_work_units SET disposition='completed',"
+                "completed_at=datetime('now'),updated_at=datetime('now') "
+                "WHERE work_unit_id=?",
+                (work_unit_id,),
+            )
+            self._event(
+                sprint_id,
+                "work_unit.completed",
+                shell_id,
+                {"work_unit_id": work_unit_id},
+                actor_kind="participant",
+            )
+            sprint = self.con.execute(
+                "SELECT lifecycle,originating_planner_shell_id FROM sprints "
+                "WHERE sprint_id=?",
+                (sprint_id,),
+            ).fetchone()
+            if sprint["lifecycle"] != "armed":
+                return []
+            planner = self._require_participant(
+                sprint_id,
+                int(sprint["originating_planner_shell_id"]),
+                "planner",
+            )
+            return self._dispatch_ready_locked(
+                sprint_id,
+                planner_participant_id=planner,
+            )
+
+    def _dispatch_ready_locked(
+        self,
+        sprint_id: int,
+        *,
+        planner_participant_id: int,
+    ) -> list[int]:
+        occupied = {
+            int(row[0])
+            for row in self.con.execute(
+                "SELECT assigned_shell_id FROM sprint_work_units "
+                "WHERE sprint_id=? AND disposition IN "
+                "('ready','active','in_review','fixing','merge_ready')",
+                (sprint_id,),
+            )
+        }
+        candidates = self.con.execute(
+            "SELECT u.*,p.participant_id FROM sprint_work_units u "
+            "JOIN sprint_participants p ON p.sprint_id=u.sprint_id "
+            "AND p.shell_id=u.assigned_shell_id AND p.role='developer' "
+            "WHERE u.sprint_id=? AND u.disposition='planned' "
+            "AND NOT EXISTS ("
+            "SELECT 1 FROM sprint_work_unit_dependencies d "
+            "JOIN sprint_work_units upstream "
+            "ON upstream.sprint_id=d.sprint_id "
+            "AND upstream.work_unit_id=d.depends_on_work_unit_id "
+            "WHERE d.sprint_id=u.sprint_id AND d.work_unit_id=u.work_unit_id "
+            "AND upstream.disposition<>'completed') "
+            "ORDER BY u.planned_wave,u.work_unit_id",
+            (sprint_id,),
+        ).fetchall()
+        wake_ids: list[int] = []
+        for unit in candidates:
+            shell_id = int(unit["assigned_shell_id"])
+            if shell_id in occupied:
+                continue
+            wake_id = self._queue_assignment(
+                sprint_id,
+                planner_participant_id=planner_participant_id,
+                unit=unit,
+            )
+            occupied.add(shell_id)
+            if wake_id not in wake_ids:
+                wake_ids.append(wake_id)
+        return wake_ids
+
+    def _queue_assignment(
+        self,
+        sprint_id: int,
+        *,
+        planner_participant_id: int,
+        unit: sqlite3.Row,
+    ) -> int:
+        unit_id = int(unit["work_unit_id"])
+        generation = int(
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_messages "
+                "WHERE work_unit_id=? AND message_kind='work_assignment'",
+                (unit_id,),
+            ).fetchone()[0]
+        ) + 1
+        key = (
+            f"sprint:{sprint_id}:work-unit:{unit_id}:assignment:{generation}"
+        )
+        message_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_messages "
+                "(sprint_id,from_participant_id,to_participant_id,work_unit_id,"
+                "message_kind,body,actionable,disposition,idempotency_key) "
+                "VALUES (?,?,?,?,?,?,1,'pending',?)",
+                (
+                    sprint_id,
+                    planner_participant_id,
+                    unit["participant_id"],
+                    unit_id,
+                    "work_assignment",
+                    f"{unit['title']}\n\n{unit['expected_output']}",
+                    key,
+                ),
+            ).lastrowid
+        )
+        pending = self.con.execute(
+            "SELECT wake_id FROM sprint_wake_outbox "
+            "WHERE sprint_id=? AND participant_id=? AND state='pending'",
+            (sprint_id, unit["participant_id"]),
+        ).fetchone()
+        wake_id = (
+            int(pending["wake_id"])
+            if pending is not None
+            else int(
+                self.con.execute(
+                    "INSERT INTO sprint_wake_outbox "
+                    "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
+                    (sprint_id, unit["participant_id"], f"wake:{key}"),
+                ).lastrowid
+            )
+        )
+        self.con.execute(
+            "INSERT INTO sprint_wake_messages "
+            "(sprint_id,wake_id,message_id) VALUES (?,?,?)",
+            (sprint_id, wake_id, message_id),
+        )
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='ready',"
+            "updated_at=datetime('now') WHERE work_unit_id=?",
+            (unit_id,),
+        )
+        self._event(
+            sprint_id,
+            "work_unit.ready",
+            None,
+            {
+                "work_unit_id": unit_id,
+                "message_id": message_id,
+                "wake_id": wake_id,
+            },
+            actor_kind="system",
+        )
+        return wake_id
+
+    def _replace_dependencies(
+        self,
+        sprint_id: int,
+        work_unit_id: int,
+        dependency_ids: tuple[int, ...],
+    ) -> None:
+        if work_unit_id in dependency_ids:
+            raise SprintInvariantError("work units cannot depend on themselves")
+        if dependency_ids:
+            placeholders = ",".join("?" for _ in dependency_ids)
+            found = {
+                int(row[0])
+                for row in self.con.execute(
+                    "SELECT work_unit_id FROM sprint_work_units "
+                    f"WHERE sprint_id=? AND work_unit_id IN ({placeholders})",
+                    (sprint_id, *dependency_ids),
+                )
+            }
+            if found != set(dependency_ids):
+                raise SprintInvariantError(
+                    "dependencies must name work units in the same Sprint"
+                )
+        self.con.execute(
+            "DELETE FROM sprint_work_unit_dependencies "
+            "WHERE sprint_id=? AND work_unit_id=?",
+            (sprint_id, work_unit_id),
+        )
+        self.con.executemany(
+            "INSERT INTO sprint_work_unit_dependencies "
+            "(sprint_id,work_unit_id,depends_on_work_unit_id) VALUES (?,?,?)",
+            (
+                (sprint_id, work_unit_id, dependency_id)
+                for dependency_id in dependency_ids
+            ),
+        )
+        self._require_acyclic(sprint_id)
+
+    def _require_acyclic(self, sprint_id: int) -> None:
+        graph: dict[int, set[int]] = {}
+        for row in self.con.execute(
+            "SELECT work_unit_id,depends_on_work_unit_id "
+            "FROM sprint_work_unit_dependencies WHERE sprint_id=?",
+            (sprint_id,),
+        ):
+            graph.setdefault(int(row[0]), set()).add(int(row[1]))
+
+        visiting: set[int] = set()
+        visited: set[int] = set()
+
+        def visit(unit_id: int) -> None:
+            if unit_id in visiting:
+                raise SprintInvariantError("work-unit dependencies must be acyclic")
+            if unit_id in visited:
+                return
+            visiting.add(unit_id)
+            for dependency_id in graph.get(unit_id, ()):
+                visit(dependency_id)
+            visiting.remove(unit_id)
+            visited.add(unit_id)
+
+        for unit_id in graph:
+            visit(unit_id)
+
+    def _require_tasks(self, sprint_id: int, task_ids: tuple[int, ...]) -> None:
+        placeholders = ",".join("?" for _ in task_ids)
+        found = {
+            int(row[0])
+            for row in self.con.execute(
+                "SELECT t.task_id FROM spec_tasks t "
+                "JOIN sprint_specs ss ON ss.document_id=t.document_id "
+                f"WHERE ss.sprint_id=? AND t.task_id IN ({placeholders})",
+                (sprint_id, *task_ids),
+            )
+        }
+        if found != set(task_ids):
+            raise SprintInvariantError(
+                "work-unit tasks must belong to a governing Sprint spec"
+            )
+
+    def _require_planner(
+        self,
+        sprint_id: int,
+        planner_shell_id: int,
+    ) -> tuple[str, int]:
+        sprint = self.con.execute(
+            "SELECT lifecycle,originating_planner_shell_id FROM sprints "
+            "WHERE sprint_id=?",
+            (sprint_id,),
+        ).fetchone()
+        if sprint is None:
+            raise KeyError(f"unknown Sprint: {sprint_id}")
+        if int(sprint["originating_planner_shell_id"]) != planner_shell_id:
+            raise SprintAuthorityError("only the originating Planner owns replanning")
+        participant = self._require_participant(
+            sprint_id, planner_shell_id, "planner"
+        )
+        return str(sprint["lifecycle"]), participant
+
+    def _require_participant(
+        self,
+        sprint_id: int,
+        shell_id: int,
+        role: str,
+    ) -> int:
+        row = self.con.execute(
+            "SELECT participant_id FROM sprint_participants "
+            "WHERE sprint_id=? AND shell_id=? AND role=?",
+            (sprint_id, shell_id, role),
+        ).fetchone()
+        if row is None:
+            raise SprintInvariantError(
+                f"shell {shell_id} is not this Sprint's assigned {role}"
+            )
+        return int(row[0])
+
+    def _unit(self, sprint_id: int, work_unit_id: int) -> sqlite3.Row:
+        row = self.con.execute(
+            "SELECT * FROM sprint_work_units WHERE sprint_id=? AND work_unit_id=?",
+            (sprint_id, work_unit_id),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown Sprint work unit: {work_unit_id}")
+        return row
+
+    def _plan_projection(self, unit: sqlite3.Row) -> dict:
+        dependencies = [
+            int(row[0])
+            for row in self.con.execute(
+                "SELECT depends_on_work_unit_id "
+                "FROM sprint_work_unit_dependencies "
+                "WHERE sprint_id=? AND work_unit_id=? "
+                "ORDER BY depends_on_work_unit_id",
+                (unit["sprint_id"], unit["work_unit_id"]),
+            )
+        ]
+        return {
+            "assigned_shell_id": int(unit["assigned_shell_id"]),
+            "reviewer_shell_id": int(unit["reviewer_shell_id"]),
+            "planned_wave": int(unit["planned_wave"]),
+            "dependency_ids": dependencies,
+        }
+
+    def _event(
+        self,
+        sprint_id: int,
+        event_type: str,
+        actor_shell_id: int | None,
+        payload: dict,
+        *,
+        actor_kind: str = "planner",
+    ) -> None:
+        self.con.execute(
+            "INSERT INTO sprint_events "
+            "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+            "VALUES (?,?,?,?,?)",
+            (
+                sprint_id,
+                event_type,
+                actor_kind,
+                actor_shell_id,
                 json.dumps(payload, sort_keys=True),
             ),
         )

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -8,14 +8,14 @@ external harness enqueue outside the database transaction.
 """
 from __future__ import annotations
 
+import json
+import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-import sqlite3
 
 import db_driver
 from sprint_domain import SprintInvariantError, SprintLifecycleStore
-
 
 FIXED_WAKE_PROMPT = (
     "Check your inbox. If you accept the task(s), mark the message as read "
@@ -110,6 +110,7 @@ class SprintMessageStore:
         """Read one message; actionable reads atomically accept it."""
         with db_driver.write_transaction(self.con, "sprint.message.read"):
             message = self._recipient_message(message_id, shell_id)
+            accepted_now = False
             if message["actionable"]:
                 if message["disposition"] == "declined":
                     return "declined"
@@ -119,6 +120,7 @@ class SprintMessageStore:
                         "read_at=datetime('now') WHERE message_id=?",
                         (message_id,),
                     )
+                    accepted_now = True
                 disposition = "accepted"
             else:
                 self.con.execute(
@@ -127,6 +129,42 @@ class SprintMessageStore:
                     (message_id,),
                 )
                 disposition = None
+            if (
+                accepted_now
+                and message["message_kind"] == "work_assignment"
+                and message["work_unit_id"] is not None
+            ):
+                changed = self.con.execute(
+                    "UPDATE sprint_work_units SET disposition='active',"
+                    "updated_at=datetime('now') WHERE sprint_id=? "
+                    "AND work_unit_id=? AND assigned_shell_id=? "
+                    "AND disposition='ready'",
+                    (
+                        message["sprint_id"],
+                        message["work_unit_id"],
+                        shell_id,
+                    ),
+                ).rowcount
+                if changed != 1:
+                    raise SprintInvariantError(
+                        "work assignment no longer owns a ready editing lane"
+                    )
+                self.con.execute(
+                    "INSERT INTO sprint_events "
+                    "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+                    "VALUES (?,'work_unit.accepted','participant',?,?)",
+                    (
+                        message["sprint_id"],
+                        shell_id,
+                        json.dumps(
+                            {
+                                "message_id": message_id,
+                                "work_unit_id": int(message["work_unit_id"]),
+                            },
+                            sort_keys=True,
+                        ),
+                    ),
+                )
             self._cancel_resolved_wakes(message_id)
             return disposition
 
@@ -152,7 +190,8 @@ class SprintMessageStore:
                 ] is not None:
                     self.con.execute(
                         "UPDATE sprint_work_units SET disposition='planned',"
-                        "updated_at=datetime('now') WHERE work_unit_id=?",
+                        "updated_at=datetime('now') WHERE work_unit_id=? "
+                        "AND disposition='ready'",
                         (message["work_unit_id"],),
                     )
             elif message["decline_reason"] != reason:

--- a/.super-coder/scripts/sprint_runtime.py
+++ b/.super-coder/scripts/sprint_runtime.py
@@ -1,0 +1,247 @@
+"""Armed-only Sprint work dispatch and native wake-turn delivery."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import conversation_broker
+import conversation_events
+import db_driver
+from sprint_domain import (
+    ArmedServiceSwitch,
+    SprintInvariantError,
+    SprintLifecycleStore,
+    SprintWorkUnitStore,
+)
+from sprint_message_delivery import SprintWakeDeliveryService
+
+DEFAULT_PULSE_SECONDS = 5.0
+
+
+def _request_hash(prompt: str) -> str:
+    return hashlib.sha256(prompt.encode()).hexdigest()
+
+
+def enqueue_conversation_turn(
+    db_path: str | Path,
+    conversation_id: str,
+    prompt: str,
+    idempotency_key: str,
+) -> str:
+    """Queue one engine-authored native turn using the wake's stable identity."""
+    prompt = prompt.strip()
+    idempotency_key = idempotency_key.strip()
+    if not prompt or not idempotency_key:
+        raise ValueError("Sprint wake prompt and idempotency key are required")
+    request_hash = _request_hash(prompt)
+    created = False
+    con = db_driver.connect(db_path)
+    try:
+        with db_driver.write_transaction(con, "sprint.wake.enqueue_turn"):
+            conversation = con.execute(
+                "SELECT state FROM conversations WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()
+            if conversation is None:
+                raise KeyError(f"unknown Sprint conversation: {conversation_id}")
+            if conversation["state"] == "closed":
+                raise SprintInvariantError(
+                    "closed Sprint conversations reject wake turns"
+                )
+            existing = con.execute(
+                "SELECT message_id,sender_kind,sender_ref,message_kind,body,"
+                "request_hash FROM conversation_messages "
+                "WHERE conversation_id=? AND idempotency_key=?",
+                (conversation_id, idempotency_key),
+            ).fetchone()
+            if existing is not None:
+                actual = (
+                    existing["sender_kind"],
+                    existing["sender_ref"],
+                    existing["message_kind"],
+                    existing["body"],
+                    existing["request_hash"],
+                )
+                expected = (
+                    "engine",
+                    "sprint-runtime",
+                    "prompt",
+                    prompt,
+                    request_hash,
+                )
+                if actual != expected:
+                    raise SprintInvariantError(
+                        "Sprint wake idempotency key was reused with different input"
+                    )
+                message_id = int(existing["message_id"])
+            else:
+                message_id = int(
+                    con.execute(
+                        "INSERT INTO conversation_messages "
+                        "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                        "idempotency_key,request_hash,state) "
+                        "VALUES (?,'engine','sprint-runtime','prompt',?,?,?,'queued')",
+                        (
+                            conversation_id,
+                            prompt,
+                            idempotency_key,
+                            request_hash,
+                        ),
+                    ).lastrowid
+                )
+                con.execute(
+                    "INSERT INTO conversation_outbox (conversation_id,message_id) "
+                    "VALUES (?,?)",
+                    (conversation_id, message_id),
+                )
+                target_state = (
+                    conversation["state"]
+                    if conversation["state"] in {"queued", "running"}
+                    else "queued"
+                )
+                con.execute(
+                    "UPDATE conversations SET state=?,"
+                    "last_activity_at=datetime('now'),version=version+1 "
+                    "WHERE conversation_id=?",
+                    (target_state, conversation_id),
+                )
+                sequence = int(
+                    con.execute(
+                        "SELECT COALESCE(MAX(sequence),0)+1 "
+                        "FROM conversation_events WHERE conversation_id=?",
+                        (conversation_id,),
+                    ).fetchone()[0]
+                )
+                con.execute(
+                    "INSERT INTO conversation_events "
+                    "(conversation_id,sequence,event_type,payload,message_id) "
+                    "VALUES (?,?,'message.accepted',?,?)",
+                    (
+                        conversation_id,
+                        sequence,
+                        json.dumps(
+                            {
+                                "message_id": message_id,
+                                "queue_state": "queued",
+                                "source": "sprint_wake",
+                            },
+                            separators=(",", ":"),
+                            sort_keys=True,
+                        ),
+                        message_id,
+                    ),
+                )
+                created = True
+    finally:
+        con.close()
+    if created:
+        conversation_events.notify(conversation_id)
+        conversation_broker.notify_commit()
+    return f"conversation-message:{message_id}"
+
+
+class SprintRuntimeService(threading.Thread):
+    """Five-second armed-service pulse for dispatch and wake delivery."""
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        deliver: Callable[[str, str, str], str | None] | None = None,
+        owner: str | None = None,
+        pulse_seconds: float = DEFAULT_PULSE_SECONDS,
+    ) -> None:
+        super().__init__(name="sprint-runtime", daemon=True)
+        if pulse_seconds <= 0:
+            raise ValueError("Sprint runtime pulse must be positive")
+        self.db_path = str(db_path)
+        self.owner = owner or f"sprint-runtime:{os.getpid()}"
+        self.pulse_seconds = pulse_seconds
+        self.deliver = deliver or (
+            lambda conversation_id, prompt, key: enqueue_conversation_turn(
+                self.db_path,
+                conversation_id,
+                prompt,
+                key,
+            )
+        )
+        self._stop_event = threading.Event()
+        self._started_once = threading.Event()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def wait_started(self, timeout: float = 5.0) -> bool:
+        return self._started_once.wait(timeout)
+
+    def pulse_once(self, *, startup: bool = False) -> bool:
+        con = db_driver.connect(self.db_path)
+        try:
+            switch = self._switch(con)
+            return switch.recover_on_startup() if startup else switch.tick()
+        finally:
+            con.close()
+
+    def _switch(self, con: sqlite3.Connection) -> ArmedServiceSwitch:
+        units = SprintWorkUnitStore(con)
+        wakes = SprintWakeDeliveryService(con)
+
+        def dispatch(sprint_id: int, _trigger: str) -> None:
+            units.dispatch_ready(sprint_id)
+
+        def deliver(_sprint_id: int, _trigger: str) -> None:
+            while not self._stop_event.is_set():
+                outcome = wakes.deliver_once(self.owner, self.deliver)
+                if outcome is None or outcome.state != "delivered":
+                    return
+
+        return ArmedServiceSwitch(
+            SprintLifecycleStore(con),
+            (dispatch, deliver),
+        )
+
+    def run(self) -> None:  # pragma: no cover - loop tested through pulse_once
+        con = db_driver.connect(self.db_path)
+        try:
+            switch = self._switch(con)
+            try:
+                switch.recover_on_startup()
+            except Exception as exc:  # noqa: BLE001 - service faults stay visible
+                print(f"sprint-runtime: startup error ({exc})", flush=True)
+            self._started_once.set()
+            while not self._stop_event.wait(self.pulse_seconds):
+                try:
+                    switch.tick()
+                except Exception as exc:  # noqa: BLE001 - keep inspection alive
+                    print(f"sprint-runtime: pulse error ({exc})", flush=True)
+        finally:
+            self._started_once.set()
+            con.close()
+
+
+_SERVICE_LOCK = threading.Lock()
+_SERVICE: SprintRuntimeService | None = None
+
+
+def start_service(
+    db_path: str | Path,
+    **kwargs: Any,
+) -> SprintRuntimeService:
+    """Install the process-wide armed Sprint runtime."""
+    global _SERVICE
+    with _SERVICE_LOCK:
+        if _SERVICE is not None and _SERVICE.is_alive():
+            return _SERVICE
+        _SERVICE = SprintRuntimeService(db_path, **kwargs)
+        _SERVICE.start()
+        return _SERVICE
+
+
+def service() -> SprintRuntimeService | None:
+    return _SERVICE

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -6,6 +6,7 @@
     ".super-coder/scripts/sprint_domain.py",
     ".super-coder/scripts/sprint_message_delivery.py",
     ".super-coder/scripts/sprint_participant_chats.py",
+    ".super-coder/scripts/sprint_runtime.py",
     ".super-coder/migrations/0144_remove_sprint_v1.sql",
     "tests/fixtures/sprint_removal/build_pre_removal_fixture.py",
     "tests/fixtures/sprint_removal/manifest.json",
@@ -14,7 +15,8 @@
     "tests/test_sprint_removal_manifest.py",
     "tests/test_sprint_v2_domain.py",
     "tests/test_sprint_message_delivery.py",
-    "tests/test_sprint_participant_chats.py"
+    "tests/test_sprint_participant_chats.py",
+    "tests/test_sprint_work_dispatch.py"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -320,8 +320,8 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
     def _start(self, bind, *, container=False, port=8800):
         """Run main([]) to the bind decision.
 
-        Returns refusal, served host, and whether the conversation broker
-        started after that successful bind.
+        Returns refusal, served host, and whether the conversation broker and
+        armed Sprint runtime started after that successful bind.
         """
         served = []
 
@@ -370,6 +370,9 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                 broker_start = enter(mock.patch.object(
                     server.conversation_broker, "start_service"
                 ))
+                sprint_start = enter(mock.patch.object(
+                    server.sprint_runtime, "start_service"
+                ))
                 enter(mock.patch.object(transport, "serve", _fake_serve))
                 enter(contextlib.redirect_stdout(io.StringIO()))
                 enter(contextlib.redirect_stderr(io.StringIO()))
@@ -382,12 +385,13 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
             refusal,
             served[0] if served else None,
             broker_start.called,
+            sprint_start.called,
         )
 
     def test_startup_refuses_an_unsafe_bind_before_serving(self):
         for bind in ("0.0.0.0", "::", "192.168.1.10", "example.com"):
             with self.subTest(bind=bind):
-                refusal, served, broker_started = self._start(bind)
+                refusal, served, broker_started, sprint_started = self._start(bind)
                 self.assertIsNotNone(
                     refusal, "main() accepted a non-loopback bind on a host")
                 self.assertIn("loopback", str(refusal))
@@ -400,11 +404,15 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                     broker_started,
                     "conversation broker started before bind refusal",
                 )
+                self.assertFalse(
+                    sprint_started,
+                    "Sprint runtime started before bind refusal",
+                )
 
     def test_startup_serves_a_loopback_bind(self):
         self.assertEqual(
             self._start("127.0.0.1"),
-            (None, "127.0.0.1", True),
+            (None, "127.0.0.1", True, True),
         )
 
     def test_startup_imports_no_removed_scheduler(self):
@@ -425,7 +433,7 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
         # unbootable, so the sandbox exception has to survive the wiring too.
         self.assertEqual(
             self._start("0.0.0.0", container=True),
-            (None, "0.0.0.0", True),
+            (None, "0.0.0.0", True, True),
         )
 
     def test_startup_binds_the_csp_to_the_served_port(self):

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -282,11 +282,12 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
             declined,
         )
         self.assertEqual(
-            "planned",
+            "active",
             self.con.execute(
                 "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
                 (self.unit_id,),
             ).fetchone()[0],
+            "declining a duplicate assignment must not release an active lane",
         )
         planner_results = [
             tuple(row)

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -151,7 +151,8 @@ class MigrationAndShapeTest(SprintDomainCase):
         sprint_id, _ = self.create_sprint()
         self.store.arm(sprint_id, 3)
         event = self.con.execute(
-            "SELECT event_id,event_type FROM sprint_events WHERE sprint_id=?",
+            "SELECT event_id,event_type FROM sprint_events WHERE sprint_id=? "
+            "AND event_type='lifecycle.armed'",
             (sprint_id,),
         ).fetchone()
         self.assertEqual("lifecycle.armed", event["event_type"])
@@ -433,7 +434,7 @@ class LifecycleTest(SprintDomainCase):
             ).fetchone()[0],
         )
 
-    def test_arm_coalesces_ready_messages_for_the_same_participant(self) -> None:
+    def test_arm_releases_only_one_ready_unit_per_participant(self) -> None:
         sprint_id, first_unit = self.create_sprint()
         second_unit = self.con.execute(
             "INSERT INTO sprint_work_units "
@@ -447,7 +448,7 @@ class LifecycleTest(SprintDomainCase):
 
         self.assertEqual(1, len(wake_ids))
         self.assertEqual(
-            [(first_unit,), (second_unit,)],
+            [(first_unit,)],
             [
                 tuple(row)
                 for row in self.con.execute(
@@ -455,6 +456,17 @@ class LifecycleTest(SprintDomainCase):
                     "JOIN sprint_messages m USING (message_id) "
                     "WHERE wm.wake_id=? ORDER BY m.message_id",
                     (wake_ids[0],),
+                )
+            ],
+        )
+        self.assertEqual(
+            [(first_unit, "ready"), (second_unit, "planned")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT work_unit_id,disposition FROM sprint_work_units "
+                    "WHERE sprint_id=? ORDER BY work_unit_id",
+                    (sprint_id,),
                 )
             ],
         )

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -1,0 +1,574 @@
+"""Stage 4 gates for Sprint work planning, dispatch, and runtime wiring."""
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+import db_driver
+import server
+import sprint_domain
+import sprint_message_delivery as delivery
+import sprint_runtime
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+class SprintWorkDispatchCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.db_path = Path(self.temp_dir.name) / "sprint.db"
+        self.con = db_driver.connect(self.db_path)
+        self.addCleanup(self.con.close)
+        apply_schema(self.con)
+        self.con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        self.con.executemany(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (?,?,?,?,?,1)",
+            (
+                (1, "Developer one", "DEV1", "dev", "prompt"),
+                (2, "Reviewer one", "REV1", "reviewer", "prompt"),
+                (3, "Planner", "PLN1", "planner", "prompt"),
+                (4, "Developer two", "DEV2", "dev", "prompt"),
+                (5, "Reviewer two", "REV2", "reviewer", "prompt"),
+            ),
+        )
+        self.feature_id = int(
+            self.con.execute(
+                "INSERT INTO roadmap (title,roadmap_status) "
+                "VALUES ('Feature','in_progress')"
+            ).lastrowid
+        )
+        body = "governing spec"
+        self.document_id = int(
+            self.con.execute(
+                "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                "VALUES (?,'spec',1,'Spec',?)",
+                (self.feature_id, body),
+            ).lastrowid
+        )
+        revision = hashlib.sha256(body.encode()).hexdigest()
+        approval_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_spec_approvals "
+                "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+                "VALUES (?,?,2,'pass')",
+                (self.document_id, revision),
+            ).lastrowid
+        )
+        self.sprint_id = int(
+            self.con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (self.feature_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_specs "
+            "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+            "VALUES (?,?,?,?)",
+            (self.sprint_id, self.document_id, revision, approval_id),
+        )
+        self.con.executemany(
+            "INSERT INTO sprint_participants "
+            "(sprint_id,shell_id,role,harness) VALUES (?,?,?,?)",
+            (
+                (self.sprint_id, 3, "planner", "codex"),
+                (self.sprint_id, 1, "developer", "codex"),
+                (self.sprint_id, 4, "developer", "codex"),
+                (self.sprint_id, 2, "reviewer", "kimi"),
+                (self.sprint_id, 5, "reviewer", "kimi"),
+            ),
+        )
+        self.task_ids = [
+            int(
+                self.con.execute(
+                    "INSERT INTO spec_tasks "
+                    "(feature_id,document_id,seq,title) VALUES (?,?,?,?)",
+                    (self.feature_id, self.document_id, seq, f"Task {seq}"),
+                ).lastrowid
+            )
+            for seq in range(8)
+        ]
+        self.con.commit()
+        self.units = sprint_domain.SprintWorkUnitStore(self.con)
+        self.lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        self.messages = delivery.SprintMessageStore(self.con)
+        self.next_task = 0
+
+    def create_unit(
+        self,
+        *,
+        developer: int,
+        reviewer: int = 2,
+        wave: int = 0,
+        dependencies: tuple[int, ...] = (),
+        title: str | None = None,
+    ) -> int:
+        task_id = self.task_ids[self.next_task]
+        self.next_task += 1
+        return self.units.create(
+            self.sprint_id,
+            3,
+            assigned_shell_id=developer,
+            reviewer_shell_id=reviewer,
+            title=title or f"Unit {self.next_task}",
+            expected_output=f"Output {self.next_task}",
+            task_ids=(task_id,),
+            planned_wave=wave,
+            dependency_ids=dependencies,
+        )
+
+    def assignment_message(self, unit_id: int) -> int:
+        return int(
+            self.con.execute(
+                "SELECT message_id FROM sprint_messages "
+                "WHERE work_unit_id=? AND message_kind='work_assignment' "
+                "ORDER BY message_id DESC LIMIT 1",
+                (unit_id,),
+            ).fetchone()[0]
+        )
+
+    def dispositions(self) -> list[tuple[int, str]]:
+        return [
+            tuple(row)
+            for row in self.con.execute(
+                "SELECT work_unit_id,disposition FROM sprint_work_units "
+                "WHERE sprint_id=? ORDER BY work_unit_id",
+                (self.sprint_id,),
+            )
+        ]
+
+    def conversation_for(self, shell_id: int) -> str:
+        return str(
+            self.con.execute(
+                "SELECT current_conversation_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=?",
+                (self.sprint_id, shell_id),
+            ).fetchone()[0]
+        )
+
+
+class DispatchGateTest(SprintWorkDispatchCase):
+    def test_ready_units_launch_in_parallel_regardless_of_wave_or_reviewer(self) -> None:
+        late_wave = self.create_unit(developer=1, wave=9, title="Late wave")
+        early_wave = self.create_unit(developer=4, wave=0, title="Early wave")
+
+        wake_ids = self.lifecycle.arm(self.sprint_id, 3)
+
+        self.assertEqual(2, len(wake_ids))
+        self.assertEqual(
+            [(late_wave, "ready"), (early_wave, "ready")],
+            self.dispositions(),
+        )
+        self.assertEqual(
+            [(late_wave, 2), (early_wave, 2)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT work_unit_id,reviewer_shell_id "
+                    "FROM sprint_work_units ORDER BY work_unit_id"
+                )
+            ],
+            "one Reviewer may cover parallel units without consuming a lane",
+        )
+        self.assertEqual(
+            [early_wave, late_wave],
+            [
+                row[0]
+                for row in self.con.execute(
+                    "SELECT work_unit_id FROM sprint_messages "
+                    "WHERE message_kind='work_assignment' ORDER BY message_id"
+                )
+            ],
+        )
+
+    def test_dependencies_block_and_each_developer_gets_one_editing_lane(self) -> None:
+        first = self.create_unit(developer=1, wave=0, title="First")
+        same_shell = self.create_unit(developer=1, wave=1, title="Second")
+        blocked = self.create_unit(
+            developer=4,
+            wave=0,
+            dependencies=(first,),
+            title="Blocked",
+        )
+
+        self.lifecycle.arm(self.sprint_id, 3)
+        self.assertEqual(
+            [(first, "ready"), (same_shell, "planned"), (blocked, "planned")],
+            self.dispositions(),
+        )
+        self.assertEqual(
+            "accepted",
+            self.messages.mark_read(self.assignment_message(first), 1),
+        )
+        self.assertEqual("active", self.dispositions()[0][1])
+
+        released = self.units.complete(self.sprint_id, first, 1)
+
+        self.assertEqual(2, len(released))
+        self.assertEqual(
+            [(first, "completed"), (same_shell, "ready"), (blocked, "ready")],
+            self.dispositions(),
+        )
+        self.assertEqual(
+            [blocked, same_shell],
+            [
+                row[0]
+                for row in self.con.execute(
+                    "SELECT work_unit_id FROM sprint_messages "
+                    "WHERE message_kind='work_assignment' AND work_unit_id<>? "
+                    "ORDER BY message_id",
+                    (first,),
+                )
+            ],
+        )
+
+    def test_declined_assignment_returns_to_pool_with_a_new_durable_identity(self) -> None:
+        unit = self.create_unit(developer=1)
+        self.lifecycle.arm(self.sprint_id, 3)
+        first_message = self.assignment_message(unit)
+        first_key = self.con.execute(
+            "SELECT idempotency_key FROM sprint_messages WHERE message_id=?",
+            (first_message,),
+        ).fetchone()[0]
+
+        self.messages.decline(first_message, 1, "capacity changed")
+        released = self.units.dispatch_ready(self.sprint_id)
+
+        second_message = self.assignment_message(unit)
+        second_key = self.con.execute(
+            "SELECT idempotency_key FROM sprint_messages WHERE message_id=?",
+            (second_message,),
+        ).fetchone()[0]
+        self.assertEqual(1, len(released))
+        self.assertNotEqual(first_message, second_message)
+        self.assertNotEqual(first_key, second_key)
+        self.assertEqual(
+            [("declined", "capacity changed"), ("pending", None)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT disposition,decline_reason FROM sprint_messages "
+                    "WHERE work_unit_id=? AND message_kind='work_assignment' "
+                    "ORDER BY message_id",
+                    (unit,),
+                )
+            ],
+        )
+        self.assertEqual([(unit, "ready")], self.dispositions())
+
+    def test_replanning_is_acyclic_and_preserves_before_after_history(self) -> None:
+        upstream = self.create_unit(developer=1, title="Upstream")
+        target = self.create_unit(
+            developer=4,
+            dependencies=(upstream,),
+            wave=1,
+            title="Target",
+        )
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "acyclic"
+        ):
+            self.units.replan(
+                self.sprint_id,
+                upstream,
+                3,
+                assigned_shell_id=1,
+                reviewer_shell_id=2,
+                planned_wave=0,
+                dependency_ids=(target,),
+            )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_work_unit_dependencies "
+                "WHERE work_unit_id=?",
+                (upstream,),
+            ).fetchone()[0],
+        )
+
+        self.assertTrue(
+            self.units.replan(
+                self.sprint_id,
+                target,
+                3,
+                assigned_shell_id=4,
+                reviewer_shell_id=5,
+                planned_wave=7,
+                dependency_ids=(),
+            )
+        )
+        event = self.con.execute(
+            "SELECT payload FROM sprint_events "
+            "WHERE event_type='work_unit.replanned'"
+        ).fetchone()
+        payload = json.loads(event["payload"])
+        self.assertEqual(
+            {
+                "assigned_shell_id": 4,
+                "reviewer_shell_id": 2,
+                "planned_wave": 1,
+                "dependency_ids": [upstream],
+            },
+            payload["before"],
+        )
+        self.assertEqual(
+            {
+                "assigned_shell_id": 4,
+                "reviewer_shell_id": 5,
+                "planned_wave": 7,
+                "dependency_ids": [],
+            },
+            payload["after"],
+        )
+
+        self.lifecycle.arm(self.sprint_id, 3)
+        self.messages.mark_read(self.assignment_message(upstream), 1)
+        self.units.complete(self.sprint_id, upstream, 1)
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "only planned"
+        ):
+            self.units.replan(
+                self.sprint_id,
+                upstream,
+                3,
+                assigned_shell_id=4,
+                reviewer_shell_id=5,
+                planned_wave=99,
+                dependency_ids=(),
+            )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='work_unit.replanned'"
+            ).fetchone()[0],
+            "failed replanning must not rewrite completed history",
+        )
+
+    def test_create_rejects_tasks_outside_the_bound_spec_without_partial_unit(self) -> None:
+        other_feature = self.con.execute(
+            "INSERT INTO roadmap (title,roadmap_status) VALUES ('Other','next')"
+        ).lastrowid
+        other_doc = self.con.execute(
+            "INSERT INTO documents (feature_id,kind,seq,title,body) "
+            "VALUES (?,'spec',1,'Other spec','body')",
+            (other_feature,),
+        ).lastrowid
+        other_task = self.con.execute(
+            "INSERT INTO spec_tasks (feature_id,document_id,seq,title) "
+            "VALUES (?,?,0,'Other task')",
+            (other_feature, other_doc),
+        ).lastrowid
+        self.con.commit()
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "governing Sprint spec"
+        ):
+            self.units.create(
+                self.sprint_id,
+                3,
+                assigned_shell_id=1,
+                reviewer_shell_id=2,
+                title="Invalid",
+                expected_output="Must not persist",
+                task_ids=(other_task,),
+            )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_work_units WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+
+
+class ProductionPulseTest(SprintWorkDispatchCase):
+    def test_armed_pulse_enqueues_every_parallel_ready_lane(self) -> None:
+        first = self.create_unit(developer=1, wave=4)
+        second = self.create_unit(developer=4, wave=0)
+        self.lifecycle.arm(self.sprint_id, 3)
+        runtime = sprint_runtime.SprintRuntimeService(
+            self.db_path,
+            owner="runtime-test",
+        )
+
+        self.assertTrue(runtime.pulse_once(startup=True))
+
+        first_conversation = self.conversation_for(1)
+        second_conversation = self.conversation_for(4)
+        self.assertEqual(
+            [(first, "ready"), (second, "ready")],
+            self.dispositions(),
+        )
+        self.assertEqual(
+            {first_conversation: 1, second_conversation: 1},
+            {
+                str(row[0]): int(row[1])
+                for row in self.con.execute(
+                    "SELECT conversation_id,COUNT(*) FROM conversation_outbox "
+                    "GROUP BY conversation_id"
+                )
+            },
+        )
+        self.assertEqual(
+            [("delivered", 1), ("delivered", 1)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT state,attempt_count FROM sprint_wake_outbox "
+                    "ORDER BY wake_id"
+                )
+            ],
+        )
+
+    def test_armed_pulse_delivers_wake_as_one_idempotent_native_turn(self) -> None:
+        unit = self.create_unit(developer=1)
+        wake_id = self.lifecycle.arm(self.sprint_id, 3)[0]
+        wake_key = self.con.execute(
+            "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
+            (wake_id,),
+        ).fetchone()[0]
+        conversation_id = self.conversation_for(1)
+        runtime = sprint_runtime.SprintRuntimeService(
+            self.db_path,
+            owner="runtime-test",
+        )
+
+        self.assertTrue(runtime.pulse_once(startup=True))
+        self.assertTrue(runtime.pulse_once())
+
+        wake = self.con.execute(
+            "SELECT state,attempt_count FROM sprint_wake_outbox WHERE wake_id=?",
+            (wake_id,),
+        ).fetchone()
+        self.assertEqual(("delivered", 1), tuple(wake))
+        native = self.con.execute(
+            "SELECT message_id,body,idempotency_key,state FROM conversation_messages "
+            "WHERE conversation_id=? AND idempotency_key=?",
+            (conversation_id, wake_key),
+        ).fetchone()
+        self.assertEqual(delivery.FIXED_WAKE_PROMPT, native["body"])
+        self.assertEqual(wake_key, native["idempotency_key"])
+        self.assertEqual("queued", native["state"])
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM conversation_outbox WHERE message_id=?",
+                (native["message_id"],),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            [(unit, "ready")],
+            self.dispositions(),
+            "delivery wakes the lane but acceptance remains shell-owned",
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM conversation_messages "
+                "WHERE conversation_id=? AND idempotency_key=?",
+                (conversation_id, wake_key),
+            ).fetchone()[0],
+            "a repeated armed pulse must not create a duplicate native turn",
+        )
+        replay_ref = sprint_runtime.enqueue_conversation_turn(
+            self.db_path,
+            conversation_id,
+            delivery.FIXED_WAKE_PROMPT,
+            wake_key,
+        )
+        attempt_ref = self.con.execute(
+            "SELECT native_run_ref FROM sprint_wake_attempts WHERE wake_id=?",
+            (wake_id,),
+        ).fetchone()[0]
+        self.assertEqual(attempt_ref, replay_ref)
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM conversation_outbox WHERE message_id=?",
+                (native["message_id"],),
+            ).fetchone()[0],
+            "a crash-window retry with the same wake key must reuse the turn",
+        )
+
+    def test_prepared_pulse_performs_no_dispatch_or_native_enqueue(self) -> None:
+        unit = self.create_unit(developer=1)
+        runtime = sprint_runtime.SprintRuntimeService(
+            self.db_path,
+            owner="runtime-test",
+        )
+
+        self.assertFalse(runtime.pulse_once())
+
+        self.assertEqual([(unit, "planned")], self.dispositions())
+        self.assertEqual(
+            (0, 0, 0),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_messages),"
+                    "(SELECT COUNT(*) FROM sprint_wake_outbox),"
+                    "(SELECT COUNT(*) FROM conversation_outbox)"
+                ).fetchone()
+            ),
+        )
+
+    def test_server_startup_wires_broker_before_sprint_runtime(self) -> None:
+        order: list[str] = []
+        preparer = object()
+        with (
+            mock.patch.object(
+                server.conversation_launch,
+                "ConversationLaunchPreparer",
+                return_value=preparer,
+            ),
+            mock.patch.object(
+                server.conversation_broker,
+                "start_service",
+                side_effect=lambda *_args, **_kwargs: order.append("broker"),
+            ) as broker_start,
+            mock.patch.object(
+                server.sprint_runtime,
+                "start_service",
+                side_effect=lambda *_args, **_kwargs: order.append("sprint"),
+            ) as sprint_start,
+        ):
+            server.start_runtime_services()
+
+        self.assertEqual(["broker", "sprint"], order)
+        broker_start.assert_called_once_with(
+            server.DB_PATH,
+            launch_preparer=preparer,
+        )
+        sprint_start.assert_called_once_with(server.DB_PATH)
+        self.assertIn(
+            "on_started=start_runtime_services",
+            inspect.getsource(server.main),
+            "the combined startup function must remain the production callback",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Outcome

- Add planner-owned Sprint work-unit creation, replanning, completion, task membership, dependency validation, and append-only history.
- Dispatch all dependency-ready lanes in wave order while enforcing one editing lane per developer; reviewer assignments do not consume developer capacity.
- Activate a ready lane when its actionable assignment is accepted, and give declined/reissued assignments a new durable generation.
- Wire the production five-second armed pulse through Sprint wake delivery into native conversation enqueueing.
- Preserve the wake `idempotency_key` as the native conversation-message idempotency key, including crash-window replay.
- Start the Sprint runtime after the conversation broker during API startup.

## Judgment

R1 is an explicit allowlist addition for the new runtime and its tests; no removed Sprint v1 names return. No migration is added because migration 0146 already owns the work-unit tables and constraints. Reusing that shipped schema keeps Stage 4 small and rollback-safe.

Wave order is advisory ordering; dependencies are the only hard sequencing constraint. Replanning is limited to planned units so accepted or active assignment history is never rewritten.

## Verification

- Focused post-rebase suite: 140 passed, 209 subtests.
- Full durable suite: 1,318 passed, 1 skipped, 736 subtests.
- Standalone `./sc verify`: rebuilt all 96 migrations, initialized the ten-shell team, rendered 40 artifacts, and completed render-only boot.
- Render check, Python compilation, Ruff on new files, and diff checks are green.
- The linked-worktree verifier refusal was expected by design; standalone verification covered the exact commit.
- Rebased over #849 and adapted the fixture to migration 0147's participant-conversation pointer rules.

No spec deviations.
