### PR TITLE
feat: monitor Sprint work liveness

### DIFF
--- a/.super-coder/migrations/0149_sprint_liveness_monitor.sql
+++ b/.super-coder/migrations/0149_sprint_liveness_monitor.sql
@@ -58,11 +58,18 @@ INSERT INTO sprint_liveness_expectations (
     last_strong_at,last_strong_key,next_evaluation_at
 )
 SELECT
-    message_id,sprint_id,to_participant_id,read_at,
-    read_at,'message.accepted:' || message_id,
-    datetime(read_at,'+5 minutes')
-FROM sprint_messages
-WHERE actionable=1 AND disposition='accepted' AND read_at IS NOT NULL;
+    m.message_id,m.sprint_id,m.to_participant_id,m.read_at,
+    m.read_at,'message.accepted:' || m.message_id,
+    datetime(m.read_at,'+5 minutes')
+FROM sprint_messages m
+JOIN sprints s ON s.sprint_id=m.sprint_id
+LEFT JOIN sprint_work_units unit
+  ON unit.sprint_id=m.sprint_id AND unit.work_unit_id=m.work_unit_id
+WHERE m.actionable=1
+  AND m.disposition='accepted'
+  AND m.read_at IS NOT NULL
+  AND s.lifecycle='armed'
+  AND (m.work_unit_id IS NULL OR unit.disposition NOT IN ('completed','cancelled'));
 
 CREATE TRIGGER trg_sprint_liveness_acceptance
 AFTER UPDATE OF disposition,read_at ON sprint_messages

