### PR TITLE
feat: add armed Sprint PR watcher

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -74,6 +74,7 @@ import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
 import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin rule)
 import sprint_participant_chats  # noqa: E402  (Sprints v2 participant chat topology)
+import sprint_pr_watcher  # noqa: E402  (Sprints v2 armed GitHub observation)
 import model_catalog  # noqa: E402  (live model-id suggestions, sibling module)
 import analytics  # noqa: E402  (token & session analytics sweep — doc #11)
 import token_parsers  # noqa: E402  (harness roster + per-parser data dirs)
@@ -3227,12 +3228,13 @@ def require_loopback_bind(bind: str) -> None:
 
 
 def start_runtime_services() -> None:
-    """Start commit-woken conversations, then the armed Sprint pulse."""
+    """Start commit-woken conversations and the armed Sprint services."""
     conversation_broker.start_service(
         DB_PATH,
         launch_preparer=conversation_launch.ConversationLaunchPreparer(DB_PATH),
     )
     sprint_runtime.start_service(DB_PATH)
+    sprint_pr_watcher.start_service(DB_PATH, repo_root=REPO_ROOT)
 
 
 def main(argv):
@@ -3277,6 +3279,15 @@ def main(argv):
         # reconciliation. Task #94 calls notify_commit() after its transaction.
         # The callback runs after the TCP bind succeeds, so a losing duplicate
         # server process cannot dispatch a queued prompt before bind refusal.
+        def _start_runtime_services():
+            conversation_broker.start_service(
+                DB_PATH,
+                launch_preparer=conversation_launch.ConversationLaunchPreparer(
+                    DB_PATH
+                ),
+            )
+            sprint_pr_watcher.start_service(DB_PATH, repo_root=REPO_ROOT)
+
         await transport.serve(
             bind,
             port,

--- a/.super-coder/scripts/github_pull_requests.py
+++ b/.super-coder/scripts/github_pull_requests.py
@@ -228,14 +228,19 @@ class GitHubPullRequestReader:
         self,
         repo_root: str | Path,
         *,
+        repository: str | None = None,
         runner: Callable[..., Any] = _run_read_process,
         timeout: float = GITHUB_TIMEOUT_SECONDS,
         max_response_bytes: int = MAX_RESPONSE_BYTES,
     ) -> None:
         self.repo_root = Path(repo_root)
+        self.repository = repository.strip() if repository else None
         self.runner = runner
         self.timeout = timeout
         self.max_response_bytes = max_response_bytes
+
+    def _repo_args(self) -> list[str]:
+        return ["--repo", self.repository] if self.repository else []
 
     def _run(self, args: list[str]) -> str:
         try:
@@ -277,6 +282,7 @@ class GitHubPullRequestReader:
                 str(LIST_LIMIT),
                 "--json",
                 _FIELDS,
+                *self._repo_args(),
             ]
         )
         try:
@@ -292,7 +298,10 @@ class GitHubPullRequestReader:
     def get(self, number: int) -> PullRequest:
         if not isinstance(number, int) or number < 1:
             raise ValueError("PR number must be a positive integer")
-        raw = self._run(["gh", "pr", "view", str(number), "--json", _FIELDS])
+        raw = self._run(
+            ["gh", "pr", "view", str(number), "--json", _FIELDS,
+             *self._repo_args()]
+        )
         try:
             payload = json.loads(raw)
         except json.JSONDecodeError as exc:
@@ -304,4 +313,6 @@ class GitHubPullRequestReader:
     def patch(self, number: int) -> str:
         if not isinstance(number, int) or number < 1:
             raise ValueError("PR number must be a positive integer")
-        return self._run(["gh", "pr", "diff", str(number), "--patch"])
+        return self._run(
+            ["gh", "pr", "diff", str(number), "--patch", *self._repo_args()]
+        )

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -84,7 +84,7 @@ class SprintMessageStore:
                 "only work assignments and review requests are actionable"
             )
         with db_driver.write_transaction(self.con, "sprint.message.send"):