--- a/.super-coder/migrations/0149_sprint_liveness_monitor.sql
+++ b/.super-coder/migrations/0149_sprint_liveness_monitor.sql
@@ -1,0 +1,117 @@
+-- 0149 — durable Sprint liveness silence episodes.
+--
+-- Every accepted actionable Sprint message is a work expectation, including
+-- review requests (which deliberately are not editing lanes).  The projection
+-- below makes the ten-minute grace, one nudge, and one Planner escalation
+-- restart-safe without deriving episode identity from message text.
+
+BEGIN;
+
+CREATE TABLE sprint_liveness_expectations (
+    message_id             INTEGER PRIMARY KEY
+                           REFERENCES sprint_messages(message_id),
+    sprint_id              INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    participant_id         INTEGER NOT NULL
+                           REFERENCES sprint_participants(participant_id),
+    accepted_at            TEXT NOT NULL,
+    last_strong_at         TEXT NOT NULL,
+    last_strong_key        TEXT NOT NULL CHECK (trim(last_strong_key)<>''),
+    silence_episode        INTEGER NOT NULL DEFAULT 1
+                           CHECK (silence_episode > 0),
+    nudge_at               TEXT,
+    escalated_at           TEXT,
+    last_evaluated_at      TEXT,
+    next_evaluation_at     TEXT,
+    last_supporting        TEXT NOT NULL DEFAULT '[]'
+                           CHECK (
+                             json_valid(last_supporting)
+                             AND json_type(last_supporting)='array'
+                           ),
+    last_unreadable        TEXT NOT NULL DEFAULT '[]'
+                           CHECK (
+                             json_valid(last_unreadable)
+                             AND json_type(last_unreadable)='array'
+                           ),
+    last_failure_key       TEXT,
+    resolved_at            TEXT,
+    resolution             TEXT,
+    UNIQUE (sprint_id, message_id),
+    FOREIGN KEY (sprint_id, participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id),
+    CHECK (
+      (resolved_at IS NULL AND resolution IS NULL)
+      OR
+      (resolved_at IS NOT NULL AND trim(COALESCE(resolution,''))<>'')
+    )
+);
+
+CREATE INDEX idx_sprint_liveness_due
+    ON sprint_liveness_expectations(
+      sprint_id, resolved_at, next_evaluation_at, message_id
+    );
+
+-- Downstream updates may already have an armed Sprint.  Start its accepted
+-- expectations from their real acceptance timestamp; the insert is naturally
+-- idempotent because message_id is the projection identity.
+INSERT INTO sprint_liveness_expectations (
+    message_id,sprint_id,participant_id,accepted_at,
+    last_strong_at,last_strong_key,next_evaluation_at
+)
+SELECT
+    message_id,sprint_id,to_participant_id,read_at,
+    read_at,'message.accepted:' || message_id,
+    datetime(read_at,'+5 minutes')
+FROM sprint_messages
+WHERE actionable=1 AND disposition='accepted' AND read_at IS NOT NULL;
+
+CREATE TRIGGER trg_sprint_liveness_acceptance
+AFTER UPDATE OF disposition,read_at ON sprint_messages
+WHEN NEW.actionable=1
+  AND NEW.disposition='accepted'
+  AND NEW.read_at IS NOT NULL
+  AND (OLD.disposition<>'accepted' OR OLD.read_at IS NULL)
+BEGIN
+  INSERT INTO sprint_liveness_expectations (
+      message_id,sprint_id,participant_id,accepted_at,
+      last_strong_at,last_strong_key,next_evaluation_at
+  ) VALUES (
+      NEW.message_id,NEW.sprint_id,NEW.to_participant_id,NEW.read_at,
+      NEW.read_at,'message.accepted:' || NEW.message_id,
+      datetime(NEW.read_at,'+5 minutes')
+  );
+END;
+
+-- Work assignments have an authoritative terminal projection.  Review-request
+-- completion is owned by the Stage-6 review outcome path and calls the monitor's
+-- explicit resolve seam; reviews remain monitored even though they own no lane.
+CREATE TRIGGER trg_sprint_liveness_work_terminal
+AFTER UPDATE OF disposition ON sprint_work_units
+WHEN NEW.disposition IN ('completed','cancelled')
+  AND OLD.disposition NOT IN ('completed','cancelled')
+BEGIN
+  UPDATE sprint_liveness_expectations
+  SET resolved_at=datetime('now'),
+      resolution='work_unit.' || NEW.disposition,
+      next_evaluation_at=NULL
+  WHERE resolved_at IS NULL
+    AND message_id IN (
+      SELECT message_id FROM sprint_messages
+      WHERE work_unit_id=NEW.work_unit_id
+        AND message_kind='work_assignment'
+    );
+END;
+
+CREATE TRIGGER trg_sprint_liveness_identity_immutable
+BEFORE UPDATE OF message_id,sprint_id,participant_id,accepted_at
+ON sprint_liveness_expectations
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint liveness expectation identity is immutable');
+END;
+
+CREATE TRIGGER trg_sprint_liveness_no_delete
+BEFORE DELETE ON sprint_liveness_expectations
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint liveness history is durable');
+END;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_liveness.py
+++ b/.super-coder/scripts/sprint_liveness.py
@@ -1,0 +1,814 @@
+"""Armed-only Sprint liveness evaluation and escalation policy.
+
+Accepted actionable Sprint messages are durable work expectations.  This
+module evaluates their evidence on a five-minute cadence, keeps one restart-
+safe silence episode per expectation, nudges the worker once after ten minutes
+of ambiguous silence, and escalates once to the Planner after a further ten
+minutes.  External delivery remains the wake outbox's responsibility.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import db_driver
+import run as run_mod
+import shell_liveness
+import sprint_participant_chats
+from sprint_message_delivery import SprintMessageStore
+
+EVALUATION_INTERVAL = timedelta(minutes=5)
+GRACE_WINDOW = timedelta(minutes=10)
+ESCALATION_WINDOW = timedelta(minutes=10)
+
+_NATIVE_EVIDENCE_EVENTS = (
+    "session.started",
+    "run.started",
+    "assistant.delta",
+    "tool.started",
+    "tool.completed",
+    "permission.requested",
+    "input.requested",
+    "usage",
+    "run.completed",
+    "run.failed",
+    "run.interrupted",
+    "run.unknown",
+)
+_PROVIDER_ALIASES = {"kimi": "moonshot", "kimi-for-coding": "moonshot"}
+
+
+def _stamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _parse(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _provider(value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = value.strip().lower()
+    return _PROVIDER_ALIASES.get(normalized, normalized)
+
+
+@dataclass(frozen=True)
+class Evidence:
+    key: str
+    kind: str
+    observed_at: datetime
+    strength: str
+    detail: str
+
+    def summary(self) -> dict[str, str]:
+        return {
+            "key": self.key,
+            "kind": self.kind,
+            "observed_at": _stamp(self.observed_at),
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class EvidenceSnapshot:
+    strong: Evidence | None
+    supporting: tuple[Evidence, ...]
+    failure: Evidence | None
+    unreadable: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EvaluationOutcome:
+    message_id: int
+    action: str
+    silence_episode: int
+
+
+@dataclass(frozen=True)
+class QuotaState:
+    provider: str | None
+    captured_at: datetime | None
+    exhausted: bool
+    healthy: bool
+    unreadable: str | None
+    key: str | None
+
+
+class SprintEvidenceCollector:
+    """Collect deterministic strong evidence plus cautious supporting signals."""
+
+    def __init__(
+        self,
+        con: sqlite3.Connection,
+        *,
+        process_probe: Callable[
+            [sqlite3.Row, datetime, datetime],
+            tuple[Evidence | None, Evidence | None, str | None],
+        ]
+        | None = None,
+    ) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+        self.process_probe = process_probe or self._launch_process_probe
+
+    def collect(self, expectation: sqlite3.Row, now: datetime) -> EvidenceSnapshot:
+        accepted_at = _parse(expectation["accepted_at"])
+        participant_id = int(expectation["participant_id"])
+        strong = self._latest_strong(participant_id, accepted_at)
+        failures = list(self._terminal_failures(participant_id, accepted_at))
+        supporting: list[Evidence] = []
+        unreadable: list[str] = []
+
+        participant = self.con.execute(
+            "SELECT p.*,sh.shortname FROM sprint_participants p "
+            "JOIN shells sh ON sh.shell_id=p.shell_id "
+            "WHERE p.participant_id=?",
+            (participant_id,),
+        ).fetchone()
+        if participant is None:
+            unreadable.append("participant row disappeared")
+        else:
+            process_support, process_failure, process_unreadable = self.process_probe(
+                participant, accepted_at, now
+            )
+            if process_support is not None:
+                supporting.append(process_support)
+            if process_failure is not None:
+                failures.append(process_failure)
+            if process_unreadable:
+                unreadable.append(process_unreadable)
+
+        git_support = self._git_support(participant_id, accepted_at, now)
+        if git_support is not None:
+            supporting.append(git_support)
+
+        quota = self.quota_state_for_participant(participant_id, now)
+        if quota.exhausted and quota.captured_at and quota.key:
+            failures.append(
+                Evidence(
+                    quota.key,
+                    "quota.exhausted",
+                    now,
+                    "failure",
+                    f"provider {quota.provider} has an exhausted current quota window",
+                )
+            )
+        elif quota.healthy and quota.captured_at and quota.key:
+            supporting.append(
+                Evidence(
+                    quota.key,
+                    "quota.available",
+                    quota.captured_at,
+                    "supporting",
+                    f"provider {quota.provider} has a non-exhausted current snapshot",
+                )
+            )
+        elif quota.unreadable:
+            unreadable.append(quota.unreadable)
+
+        failure = max(failures, key=lambda item: item.observed_at, default=None)
+        return EvidenceSnapshot(
+            strong=strong,
+            supporting=tuple(sorted(supporting, key=lambda item: item.key)),
+            failure=failure,
+            unreadable=tuple(sorted(set(unreadable))),
+        )
+
+    def quota_state_for_participant(
+        self, participant_id: int, now: datetime
+    ) -> QuotaState:
+        row = self.con.execute(
+            "SELECT c.provider FROM sprint_participants p "
+            "LEFT JOIN conversations c ON c.conversation_id=p.current_conversation_id "
+            "WHERE p.participant_id=?",
+            (participant_id,),
+        ).fetchone()
+        return self.quota_state(_provider(row["provider"] if row else None), now)
+
+    def quota_state(self, provider: str | None, now: datetime) -> QuotaState:
+        provider = _provider(provider)
+        if provider is None:
+            return QuotaState(None, None, False, False, "quota provider is unknown", None)
+        rows = self.con.execute(
+            "SELECT w.window_pk,w.used_percent,w.used,w.limit_value,w.resets_at,"
+            "w.captured_at,w.status FROM harness_quota_window w "
+            "JOIN harness_quota_account a ON a.account_pk=w.account_pk "
+            "WHERE a.provider=? AND datetime(w.captured_at)=("
+            "SELECT MAX(datetime(latest.captured_at)) "
+            "FROM harness_quota_window latest "
+            "JOIN harness_quota_account latest_account "
+            "ON latest_account.account_pk=latest.account_pk "
+            "WHERE latest_account.provider=?) ORDER BY w.window_pk",
+            (provider, provider),
+        ).fetchall()
+        if not rows:
+            return QuotaState(
+                provider, None, False, False, f"quota snapshot unavailable for {provider}", None
+            )
+        captured_at = max(_parse(row["captured_at"]) for row in rows)
+        statuses = {str(row["status"]) for row in rows}
+        if statuses != {"ok"}:
+            return QuotaState(
+                provider,
+                captured_at,
+                False,
+                False,
+                f"quota snapshot for {provider} is unreadable ({','.join(sorted(statuses))})",
+                f"quota:{provider}:{_stamp(captured_at)}",
+            )
+
+        fresh = now - captured_at <= GRACE_WINDOW
+
+        def active(row: sqlite3.Row) -> bool:
+            return row["resets_at"] is None or _parse(row["resets_at"]) > now
+
+        exhausted = any(
+            active(row)
+            and (fresh or row["resets_at"] is not None)
+            and (
+                (row["used_percent"] is not None and float(row["used_percent"]) >= 100)
+                or (
+                    row["used"] is not None
+                    and row["limit_value"] is not None
+                    and int(row["limit_value"]) > 0
+                    and int(row["used"]) >= int(row["limit_value"])
+                )
+            )
+            for row in rows
+        )
+        key = "quota:{}:{}:{}".format(
+            provider,
+            _stamp(captured_at),
+            ",".join(str(row["window_pk"]) for row in rows),
+        )
+        if not exhausted and not fresh:
+            return QuotaState(
+                provider,
+                captured_at,
+                False,
+                False,
+                f"quota snapshot for {provider} is stale",
+                key,
+            )
+        return QuotaState(provider, captured_at, exhausted, not exhausted, None, key)
+
+    def _latest_strong(
+        self, participant_id: int, accepted_at: datetime
+    ) -> Evidence | None:
+        threshold = _stamp(accepted_at)
+        candidates: list[Evidence] = []
+        event_types = ",".join("?" for _ in _NATIVE_EVIDENCE_EVENTS)
+        row = self.con.execute(
+            "SELECT e.event_id,e.event_type,e.created_at FROM conversation_events e "
+            "JOIN sprint_participant_conversations pc "
+            "ON pc.conversation_id=e.conversation_id "
+            f"WHERE pc.sprint_participant_id=? AND e.event_type IN ({event_types}) "
+            "AND e.created_at>=? ORDER BY e.created_at DESC,e.event_id DESC LIMIT 1",
+            (participant_id, *_NATIVE_EVIDENCE_EVENTS, threshold),
+        ).fetchone()
+        if row is not None:
+            candidates.append(
+                Evidence(
+                    f"conversation.event:{row['event_id']}",
+                    str(row["event_type"]),
+                    _parse(row["created_at"]),
+                    "strong",
+                    "normalized native conversation event",
+                )
+            )
+
+        row = self.con.execute(
+            "SELECT r.run_id,r.heartbeat_at FROM conversation_runs r "
+            "JOIN sprint_participant_conversations pc "
+            "ON pc.conversation_id=r.conversation_id "
+            "WHERE pc.sprint_participant_id=? AND r.heartbeat_at>=? "
+            "AND r.harness_session_after IS NOT NULL AND r.runner_ref IS NOT NULL "
+            "ORDER BY r.heartbeat_at DESC,r.run_id DESC LIMIT 1",
+            (participant_id, threshold),
+        ).fetchone()
+        if row is not None:
+            candidates.append(
+                Evidence(
+                    f"run.heartbeat:{row['run_id']}:{row['heartbeat_at']}",
+                    "run.heartbeat",
+                    _parse(row["heartbeat_at"]),
+                    "strong",
+                    "fresh broker lease heartbeat bound to an exact native run",
+                )
+            )
+
+        row = self.con.execute(
+            "SELECT message_id,message_kind,created_at FROM sprint_messages "
+            "WHERE from_participant_id=? AND created_at>=? "
+            "ORDER BY created_at DESC,message_id DESC LIMIT 1",
+            (participant_id, threshold),
+        ).fetchone()
+        if row is not None:
+            candidates.append(
+                Evidence(
+                    f"sprint.message:{row['message_id']}",
+                    f"sprint_message.{row['message_kind']}",
+                    _parse(row["created_at"]),
+                    "strong",
+                    "durable Sprint message authored by the participant",
+                )
+            )
+
+        participant = self.con.execute(
+            "SELECT sprint_id,shell_id FROM sprint_participants WHERE participant_id=?",
+            (participant_id,),
+        ).fetchone()
+        if participant is not None:
+            row = self.con.execute(
+                "SELECT event_id,event_type,created_at FROM sprint_events "
+                "WHERE sprint_id=? AND actor_kind='participant' AND actor_shell_id=? "
+                "AND created_at>=? ORDER BY created_at DESC,event_id DESC LIMIT 1",
+                (participant["sprint_id"], participant["shell_id"], threshold),
+            ).fetchone()
+            if row is not None:
+                candidates.append(
+                    Evidence(
+                        f"sprint.event:{row['event_id']}",
+                        str(row["event_type"]),
+                        _parse(row["created_at"]),
+                        "strong",
+                        "durable participant Sprint state transition",
+                    )
+                )
+
+        row = self.con.execute(
+            "SELECT t.transition_id,t.normalized_state,t.observed_at "
+            "FROM sprint_pr_transitions t JOIN sprint_registered_prs pr "
+            "ON pr.registered_pr_id=t.registered_pr_id "
+            "WHERE pr.owner_participant_id=? AND t.observed_at>=? "
+            "ORDER BY t.observed_at DESC,t.transition_id DESC LIMIT 1",
+            (participant_id, threshold),
+        ).fetchone()
+        if row is not None:
+            candidates.append(
+                Evidence(
+                    f"pr.transition:{row['transition_id']}",
+                    f"pr.{row['normalized_state']}",
+                    _parse(row["observed_at"]),
+                    "strong",
+                    "registered PR transition",
+                )
+            )
+
+        row = self.con.execute(
+            "SELECT target_id,latest_head_sha,last_seen_at "
+            "FROM conversation_git_targets target "
+            "JOIN sprint_participant_conversations pc "
+            "ON pc.conversation_id=target.conversation_id "
+            "WHERE pc.sprint_participant_id=? AND target.last_seen_at>=? "
+            "ORDER BY target.last_seen_at DESC,target.target_id LIMIT 1",
+            (participant_id, threshold),
+        ).fetchone()
+        if row is not None:
+            candidates.append(
+                Evidence(
+                    f"git.head:{row['target_id']}:{row['latest_head_sha']}",
+                    "git.head",
+                    _parse(row["last_seen_at"]),
+                    "strong",
+                    "durable local Git head observation",
+                )
+            )
+        return max(candidates, key=lambda item: (item.observed_at, item.key), default=None)
+
+    def _terminal_failures(
+        self, participant_id: int, accepted_at: datetime
+    ) -> tuple[Evidence, ...]:
+        row = self.con.execute(
+            "SELECT r.run_id,r.state,r.ended_at,COALESCE(r.error_code,'') error_code "
+            "FROM conversation_runs r JOIN sprint_participant_conversations pc "
+            "ON pc.conversation_id=r.conversation_id "
+            "WHERE pc.sprint_participant_id=? AND r.state IN ('failed','unknown') "
+            "AND r.ended_at>=? ORDER BY r.ended_at DESC,r.run_id DESC LIMIT 1",
+            (participant_id, _stamp(accepted_at)),
+        ).fetchone()
+        if row is None:
+            return ()
+        return (
+            Evidence(
+                f"run.failure:{row['run_id']}:{row['state']}",
+                f"run.{row['state']}",
+                _parse(row["ended_at"]),
+                "failure",
+                f"proven terminal native run {row['state']} {row['error_code']}".strip(),
+            ),
+        )
+
+    def _git_support(
+        self, participant_id: int, accepted_at: datetime, now: datetime
+    ) -> Evidence | None:
+        threshold = max(accepted_at, now - GRACE_WINDOW)
+        row = self.con.execute(
+            "SELECT target.target_id,target.last_seen_at "
+            "FROM conversation_git_targets target "
+            "JOIN sprint_participant_conversations pc "
+            "ON pc.conversation_id=target.conversation_id "
+            "WHERE pc.sprint_participant_id=? AND target.last_seen_at>=? "
+            "ORDER BY target.last_seen_at DESC,target.target_id LIMIT 1",
+            (participant_id, _stamp(threshold)),
+        ).fetchone()
+        if row is None:
+            return None
+        return Evidence(
+            f"worktree.observed:{row['target_id']}:{row['last_seen_at']}",
+            "worktree.observed",
+            _parse(row["last_seen_at"]),
+            "supporting",
+            "worktree Git target was observed",
+        )
+
+    def _launch_process_probe(
+        self, participant: sqlite3.Row, accepted_at: datetime, now: datetime
+    ) -> tuple[Evidence | None, Evidence | None, str | None]:
+        try:
+            claim = self.con.execute(
+                "SELECT pid,start_ticks,worktree,launched_at "
+                "FROM shell_launch_records WHERE shell_id=?",
+                (participant["shell_id"],),
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return None, None, "shell launch evidence is unavailable"
+        if claim is None or _parse(claim["launched_at"]) < accepted_at:
+            return None, None, None
+        claim_dict = dict(claim)
+        if shell_liveness.claim_live(claim_dict):
+            return (
+                Evidence(
+                    f"process.present:{claim['pid']}:{claim['start_ticks']}",
+                    "process.present",
+                    now,
+                    "supporting",
+                    "accepted work's claimed harness process is present",
+                ),
+                None,
+                None,
+            )
+        return (
+            None,
+            Evidence(
+                f"process.missing:{claim['pid']}:{claim['start_ticks']}",
+                "process.missing",
+                now,
+                "failure",
+                "accepted work's exact claimed harness process is missing",
+            ),
+            None,
+        )
+
+
+class PlannerEscalationRouter:
+    """Move escalation delivery only when the Planner's provider is exhausted."""
+
+    def __init__(self, con: sqlite3.Connection, collector: SprintEvidenceCollector) -> None:
+        self.con = con
+        self.collector = collector
+
+    def prepare(
+        self,
+        sprint_id: int,
+        *,
+        expectation_message_id: int,
+        silence_episode: int,
+        now: datetime,
+        reason: str,
+    ) -> tuple[int, str]:
+        planner = self.con.execute(
+            "SELECT p.participant_id,p.harness,p.model,p.effort,sh.flavor,"
+            "c.harness current_harness,c.provider current_provider "
+            "FROM sprint_participants p JOIN shells sh ON sh.shell_id=p.shell_id "
+            "LEFT JOIN conversations c ON c.conversation_id=p.current_conversation_id "
+            "WHERE p.sprint_id=? AND p.role='planner'",
+            (sprint_id,),
+        ).fetchone()
+        if planner is None:
+            raise RuntimeError("armed Sprint has no Planner participant")
+        participant_id = int(planner["participant_id"])
+        primary = self.collector.quota_state(_provider(planner["current_provider"]), now)
+        if not primary.exhausted:
+            return participant_id, "primary"
+
+        candidates = self.con.execute(
+            "SELECT harness,model FROM flavor_defaults WHERE flavor=? "
+            "AND harness<>? ORDER BY is_default DESC,harness",
+            (planner["flavor"], planner["current_harness"] or planner["harness"]),
+        ).fetchall()
+        for candidate in candidates:
+            candidate_provider = _provider(
+                run_mod.session_provider(candidate["harness"], candidate["model"])
+            )
+            if candidate_provider == primary.provider:
+                continue
+            if self.collector.quota_state(candidate_provider, now).exhausted:
+                continue
+            sprint_participant_chats.create_planner_fallback(
+                self.con,
+                participant_id=participant_id,
+                reason=reason,
+                harness=candidate["harness"],
+                model=candidate["model"],
+                effort=planner["effort"],
+                idempotency_key=(
+                    f"sprint:{sprint_id}:liveness:{expectation_message_id}:"
+                    f"episode:{silence_episode}:planner-fallback"
+                ),
+            )
+            return participant_id, f"fallback:{candidate['harness']}"
+        return participant_id, "unavailable"
+
+
+class SprintLivenessMonitor:
+    """Evaluate due expectations and atomically commit nudge/escalation facts."""
+
+    def __init__(
+        self,
+        con: sqlite3.Connection,
+        *,
+        now: Callable[[], datetime] | None = None,
+        collector: SprintEvidenceCollector | None = None,
+    ) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+        self.now = now or (lambda: datetime.now(timezone.utc))
+        self.collector = collector or SprintEvidenceCollector(con)
+        self.messages = SprintMessageStore(con)
+        self.router = PlannerEscalationRouter(con, self.collector)
+
+    def evaluate(self, sprint_id: int) -> tuple[EvaluationOutcome, ...]:
+        now = self.now().astimezone(timezone.utc)
+        if not self._armed(sprint_id):
+            return ()
+        due = self.con.execute(
+            "SELECT e.* FROM sprint_liveness_expectations e "
+            "JOIN sprint_messages m ON m.message_id=e.message_id "
+            "WHERE e.sprint_id=? AND e.resolved_at IS NULL "
+            "AND e.next_evaluation_at IS NOT NULL "
+            "AND e.next_evaluation_at<=? AND m.disposition='accepted' "
+            "ORDER BY e.message_id",
+            (sprint_id, _stamp(now)),
+        ).fetchall()
+        outcomes = []
+        for expectation in due:
+            snapshot = self.collector.collect(expectation, now)
+            outcome = self._apply(int(expectation["message_id"]), snapshot, now)
+            if outcome is not None:
+                outcomes.append(outcome)
+        return tuple(outcomes)
+
+    def resolve(self, message_id: int, resolution: str) -> bool:
+        resolution = resolution.strip()
+        if not resolution:
+            raise ValueError("liveness expectation resolution is empty")
+        with db_driver.write_transaction(self.con, "sprint.liveness.resolve"):
+            changed = self.con.execute(
+                "UPDATE sprint_liveness_expectations SET resolved_at=?,resolution=?,"
+                "next_evaluation_at=NULL WHERE message_id=? AND resolved_at IS NULL",
+                (_stamp(self.now()), resolution, message_id),
+            ).rowcount
+        return changed == 1
+
+    def _apply(
+        self, message_id: int, snapshot: EvidenceSnapshot, now: datetime
+    ) -> EvaluationOutcome | None:
+        with db_driver.write_transaction(self.con, "sprint.liveness.evaluate"):
+            row = self.con.execute(
+                "SELECT e.* FROM sprint_liveness_expectations e "
+                "JOIN sprints s ON s.sprint_id=e.sprint_id "
+                "WHERE e.message_id=? AND e.resolved_at IS NULL "
+                "AND s.lifecycle='armed' AND e.next_evaluation_at<=?",
+                (message_id, _stamp(now)),
+            ).fetchone()
+            if row is None:
+                return None
+            episode = int(row["silence_episode"])
+            last_strong_at = _parse(row["last_strong_at"])
+            fresh_strong = self._fresh_strong(row, snapshot.strong)
+            failure = snapshot.failure
+
+            if fresh_strong is not None and (
+                failure is None or fresh_strong.observed_at > failure.observed_at
+            ):
+                episode += 1
+                self.con.execute(
+                    "UPDATE sprint_liveness_expectations SET last_strong_at=?,"
+                    "last_strong_key=?,silence_episode=?,nudge_at=NULL,"
+                    "escalated_at=NULL,last_failure_key=NULL,last_evaluated_at=?,"
+                    "next_evaluation_at=?,last_supporting=?,last_unreadable=? "
+                    "WHERE message_id=?",
+                    (
+                        _stamp(fresh_strong.observed_at),
+                        fresh_strong.key,
+                        episode,
+                        _stamp(now),
+                        _stamp(now + EVALUATION_INTERVAL),
+                        _json([item.summary() for item in snapshot.supporting]),
+                        _json(list(snapshot.unreadable)),
+                        message_id,
+                    ),
+                )
+                return EvaluationOutcome(message_id, "strong-evidence", episode)
+
+            if failure is not None and (
+                failure.observed_at >= last_strong_at
+                or failure.kind in {"quota.exhausted", "process.missing"}
+            ):
+                if row["escalated_at"] is None:
+                    return self._escalate(row, episode, snapshot, now, failure=failure)
+
+            accepted_silence = now - last_strong_at
+            if row["nudge_at"] is None and accepted_silence >= GRACE_WINDOW:
+                receipt = self.messages.send_in_transaction(
+                    int(row["sprint_id"]),
+                    to_participant_id=int(row["participant_id"]),
+                    message_kind="nudge",
+                    body=(
+                        f"Liveness check for accepted Sprint message #{message_id}: "
+                        "please confirm activity or record the current blocker."
+                    ),
+                    idempotency_key=(
+                        f"liveness:{message_id}:episode:{episode}:nudge"
+                    ),
+                    actionable=False,
+                    active=True,
+                )
+                self._event(
+                    int(row["sprint_id"]),
+                    "liveness.nudged",
+                    {
+                        "expectation_message_id": message_id,
+                        "silence_episode": episode,
+                        "nudge_message_id": receipt.message_id,
+                    },
+                )
+                self._update_observation(
+                    message_id,
+                    now,
+                    snapshot,
+                    nudge_at=_stamp(now),
+                    failure_key=failure.key if failure else None,
+                )
+                return EvaluationOutcome(message_id, "nudged", episode)
+
+            nudge_at = _parse(row["nudge_at"]) if row["nudge_at"] else None
+            if (
+                row["escalated_at"] is None
+                and nudge_at is not None
+                and now - nudge_at >= ESCALATION_WINDOW
+                and not snapshot.supporting
+            ):
+                return self._escalate(row, episode, snapshot, now, failure=None)
+
+            self._update_observation(
+                message_id,
+                now,
+                snapshot,
+                failure_key=failure.key if failure else None,
+            )
+            action = "supporting-evidence" if snapshot.supporting else "observed"
+            return EvaluationOutcome(message_id, action, episode)
+
+    def _escalate(
+        self,
+        row: sqlite3.Row,
+        episode: int,
+        snapshot: EvidenceSnapshot,
+        now: datetime,
+        *,
+        failure: Evidence | None,
+    ) -> EvaluationOutcome:
+        reason = failure.detail if failure else "continued silence after one nudge"
+        planner_id, route = self.router.prepare(
+            int(row["sprint_id"]),
+            expectation_message_id=int(row["message_id"]),
+            silence_episode=episode,
+            now=now,
+            reason=f"Liveness escalation delivery: {reason}",
+        )
+        body = _json(
+            {
+                "expectation_message_id": int(row["message_id"]),
+                "participant_id": int(row["participant_id"]),
+                "silence_episode": episode,
+                "accepted_at": row["accepted_at"],
+                "last_strong_at": row["last_strong_at"],
+                "reason": reason,
+                "failure": failure.summary() if failure else None,
+                "supporting_evidence": [
+                    item.summary() for item in snapshot.supporting
+                ],
+                "unreadable_signals": list(snapshot.unreadable),
+                "planner_delivery_route": route,
+                "pause_option": route == "unavailable",
+            }
+        )
+        receipt = self.messages.send_in_transaction(
+            int(row["sprint_id"]),
+            to_participant_id=planner_id,
+            message_kind="escalation",
+            body=body,
+            idempotency_key=(
+                f"liveness:{row['message_id']}:episode:{episode}:planner-escalation"
+            ),
+            actionable=False,
+            active=route != "unavailable",
+        )
+        event_type = (
+            "liveness.escalation_delivery_unavailable"
+            if route == "unavailable"
+            else "liveness.escalated"
+        )
+        self._event(
+            int(row["sprint_id"]),
+            event_type,
+            {
+                "expectation_message_id": int(row["message_id"]),
+                "silence_episode": episode,
+                "escalation_message_id": receipt.message_id,
+                "planner_delivery_route": route,
+            },
+        )
+        self._update_observation(
+            int(row["message_id"]),
+            now,
+            snapshot,
+            escalated_at=_stamp(now),
+            failure_key=failure.key if failure else None,
+        )
+        return EvaluationOutcome(int(row["message_id"]), "escalated", episode)
+
+    def _update_observation(
+        self,
+        message_id: int,
+        now: datetime,
+        snapshot: EvidenceSnapshot,
+        *,
+        nudge_at: str | None = None,
+        escalated_at: str | None = None,
+        failure_key: str | None = None,
+    ) -> None:
+        assignments = [
+            "last_evaluated_at=?",
+            "next_evaluation_at=?",
+            "last_supporting=?",
+            "last_unreadable=?",
+            "last_failure_key=?",
+        ]
+        values: list[Any] = [
+            _stamp(now),
+            _stamp(now + EVALUATION_INTERVAL),
+            _json([item.summary() for item in snapshot.supporting]),
+            _json(list(snapshot.unreadable)),
+            failure_key,
+        ]
+        if nudge_at is not None:
+            assignments.append("nudge_at=?")
+            values.append(nudge_at)
+        if escalated_at is not None:
+            assignments.append("escalated_at=?")
+            values.append(escalated_at)
+        values.append(message_id)
+        self.con.execute(
+            f"UPDATE sprint_liveness_expectations SET {','.join(assignments)} "
+            "WHERE message_id=?",
+            values,
+        )
+
+    @staticmethod
+    def _fresh_strong(row: sqlite3.Row, evidence: Evidence | None) -> Evidence | None:
+        if evidence is None:
+            return None
+        current_at = _parse(row["last_strong_at"])
+        if evidence.observed_at > current_at:
+            return evidence
+        if evidence.observed_at == current_at and evidence.key != row["last_strong_key"]:
+            return evidence
+        return None
+
+    def _armed(self, sprint_id: int) -> bool:
+        row = self.con.execute(
+            "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+        ).fetchone()
+        return row is not None and row["lifecycle"] == "armed"
+
+    def _event(self, sprint_id: int, event_type: str, payload: dict[str, Any]) -> None:
+        self.con.execute(
+            "INSERT INTO sprint_events "
+            "(sprint_id,event_type,actor_kind,payload) VALUES (? ,?,'system',?)",
+            (sprint_id, event_type, _json(payload)),
+        )

--- a/.super-coder/scripts/sprint_liveness.py
+++ b/.super-coder/scripts/sprint_liveness.py
@@ -8,6 +8,7 @@ minutes.  External delivery remains the wake outbox's responsibility.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from collections.abc import Callable
@@ -35,9 +36,7 @@ _NATIVE_EVIDENCE_EVENTS = (
     "input.requested",
     "usage",
     "run.completed",
-    "run.failed",
     "run.interrupted",
-    "run.unknown",
 )
 _PROVIDER_ALIASES = {"kimi": "moonshot", "kimi-for-coding": "moonshot"}
 
@@ -130,6 +129,9 @@ class SprintEvidenceCollector:
         failures = list(self._terminal_failures(participant_id, accepted_at))
         supporting: list[Evidence] = []
         unreadable: list[str] = []
+        unknown_outcome = self._latest_unknown_outcome(participant_id, accepted_at)
+        if unknown_outcome is not None:
+            unreadable.append(unknown_outcome)
 
         participant = self.con.execute(
             "SELECT p.*,sh.shortname FROM sprint_participants p "
@@ -367,25 +369,6 @@ class SprintEvidenceCollector:
                 )
             )
 