-            return self._send(
+            return self.send_in_transaction(
                 sprint_id,
                 to_participant_id=to_participant_id,
                 message_kind=message_kind,
@@ -95,6 +95,49 @@ class SprintMessageStore:
                 actionable=actionable,
                 active=active,
             )
+
+    def send_in_transaction(
+        self,
+        sprint_id: int,
+        *,
+        to_participant_id: int,
+        message_kind: str,
+        body: str,
+        idempotency_key: str,
+        from_participant_id: int | None = None,
+        work_unit_id: int | None = None,
+        actionable: bool = False,
+        active: bool = True,
+    ) -> MessageReceipt:
+        """Commit through a caller-owned transaction.
+
+        Deterministic producers use this seam when their evidence row and the
+        resulting message+wake must either all commit or all roll back.  The
+        caller must already hold the short database-only transaction.
+        """
+        if not self.con.in_transaction:
+            raise RuntimeError("send_in_transaction requires an active transaction")
+        body = body.strip()
+        key = idempotency_key.strip()
+        if not body:
+            raise ValueError("Sprint message body is empty")
+        if not key:
+            raise ValueError("Sprint message idempotency key is empty")
+        if actionable and message_kind not in ACTIONABLE_KINDS:
+            raise SprintInvariantError(
+                "only work assignments and review requests are actionable"
+            )
+        return self._send(
+            sprint_id,
+            to_participant_id=to_participant_id,
+            message_kind=message_kind,
+            body=body,
+            idempotency_key=key,
+            from_participant_id=from_participant_id,
+            work_unit_id=work_unit_id,
+            actionable=actionable,
+            active=active,
+        )
 
     def inbox(self, sprint_id: int, shell_id: int) -> list[sqlite3.Row]:
         return self.con.execute(

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1,0 +1,586 @@
+"""Armed-only GitHub observation for registered Sprints v2 pull requests.
+
+Registration is a short database transaction.  GitHub reads happen outside
+transactions; each result is revalidated against the armed Sprint before its
+append-only transition and routed messages+wakes commit together.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import threading
+import time
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from contextlib import closing
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import db_driver
+from github_pull_requests import (
+    GitHubPullRequestReader,
+    GitHubReadError,
+    PullRequest,
+)
+from sprint_domain import (
+    ArmedServiceSwitch,
+    SprintInvariantError,
+    SprintLifecycleStore,
+)
+from sprint_message_delivery import SprintMessageStore
+
+PULSE_SECONDS = 5.0
+MAX_BACKOFF_SECONDS = 300.0
+RATE_BACKOFF_SECONDS = 60.0
+_REPOSITORY = re.compile(r"^[^/\s]+/[^/\s]+$")
+
+
+@dataclass(frozen=True)
+class RegistrationReceipt:
+    registered_pr_id: int
+    created: bool
+
+
+@dataclass(frozen=True)
+class TransitionReceipt:
+    transition_id: int
+    normalized_state: str
+    transition_key: str
+
+
+@dataclass
+class _FailureBackoff:
+    failures: int
+    retry_at: float
+
+
+def normalize_state(pull_request: PullRequest) -> str:
+    """Project one GitHub response onto the durable Sprint state vocabulary."""
+    if (
+        pull_request.state == "MERGED"
+        or pull_request.merged_at is not None
+        or pull_request.merge_sha is not None
+    ):
+        return "merged"
+    if pull_request.state == "CLOSED":
+        return "closed"
+    if pull_request.checks_failed:
+        return "red"
+    if pull_request.checks == "SUCCESS":
+        return "green"
+    if pull_request.checks == "PENDING":
+        return "pending"
+    return "created"
+
+
+class SprintPRRegistrationStore:
+    """Validate and commit registered-PR ownership and work-unit linkage."""
+
+    def __init__(self, con: sqlite3.Connection) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+
+    def register(
+        self,
+        sprint_id: int,
+        *,
+        owner_shell_id: int,
+        repository: str,
+        pr_number: int,
+        work_unit_ids: Iterable[int],
+    ) -> RegistrationReceipt:
+        repository = repository.strip().lower()
+        if not _REPOSITORY.fullmatch(repository):
+            raise ValueError("repository must be owner/name")
+        if not isinstance(pr_number, int) or pr_number < 1:
+            raise ValueError("PR number must be a positive integer")
+        unit_ids = tuple(sorted({int(item) for item in work_unit_ids}))
+        if not unit_ids or any(item < 1 for item in unit_ids):
+            raise ValueError("registration requires positive work-unit IDs")
+
+        with db_driver.write_transaction(self.con, "sprint.pr.register"):
+            sprint = self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()
+            if sprint is None:
+                raise KeyError(f"unknown Sprint: {sprint_id}")
+            if sprint["lifecycle"] != "armed":
+                raise SprintInvariantError(
+                    "pull requests may be registered only for an armed Sprint"
+                )
+            owner = self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=? AND role='developer'",
+                (sprint_id, owner_shell_id),
+            ).fetchone()
+            if owner is None:
+                raise SprintInvariantError(
+                    "registered PR owner must be a Developer participant"
+                )
+            placeholders = ",".join("?" for _ in unit_ids)
+            units = self.con.execute(
+                "SELECT work_unit_id FROM sprint_work_units "
+                f"WHERE sprint_id=? AND assigned_shell_id=? "
+                f"AND work_unit_id IN ({placeholders})",
+                (sprint_id, owner_shell_id, *unit_ids),
+            ).fetchall()
+            if {int(row[0]) for row in units} != set(unit_ids):
+                raise SprintInvariantError(
+                    "registered PR work units must belong to the owning Developer"
+                )
+
+            existing = self.con.execute(
+                "SELECT registered_pr_id,sprint_id,owner_participant_id "
+                "FROM sprint_registered_prs WHERE repository=? AND pr_number=?",
+                (repository, pr_number),
+            ).fetchone()
+            if existing is not None:
+                actual_units = {
+                    int(row[0])
+                    for row in self.con.execute(
+                        "SELECT work_unit_id FROM sprint_pr_work_units "
+                        "WHERE registered_pr_id=?",
+                        (existing["registered_pr_id"],),
+                    )
+                }
+                exact = (
+                    int(existing["sprint_id"]) == sprint_id
+                    and int(existing["owner_participant_id"])
+                    == int(owner["participant_id"])
+                    and actual_units == set(unit_ids)
+                )
+                if not exact:
+                    raise SprintInvariantError(
+                        "registered PR identity was reused with different ownership"
+                    )
+                return RegistrationReceipt(int(existing["registered_pr_id"]), False)
+
+            registered_pr_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_registered_prs "
+                    "(sprint_id,owner_participant_id,repository,pr_number) "
+                    "VALUES (?,?,?,?)",
+                    (sprint_id, owner["participant_id"], repository, pr_number),
+                ).lastrowid
+            )
+            self.con.executemany(
+                "INSERT INTO sprint_pr_work_units "
+                "(sprint_id,registered_pr_id,work_unit_id) VALUES (?,?,?)",
+                (
+                    (sprint_id, registered_pr_id, work_unit_id)
+                    for work_unit_id in unit_ids
+                ),
+            )
+            self.con.execute(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+                "VALUES (?,'pr.registered','participant',?,?)",
+                (
+                    sprint_id,
+                    owner_shell_id,
+                    json.dumps(
+                        {
+                            "registered_pr_id": registered_pr_id,
+                            "repository": repository,
+                            "pr_number": pr_number,
+                            "work_unit_ids": unit_ids,
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+        return RegistrationReceipt(registered_pr_id, True)
+
+
+class SprintPRWatcher:
+    """Observe one armed Sprint and append only normalized state changes."""
+
+    def __init__(
+        self,
+        con: sqlite3.Connection,
+        *,
+        repo_root: str | Path,
+        reader_factory: Callable[[str], Any] | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+        self.repo_root = Path(repo_root)
+        self.reader_factory = reader_factory or (
+            lambda repository: GitHubPullRequestReader(
+                self.repo_root, repository=repository
+            )
+        )
+        self.monotonic = monotonic
+        self.registration = SprintPRRegistrationStore(con)
+        self.messages = SprintMessageStore(con)
+        self._backoff: dict[int, _FailureBackoff] = {}
+        self._trigger = "pulse"
+        self._switch = ArmedServiceSwitch(
+            SprintLifecycleStore(con), (self._poll_armed,)
+        )
+
+    def register(
+        self,
+        sprint_id: int,
+        *,
+        owner_shell_id: int,
+        repository: str,
+        pr_number: int,
+        work_unit_ids: Iterable[int],
+    ) -> RegistrationReceipt:
+        """Register, then take the required initial snapshot after commit."""
+        receipt = self.registration.register(
+            sprint_id,
+            owner_shell_id=owner_shell_id,
+            repository=repository,
+            pr_number=pr_number,
+            work_unit_ids=work_unit_ids,
+        )
+        row = self._registered_row(receipt.registered_pr_id, sprint_id)
+        if receipt.created and row is not None:
+            self._observe_rows((row,), "registration", ignore_backoff=True)
+        return receipt
+
+    def poll_once(self, *, startup: bool = False) -> bool:
+        self._trigger = "startup" if startup else "pulse"
+        if startup:
+            return self._switch.recover_on_startup()
+        return self._switch.tick()
+
+    def _poll_armed(self, sprint_id: int, _trigger: str) -> None:
+        rows = self.con.execute(
+            "SELECT registered_pr_id,sprint_id,repository,pr_number "
+            "FROM sprint_registered_prs WHERE sprint_id=? "
+            "ORDER BY registered_pr_id",
+            (sprint_id,),
+        ).fetchall()
+        self._observe_rows(rows, self._trigger)
+
+    def _registered_row(
+        self, registered_pr_id: int, sprint_id: int
+    ) -> sqlite3.Row | None:
+        return self.con.execute(
+            "SELECT registered_pr_id,sprint_id,repository,pr_number "
+            "FROM sprint_registered_prs "
+            "WHERE registered_pr_id=? AND sprint_id=?",
+            (registered_pr_id, sprint_id),
+        ).fetchone()
+
+    def _observe_rows(
+        self,
+        rows: Iterable[sqlite3.Row],
+        trigger: str,
+        *,
+        ignore_backoff: bool = False,
+    ) -> None:
+        now = self.monotonic()
+        due = [
+            row
+            for row in rows
+            if ignore_backoff
+            or int(row["registered_pr_id"]) not in self._backoff
+            or self._backoff[int(row["registered_pr_id"])].retry_at <= now
+        ]
+        grouped: dict[str, list[sqlite3.Row]] = defaultdict(list)
+        for row in due:
+            grouped[str(row["repository"])].append(row)
+        for repository, repo_rows in grouped.items():
+            reader = self.reader_factory(repository)
+            if len(repo_rows) == 1:
+                self._read_exact(reader, repo_rows[0], trigger)
+                continue
+            try:
+                listed = {item.number: item for item in reader.list()}
+            except GitHubReadError as exc:
+                for row in repo_rows:
+                    self._poll_failed(row, trigger, exc)
+                continue
+            for row in repo_rows:
+                pull_request = listed.get(int(row["pr_number"]))
+                if pull_request is None:
+                    self._read_exact(reader, row, trigger)
+                    continue
+                self._observe(row, pull_request, trigger)
+
+    def _read_exact(self, reader: Any, row: sqlite3.Row, trigger: str) -> None:
+        try:
+            pull_request = reader.get(int(row["pr_number"]))
+        except GitHubReadError as exc:
+            self._poll_failed(row, trigger, exc)
+            return
+        self._observe(row, pull_request, trigger)
+
+    def _observe(
+        self,
+        registered: sqlite3.Row,
+        pull_request: PullRequest,
+        trigger: str,
+    ) -> TransitionReceipt | None:
+        registered_pr_id = int(registered["registered_pr_id"])
+        if pull_request.number != int(registered["pr_number"]):
+            self._poll_failed(
+                registered,
+                trigger,
+                GitHubReadError("GitHub returned a different PR identity"),
+            )
+            return None
+        state = normalize_state(pull_request)
+        evidence = {
+            "base_ref": pull_request.base_ref,
+            "checks": pull_request.checks,
+            "checks_failed": pull_request.checks_failed,
+            "head_ref": pull_request.head_ref,
+            "merge_sha": pull_request.merge_sha,
+            "review_decision": pull_request.review_decision,
+            "state": pull_request.state,
+            "title": pull_request.title,
+            "trigger": trigger,
+            "url": pull_request.url,
+        }
+        with db_driver.write_transaction(self.con, "sprint.pr.observe"):
+            current = self.con.execute(
+                "SELECT p.*,s.lifecycle FROM sprint_registered_prs p "
+                "JOIN sprints s USING (sprint_id) "
+                "WHERE p.registered_pr_id=?",
+                (registered_pr_id,),
+            ).fetchone()
+            if current is None or current["lifecycle"] != "armed":
+                return None
+            latest = self.con.execute(
+                "SELECT transition_key,normalized_state "
+                "FROM sprint_pr_transitions WHERE registered_pr_id=? "
+                "ORDER BY transition_id DESC LIMIT 1",
+                (registered_pr_id,),
+            ).fetchone()
+            if latest is not None and latest["normalized_state"] == state:
+                self._backoff.pop(registered_pr_id, None)
+                return None
+            parent_key = latest["transition_key"] if latest is not None else "root"
+            transition_key = hashlib.sha256(
+                f"{registered_pr_id}:{parent_key}:{state}".encode()
+            ).hexdigest()
+            transition_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_pr_transitions "
+                    "(registered_pr_id,normalized_state,transition_key,"
+                    "observed_head_sha,evidence) VALUES (?,?,?,?,?)",
+                    (
+                        registered_pr_id,
+                        state,
+                        transition_key,
+                        pull_request.head_sha,
+                        json.dumps(evidence, sort_keys=True),
+                    ),
+                ).lastrowid
+            )
+            self._route_transition(current, transition_key, state, pull_request)
+            self.con.execute(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,payload) "
+                "VALUES (?,'pr.transition','system',?)",
+                (
+                    current["sprint_id"],
+                    json.dumps(
+                        {
+                            "normalized_state": state,
+                            "registered_pr_id": registered_pr_id,
+                            "transition_id": transition_id,
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+        self._backoff.pop(registered_pr_id, None)
+        return TransitionReceipt(transition_id, state, transition_key)
+
+    def _route_transition(
+        self,
+        registered: sqlite3.Row,
+        transition_key: str,
+        state: str,
+        pull_request: PullRequest,
+    ) -> None:
+        sprint_id = int(registered["sprint_id"])
+        registered_pr_id = int(registered["registered_pr_id"])
+        unit_rows = self.con.execute(
+            "SELECT l.work_unit_id,u.reviewer_shell_id "
+            "FROM sprint_pr_work_units l JOIN sprint_work_units u "
+            "ON u.sprint_id=l.sprint_id AND u.work_unit_id=l.work_unit_id "
+            "WHERE l.registered_pr_id=? ORDER BY l.work_unit_id",
+            (registered_pr_id,),
+        ).fetchall()
+        work_unit_id = (
+            int(unit_rows[0]["work_unit_id"]) if len(unit_rows) == 1 else None
+        )
+        recipients: dict[int, bool] = {
+            int(registered["owner_participant_id"]): state in {"red", "green"}
+        }
+        planner = self.con.execute(
+            "SELECT participant_id FROM sprint_participants "
+            "WHERE sprint_id=? AND role='planner'",
+            (sprint_id,),
+        ).fetchone()
+        if planner is None:
+            raise SprintInvariantError("registered PR has no Planner participant")
+        planner_id = int(planner["participant_id"])
+        recipients[planner_id] = recipients.get(planner_id, False) or state == "closed"
+        reviewer_shell_ids = {int(row["reviewer_shell_id"]) for row in unit_rows}
+        for shell_id in reviewer_shell_ids:
+            reviewer = self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=? AND role='reviewer'",
+                (sprint_id, shell_id),
+            ).fetchone()
+            if reviewer is None:
+                raise SprintInvariantError(
+                    "registered PR work unit has no Reviewer participant"
+                )
+            reviewer_id = int(reviewer["participant_id"])
+            recipients.setdefault(reviewer_id, False)
+
+        head = pull_request.head_sha or "unknown head"
+        body = (
+            f"GitHub observed {registered['repository']} PR "
+            f"#{registered['pr_number']}: {state} at {head}."
+        )
+        for participant_id, active in recipients.items():
+            self.messages.send_in_transaction(
+                sprint_id,
+                to_participant_id=participant_id,
+                work_unit_id=work_unit_id,
+                message_kind="notification",
+                body=body,
+                active=active,
+                idempotency_key=(
+                    f"pr-transition:{transition_key}:participant:{participant_id}"
+                ),
+            )
+
+    def _poll_failed(
+        self,
+        registered: sqlite3.Row,
+        trigger: str,
+        error: GitHubReadError,
+    ) -> None:
+        registered_pr_id = int(registered["registered_pr_id"])
+        previous = self._backoff.get(registered_pr_id)
+        failures = 1 if previous is None else previous.failures + 1
+        detail = (str(error).strip() or error.__class__.__name__)[:500]
+        delay = min(MAX_BACKOFF_SECONDS, PULSE_SECONDS * (2 ** failures))
+        if "rate" in detail.lower():
+            delay = max(delay, RATE_BACKOFF_SECONDS)
+        self._backoff[registered_pr_id] = _FailureBackoff(
+            failures, self.monotonic() + delay
+        )
+        with db_driver.write_transaction(self.con, "sprint.pr.poll_failure"):
+            current = self.con.execute(
+                "SELECT p.sprint_id,s.lifecycle FROM sprint_registered_prs p "
+                "JOIN sprints s USING (sprint_id) "
+                "WHERE p.registered_pr_id=?",
+                (registered_pr_id,),
+            ).fetchone()
+            if current is None or current["lifecycle"] != "armed":
+                return
+            self.con.execute(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,payload) "
+                "VALUES (?,'pr.poll_failed','system',?)",
+                (
+                    current["sprint_id"],
+                    json.dumps(
+                        {
+                            "backoff_seconds": delay,
+                            "error": detail,
+                            "failure_count": failures,
+                            "pr_number": int(registered["pr_number"]),
+                            "registered_pr_id": registered_pr_id,
+                            "repository": str(registered["repository"]),
+                            "trigger": trigger,
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+
+
+class SprintPRWatcherService(threading.Thread):
+    """Installation-level five-second service started with the engine API."""
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        repo_root: str | Path,
+        pulse_seconds: float = PULSE_SECONDS,
+        reader_factory: Callable[[str], Any] | None = None,
+    ) -> None:
+        super().__init__(name="sprint-pr-watcher", daemon=True)
+        if pulse_seconds <= 0:
+            raise ValueError("watcher pulse must be positive")
+        self.db_path = Path(db_path)
+        self.repo_root = Path(repo_root)
+        self.pulse_seconds = pulse_seconds
+        self.reader_factory = reader_factory
+        self._wake = threading.Event()
+        self._stop_event = threading.Event()
+
+    def notify(self) -> None:
+        self._wake.set()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._wake.set()
+
+    def run(self) -> None:
+        try:
+            with closing(db_driver.connect(self.db_path)) as con:
+                watcher = SprintPRWatcher(
+                    con,
+                    repo_root=self.repo_root,
+                    reader_factory=self.reader_factory,
+                )
+                startup = True
+                while not self._stop_event.is_set():
+                    try:
+                        watcher.poll_once(startup=startup)
+                    except Exception as exc:  # noqa: BLE001 - keep service alive
+                        print(f"sprint-pr-watcher: pulse failed ({exc})", flush=True)
+                    startup = False
+                    self._wake.wait(self.pulse_seconds)
+                    self._wake.clear()
+        except Exception as exc:  # noqa: BLE001 - surface startup failure
+            print(f"sprint-pr-watcher: service failed ({exc})", flush=True)
+
+
+_SERVICE_LOCK = threading.Lock()
+_SERVICE: SprintPRWatcherService | None = None
+
+
+def start_service(
+    db_path: str | Path,
+    *,
+    repo_root: str | Path,
+    **kwargs: Any,
+) -> SprintPRWatcherService:
+    global _SERVICE
+    with _SERVICE_LOCK:
+        if _SERVICE is not None and _SERVICE.is_alive():
+            return _SERVICE
+        _SERVICE = SprintPRWatcherService(
+            db_path, repo_root=repo_root, **kwargs
+        )
+        _SERVICE.start()
+        return _SERVICE
+
+
+def notify_commit() -> bool:
+    with _SERVICE_LOCK:
+        service = _SERVICE
+    if service is None or not service.is_alive():
+        return False
+    service.notify()
+    return True

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -7,6 +7,7 @@
     ".super-coder/scripts/sprint_message_delivery.py",
     ".super-coder/scripts/sprint_participant_chats.py",
     ".super-coder/scripts/sprint_runtime.py",
+    ".super-coder/scripts/sprint_pr_watcher.py",
     ".super-coder/migrations/0144_remove_sprint_v1.sql",
     "tests/fixtures/sprint_removal/build_pre_removal_fixture.py",
     "tests/fixtures/sprint_removal/manifest.json",
@@ -16,7 +17,8 @@
     "tests/test_sprint_v2_domain.py",
     "tests/test_sprint_message_delivery.py",
     "tests/test_sprint_participant_chats.py",
-    "tests/test_sprint_work_dispatch.py"
+    "tests/test_sprint_work_dispatch.py",
+    "tests/test_sprint_pr_watcher.py"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_git_review.py
+++ b/tests/test_git_review.py
@@ -85,6 +85,23 @@ class GitHubReaderTest(unittest.TestCase):
         self.assertEqual(calls[0][:4], ["gh", "pr", "view", "823"])
         self.assertEqual(calls[1], ["gh", "pr", "diff", "823", "--patch"])
 
+    def test_explicit_repository_scopes_every_read(self) -> None:
+        payload = json.dumps(MockGitHub().pr(821)).encode()
+        calls = []
+
+        def runner(args, **kwargs):
+            calls.append(args)
+            return SimpleNamespace(returncode=0, stdout=payload, stderr=b"")
+
+        reader = GitHubPullRequestReader(
+            "/tmp/repo", repository="acme/project", runner=runner
+        )
+        self.assertEqual(821, reader.get(821).number)
+        self.assertEqual(
+            ["gh", "pr", "view", "821", "--json"], calls[0][:5]
+        )
+        self.assertEqual(["--repo", "acme/project"], calls[0][-2:])
+
     def test_response_cap_fails_closed(self) -> None:
         def runner(args, **kwargs):
             return SimpleNamespace(returncode=0, stdout=b"x" * 11, stderr=b"")

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -373,6 +373,9 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                 sprint_start = enter(mock.patch.object(
                     server.sprint_runtime, "start_service"
                 ))
+                watcher_start = enter(mock.patch.object(
+                    server.sprint_pr_watcher, "start_service"
+                ))
                 enter(mock.patch.object(transport, "serve", _fake_serve))
                 enter(contextlib.redirect_stdout(io.StringIO()))
                 enter(contextlib.redirect_stderr(io.StringIO()))
@@ -386,12 +389,19 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
             served[0] if served else None,
             broker_start.called,
             sprint_start.called,
+            watcher_start.called,
         )
 
     def test_startup_refuses_an_unsafe_bind_before_serving(self):
         for bind in ("0.0.0.0", "::", "192.168.1.10", "example.com"):
             with self.subTest(bind=bind):
-                refusal, served, broker_started, sprint_started = self._start(bind)
+                (
+                    refusal,
+                    served,
+                    broker_started,
+                    sprint_started,
+                    watcher_started,
+                ) = self._start(bind)
                 self.assertIsNotNone(
                     refusal, "main() accepted a non-loopback bind on a host")
                 self.assertIn("loopback", str(refusal))
@@ -408,11 +418,15 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                     sprint_started,
                     "Sprint runtime started before bind refusal",
                 )
+                self.assertFalse(
+                    watcher_started,
+                    "Sprint PR watcher started before bind refusal",
+                )
 
     def test_startup_serves_a_loopback_bind(self):
         self.assertEqual(
             self._start("127.0.0.1"),
-            (None, "127.0.0.1", True, True),
+            (None, "127.0.0.1", True, True, True),
         )
 
     def test_startup_imports_no_removed_scheduler(self):
@@ -433,7 +447,7 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
         # unbootable, so the sandbox exception has to survive the wiring too.
         self.assertEqual(
             self._start("0.0.0.0", container=True),
-            (None, "0.0.0.0", True, True),
+            (None, "0.0.0.0", True, True, True),
         )
 
     def test_startup_binds_the_csp_to_the_served_port(self):

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -1,0 +1,458 @@
+"""Stage 5 gates for registered-PR observation and routed wakes."""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path[:0] = [str(SCRIPTS), str(ROOT / "tests")]
+
+import sprint_domain
+import sprint_message_delivery
+import sprint_pr_watcher
+from github_pull_requests import GitHubReadError, PullRequest
+from test_sprint_message_delivery import SprintMessageCase
+
+
+def pull_request(
+    *,
+    number: int = 42,
+    state: str = "OPEN",
+    checks: str | None = "FAILURE",
+    checks_failed: bool = True,
+    head_sha: str = "a" * 40,
+) -> PullRequest:
+    return PullRequest(
+        number=number,
+        head_ref=f"feature/pr-{number}",
+        base_ref="main",
+        head_sha=head_sha,
+        state=state,
+        merged_at="2026-07-31T20:00:00Z" if state == "MERGED" else None,
+        merge_sha="b" * 40 if state == "MERGED" else None,
+        title=f"PR {number}",
+        url=f"https://github.example/acme/repo/pull/{number}",
+        review_decision=None,
+        checks=checks,
+        checks_failed=checks_failed,
+    )
+
+
+class FakeReader:
+    def __init__(self, current: PullRequest | Exception) -> None:
+        self.current = current
+        self.by_number: dict[int, PullRequest] = {}
+        self.get_calls: list[int] = []
+        self.list_calls = 0
+
+    def get(self, number: int) -> PullRequest:
+        self.get_calls.append(number)
+        if isinstance(self.current, Exception):
+            raise self.current
+        return self.by_number.get(number, self.current)
+
+    def list(self) -> list[PullRequest]:
+        self.list_calls += 1
+        if isinstance(self.current, Exception):
+            raise self.current
+        return list(self.by_number.values()) or [self.current]
+
+
+class SprintPRWatcherCase(SprintMessageCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.clock = [0.0]
+        self.reader = FakeReader(pull_request())
+        self.repositories: list[str] = []
+
+        def reader_factory(repository: str) -> FakeReader:
+            self.repositories.append(repository)
+            return self.reader
+
+        self.watcher = sprint_pr_watcher.SprintPRWatcher(
+            self.con,
+            repo_root=ROOT,
+            reader_factory=reader_factory,
+            monotonic=lambda: self.clock[0],
+        )
+
+    def register(self, *, number: int = 42):
+        return self.watcher.register(
+            self.sprint_id,
+            owner_shell_id=1,
+            repository="Acme/Repo",
+            pr_number=number,
+            work_unit_ids=(self.unit_id,),
+        )
+
+
+class RegistrationTest(SprintPRWatcherCase):
+    def test_registration_is_exactly_idempotent_and_takes_initial_snapshot(self):
+        first = self.register()
+        second = self.register()
+
+        self.assertTrue(first.created)
+        self.assertFalse(second.created)
+        self.assertEqual(first.registered_pr_id, second.registered_pr_id)
+        self.assertEqual([42], self.reader.get_calls)
+        self.assertEqual(["acme/repo"], self.repositories)
+        self.assertEqual(
+            [("acme/repo", 42)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT repository,pr_number FROM sprint_registered_prs"
+                )
+            ],
+        )
+        self.assertEqual(
+            [(self.unit_id,)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT work_unit_id FROM sprint_pr_work_units"
+                )
+            ],
+        )
+        self.assertEqual(
+            [("red", "a" * 40)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT normalized_state,observed_head_sha "
+                    "FROM sprint_pr_transitions"
+                )
+            ],
+        )
+
+    def test_registration_rejects_non_owner_work_and_non_armed_sprint(self):
+        other_unit = int(
+            self.con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output,planned_wave) VALUES (?,2,2,'Other','No',2)",
+                (self.sprint_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "owning Developer"
+        ):
+            self.watcher.registration.register(
+                self.sprint_id,
+                owner_shell_id=1,
+                repository="acme/repo",
+                pr_number=41,
+                work_unit_ids=(other_unit,),
+            )
+
+        sprint_domain.SprintLifecycleStore(self.con).transition(
+            self.sprint_id,
+            "paused",
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="test",
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "only for an armed Sprint"
+        ):
+            self.watcher.registration.register(
+                self.sprint_id,
+                owner_shell_id=1,
+                repository="acme/repo",
+                pr_number=41,
+                work_unit_ids=(self.unit_id,),
+            )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_registered_prs"
+            ).fetchone()[0],
+        )
+
+
+class TransitionRoutingTest(SprintPRWatcherCase):
+    def test_first_red_routes_one_active_owner_wake_and_passive_evidence(self):
+        self.register()
+
+        transition = self.con.execute(
+            "SELECT transition_id,normalized_state,evidence "
+            "FROM sprint_pr_transitions"
+        ).fetchone()
+        self.assertEqual("red", transition["normalized_state"])
+        self.assertEqual("registration", json.loads(transition["evidence"])["trigger"])
+        routed = self.con.execute(
+            "SELECT message_id,to_participant_id,body FROM sprint_messages "
+            "WHERE idempotency_key LIKE 'pr-transition:%' ORDER BY to_participant_id"
+        ).fetchall()
+        self.assertEqual(
+            sorted([self.developer_id, self.reviewer_id, self.planner_id]),
+            [int(row["to_participant_id"]) for row in routed],
+        )
+        self.assertEqual(
+            {"GitHub observed acme/repo PR #42: red at " + "a" * 40 + "."},
+            {str(row["body"]) for row in routed},
+        )
+        wakes = self.con.execute(
+            "SELECT m.to_participant_id,w.wake_id,w.state "
+            "FROM sprint_messages m "
+            "JOIN sprint_wake_messages wm USING (message_id) "
+            "JOIN sprint_wake_outbox w USING (wake_id) "
+            "WHERE m.idempotency_key LIKE 'pr-transition:%'"
+        ).fetchall()
+        self.assertEqual(
+            [(self.developer_id, wakes[0]["wake_id"], "pending")],
+            [(int(row[0]), row[1], row[2]) for row in wakes],
+        )
+        lease = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).claim_next("watch-test")
+        self.assertEqual(self.developer_id, lease.participant_id)
+        self.assertEqual(self.developer_conversation_id, lease.target_conversation_id)
+
+    def test_red_green_red_occurrences_wake_once_each_and_coalesce(self):
+        self.register()
+        self.reader.current = pull_request(
+            checks="SUCCESS", checks_failed=False, head_sha="b" * 40
+        )
+        self.assertTrue(self.watcher.poll_once())
+        self.reader.current = pull_request(
+            checks="FAILURE", checks_failed=True, head_sha="b" * 40
+        )
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(
+            ["red", "green", "red"],
+            [
+                row[0]
+                for row in self.con.execute(
+                    "SELECT normalized_state FROM sprint_pr_transitions "
+                    "ORDER BY transition_id"
+                )
+            ],
+        )
+        owner_messages = self.con.execute(
+            "SELECT message_id FROM sprint_messages "
+            "WHERE to_participant_id=? AND idempotency_key LIKE 'pr-transition:%'",
+            (self.developer_id,),
+        ).fetchall()
+        self.assertEqual(3, len(owner_messages))
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(DISTINCT wm.wake_id) FROM sprint_wake_messages wm "
+                "JOIN sprint_messages m USING (message_id) "
+                "WHERE m.to_participant_id=? "
+                "AND m.idempotency_key LIKE 'pr-transition:%'",
+                (self.developer_id,),
+            ).fetchone()[0],
+        )
+
+    def test_closed_without_merge_actively_notifies_only_planner(self):
+        self.reader.current = pull_request(
+            state="CLOSED", checks=None, checks_failed=False
+        )
+        self.register()
+
+        active_recipients = [
+            int(row[0])
+            for row in self.con.execute(
+                "SELECT m.to_participant_id FROM sprint_messages m "
+                "JOIN sprint_wake_messages wm USING (message_id) "
+                "WHERE m.idempotency_key LIKE 'pr-transition:%'"
+            )
+        ]
+        self.assertEqual([self.planner_id], active_recipients)
+        self.assertEqual(
+            sorted([self.developer_id, self.reviewer_id, self.planner_id]),
+            sorted(
+                int(row[0])
+                for row in self.con.execute(
+                    "SELECT to_participant_id FROM sprint_messages "
+                    "WHERE idempotency_key LIKE 'pr-transition:%'"
+                )
+            ),
+        )
+
+
+class RecoveryAndFailureTest(SprintPRWatcherCase):
+    def test_restart_and_unchanged_resume_emit_no_duplicate(self):
+        self.register()
+        before = tuple(
+            self.con.execute(
+                "SELECT (SELECT COUNT(*) FROM sprint_pr_transitions),"
+                "(SELECT COUNT(*) FROM sprint_messages "
+                "WHERE idempotency_key LIKE 'pr-transition:%'),"
+                "(SELECT COUNT(*) FROM sprint_wake_messages wm "
+                "JOIN sprint_messages m USING (message_id) "
+                "WHERE m.idempotency_key LIKE 'pr-transition:%')"
+            ).fetchone()
+        )
+        restarted = sprint_pr_watcher.SprintPRWatcher(
+            self.con,
+            repo_root=ROOT,
+            reader_factory=lambda _repository: self.reader,
+        )
+        self.assertTrue(restarted.poll_once(startup=True))
+
+        lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        lifecycle.transition(
+            self.sprint_id,
+            "paused",
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="test",
+        )
+        calls_before_pause = len(self.reader.get_calls)
+        self.assertFalse(restarted.poll_once())
+        self.assertEqual(calls_before_pause, len(self.reader.get_calls))
+        lifecycle.transition(
+            self.sprint_id,
+            "armed",
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+        self.assertTrue(restarted.poll_once())
+
+        after = tuple(
+            self.con.execute(
+                "SELECT (SELECT COUNT(*) FROM sprint_pr_transitions),"
+                "(SELECT COUNT(*) FROM sprint_messages "
+                "WHERE idempotency_key LIKE 'pr-transition:%'),"
+                "(SELECT COUNT(*) FROM sprint_wake_messages wm "
+                "JOIN sprint_messages m USING (message_id) "
+                "WHERE m.idempotency_key LIKE 'pr-transition:%')"
+            ).fetchone()
+        )
+        self.assertEqual(before, after)
+
+    def test_paused_change_is_observed_once_after_resume(self):
+        self.register()
+        lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        lifecycle.transition(
+            self.sprint_id,
+            "paused",
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="test",
+        )
+        self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
+        self.assertFalse(self.watcher.poll_once())
+        self.assertEqual(["red"], self._states())
+
+        lifecycle.transition(
+            self.sprint_id,
+            "armed",
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual(["red", "green"], self._states())
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual(["red", "green"], self._states())
+
+    def test_terminal_sprint_performs_zero_github_calls(self):
+        self.register()
+        lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        lifecycle.transition(
+            self.sprint_id,
+            "completed",
+            sprint_domain.LifecycleActor("planner", 3),
+            terminal_outcome="delivered",
+        )
+        calls = len(self.reader.get_calls)
+
+        self.assertFalse(self.watcher.poll_once())
+        self.assertEqual(calls, len(self.reader.get_calls))
+        self.assertEqual(0, self.reader.list_calls)
+
+    def test_failure_is_durable_backs_off_and_never_invents_state(self):
+        self.reader.current = GitHubReadError("rate limit reached")
+        self.register()
+        self.assertEqual([42], self.reader.get_calls)
+        self.assertEqual([], self._states())
+        failure = self.con.execute(
+            "SELECT payload FROM sprint_events WHERE event_type='pr.poll_failed'"
+        ).fetchone()
+        payload = json.loads(failure["payload"])
+        self.assertEqual(60.0, payload["backoff_seconds"])
+        self.assertEqual("rate limit reached", payload["error"])
+
+        self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
+        self.clock[0] = 59.0
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual([42], self.reader.get_calls)
+        self.assertEqual([], self._states())
+        self.clock[0] = 60.0
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual([42, 42], self.reader.get_calls)
+        self.assertEqual(["green"], self._states())
+        active_recipient = self.con.execute(
+            "SELECT m.to_participant_id FROM sprint_messages m "
+            "JOIN sprint_wake_messages wm USING (message_id) "
+            "WHERE m.idempotency_key LIKE 'pr-transition:%'"
+        ).fetchone()
+        self.assertEqual(self.developer_id, int(active_recipient[0]))
+
+    def _states(self) -> list[str]:
+        return [
+            str(row[0])
+            for row in self.con.execute(
+                "SELECT normalized_state FROM sprint_pr_transitions "
+                "ORDER BY transition_id"
+            )
+        ]
+
+
+class BatchAndNormalizationTest(SprintPRWatcherCase):
+    def test_multiple_registered_prs_share_one_repository_list_read(self):
+        self.reader.by_number = {42: pull_request(number=42)}
+        self.register(number=42)
+        self.reader.by_number[43] = pull_request(number=43)
+        self.register(number=43)
+        get_count = len(self.reader.get_calls)
+
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(1, self.reader.list_calls)
+        self.assertEqual(get_count, len(self.reader.get_calls))
+        self.assertEqual(
+            [(42, "red"), (43, "red")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT p.pr_number,t.normalized_state "
+                    "FROM sprint_registered_prs p "
+                    "JOIN sprint_pr_transitions t USING (registered_pr_id) "
+                    "ORDER BY p.pr_number"
+                )
+            ],
+        )
+
+    def test_normalized_state_precedence_is_literal(self):
+        closed_with_merge_evidence = replace(
+            pull_request(state="CLOSED", checks=None, checks_failed=False),
+            merged_at="2026-07-31T20:00:00Z",
+            merge_sha="b" * 40,
+        )
+        cases = (
+            (pull_request(state="MERGED", checks="FAILURE"), "merged"),
+            (closed_with_merge_evidence, "merged"),
+            (pull_request(state="CLOSED", checks="SUCCESS"), "closed"),
+            (pull_request(), "red"),
+            (pull_request(checks="SUCCESS", checks_failed=False), "green"),
+            (pull_request(checks="PENDING", checks_failed=False), "pending"),
+            (pull_request(checks=None, checks_failed=False), "created"),
+        )
+        for observed, expected in cases:
+            with self.subTest(expected=expected):
+                self.assertEqual(expected, sprint_pr_watcher.normalize_state(observed))
+
+    def test_service_default_is_the_five_second_armed_pulse(self):
+        service = sprint_pr_watcher.SprintPRWatcherService(
+            ROOT / "unused.db", repo_root=ROOT
+        )
+        self.assertEqual(5.0, service.pulse_seconds)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- register Sprint-owned PRs against Developer work units and take an initial normalized snapshot
- run one five-second API-started watcher only while a Sprint is armed, batching reads per repository when useful
- atomically append changed PR states with passive evidence and active Developer red/green or Planner closed-without-merge messages through the Sprint wake outbox
- persist poll failures with bounded backoff and deduplicate unchanged restart/resume observations using chained transition identities

## Verification
- focused: 84 passed, 203 subtests
- full: 1,322 passed, 1 skipped
- render-check: green
- new-file Ruff + critical changed-file lint: green
- git diff --check: green

## Judgements
- R1: extended the v1-removal manifest only for the new v2 watcher module/test; the v1 assertions remain unchanged.
- Transition evidence and routed message+wake rows share one short transaction so a committed transition cannot suppress a lost notification on retry.
- Reused the existing bounded GitHub reader and added explicit repository scoping; no v1 watcher path was revived.

## Environment gates
- `./sc map` intentionally not run: this install assigns catalogue writes to the cartographer; the stale map was reported in message #497.
- `./sc verify` is destructive and refuses linked worktrees; the full suite includes the clean-clone verify gate.