-        row = self.con.execute(
-            "SELECT target_id,latest_head_sha,last_seen_at "
-            "FROM conversation_git_targets target "
-            "JOIN sprint_participant_conversations pc "
-            "ON pc.conversation_id=target.conversation_id "
-            "WHERE pc.sprint_participant_id=? AND target.last_seen_at>=? "
-            "ORDER BY target.last_seen_at DESC,target.target_id LIMIT 1",
-            (participant_id, threshold),
-        ).fetchone()
-        if row is not None:
-            candidates.append(
-                Evidence(
-                    f"git.head:{row['target_id']}:{row['latest_head_sha']}",
-                    "git.head",
-                    _parse(row["last_seen_at"]),
-                    "strong",
-                    "durable local Git head observation",
-                )
-            )
         return max(candidates, key=lambda item: (item.observed_at, item.key), default=None)
 
     def _terminal_failures(
@@ -395,7 +378,7 @@ class SprintEvidenceCollector:
             "SELECT r.run_id,r.state,r.ended_at,COALESCE(r.error_code,'') error_code "
             "FROM conversation_runs r JOIN sprint_participant_conversations pc "
             "ON pc.conversation_id=r.conversation_id "
-            "WHERE pc.sprint_participant_id=? AND r.state IN ('failed','unknown') "
+            "WHERE pc.sprint_participant_id=? AND r.state='failed' "
             "AND r.ended_at>=? ORDER BY r.ended_at DESC,r.run_id DESC LIMIT 1",
             (participant_id, _stamp(accepted_at)),
         ).fetchone()
@@ -410,6 +393,24 @@ class SprintEvidenceCollector:
                 f"proven terminal native run {row['state']} {row['error_code']}".strip(),
             ),
         )
+
+    def _latest_unknown_outcome(
+        self, participant_id: int, accepted_at: datetime
+    ) -> str | None:
+        row = self.con.execute(
+            "SELECT r.run_id,COALESCE(r.error_code,'') error_code "
+            "FROM conversation_runs r JOIN sprint_participant_conversations pc "
+            "ON pc.conversation_id=r.conversation_id "
+            "WHERE pc.sprint_participant_id=? AND r.state='unknown' "
+            "AND r.ended_at>=? ORDER BY r.ended_at DESC,r.run_id DESC LIMIT 1",
+            (participant_id, _stamp(accepted_at)),
+        ).fetchone()
+        if row is None:
+            return None
+        detail = f"native run {row['run_id']} outcome is unknown"
+        if row["error_code"]:
+            detail += f" ({row['error_code']})"
+        return detail
 
     def _git_support(
         self, participant_id: int, accepted_at: datetime, now: datetime
@@ -484,30 +485,48 @@ class PlannerEscalationRouter:
         self,
         sprint_id: int,
         *,
-        expectation_message_id: int,
-        silence_episode: int,
         now: datetime,
         reason: str,
     ) -> tuple[int, str]:
         planner = self.con.execute(
-            "SELECT p.participant_id,p.harness,p.model,p.effort,sh.flavor,"
-            "c.harness current_harness,c.provider current_provider "
+            "SELECT p.participant_id,p.harness,p.model,p.effort,sh.flavor "
             "FROM sprint_participants p JOIN shells sh ON sh.shell_id=p.shell_id "
-            "LEFT JOIN conversations c ON c.conversation_id=p.current_conversation_id "
             "WHERE p.sprint_id=? AND p.role='planner'",
             (sprint_id,),
         ).fetchone()
         if planner is None:
             raise RuntimeError("armed Sprint has no Planner participant")
         participant_id = int(planner["participant_id"])
-        primary = self.collector.quota_state(_provider(planner["current_provider"]), now)
+        primary_provider = _provider(
+            run_mod.session_provider(planner["harness"], planner["model"])
+        )
+        primary = self.collector.quota_state(primary_provider, now)
         if not primary.exhausted:
             return participant_id, "primary"
+
+        incident_source = primary.key or primary.provider or "unknown"
+        incident = hashlib.sha256(incident_source.encode()).hexdigest()[:16]
+        fallback_key = f"sprint:{sprint_id}:liveness:planner-fallback:{incident}"
+        existing = self.con.execute(
+            "SELECT c.conversation_id,c.harness "
+            "FROM sprint_participant_conversations link "
+            "JOIN conversations c ON c.conversation_id=link.conversation_id "
+            "WHERE link.sprint_participant_id=? AND link.purpose='fallback' "
+            "AND c.creation_idempotency_key=?",
+            (participant_id, fallback_key),
+        ).fetchone()
+        if existing is not None:
+            self.con.execute(
+                "UPDATE sprint_participants SET current_conversation_id=? "
+                "WHERE participant_id=?",
+                (existing["conversation_id"], participant_id),
+            )
+            return participant_id, f"fallback:{existing['harness']}"
 
         candidates = self.con.execute(
             "SELECT harness,model FROM flavor_defaults WHERE flavor=? "
             "AND harness<>? ORDER BY is_default DESC,harness",
-            (planner["flavor"], planner["current_harness"] or planner["harness"]),
+            (planner["flavor"], planner["harness"]),
         ).fetchall()
         for candidate in candidates:
             candidate_provider = _provider(
@@ -524,10 +543,7 @@ class PlannerEscalationRouter:
                 harness=candidate["harness"],
                 model=candidate["model"],
                 effort=planner["effort"],
-                idempotency_key=(
-                    f"sprint:{sprint_id}:liveness:{expectation_message_id}:"
-                    f"episode:{silence_episode}:planner-fallback"
-                ),
+                idempotency_key=fallback_key,
             )
             return participant_id, f"fallback:{candidate['harness']}"
         return participant_id, "unavailable"
@@ -627,9 +643,21 @@ class SprintLivenessMonitor:
             if failure is not None and (
                 failure.observed_at >= last_strong_at
                 or failure.kind in {"quota.exhausted", "process.missing"}
+            ) and (
+                    row["escalated_at"] is None
+                    or failure.key != row["last_failure_key"]
             ):
-                if row["escalated_at"] is None:
-                    return self._escalate(row, episode, snapshot, now, failure=failure)
+                return self._escalate(row, episode, snapshot, now, failure=failure)
+
+            if row["escalated_at"] is not None:
+                self._update_observation(
+                    message_id,
+                    now,
+                    snapshot,
+                    failure_key=row["last_failure_key"],
+                )
+                action = "supporting-evidence" if snapshot.supporting else "observed"
+                return EvaluationOutcome(message_id, action, episode)
 
             accepted_silence = now - last_strong_at
             if row["nudge_at"] is None and accepted_silence >= GRACE_WINDOW:
@@ -695,8 +723,6 @@ class SprintLivenessMonitor:
         reason = failure.detail if failure else "continued silence after one nudge"
         planner_id, route = self.router.prepare(
             int(row["sprint_id"]),
-            expectation_message_id=int(row["message_id"]),
-            silence_episode=episode,
             now=now,
             reason=f"Liveness escalation delivery: {reason}",
         )
@@ -717,13 +743,18 @@ class SprintLivenessMonitor:
                 "pause_option": route == "unavailable",
             }
         )
+        escalation_key = "silence"
+        if failure is not None:
+            digest = hashlib.sha256(failure.key.encode()).hexdigest()[:16]
+            escalation_key = f"failure:{digest}"
         receipt = self.messages.send_in_transaction(
             int(row["sprint_id"]),
             to_participant_id=planner_id,
             message_kind="escalation",
             body=body,
             idempotency_key=(
-                f"liveness:{row['message_id']}:episode:{episode}:planner-escalation"
+                f"liveness:{row['message_id']}:episode:{episode}:"
+                f"planner-escalation:{escalation_key}"
             ),
             actionable=False,
             active=route != "unavailable",

--- a/.super-coder/scripts/sprint_runtime.py
+++ b/.super-coder/scripts/sprint_runtime.py
@@ -20,6 +20,7 @@ from sprint_domain import (
     SprintWorkUnitStore,
 )
 from sprint_message_delivery import SprintWakeDeliveryService
+from sprint_liveness import SprintLivenessMonitor
 
 DEFAULT_PULSE_SECONDS = 5.0
 
@@ -191,6 +192,7 @@ class SprintRuntimeService(threading.Thread):
     def _switch(self, con: sqlite3.Connection) -> ArmedServiceSwitch:
         units = SprintWorkUnitStore(con)
         wakes = SprintWakeDeliveryService(con)
+        liveness = SprintLivenessMonitor(con)
 
         def dispatch(sprint_id: int, _trigger: str) -> None:
             units.dispatch_ready(sprint_id)
@@ -201,9 +203,12 @@ class SprintRuntimeService(threading.Thread):
                 if outcome is None or outcome.state != "delivered":
                     return
 
+        def evaluate_liveness(sprint_id: int, _trigger: str) -> None:
+            liveness.evaluate(sprint_id)
+
         return ArmedServiceSwitch(
             SprintLifecycleStore(con),
-            (dispatch, deliver),
+            (dispatch, evaluate_liveness, deliver),
         )
 
     def run(self) -> None:  # pragma: no cover - loop tested through pulse_once

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -3,7 +3,9 @@
     ".super-coder/migrations/0146_sprint_v2_domain.sql",
     ".super-coder/migrations/0147_sprint_participant_conversations.sql",
     ".super-coder/migrations/0148_sprint_message_delivery.sql",
+    ".super-coder/migrations/0149_sprint_liveness_monitor.sql",
     ".super-coder/scripts/sprint_domain.py",
+    ".super-coder/scripts/sprint_liveness.py",
     ".super-coder/scripts/sprint_message_delivery.py",
     ".super-coder/scripts/sprint_participant_chats.py",
     ".super-coder/scripts/sprint_runtime.py",
@@ -16,6 +18,7 @@
     "tests/test_sprint_removal_manifest.py",
     "tests/test_sprint_v2_domain.py",
     "tests/test_sprint_message_delivery.py",
+    "tests/test_sprint_liveness.py",
     "tests/test_sprint_participant_chats.py",
     "tests/test_sprint_work_dispatch.py",
     "tests/test_sprint_pr_watcher.py"

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -1,0 +1,571 @@
+"""Stage 7 fake-clock gates for Sprint liveness and quota escalation."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import sys
+import unittest
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+MIGRATIONS = ENGINE / "migrations"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import sprint_domain  # noqa: E402
+import sprint_liveness  # noqa: E402
+import sprint_message_delivery  # noqa: E402
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted(MIGRATIONS.glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+def stamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def parse(value: str) -> datetime:
+    return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+
+
+@dataclass
+class FakeClock:
+    value: datetime
+
+    def __call__(self) -> datetime:
+        return self.value
+
+    def at(self, value: datetime) -> None:
+        self.value = value
+
+
+class SprintLivenessCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = sqlite3.connect(":memory:")
+        self.addCleanup(self.con.close)
+        self.con.row_factory = sqlite3.Row
+        apply_schema(self.con)
+        self.con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        self.con.executemany(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (?,?,?,?,?,1)",
+            (
+                (1, "Developer", "DEV1", "dev", "prompt"),
+                (2, "Reviewer", "REV1", "reviewer", "prompt"),
+                (3, "Planner", "PLN1", "planner", "prompt"),
+            ),
+        )
+        feature_id = int(
+            self.con.execute(
+                "INSERT INTO roadmap (title,roadmap_status) "
+                "VALUES ('Feature','in_progress')"
+            ).lastrowid
+        )
+        body = "governing spec"
+        document_id = int(
+            self.con.execute(
+                "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                "VALUES (?,'spec',1,'Spec',?)",
+                (feature_id, body),
+            ).lastrowid
+        )
+        revision = hashlib.sha256(body.encode()).hexdigest()
+        approval_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_spec_approvals "
+                "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+                "VALUES (?,?,2,'pass')",
+                (document_id, revision),
+            ).lastrowid
+        )
+        self.sprint_id = int(
+            self.con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_specs "
+            "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+            "VALUES (?,?,?,?)",
+            (self.sprint_id, document_id, revision, approval_id),
+        )
+        self.con.executemany(
+            "INSERT INTO sprint_participants "
+            "(sprint_id,shell_id,role,harness,model,effort) VALUES (?,?,?,?,?,?)",
+            (
+                (self.sprint_id, 3, "planner", "codex", "gpt", "high"),
+                (self.sprint_id, 1, "developer", "codex", "gpt", "high"),
+                (self.sprint_id, 2, "reviewer", "kimi", "kimi", "high"),
+            ),
+        )
+        participants = {
+            row["role"]: int(row["participant_id"])
+            for row in self.con.execute(
+                "SELECT role,participant_id FROM sprint_participants "
+                "WHERE sprint_id=?",
+                (self.sprint_id,),
+            )
+        }
+        self.planner_id = participants["planner"]
+        self.developer_id = participants["developer"]
+        self.reviewer_id = participants["reviewer"]
+        task_id = int(
+            self.con.execute(
+                "INSERT INTO spec_tasks (feature_id,document_id,seq,title) "
+                "VALUES (?,?,1,'Task')",
+                (feature_id, document_id),
+            ).lastrowid
+        )
+        self.unit_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,expected_output) "
+                "VALUES (?,1,2,'Unit','Ship it')",
+                (self.sprint_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_work_unit_tasks (sprint_id,work_unit_id,task_id) "
+            "VALUES (?,?,?)",
+            (self.sprint_id, self.unit_id, task_id),
+        )
+        self.con.commit()
+        wake_id = sprint_domain.SprintLifecycleStore(self.con).arm(
+            self.sprint_id, 3
+        )[0]
+        self.assignment_message_id = int(
+            self.con.execute(
+                "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",
+                (wake_id,),
+            ).fetchone()[0]
+        )
+        self.messages = sprint_message_delivery.SprintMessageStore(self.con)
+        self.assertEqual(
+            "accepted", self.messages.mark_read(self.assignment_message_id, 1)
+        )
+        expectation = self.expectation(self.assignment_message_id)
+        self.started_at = parse(expectation["accepted_at"])
+        self.clock = FakeClock(self.started_at)
+
+    def expectation(self, message_id: int | None = None) -> sqlite3.Row:
+        row = self.con.execute(
+            "SELECT * FROM sprint_liveness_expectations WHERE message_id=?",
+            (message_id or self.assignment_message_id,),
+        ).fetchone()
+        self.assertIsNotNone(row)
+        return row
+
+    def monitor(self, process_probe=None) -> sprint_liveness.SprintLivenessMonitor:
+        if process_probe is None:
+            process_probe = lambda _participant, _accepted, _now: (None, None, None)
+        collector = sprint_liveness.SprintEvidenceCollector(
+            self.con, process_probe=process_probe
+        )
+        return sprint_liveness.SprintLivenessMonitor(
+            self.con, now=self.clock, collector=collector
+        )
+
+    def advance(self, minutes: int) -> None:
+        self.clock.at(self.started_at + timedelta(minutes=minutes))
+
+    def message_rows(self, kind: str) -> list[sqlite3.Row]:
+        return self.con.execute(
+            "SELECT * FROM sprint_messages WHERE message_kind=? ORDER BY message_id",
+            (kind,),
+        ).fetchall()
+
+    def add_native_event(self, event_type: str, minutes: int) -> int:
+        conversation_id = self.con.execute(
+            "SELECT current_conversation_id FROM sprint_participants "
+            "WHERE participant_id=?",
+            (self.developer_id,),
+        ).fetchone()[0]
+        sequence = int(
+            self.con.execute(
+                "SELECT COALESCE(MAX(sequence),0)+1 FROM conversation_events "
+                "WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0]
+        )
+        event_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,created_at) "
+                "VALUES (?,?,?,'{}',?)",
+                (
+                    conversation_id,
+                    sequence,
+                    event_type,
+                    stamp(self.started_at + timedelta(minutes=minutes)),
+                ),
+            ).lastrowid
+        )
+        self.con.commit()
+        return event_id
+
+
+class FakeClockPolicyTest(SprintLivenessCase):
+    def test_grace_nudge_escalation_and_restart_dedup(self) -> None:
+        monitor = self.monitor()
+        self.advance(5)
+        self.assertEqual("strong-evidence", monitor.evaluate(self.sprint_id)[0].action)
+        self.assertEqual([], self.message_rows("nudge"))
+
+        self.advance(10)
+        self.assertEqual("nudged", monitor.evaluate(self.sprint_id)[0].action)
+        nudges = self.message_rows("nudge")
+        self.assertEqual(1, len(nudges))
+        self.assertEqual(self.developer_id, nudges[0]["to_participant_id"])
+        self.assertIn(
+            f"accepted Sprint message #{self.assignment_message_id}",
+            nudges[0]["body"],
+        )
+
+        self.advance(15)
+        self.assertEqual("observed", monitor.evaluate(self.sprint_id)[0].action)
+        self.assertEqual([], self.message_rows("escalation"))
+
+        self.advance(20)
+        self.assertEqual("escalated", monitor.evaluate(self.sprint_id)[0].action)
+        escalations = self.message_rows("escalation")
+        self.assertEqual(1, len(escalations))
+        self.assertEqual(self.planner_id, escalations[0]["to_participant_id"])
+        payload = json.loads(escalations[0]["body"])
+        self.assertEqual(self.assignment_message_id, payload["expectation_message_id"])
+        self.assertEqual("continued silence after one nudge", payload["reason"])
+
+        restarted = self.monitor()
+        for minute in (25, 30, 60):
+            self.advance(minute)
+            restarted.evaluate(self.sprint_id)
+        self.assertEqual(1, len(self.message_rows("nudge")))
+        self.assertEqual(1, len(self.message_rows("escalation")))
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='liveness.escalated'"
+            ).fetchone()[0],
+        )
+
+    def test_fresh_strong_evidence_extends_grace_and_starts_new_episode(self) -> None:
+        monitor = self.monitor()
+        self.advance(5)
+        monitor.evaluate(self.sprint_id)
+        event_id = self.add_native_event("tool.completed", 9)
+
+        self.advance(10)
+        outcome = monitor.evaluate(self.sprint_id)[0]
+        self.assertEqual("strong-evidence", outcome.action)
+        self.assertEqual([], self.message_rows("nudge"))
+        expectation = self.expectation()
+        self.assertEqual(f"conversation.event:{event_id}", expectation["last_strong_key"])
+        self.assertEqual(
+            stamp(self.started_at + timedelta(minutes=9)),
+            expectation["last_strong_at"],
+        )
+
+        self.advance(15)
+        monitor.evaluate(self.sprint_id)
+        self.assertEqual([], self.message_rows("nudge"))
+        self.advance(20)
+        self.assertEqual("nudged", monitor.evaluate(self.sprint_id)[0].action)
+        self.assertEqual(1, len(self.message_rows("nudge")))
+
+    def test_supporting_process_health_allows_one_nudge_but_defers_escalation(self) -> None:
+        def healthy(_participant, _accepted, _now):
+            return (
+                sprint_liveness.Evidence(
+                    "process:123:1",
+                    "process.present",
+                    self.clock(),
+                    "supporting",
+                    "healthy long-running tool",
+                ),
+                None,
+                None,
+            )
+
+        monitor = self.monitor(healthy)
+        self.advance(5)
+        monitor.evaluate(self.sprint_id)
+        self.advance(10)
+        self.assertEqual("nudged", monitor.evaluate(self.sprint_id)[0].action)
+        self.advance(20)
+        self.assertEqual(
+            "supporting-evidence", monitor.evaluate(self.sprint_id)[0].action
+        )
+        self.advance(40)
+        self.assertEqual(
+            "supporting-evidence", monitor.evaluate(self.sprint_id)[0].action
+        )
+        self.assertEqual(1, len(self.message_rows("nudge")))
+        self.assertEqual([], self.message_rows("escalation"))
+
+    def test_proven_failure_escalates_immediately_without_nudging_worker(self) -> None:
+        failure_at = self.started_at + timedelta(minutes=1)
+
+        def failed(_participant, _accepted, _now):
+            return (
+                None,
+                sprint_liveness.Evidence(
+                    "run:failed:7",
+                    "run.failed",
+                    failure_at,
+                    "failure",
+                    "proven failed native run",
+                ),
+                None,
+            )
+
+        self.advance(5)
+        outcome = self.monitor(failed).evaluate(self.sprint_id)[0]
+        self.assertEqual("escalated", outcome.action)
+        self.assertEqual([], self.message_rows("nudge"))
+        payload = json.loads(self.message_rows("escalation")[0]["body"])
+        self.assertEqual("proven failed native run", payload["reason"])
+        self.assertEqual("run:failed:7", payload["failure"]["key"])
+
+    def test_fresh_exhausted_worker_quota_escalates_on_first_evaluation(self) -> None:
+        self.con.execute("DELETE FROM flavor_defaults WHERE flavor='planner'")
+        self.con.executemany(
+            "INSERT INTO flavor_defaults (flavor,harness,model,is_default) "
+            "VALUES ('planner',?,?,?)",
+            (("codex", "gpt", 1), ("claude", "sonnet", 0)),
+        )
+        account = int(
+            self.con.execute(
+                "INSERT INTO harness_quota_account (provider,account_ref) "
+                "VALUES ('openai','worker')"
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO harness_quota_window "
+            "(account_pk,window_kind,used_percent,captured_at,status) "
+            "VALUES (?,'five_hour',100,?,'ok')",
+            (account, stamp(self.started_at + timedelta(minutes=4))),
+        )
+        self.con.commit()
+
+        self.advance(5)
+        outcome = self.monitor().evaluate(self.sprint_id)[0]
+        self.assertEqual("escalated", outcome.action)
+        self.assertEqual([], self.message_rows("nudge"))
+        payload = json.loads(self.message_rows("escalation")[0]["body"])
+        self.assertEqual("quota.exhausted", payload["failure"]["kind"])
+        self.assertIn("openai", payload["reason"])
+
+    def test_review_request_is_an_expectation_even_without_an_editing_lane(self) -> None:
+        self.monitor().resolve(self.assignment_message_id, "handoff to review")
+        review = self.messages.send(
+            self.sprint_id,
+            to_participant_id=self.reviewer_id,
+            from_participant_id=self.developer_id,
+            work_unit_id=self.unit_id,
+            message_kind="review_request",
+            body="Please review",
+            actionable=True,
+            active=True,
+            idempotency_key="review-request:1",
+        )
+        self.assertEqual("accepted", self.messages.mark_read(review.message_id, 2))
+        review_expectation = self.expectation(review.message_id)
+        self.assertIsNone(review_expectation["resolved_at"])
+        reviewer_units = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_work_units WHERE assigned_shell_id=2 "
+            "AND disposition IN ('active','in_review','fixing','merge_ready')"
+        ).fetchone()[0]
+        self.assertEqual(0, reviewer_units)
+
+        review_start = parse(review_expectation["accepted_at"])
+        self.clock.at(review_start + timedelta(minutes=5))
+        self.monitor().evaluate(self.sprint_id)
+        self.clock.at(review_start + timedelta(minutes=10))
+        self.monitor().evaluate(self.sprint_id)
+        nudges = self.message_rows("nudge")
+        self.assertEqual(1, len(nudges))
+        self.assertEqual(self.reviewer_id, nudges[0]["to_participant_id"])
+
+
+class DeliveryAndActivationTest(SprintLivenessCase):
+    def test_planner_quota_exhaustion_routes_escalation_to_fallback_only(self) -> None:
+        self.con.execute("DELETE FROM flavor_defaults WHERE flavor='planner'")
+        self.con.executemany(
+            "INSERT INTO flavor_defaults (flavor,harness,model,is_default) "
+            "VALUES ('planner',?,?,?)",
+            (("codex", "gpt", 1), ("claude", "sonnet", 0)),
+        )
+        account = int(
+            self.con.execute(
+                "INSERT INTO harness_quota_account (provider,account_ref) "
+                "VALUES ('openai','acct')"
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO harness_quota_window "
+            "(account_pk,window_kind,used_percent,captured_at,status) "
+            "VALUES (?,'session',100,?,'ok')",
+            (account, stamp(self.started_at)),
+        )
+        self.con.commit()
+
+        failure_at = self.started_at + timedelta(minutes=1)
+
+        def failed(_participant, _accepted, _now):
+            return (
+                None,
+                sprint_liveness.Evidence(
+                    "worker:missing",
+                    "process.missing",
+                    failure_at,
+                    "failure",
+                    "worker disappeared",
+                ),
+                None,
+            )
+
+        self.advance(5)
+        self.assertEqual(
+            "escalated", self.monitor(failed).evaluate(self.sprint_id)[0].action
+        )
+        planner = self.con.execute(
+            "SELECT persistent_conversation_id,current_conversation_id "
+            "FROM sprint_participants WHERE participant_id=?",
+            (self.planner_id,),
+        ).fetchone()
+        self.assertNotEqual(
+            planner["persistent_conversation_id"], planner["current_conversation_id"]
+        )
+        fallback = self.con.execute(
+            "SELECT link.purpose,c.harness FROM sprint_participant_conversations link "
+            "JOIN conversations c ON c.conversation_id=link.conversation_id "
+            "WHERE link.conversation_id=?",
+            (planner["current_conversation_id"],),
+        ).fetchone()
+        self.assertEqual(("fallback", "claude"), tuple(fallback))
+        escalation = self.message_rows("escalation")[0]
+        payload = json.loads(escalation["body"])
+        self.assertEqual("fallback:claude", payload["planner_delivery_route"])
+        wake = self.con.execute(
+            "SELECT w.participant_id,w.state FROM sprint_wake_outbox w "
+            "JOIN sprint_wake_messages wm USING (sprint_id,wake_id) "
+            "WHERE wm.message_id=?",
+            (escalation["message_id"],),
+        ).fetchone()
+        self.assertEqual((self.planner_id, "pending"), tuple(wake))
+        self.assertEqual([], self.message_rows("nudge"))
+
+    def test_paused_sprint_does_no_evaluation_or_delivery_work(self) -> None:
+        self.advance(20)
+        sprint_domain.SprintLifecycleStore(self.con).transition(
+            self.sprint_id,
+            "paused",
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="hold",
+        )
+        before = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_messages"
+        ).fetchone()[0]
+        self.assertEqual((), self.monitor().evaluate(self.sprint_id))
+        after = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_messages"
+        ).fetchone()[0]
+        self.assertEqual(before, after)
+        self.assertIsNone(self.expectation()["last_evaluated_at"])
+
+    def test_terminal_work_unit_resolves_assignment_expectation(self) -> None:
+        sprint_domain.SprintWorkUnitStore(self.con).complete(
+            self.sprint_id, self.unit_id, 1
+        )
+        expectation = self.expectation()
+        self.assertIsNotNone(expectation["resolved_at"])
+        self.assertEqual("work_unit.completed", expectation["resolution"])
+        self.assertIsNone(expectation["next_evaluation_at"])
+
+
+class MigrationGateTest(unittest.TestCase):
+    def test_upgrade_backfills_already_accepted_actionable_messages(self) -> None:
+        con = sqlite3.connect(":memory:")
+        self.addCleanup(con.close)
+        con.row_factory = sqlite3.Row
+        con.executescript((ENGINE / "schema.sql").read_text())
+        for migration in sorted(MIGRATIONS.glob("*.sql")):
+            if migration.name >= "0149_sprint_liveness_monitor.sql":
+                break
+            con.executescript(migration.read_text())
+        con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        con.executemany(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (?,?,?,?,?,1)",
+            (
+                (1, "Developer", "DEV1", "dev", "prompt"),
+                (3, "Planner", "PLN1", "planner", "prompt"),
+            ),
+        )
+        feature_id = int(
+            con.execute(
+                "INSERT INTO roadmap (title,roadmap_status) "
+                "VALUES ('Feature','in_progress')"
+            ).lastrowid
+        )
+        sprint_id = int(
+            con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+        )
+        participant_id = int(
+            con.execute(
+                "INSERT INTO sprint_participants "
+                "(sprint_id,shell_id,role,harness) VALUES (?,1,'developer','codex')",
+                (sprint_id,),
+            ).lastrowid
+        )
+        accepted_at = "2026-07-31 12:00:00"
+        message_id = int(
+            con.execute(
+                "INSERT INTO sprint_messages "
+                "(sprint_id,to_participant_id,message_kind,body,actionable,"
+                "disposition,read_at,idempotency_key) "
+                "VALUES (?,?,'review_request','Review',1,'accepted',?,'existing')",
+                (sprint_id, participant_id, accepted_at),
+            ).lastrowid
+        )
+        con.commit()
+
+        con.executescript(
+            (MIGRATIONS / "0149_sprint_liveness_monitor.sql").read_text()
+        )
+
+        expectation = con.execute(
+            "SELECT message_id,accepted_at,last_strong_key,next_evaluation_at "
+            "FROM sprint_liveness_expectations"
+        ).fetchone()
+        self.assertEqual(
+            (
+                message_id,
+                accepted_at,
+                f"message.accepted:{message_id}",
+                "2026-07-31 12:05:00",
+            ),
+            tuple(expectation),
+        )
+        self.assertEqual([], con.execute("PRAGMA foreign_key_check").fetchall())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -214,11 +214,47 @@ class SprintLivenessCase(unittest.TestCase):
         self.con.commit()
         return event_id
 
+    def add_terminal_run(
+        self, state: str, minutes: int, error_code: str | None = None
+    ) -> int:
+        conversation_id = self.con.execute(
+            "SELECT current_conversation_id FROM sprint_participants "
+            "WHERE participant_id=?",
+            (self.developer_id,),
+        ).fetchone()[0]
+        token = self.con.execute(
+            "SELECT COUNT(*)+1 FROM conversation_runs"
+        ).fetchone()[0]
+        ended_at = stamp(self.started_at + timedelta(minutes=minutes))
+        message_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state,completed_at) "
+                "VALUES (?,'engine','test','notice','run fixture',?,?,"
+                "'completed',?)",
+                (conversation_id, f"test-run:{token}", f"test-run:{token}", ended_at),
+            ).lastrowid
+        )
+        run_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,state,lease_owner,"
+                "lease_expires_at,ended_at,error_code) "
+                "VALUES (?,1,?,?,'test','2999-01-01 00:00:00',?,?)",
+                (conversation_id, message_id, state, ended_at, error_code),
+            ).lastrowid
+        )
+        self.con.commit()
+        return run_id
+
 
 class FakeClockPolicyTest(SprintLivenessCase):
     def test_grace_nudge_escalation_and_restart_dedup(self) -> None:
         monitor = self.monitor()
         self.advance(5)
+        # Acceptance also emits work_unit.accepted in the same SQLite second;
+        # its different key is the initial strong-evidence observation here.
         self.assertEqual("strong-evidence", monitor.evaluate(self.sprint_id)[0].action)
         self.assertEqual([], self.message_rows("nudge"))
 
@@ -315,6 +351,10 @@ class FakeClockPolicyTest(SprintLivenessCase):
 
     def test_proven_failure_escalates_immediately_without_nudging_worker(self) -> None:
         failure_at = self.started_at + timedelta(minutes=1)
+        unknown_run_id = self.add_terminal_run(
+            "unknown", 1, "HARNESS_OUTCOME_UNKNOWN"
+        )
+        self.add_native_event("run.unknown", 1)
 
         def failed(_participant, _accepted, _now):
             return (
@@ -336,6 +376,113 @@ class FakeClockPolicyTest(SprintLivenessCase):
         payload = json.loads(self.message_rows("escalation")[0]["body"])
         self.assertEqual("proven failed native run", payload["reason"])
         self.assertEqual("run:failed:7", payload["failure"]["key"])
+        self.assertTrue(
+            any(
+                f"native run {unknown_run_id} outcome is unknown" in signal
+                for signal in payload["unreadable_signals"]
+            )
+        )
+
+        self.advance(10)
+        self.assertEqual(
+            "observed", self.monitor(failed).evaluate(self.sprint_id)[0].action
+        )
+        self.assertEqual([], self.message_rows("nudge"))
+        self.assertEqual(1, len(self.message_rows("escalation")))
+
+    def test_unknown_run_is_ambiguous_silence_not_terminal_failure(self) -> None:
+        unknown_run_id = self.add_terminal_run(
+            "unknown", 1, "HARNESS_OUTCOME_UNKNOWN"
+        )
+        self.add_native_event("run.unknown", 1)
+        monitor = self.monitor()
+
+        self.advance(5)
+        self.assertEqual("strong-evidence", monitor.evaluate(self.sprint_id)[0].action)
+        self.assertEqual([], self.message_rows("escalation"))
+        self.advance(10)
+        self.assertEqual("nudged", monitor.evaluate(self.sprint_id)[0].action)
+        self.advance(20)
+        self.assertEqual("escalated", monitor.evaluate(self.sprint_id)[0].action)
+
+        payload = json.loads(self.message_rows("escalation")[0]["body"])
+        self.assertIsNone(payload["failure"])
+        self.assertTrue(
+            any(
+                f"native run {unknown_run_id} outcome is unknown" in signal
+                for signal in payload["unreadable_signals"]
+            )
+        )
+
+    def test_unchanged_git_observation_does_not_mask_failed_run(self) -> None:
+        run_id = self.add_terminal_run("failed", 1, "BROKER_RUN_ERROR")
+        self.add_native_event("run.failed", 2)
+        conversation_id = self.con.execute(
+            "SELECT current_conversation_id FROM sprint_participants "
+            "WHERE participant_id=?",
+            (self.developer_id,),
+        ).fetchone()[0]
+        head = "a" * 40
+        self.con.execute(
+            "INSERT INTO conversation_git_targets "
+            "(conversation_id,branch_name,base_ref,first_head_sha,latest_head_sha,"
+            "first_seen_at,last_seen_at) VALUES (?,?,?,?,?,?,?)",
+            (
+                conversation_id,
+                "feat/test",
+                "main",
+                head,
+                head,
+                stamp(self.started_at + timedelta(minutes=2)),
+                stamp(self.started_at + timedelta(minutes=4)),
+            ),
+        )
+        self.con.commit()
+
+        self.advance(5)
+        outcome = self.monitor().evaluate(self.sprint_id)[0]
+        self.assertEqual("escalated", outcome.action)
+        self.assertEqual([], self.message_rows("nudge"))
+        payload = json.loads(self.message_rows("escalation")[0]["body"])
+        self.assertEqual(f"run.failure:{run_id}:failed", payload["failure"]["key"])
+        self.assertEqual("run.failed", payload["failure"]["kind"])
+
+    def test_new_failure_key_re_escalates_without_worker_nudge(self) -> None:
+        failure_key = ["run:failed:7"]
+        failure_at = [self.started_at + timedelta(minutes=1)]
+
+        def failed(_participant, _accepted, _now):
+            return (
+                None,
+                sprint_liveness.Evidence(
+                    failure_key[0],
+                    "run.failed",
+                    failure_at[0],
+                    "failure",
+                    f"failure {failure_key[0]}",
+                ),
+                None,
+            )
+
+        monitor = self.monitor(failed)
+        self.advance(5)
+        self.assertEqual("escalated", monitor.evaluate(self.sprint_id)[0].action)
+        self.advance(10)
+        self.assertEqual("observed", monitor.evaluate(self.sprint_id)[0].action)
+        self.assertEqual(1, len(self.message_rows("escalation")))
+
+        failure_key[0] = "run:failed:8"
+        failure_at[0] = self.started_at + timedelta(minutes=14)
+        self.advance(15)
+        self.assertEqual("escalated", monitor.evaluate(self.sprint_id)[0].action)
+        escalations = self.message_rows("escalation")
+        self.assertEqual(2, len(escalations))
+        self.assertEqual(
+            ["run:failed:7", "run:failed:8"],
+            [json.loads(row["body"])["failure"]["key"] for row in escalations],
+        )
+        self.assertEqual([], self.message_rows("nudge"))
+        self.assertEqual("run:failed:8", self.expectation()["last_failure_key"])
 
     def test_fresh_exhausted_worker_quota_escalates_on_first_evaluation(self) -> None:
         self.con.execute("DELETE FROM flavor_defaults WHERE flavor='planner'")
@@ -419,6 +566,18 @@ class DeliveryAndActivationTest(SprintLivenessCase):
             (account, stamp(self.started_at)),
         )
         self.con.commit()
+        review = self.messages.send(
+            self.sprint_id,
+            to_participant_id=self.reviewer_id,
+            from_participant_id=self.developer_id,
+            work_unit_id=self.unit_id,
+            message_kind="review_request",
+            body="Please review",
+            actionable=True,
+            active=True,
+            idempotency_key="review-request:fallback-dedup",
+        )
+        self.assertEqual("accepted", self.messages.mark_read(review.message_id, 2))
 
         failure_at = self.started_at + timedelta(minutes=1)
 
@@ -436,8 +595,9 @@ class DeliveryAndActivationTest(SprintLivenessCase):
             )
 
         self.advance(5)
+        outcomes = self.monitor(failed).evaluate(self.sprint_id)
         self.assertEqual(
-            "escalated", self.monitor(failed).evaluate(self.sprint_id)[0].action
+            ["escalated", "escalated"], [outcome.action for outcome in outcomes]
         )
         planner = self.con.execute(
             "SELECT persistent_conversation_id,current_conversation_id "
@@ -447,23 +607,29 @@ class DeliveryAndActivationTest(SprintLivenessCase):
         self.assertNotEqual(
             planner["persistent_conversation_id"], planner["current_conversation_id"]
         )
-        fallback = self.con.execute(
+        fallbacks = self.con.execute(
             "SELECT link.purpose,c.harness FROM sprint_participant_conversations link "
             "JOIN conversations c ON c.conversation_id=link.conversation_id "
-            "WHERE link.conversation_id=?",
-            (planner["current_conversation_id"],),
-        ).fetchone()
-        self.assertEqual(("fallback", "claude"), tuple(fallback))
-        escalation = self.message_rows("escalation")[0]
-        payload = json.loads(escalation["body"])
-        self.assertEqual("fallback:claude", payload["planner_delivery_route"])
-        wake = self.con.execute(
+            "WHERE link.sprint_participant_id=? AND link.purpose='fallback'",
+            (self.planner_id,),
+        ).fetchall()
+        self.assertEqual([("fallback", "claude")], [tuple(row) for row in fallbacks])
+        escalations = self.message_rows("escalation")
+        self.assertEqual(2, len(escalations))
+        self.assertEqual(
+            ["fallback:claude", "fallback:claude"],
+            [json.loads(row["body"])["planner_delivery_route"] for row in escalations],
+        )
+        wakes = self.con.execute(
             "SELECT w.participant_id,w.state FROM sprint_wake_outbox w "
             "JOIN sprint_wake_messages wm USING (sprint_id,wake_id) "
-            "WHERE wm.message_id=?",
-            (escalation["message_id"],),
-        ).fetchone()
-        self.assertEqual((self.planner_id, "pending"), tuple(wake))
+            "WHERE wm.message_id IN (?,?) ORDER BY wm.message_id",
+            (escalations[0]["message_id"], escalations[1]["message_id"]),
+        ).fetchall()
+        self.assertEqual(
+            [(self.planner_id, "pending"), (self.planner_id, "pending")],
+            [tuple(row) for row in wakes],
+        )
         self.assertEqual([], self.message_rows("nudge"))
 
     def test_paused_sprint_does_no_evaluation_or_delivery_work(self) -> None:
@@ -495,7 +661,7 @@ class DeliveryAndActivationTest(SprintLivenessCase):
 
 
 class MigrationGateTest(unittest.TestCase):
-    def test_upgrade_backfills_already_accepted_actionable_messages(self) -> None:
+    def test_upgrade_backfills_only_armed_nonterminal_expectations(self) -> None:
         con = sqlite3.connect(":memory:")
         self.addCleanup(con.close)
         con.row_factory = sqlite3.Row
@@ -511,6 +677,7 @@ class MigrationGateTest(unittest.TestCase):
             "VALUES (?,?,?,?,?,1)",
             (
                 (1, "Developer", "DEV1", "dev", "prompt"),
+                (2, "Reviewer", "REV1", "reviewer", "prompt"),
                 (3, "Planner", "PLN1", "planner", "prompt"),
             ),
         )
@@ -535,15 +702,56 @@ class MigrationGateTest(unittest.TestCase):
                 (sprint_id,),
             ).lastrowid
         )
+        active_unit_id = int(
+            con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,expected_output) "
+                "VALUES (?,1,2,'Active','Ship it')",
+                (sprint_id,),
+            ).lastrowid
+        )
+        terminal_unit_id = int(
+            con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output,disposition,completed_at) "
+                "VALUES (?,1,2,'Done','Already shipped','completed',?)",
+                (sprint_id, "2026-07-31 11:00:00"),
+            ).lastrowid
+        )
         accepted_at = "2026-07-31 12:00:00"
-        message_id = int(
+        active_message_id = int(
+            con.execute(
+                "INSERT INTO sprint_messages "
+                "(sprint_id,to_participant_id,work_unit_id,message_kind,body,"
+                "actionable,"
+                "disposition,read_at,idempotency_key) "
+                "VALUES (?,?,?,'work_assignment','Build',1,'accepted',?,'active')",
+                (sprint_id, participant_id, active_unit_id, accepted_at),
+            ).lastrowid
+        )
+        terminal_message_id = int(
+            con.execute(
+                "INSERT INTO sprint_messages "
+                "(sprint_id,to_participant_id,work_unit_id,message_kind,body,"
+                "actionable,"
+                "disposition,read_at,idempotency_key) "
+                "VALUES (?,?,?,'work_assignment','Done',1,'accepted',?,'terminal')",
+                (sprint_id, participant_id, terminal_unit_id, accepted_at),
+            ).lastrowid
+        )
+        review_message_id = int(
             con.execute(
                 "INSERT INTO sprint_messages "
                 "(sprint_id,to_participant_id,message_kind,body,actionable,"
                 "disposition,read_at,idempotency_key) "
-                "VALUES (?,?,'review_request','Review',1,'accepted',?,'existing')",
+                "VALUES (?,?,'review_request','Review',1,'accepted',?,'review')",
                 (sprint_id, participant_id, accepted_at),
             ).lastrowid
+        )
+        con.execute(
+            "UPDATE sprints SET lifecycle='armed',armed_at=? WHERE sprint_id=?",
+            (accepted_at, sprint_id),
         )
         con.commit()
 
@@ -551,18 +759,29 @@ class MigrationGateTest(unittest.TestCase):
             (MIGRATIONS / "0149_sprint_liveness_monitor.sql").read_text()
         )
 
-        expectation = con.execute(
+        expectations = con.execute(
             "SELECT message_id,accepted_at,last_strong_key,next_evaluation_at "
-            "FROM sprint_liveness_expectations"
-        ).fetchone()
+            "FROM sprint_liveness_expectations ORDER BY message_id"
+        ).fetchall()
         self.assertEqual(
-            (
-                message_id,
-                accepted_at,
-                f"message.accepted:{message_id}",
-                "2026-07-31 12:05:00",
-            ),
-            tuple(expectation),
+            [
+                (
+                    active_message_id,
+                    accepted_at,
+                    f"message.accepted:{active_message_id}",
+                    "2026-07-31 12:05:00",
+                ),
+                (
+                    review_message_id,
+                    accepted_at,
+                    f"message.accepted:{review_message_id}",
+                    "2026-07-31 12:05:00",
+                ),
+            ],
+            [tuple(row) for row in expectations],
+        )
+        self.assertNotIn(
+            terminal_message_id, [row["message_id"] for row in expectations]
         )
         self.assertEqual([], con.execute("PRAGMA foreign_key_check").fetchall())
 


### PR DESCRIPTION
## Summary

- persist one liveness silence episode for every accepted actionable Sprint message, including review requests
- evaluate strong, supporting, failure, and unreadable evidence on the armed runtime pulse
- apply ten-minute grace, exactly one worker nudge, one deduplicated Planner escalation, and Planner-only fallback routing on exhausted quota
- resolve terminal work assignments and expose an explicit resolution seam for the Stage-6 review outcome path

## Verification

- `uv run --with pytest python -m pytest -q` — 1341 passed, 1 skipped, 745 subtests
- `./sc render-check`
- `git diff --check`
- fake-clock gate red-proven against wrong grace, ignored supporting health, and repeated escalation mutations

## Judgements

- strong evidence resets a durable silence episode; supporting evidence does not reset grace or permit another nudge, but suppresses escalation while it positively shows healthy work (decision #42)
- R1: deliberately extends the Sprint-v2 removal allowlist for migration 0149, `sprint_liveness.py`, and its gate
- `./sc verify` remains unavailable from required linked worktrees; reproduced and attached to existing issue #769, with the full worktree-local suite used as the verification gate