### PR TITLE
feat: wire Sprint dev review loop

### DIFF
--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -642,6 +642,85 @@ class SprintWorkUnitStore:
                 planner_participant_id=planner,
             )
 
+    def complete_from_merge_in_transaction(
+        self,
+        sprint_id: int,
+        work_unit_ids: Iterable[int],
+        *,
+        transition_key: str,
+    ) -> list[int]:
+        """Project an observed merge, then release newly ready work atomically."""
+        if not self.con.in_transaction:
+            raise RuntimeError("merge observation requires an active transaction")
+        unit_ids = tuple(sorted({int(unit_id) for unit_id in work_unit_ids}))
+        if not unit_ids:
+            raise SprintInvariantError("merged PR has no linked work units")
+        sprint = self.con.execute(
+            "SELECT lifecycle,originating_planner_shell_id FROM sprints "
+            "WHERE sprint_id=?",
+            (sprint_id,),
+        ).fetchone()
+        if sprint is None:
+            raise KeyError(f"unknown Sprint: {sprint_id}")
+        if sprint["lifecycle"] != "armed":
+            return []
+        placeholders = ",".join("?" for _ in unit_ids)
+        units = self.con.execute(
+            "SELECT work_unit_id,assigned_shell_id,disposition "
+            "FROM sprint_work_units "
+            f"WHERE sprint_id=? AND work_unit_id IN ({placeholders}) "
+            "ORDER BY work_unit_id",
+            (sprint_id, *unit_ids),
+        ).fetchall()
+        if {int(unit["work_unit_id"]) for unit in units} != set(unit_ids):
+            raise SprintInvariantError("merged PR links unknown Sprint work units")
+
+        changed = False
+        for unit in units:
+            if unit["disposition"] == "completed":
+                continue
+            changed = True
+            if unit["disposition"] != "merge_ready":
+                self._event(
+                    sprint_id,
+                    "merge.grant_bypassed",
+                    None,
+                    {
+                        "before": unit["disposition"],
+                        "transition_key": transition_key,
+                        "work_unit_id": int(unit["work_unit_id"]),
+                    },
+                    actor_kind="system",
+                )
+            self.con.execute(
+                "UPDATE sprint_work_units SET disposition='completed',"
+                "completed_at=datetime('now'),updated_at=datetime('now') "
+                "WHERE work_unit_id=?",
+                (unit["work_unit_id"],),
+            )
+            self._event(
+                sprint_id,
+                "work_unit.completed",
+                None,
+                {
+                    "source": "pr.merge_observed",
+                    "transition_key": transition_key,
+                    "work_unit_id": int(unit["work_unit_id"]),
+                },
+                actor_kind="system",
+            )
+        if not changed:
+            return []
+        planner = self._require_participant(
+            sprint_id,
+            int(sprint["originating_planner_shell_id"]),
+            "planner",
+        )
+        return self._dispatch_ready_locked(
+            sprint_id,
+            planner_participant_id=planner,
+        )
+
     def _dispatch_ready_locked(
         self,
         sprint_id: int,
@@ -695,6 +774,9 @@ class SprintWorkUnitStore:
         unit: sqlite3.Row,
     ) -> int:
         unit_id = int(unit["work_unit_id"])
+        sprint_participant_chats.select_work(
+            self.con, int(unit["participant_id"])
+        )
         generation = int(
             self.con.execute(
                 "SELECT COUNT(*) FROM sprint_messages "

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -269,6 +269,53 @@ def select_work(con, participant_id: int) -> str:
     return conversation_id
 
 
+def create_review_outcome(
+    con,
+    *,
+    participant_id: int,
+    purpose: str,
+    idempotency_key: str,
+) -> str:
+    """Create and select a fresh Developer fix or merge conversation."""
+    if purpose not in {"fix", "merge"}:
+        raise SprintConversationError("review outcomes create fix or merge chats")
+    row = con.execute(
+        "SELECT p.sprint_id,p.role,p.harness,p.model,p.effort,"
+        "p.current_conversation_id,sh.shortname,sh.flavor,owner.user_id "
+        "FROM sprint_participants p "
+        "JOIN sprints s ON s.sprint_id=p.sprint_id "
+        "JOIN shells sh ON sh.shell_id=p.shell_id "
+        "JOIN shells owner ON owner.shell_id=s.originating_planner_shell_id "
+        "WHERE p.participant_id=?",
+        (participant_id,),
+    ).fetchone()
+    if row is None:
+        raise SprintConversationError("Sprint participant does not exist")
+    if row["role"] != "developer":
+        raise SprintConversationError("review outcomes target a Developer")
+    if row["current_conversation_id"] is None:
+        raise SprintConversationError("Developer has no current Sprint conversation")
+    if row["user_id"] is None:
+        raise SprintConversationError("originating Planner has no browser owner")
+    worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
+    return create_and_select(
+        con,
+        participant_id=participant_id,
+        owner_user_id=int(row["user_id"]),
+        purpose=purpose,
+        harness=row["harness"],
+        provider=run_mod.session_provider(row["harness"], row["model"]),
+        model=row["model"],
+        effort=row["effort"],
+        worktree=str(worktree.resolve(strict=False)),
+        title=(
+            f"Sprint {row['sprint_id']} · {purpose.title()} · {row['shortname']}"
+        ),
+        idempotency_key=idempotency_key,
+        parent_conversation_id=row["current_conversation_id"],
+    )
+
+
 def provision_at_arming(con, sprint_id: int) -> list[str]:
     """Create every participant's persistent conversation during arming.
 

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -102,6 +102,10 @@ class SprintPRRegistrationStore:
         unit_ids = tuple(sorted({int(item) for item in work_unit_ids}))
         if not unit_ids or any(item < 1 for item in unit_ids):
             raise ValueError("registration requires positive work-unit IDs")
+        if len(unit_ids) != 1:
+            raise SprintInvariantError(
+                "registered PR requires exactly one owning work unit"
+            )
 
         with db_driver.write_transaction(self.con, "sprint.pr.register"):
             sprint = self.con.execute(

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -31,6 +31,7 @@ from sprint_domain import (
     SprintLifecycleStore,
 )
 from sprint_message_delivery import SprintMessageStore
+from sprint_review_loop import SprintReviewLoopStore
 
 PULSE_SECONDS = 5.0
 MAX_BACKOFF_SECONDS = 300.0
@@ -91,6 +92,7 @@ class SprintPRRegistrationStore:
         repository: str,
         pr_number: int,
         work_unit_ids: Iterable[int],
+        notify_service: bool = True,
     ) -> RegistrationReceipt:
         repository = repository.strip().lower()
         if not _REPOSITORY.fullmatch(repository):
@@ -192,6 +194,8 @@ class SprintPRRegistrationStore:
                     ),
                 ),
             )
+        if notify_service:
+            notify_commit()
         return RegistrationReceipt(registered_pr_id, True)
 
 
@@ -217,6 +221,11 @@ class SprintPRWatcher:
         self.monotonic = monotonic
         self.registration = SprintPRRegistrationStore(con)
         self.messages = SprintMessageStore(con)
+        self.review_loop = SprintReviewLoopStore(
+            con,
+            repo_root=self.repo_root,
+            reader_factory=self.reader_factory,
+        )
         self._backoff: dict[int, _FailureBackoff] = {}
         self._trigger = "pulse"
         self._switch = ArmedServiceSwitch(
@@ -239,6 +248,7 @@ class SprintPRWatcher:
             repository=repository,
             pr_number=pr_number,
             work_unit_ids=work_unit_ids,
+            notify_service=False,
         )
         row = self._registered_row(receipt.registered_pr_id, sprint_id)
         if receipt.created and row is not None:
@@ -378,6 +388,11 @@ class SprintPRWatcher:
                 ).lastrowid
             )
             self._route_transition(current, transition_key, state, pull_request)
+            if state == "merged":
+                self.review_loop.observe_merge_in_transaction(
+                    registered_pr_id,
+                    transition_key=transition_key,
+                )
             self.con.execute(
                 "INSERT INTO sprint_events "
                 "(sprint_id,event_type,actor_kind,payload) "

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import db_driver
+import sprint_liveness
 import sprint_participant_chats
 from github_pull_requests import GitHubPullRequestReader, PullRequest
 from sprint_domain import (
@@ -143,7 +144,7 @@ class SprintReviewLoopStore:
             self._require_armed(lane)
             if int(lane["reviewer_shell_id"]) != reviewer_shell_id:
                 raise SprintAuthorityError("only the assigned Reviewer owns the verdict")
-            requested_head = self._accepted_review_head(lane)
+            review_message_id, requested_head = self._accepted_review_request(lane)
             purpose = "fix" if verdict == "changes_requested" else "merge"
             disposition = "fixing" if verdict == "changes_requested" else "merge_ready"
             notification = (
@@ -167,48 +168,55 @@ class SprintReviewLoopStore:
             conversation_key = f"{idempotency_key}:conversation"
             if not receipt.created:
                 conversation_id = self._conversation_for_key(conversation_key)
-                return self._outcome_receipt(
+                outcome = self._outcome_receipt(
                     lane, conversation_id, receipt, disposition
                 )
-            if lane["disposition"] != "in_review":
-                raise SprintInvariantError(
-                    f"review verdict cannot start from {lane['disposition']}"
+            else:
+                if lane["disposition"] != "in_review":
+                    raise SprintInvariantError(
+                        f"review verdict cannot start from {lane['disposition']}"
+                    )
+                transition = self._latest_transition(registered_pr_id)
+                if transition["observed_head_sha"] != requested_head:
+                    raise SprintInvariantError("review request is stale for the PR head")
+                conversation_id = sprint_participant_chats.create_review_outcome(
+                    self.con,
+                    participant_id=int(lane["developer_participant_id"]),
+                    purpose=purpose,
+                    idempotency_key=conversation_key,
                 )
-            transition = self._latest_transition(registered_pr_id)
-            if transition["observed_head_sha"] != requested_head:
-                raise SprintInvariantError("review request is stale for the PR head")
-            conversation_id = sprint_participant_chats.create_review_outcome(
-                self.con,
-                participant_id=int(lane["developer_participant_id"]),
-                purpose=purpose,
-                idempotency_key=conversation_key,
-            )
-            self._record_judgment(
-                lane,
-                reviewer_shell_id,
-                "issue" if verdict == "changes_requested" else "decision",
-                body,
-            )
-            self.con.execute(
-                "UPDATE sprint_work_units SET disposition=?,"
-                "updated_at=datetime('now') WHERE work_unit_id=?",
-                (disposition, lane["work_unit_id"]),
-            )
-            self._event(
-                sprint_id,
-                f"review.{verdict}",
-                reviewer_shell_id,
-                {
-                    "conversation_id": conversation_id,
-                    "head_sha": requested_head,
-                    "message_id": receipt.message_id,
-                    "registered_pr_id": registered_pr_id,
-                    "work_unit_id": int(lane["work_unit_id"]),
-                },
-            )
-            return self._outcome_receipt(
-                lane, conversation_id, receipt, disposition
-            )
+                self._record_judgment(
+                    lane,
+                    reviewer_shell_id,
+                    "issue" if verdict == "changes_requested" else "decision",
+                    body,
+                )
+                self.con.execute(
+                    "UPDATE sprint_work_units SET disposition=?,"
+                    "updated_at=datetime('now') WHERE work_unit_id=?",
+                    (disposition, lane["work_unit_id"]),
+                )
+                self._event(
+                    sprint_id,
+                    f"review.{verdict}",
+                    reviewer_shell_id,
+                    {
+                        "conversation_id": conversation_id,
+                        "head_sha": requested_head,
+                        "message_id": receipt.message_id,
+                        "registered_pr_id": registered_pr_id,
+                        "work_unit_id": int(lane["work_unit_id"]),
+                    },
+                )
+                outcome = self._outcome_receipt(
+                    lane, conversation_id, receipt, disposition
+                )
+
+        sprint_liveness.SprintLivenessMonitor(self.con).resolve(
+            review_message_id,
+            f"review submitted: {verdict}",
+        )
+        return outcome
 
     def authorize_merge(
         self,
@@ -346,7 +354,7 @@ class SprintReviewLoopStore:
             raise SprintInvariantError("registered PR has no exact observed head")
         return row
 
-    def _accepted_review_head(self, lane: sqlite3.Row) -> str:
+    def _accepted_review_request(self, lane: sqlite3.Row) -> tuple[int, str]:
         latest = self.con.execute(
             "SELECT message_id,disposition FROM sprint_messages WHERE sprint_id=? "
             "AND work_unit_id=? AND to_participant_id=? "
@@ -372,7 +380,7 @@ class SprintReviewLoopStore:
         head_sha = json.loads(event["payload"]).get("head_sha")
         if not isinstance(head_sha, str) or not head_sha:
             raise SprintInvariantError("accepted review request has no exact head")
-        return head_sha
+        return int(latest["message_id"]), head_sha
 
     def _record_judgment(
         self,

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -1,0 +1,473 @@
+"""Transactional Sprints v2 Developer and Reviewer handoff loop."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import db_driver
+import sprint_participant_chats
+from github_pull_requests import GitHubPullRequestReader, PullRequest
+from sprint_domain import (
+    SprintAuthorityError,
+    SprintInvariantError,
+    SprintWorkUnitStore,
+)
+from sprint_message_delivery import MessageReceipt, SprintMessageStore
+
+
+@dataclass(frozen=True)
+class ReviewHandoffReceipt:
+    work_unit_id: int
+    message_id: int
+    wake_id: int
+    created: bool
+
+
+@dataclass(frozen=True)
+class ReviewOutcomeReceipt:
+    work_unit_id: int
+    conversation_id: str
+    message_id: int
+    wake_id: int
+    disposition: str
+    created: bool
+
+
+@dataclass(frozen=True)
+class MergeAuthorization:
+    registered_pr_id: int
+    repository: str
+    pr_number: int
+    head_sha: str
+
+
+class SprintReviewLoopStore:
+    """Compose review state from the existing authoritative Sprint records."""
+
+    def __init__(
+        self,
+        con: sqlite3.Connection,
+        *,
+        repo_root: str | Path,
+        reader_factory: Callable[[str], Any] | None = None,
+    ) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+        self.repo_root = Path(repo_root)
+        self.reader_factory = reader_factory or (
+            lambda repository: GitHubPullRequestReader(
+                self.repo_root, repository=repository
+            )
+        )
+        self.messages = SprintMessageStore(con)
+        self.units = SprintWorkUnitStore(con)
+
+    def request_review(
+        self,
+        sprint_id: int,
+        registered_pr_id: int,
+        developer_shell_id: int,
+        *,
+        readiness: str,
+        idempotency_key: str,
+    ) -> ReviewHandoffReceipt:
+        """Record Developer readiness and actively hand the green PR to review."""
+        readiness = self._required(readiness, "readiness judgment")
+        idempotency_key = self._required(idempotency_key, "idempotency key", 255)
+        with db_driver.write_transaction(self.con, "sprint.review.request"):
+            lane = self._lane(sprint_id, registered_pr_id)
+            self._require_armed(lane)
+            self._require_developer(lane, developer_shell_id)
+            transition = self._latest_transition(registered_pr_id)
+            if transition["normalized_state"] != "green":
+                raise SprintInvariantError("review handoff requires observed green checks")
+            receipt = self.messages.send_in_transaction(
+                sprint_id,
+                to_participant_id=int(lane["reviewer_participant_id"]),
+                from_participant_id=int(lane["developer_participant_id"]),
+                work_unit_id=int(lane["work_unit_id"]),
+                message_kind="review_request",
+                body=readiness,
+                actionable=True,
+                active=True,
+                idempotency_key=idempotency_key,
+            )
+            if receipt.wake_id is None:
+                raise SprintInvariantError("active review request has no wake")
+            if not receipt.created:
+                return self._handoff_receipt(lane, receipt)
+            if lane["disposition"] not in {"active", "fixing"}:
+                raise SprintInvariantError(
+                    f"review handoff cannot start from {lane['disposition']}"
+                )
+            self._record_judgment(lane, developer_shell_id, "decision", readiness)
+            self.con.execute(
+                "UPDATE sprint_work_units SET disposition='in_review',"
+                "updated_at=datetime('now') WHERE work_unit_id=?",
+                (lane["work_unit_id"],),
+            )
+            self._event(
+                sprint_id,
+                "review.requested",
+                developer_shell_id,
+                {
+                    "head_sha": transition["observed_head_sha"],
+                    "message_id": receipt.message_id,
+                    "registered_pr_id": registered_pr_id,
+                    "work_unit_id": int(lane["work_unit_id"]),
+                },
+            )
+            return self._handoff_receipt(lane, receipt)
+
+    def record_review(
+        self,
+        sprint_id: int,
+        registered_pr_id: int,
+        reviewer_shell_id: int,
+        *,
+        verdict: str,
+        body: str,
+        idempotency_key: str,
+    ) -> ReviewOutcomeReceipt:
+        """Route a Review verdict onto a fresh fix or merge conversation."""
+        if verdict not in {"changes_requested", "approved"}:
+            raise ValueError("review verdict must be changes_requested or approved")
+        body = self._required(body, "review body")
+        idempotency_key = self._required(idempotency_key, "idempotency key", 255)
+        with db_driver.write_transaction(self.con, "sprint.review.outcome"):
+            lane = self._lane(sprint_id, registered_pr_id)
+            self._require_armed(lane)
+            if int(lane["reviewer_shell_id"]) != reviewer_shell_id:
+                raise SprintAuthorityError("only the assigned Reviewer owns the verdict")
+            requested_head = self._accepted_review_head(lane)
+            purpose = "fix" if verdict == "changes_requested" else "merge"
+            disposition = "fixing" if verdict == "changes_requested" else "merge_ready"
+            notification = (
+                f"Review changes requested for PR #{lane['pr_number']}: {body}"
+                if verdict == "changes_requested"
+                else f"Review approved for PR #{lane['pr_number']}: {body}"
+            )
+            receipt = self.messages.send_in_transaction(
+                sprint_id,
+                to_participant_id=int(lane["developer_participant_id"]),
+                from_participant_id=int(lane["reviewer_participant_id"]),
+                work_unit_id=int(lane["work_unit_id"]),
+                message_kind="notification",
+                body=notification,
+                actionable=False,
+                active=True,
+                idempotency_key=idempotency_key,
+            )
+            if receipt.wake_id is None:
+                raise SprintInvariantError("active review outcome has no wake")
+            conversation_key = f"{idempotency_key}:conversation"
+            if not receipt.created:
+                conversation_id = self._conversation_for_key(conversation_key)
+                return self._outcome_receipt(
+                    lane, conversation_id, receipt, disposition
+                )
+            if lane["disposition"] != "in_review":
+                raise SprintInvariantError(
+                    f"review verdict cannot start from {lane['disposition']}"
+                )
+            transition = self._latest_transition(registered_pr_id)
+            if transition["observed_head_sha"] != requested_head:
+                raise SprintInvariantError("review request is stale for the PR head")
+            conversation_id = sprint_participant_chats.create_review_outcome(
+                self.con,
+                participant_id=int(lane["developer_participant_id"]),
+                purpose=purpose,
+                idempotency_key=conversation_key,
+            )
+            self._record_judgment(
+                lane,
+                reviewer_shell_id,
+                "issue" if verdict == "changes_requested" else "decision",
+                body,
+            )
+            self.con.execute(
+                "UPDATE sprint_work_units SET disposition=?,"
+                "updated_at=datetime('now') WHERE work_unit_id=?",
+                (disposition, lane["work_unit_id"]),
+            )
+            self._event(
+                sprint_id,
+                f"review.{verdict}",
+                reviewer_shell_id,
+                {
+                    "conversation_id": conversation_id,
+                    "head_sha": requested_head,
+                    "message_id": receipt.message_id,
+                    "registered_pr_id": registered_pr_id,
+                    "work_unit_id": int(lane["work_unit_id"]),
+                },
+            )
+            return self._outcome_receipt(
+                lane, conversation_id, receipt, disposition
+            )
+
+    def authorize_merge(
+        self,
+        sprint_id: int,
+        registered_pr_id: int,
+        developer_shell_id: int,
+    ) -> MergeAuthorization:
+        """Re-read GitHub, then authorize only the approved head with live green."""
+        identity = self.con.execute(
+            "SELECT repository,pr_number FROM sprint_registered_prs "
+            "WHERE sprint_id=? AND registered_pr_id=?",
+            (sprint_id, registered_pr_id),
+        ).fetchone()
+        if identity is None:
+            raise KeyError(f"unknown registered PR: {registered_pr_id}")
+        live = self.reader_factory(str(identity["repository"])).get(
+            int(identity["pr_number"])
+        )
+        self._require_live_green(identity, live)
+        with db_driver.write_transaction(self.con, "sprint.merge.authorize"):
+            lane = self._lane(sprint_id, registered_pr_id)
+            self._require_armed(lane)
+            self._require_developer(lane, developer_shell_id)
+            if int(lane["merge_grant_enabled"]) != 1:
+                raise SprintInvariantError("Sprint merge grant is not enabled")
+            if lane["disposition"] != "merge_ready":
+                raise SprintInvariantError("merge requires an approved work unit")
+            approved_head = self._approved_head(lane)
+            if approved_head != live.head_sha:
+                raise SprintInvariantError(
+                    "review approval is stale for the live PR head"
+                )
+            self._event(
+                sprint_id,
+                "merge.authorized",
+                developer_shell_id,
+                {
+                    "head_sha": live.head_sha,
+                    "pr_number": live.number,
+                    "registered_pr_id": registered_pr_id,
+                    "work_unit_id": int(lane["work_unit_id"]),
+                },
+            )
+        return MergeAuthorization(
+            registered_pr_id,
+            str(identity["repository"]),
+            live.number,
+            str(live.head_sha),
+        )
+
+    def observe_merge_in_transaction(
+        self,
+        registered_pr_id: int,
+        *,
+        transition_key: str,
+    ) -> list[int]:
+        if not self.con.in_transaction:
+            raise RuntimeError("merge observation requires an active transaction")
+        row = self.con.execute(
+            "SELECT sprint_id FROM sprint_registered_prs WHERE registered_pr_id=?",
+            (registered_pr_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown registered PR: {registered_pr_id}")
+        unit_ids = [
+            int(unit[0])
+            for unit in self.con.execute(
+                "SELECT work_unit_id FROM sprint_pr_work_units "
+                "WHERE registered_pr_id=? ORDER BY work_unit_id",
+                (registered_pr_id,),
+            )
+        ]
+        return self.units.complete_from_merge_in_transaction(
+            int(row["sprint_id"]),
+            unit_ids,
+            transition_key=transition_key,
+        )
+
+    def _lane(self, sprint_id: int, registered_pr_id: int) -> sqlite3.Row:
+        rows = self.con.execute(
+            "SELECT rp.sprint_id,rp.registered_pr_id,rp.repository,rp.pr_number,"
+            "s.lifecycle,s.merge_grant_enabled,u.work_unit_id,u.disposition,"
+            "u.assigned_shell_id,u.reviewer_shell_id,"
+            "dev.participant_id AS developer_participant_id,"
+            "rev.participant_id AS reviewer_participant_id "
+            "FROM sprint_registered_prs rp "
+            "JOIN sprints s ON s.sprint_id=rp.sprint_id "
+            "JOIN sprint_pr_work_units link "
+            "ON link.sprint_id=rp.sprint_id "
+            "AND link.registered_pr_id=rp.registered_pr_id "
+            "JOIN sprint_work_units u ON u.sprint_id=link.sprint_id "
+            "AND u.work_unit_id=link.work_unit_id "
+            "JOIN sprint_participants dev ON dev.sprint_id=rp.sprint_id "
+            "AND dev.participant_id=rp.owner_participant_id "
+            "AND dev.shell_id=u.assigned_shell_id AND dev.role='developer' "
+            "JOIN sprint_participants rev ON rev.sprint_id=rp.sprint_id "
+            "AND rev.shell_id=u.reviewer_shell_id AND rev.role='reviewer' "
+            "WHERE rp.sprint_id=? AND rp.registered_pr_id=?",
+            (sprint_id, registered_pr_id),
+        ).fetchall()
+        if not rows:
+            raise KeyError(f"unknown registered PR: {registered_pr_id}")
+        if len(rows) != 1:
+            raise SprintInvariantError("review loop requires one work unit per PR")
+        return rows[0]
+
+    @staticmethod
+    def _required(value: str, name: str, maximum: int = 8000) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError(f"{name} is empty")
+        if len(value) > maximum:
+            raise ValueError(f"{name} exceeds {maximum} characters")
+        return value
+
+    @staticmethod
+    def _require_armed(lane: sqlite3.Row) -> None:
+        if lane["lifecycle"] != "armed":
+            raise SprintInvariantError("review loop requires an armed Sprint")
+
+    @staticmethod
+    def _require_developer(lane: sqlite3.Row, shell_id: int) -> None:
+        if int(lane["assigned_shell_id"]) != shell_id:
+            raise SprintAuthorityError("only the owning Developer controls the PR")
+
+    def _latest_transition(self, registered_pr_id: int) -> sqlite3.Row:
+        row = self.con.execute(
+            "SELECT normalized_state,observed_head_sha FROM sprint_pr_transitions "
+            "WHERE registered_pr_id=? ORDER BY transition_id DESC LIMIT 1",
+            (registered_pr_id,),
+        ).fetchone()
+        if row is None:
+            raise SprintInvariantError("registered PR has no observed state")
+        if row["observed_head_sha"] is None:
+            raise SprintInvariantError("registered PR has no exact observed head")
+        return row
+
+    def _accepted_review_head(self, lane: sqlite3.Row) -> str:
+        latest = self.con.execute(
+            "SELECT message_id,disposition FROM sprint_messages WHERE sprint_id=? "
+            "AND work_unit_id=? AND to_participant_id=? "
+            "AND message_kind='review_request' "
+            "ORDER BY message_id DESC LIMIT 1",
+            (
+                lane["sprint_id"],
+                lane["work_unit_id"],
+                lane["reviewer_participant_id"],
+            ),
+        ).fetchone()
+        if latest is None or latest["disposition"] != "accepted":
+            raise SprintInvariantError("review verdict requires an accepted request")
+        event = self.con.execute(
+            "SELECT payload FROM sprint_events WHERE sprint_id=? "
+            "AND event_type='review.requested' "
+            "AND json_extract(payload,'$.message_id')=? "
+            "ORDER BY event_id DESC LIMIT 1",
+            (lane["sprint_id"], latest["message_id"]),
+        ).fetchone()
+        if event is None:
+            raise SprintInvariantError("accepted review request has no head evidence")
+        head_sha = json.loads(event["payload"]).get("head_sha")
+        if not isinstance(head_sha, str) or not head_sha:
+            raise SprintInvariantError("accepted review request has no exact head")
+        return head_sha
+
+    def _record_judgment(
+        self,
+        lane: sqlite3.Row,
+        shell_id: int,
+        kind: str,
+        body: str,
+    ) -> None:
+        participant_id = (
+            lane["developer_participant_id"]
+            if shell_id == int(lane["assigned_shell_id"])
+            else lane["reviewer_participant_id"]
+        )
+        self.con.execute(
+            "INSERT INTO sprint_judgments "
+            "(sprint_id,participant_id,work_unit_id,kind,body) VALUES (?,?,?,?,?)",
+            (
+                self._sprint_id(lane),
+                participant_id,
+                lane["work_unit_id"],
+                kind,
+                body,
+            ),
+        )
+
+    def _approved_head(self, lane: sqlite3.Row) -> str | None:
+        row = self.con.execute(
+            "SELECT payload FROM sprint_events WHERE sprint_id=? "
+            "AND event_type='review.approved' "
+            "AND json_extract(payload,'$.work_unit_id')=? "
+            "ORDER BY event_id DESC LIMIT 1",
+            (self._sprint_id(lane), lane["work_unit_id"]),
+        ).fetchone()
+        return json.loads(row["payload"]).get("head_sha") if row is not None else None
+
+    def _conversation_for_key(self, key: str) -> str:
+        row = self.con.execute(
+            "SELECT conversation_id FROM conversations "
+            "WHERE creation_idempotency_key=?",
+            (key,),
+        ).fetchone()
+        if row is None:
+            raise SprintInvariantError("review outcome replay lost its conversation")
+        return str(row["conversation_id"])
+
+    @staticmethod
+    def _require_live_green(identity: sqlite3.Row, live: PullRequest) -> None:
+        if live.number != int(identity["pr_number"]):
+            raise SprintInvariantError("GitHub returned a different PR identity")
+        if live.state != "OPEN" or live.head_sha is None:
+            raise SprintInvariantError("merge requires an open PR with an exact head")
+        if live.checks_failed or live.checks != "SUCCESS":
+            raise SprintInvariantError("merge requires checks green at merge time")
+
+    @staticmethod
+    def _sprint_id(lane: sqlite3.Row) -> int:
+        return int(lane["sprint_id"])
+
+    @staticmethod
+    def _handoff_receipt(
+        lane: sqlite3.Row, receipt: MessageReceipt
+    ) -> ReviewHandoffReceipt:
+        return ReviewHandoffReceipt(
+            int(lane["work_unit_id"]),
+            receipt.message_id,
+            int(receipt.wake_id),
+            receipt.created,
+        )
+
+    @staticmethod
+    def _outcome_receipt(
+        lane: sqlite3.Row,
+        conversation_id: str,
+        receipt: MessageReceipt,
+        disposition: str,
+    ) -> ReviewOutcomeReceipt:
+        return ReviewOutcomeReceipt(
+            int(lane["work_unit_id"]),
+            conversation_id,
+            receipt.message_id,
+            int(receipt.wake_id),
+            disposition,
+            receipt.created,
+        )
+
+    def _event(
+        self,
+        sprint_id: int,
+        event_type: str,
+        shell_id: int,
+        payload: dict[str, Any],
+    ) -> None:
+        self.con.execute(
+            "INSERT INTO sprint_events "
+            "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+            "VALUES (?,?,'participant',?,?)",
+            (sprint_id, event_type, shell_id, json.dumps(payload, sort_keys=True)),
+        )

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -10,6 +10,7 @@
     ".super-coder/scripts/sprint_participant_chats.py",
     ".super-coder/scripts/sprint_runtime.py",
     ".super-coder/scripts/sprint_pr_watcher.py",
+    ".super-coder/scripts/sprint_review_loop.py",
     ".super-coder/migrations/0144_remove_sprint_v1.sql",
     "tests/fixtures/sprint_removal/build_pre_removal_fixture.py",
     "tests/fixtures/sprint_removal/manifest.json",
@@ -21,7 +22,8 @@
     "tests/test_sprint_liveness.py",
     "tests/test_sprint_participant_chats.py",
     "tests/test_sprint_work_dispatch.py",
-    "tests/test_sprint_pr_watcher.py"
+    "tests/test_sprint_pr_watcher.py",
+    "tests/test_sprint_review_loop.py"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -129,6 +129,43 @@ class RegistrationTest(SprintPRWatcherCase):
             ],
         )
 
+    def test_registration_rejects_multiple_work_units_without_side_effects(self):
+        other_unit = int(
+            self.con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output,planned_wave) VALUES (?,1,2,'Other','No',2)",
+                (self.sprint_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "exactly one owning work unit",
+        ):
+            self.watcher.register(
+                self.sprint_id,
+                owner_shell_id=1,
+                repository="acme/repo",
+                pr_number=41,
+                work_unit_ids=(self.unit_id, other_unit),
+            )
+
+        self.assertEqual([], self.reader.get_calls)
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_registered_prs"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_pr_work_units"
+            ).fetchone()[0],
+        )
+
     def test_registration_rejects_non_owner_work_and_non_armed_sprint(self):
         other_unit = int(
             self.con.execute(

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -227,6 +227,16 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         ).fetchone()
         self.assertEqual(("fix", self.developer_conversation_id), tuple(fix_link))
         self.assertIsNone(self.messages.mark_read(changed.message_id, 1))
+        self.assertEqual(
+            ("review submitted: changes_requested", 0),
+            tuple(
+                self.con.execute(
+                    "SELECT resolution,next_evaluation_at IS NOT NULL "
+                    "FROM sprint_liveness_expectations WHERE message_id=?",
+                    (first.message_id,),
+                ).fetchone()
+            ),
+        )
 
         self.reader.current = pull_request(
             checks="FAILURE", checks_failed=True, head_sha="b" * 40
@@ -278,6 +288,16 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
                 "WHERE participant_id=?",
                 (self.developer_id,),
             ).fetchone()[0],
+        )
+        self.assertEqual(
+            ("review submitted: approved", 0),
+            tuple(
+                self.con.execute(
+                    "SELECT resolution,next_evaluation_at IS NOT NULL "
+                    "FROM sprint_liveness_expectations WHERE message_id=?",
+                    (second.message_id,),
+                ).fetchone()
+            ),
         )
         self.assertEqual(
             [("issue", "Medium: preserve the exact reviewed head."),

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -1,0 +1,593 @@
+"""Stage 6 gates for the Sprints v2 Developer and Reviewer loop."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path[:0] = [str(SCRIPTS), str(ROOT / "tests")]
+
+import sprint_domain
+import sprint_message_delivery
+import sprint_pr_watcher
+import sprint_review_loop
+from test_sprint_pr_watcher import SprintPRWatcherCase, pull_request
+
+
+class SprintReviewLoopCase(SprintPRWatcherCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.reader.current = pull_request(
+            checks="SUCCESS", checks_failed=False, head_sha="a" * 40
+        )
+        self.registered_pr_id = self.register().registered_pr_id
+        initial_green = self.con.execute(
+            "SELECT message_id FROM sprint_messages "
+            "WHERE to_participant_id=? "
+            "AND idempotency_key LIKE 'pr-transition:%' "
+            "ORDER BY message_id DESC LIMIT 1",
+            (self.developer_id,),
+        ).fetchone()
+        self.messages.mark_read(int(initial_green["message_id"]), 1)
+        self.loop = sprint_review_loop.SprintReviewLoopStore(
+            self.con,
+            repo_root=ROOT,
+            reader_factory=lambda _repository: self.reader,
+        )
+
+    def request_review(self, key: str = "review-1"):
+        return self.loop.request_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            1,
+            readiness="Focused and full gates are green; ready for review.",
+            idempotency_key=key,
+        )
+
+    def accept_review(self, message_id: int) -> None:
+        self.assertEqual("accepted", self.messages.mark_read(message_id, 2))
+
+    def approve(self, key: str = "approved-1"):
+        handoff = self.request_review(f"{key}:request")
+        self.accept_review(handoff.message_id)
+        return self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="approved",
+            body="No Medium-or-higher findings remain.",
+            idempotency_key=key,
+        )
+
+
+class ReviewHandoffTest(SprintReviewLoopCase):
+    def test_green_readiness_commits_judgment_and_active_reviewer_request(self):
+        handoff = self.request_review()
+
+        self.assertTrue(handoff.created)
+        self.assertEqual(self.unit_id, handoff.work_unit_id)
+        unit = self.con.execute(
+            "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+            (self.unit_id,),
+        ).fetchone()
+        self.assertEqual("in_review", unit["disposition"])
+        message = self.con.execute(
+            "SELECT from_participant_id,to_participant_id,message_kind,body,"
+            "actionable,disposition FROM sprint_messages WHERE message_id=?",
+            (handoff.message_id,),
+        ).fetchone()
+        self.assertEqual(
+            (
+                self.developer_id,
+                self.reviewer_id,
+                "review_request",
+                "Focused and full gates are green; ready for review.",
+                1,
+                "pending",
+            ),
+            tuple(message),
+        )
+        judgment = self.con.execute(
+            "SELECT participant_id,kind,body FROM sprint_judgments "
+            "WHERE work_unit_id=?",
+            (self.unit_id,),
+        ).fetchone()
+        self.assertEqual(
+            (
+                self.developer_id,
+                "decision",
+                "Focused and full gates are green; ready for review.",
+            ),
+            tuple(judgment),
+        )
+        lease = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).claim_next("stage6-review")
+        reviewer_chat = self.con.execute(
+            "SELECT current_conversation_id FROM sprint_participants "
+            "WHERE participant_id=?",
+            (self.reviewer_id,),
+        ).fetchone()[0]
+        self.assertEqual(self.reviewer_id, lease.participant_id)
+        self.assertEqual(reviewer_chat, lease.target_conversation_id)
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_messages "
+                "WHERE message_id=? AND to_participant_id=?",
+                (handoff.message_id, self.planner_id),
+            ).fetchone()[0],
+            "the watcher never bypasses Developer judgment to request review",
+        )
+
+    def test_non_green_and_wrong_developer_leave_no_review_evidence(self):
+        self.reader.current = pull_request(
+            checks="PENDING", checks_failed=False, head_sha="a" * 40
+        )
+        self.watcher.poll_once()
+        before = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_messages"
+        ).fetchone()[0]
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "observed green"
+        ):
+            self.request_review()
+        with self.assertRaisesRegex(
+            sprint_domain.SprintAuthorityError, "owning Developer"
+        ):
+            self.loop.request_review(
+                self.sprint_id,
+                self.registered_pr_id,
+                99,
+                readiness="wrong owner",
+                idempotency_key="wrong-owner",
+            )
+
+        self.assertEqual(
+            before,
+            self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0],
+        )
+        self.assertEqual(
+            "active",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+
+    def test_handoff_and_outcome_replay_without_duplicate_durable_facts(self):
+        first = self.request_review("idempotent-request")
+        replay = self.request_review("idempotent-request")
+        self.assertEqual(
+            (first.work_unit_id, first.message_id, first.wake_id),
+            (replay.work_unit_id, replay.message_id, replay.wake_id),
+        )
+        self.accept_review(first.message_id)
+        approved = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="approved",
+            body="Clean on the reviewed head.",
+            idempotency_key="idempotent-approval",
+        )
+        approval_replay = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="approved",
+            body="Clean on the reviewed head.",
+            idempotency_key="idempotent-approval",
+        )
+
+        self.assertFalse(replay.created)
+        self.assertFalse(approval_replay.created)
+        self.assertEqual(approved.message_id, approval_replay.message_id)
+        self.assertEqual(approved.conversation_id, approval_replay.conversation_id)
+        self.assertEqual(
+            (2, 2, 1),
+            tuple(
+                self.con.execute(
+                    "SELECT COUNT(*),"
+                    "(SELECT COUNT(*) FROM sprint_judgments WHERE work_unit_id=?),"
+                    "(SELECT COUNT(*) FROM sprint_participant_conversations "
+                    " WHERE purpose='merge') "
+                    "FROM sprint_messages WHERE idempotency_key IN (?,?)",
+                    (
+                        self.unit_id,
+                        "idempotent-request",
+                        "idempotent-approval",
+                    ),
+                ).fetchone()
+            ),
+        )
+
+
+class ReviewOutcomeTest(SprintReviewLoopCase):
+    def test_changes_and_approval_select_fresh_linked_conversations(self):
+        first = self.request_review()
+        self.accept_review(first.message_id)
+        changed = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="changes_requested",
+            body="Medium: preserve the exact reviewed head.",
+            idempotency_key="changes-1",
+        )
+        self.assertEqual("fixing", changed.disposition)
+        self.assertNotEqual(self.developer_conversation_id, changed.conversation_id)
+        fix_link = self.con.execute(
+            "SELECT purpose,parent_conversation_id FROM "
+            "sprint_participant_conversations WHERE conversation_id=?",
+            (changed.conversation_id,),
+        ).fetchone()
+        self.assertEqual(("fix", self.developer_conversation_id), tuple(fix_link))
+        self.assertIsNone(self.messages.mark_read(changed.message_id, 1))
+
+        self.reader.current = pull_request(
+            checks="FAILURE", checks_failed=True, head_sha="b" * 40
+        )
+        self.watcher.poll_once()
+        red_lease = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).claim_next("stage6-fix-red")
+        self.assertEqual(changed.conversation_id, red_lease.target_conversation_id)
+        red_messages = self.con.execute(
+            "SELECT m.message_id FROM sprint_messages m "
+            "JOIN sprint_wake_messages wm USING(message_id) "
+            "WHERE wm.wake_id=?",
+            (red_lease.wake_id,),
+        ).fetchall()
+        for message in red_messages:
+            self.messages.mark_read(int(message["message_id"]), 1)
+
+        self.reader.current = pull_request(
+            checks="SUCCESS", checks_failed=False, head_sha="b" * 40
+        )
+        self.watcher.poll_once()
+        second = self.request_review("review-2")
+        self.accept_review(second.message_id)
+        approved = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="approved",
+            body="The fix closes the Medium finding.",
+            idempotency_key="approved-2",
+        )
+
+        self.assertEqual("merge_ready", approved.disposition)
+        self.assertNotIn(
+            approved.conversation_id,
+            {self.developer_conversation_id, changed.conversation_id},
+        )
+        merge_link = self.con.execute(
+            "SELECT purpose,parent_conversation_id FROM "
+            "sprint_participant_conversations WHERE conversation_id=?",
+            (approved.conversation_id,),
+        ).fetchone()
+        self.assertEqual(("merge", changed.conversation_id), tuple(merge_link))
+        self.assertEqual(
+            approved.conversation_id,
+            self.con.execute(
+                "SELECT current_conversation_id FROM sprint_participants "
+                "WHERE participant_id=?",
+                (self.developer_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            [("issue", "Medium: preserve the exact reviewed head."),
+             ("decision", "The fix closes the Medium finding.")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT kind,body FROM sprint_judgments "
+                    "WHERE participant_id=? ORDER BY judgment_id",
+                    (self.reviewer_id,),
+                )
+            ],
+        )
+
+    def test_outcome_requires_assigned_reviewer_and_accepted_request(self):
+        handoff = self.request_review()
+        before = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_participant_conversations"
+        ).fetchone()[0]
+        with self.assertRaisesRegex(
+            sprint_domain.SprintAuthorityError, "assigned Reviewer"
+        ):
+            self.loop.record_review(
+                self.sprint_id,
+                self.registered_pr_id,
+                99,
+                verdict="approved",
+                body="wrong reviewer",
+                idempotency_key="wrong-reviewer",
+            )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "accepted request"
+        ):
+            self.loop.record_review(
+                self.sprint_id,
+                self.registered_pr_id,
+                2,
+                verdict="approved",
+                body="not accepted",
+                idempotency_key="unaccepted",
+            )
+        self.assertEqual(
+            before,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_participant_conversations"
+            ).fetchone()[0],
+        )
+        self.assertEqual("pending", self.con.execute(
+            "SELECT disposition FROM sprint_messages WHERE message_id=?",
+            (handoff.message_id,),
+        ).fetchone()[0])
+
+    def test_old_acceptance_does_not_authorize_a_new_pending_review_cycle(self):
+        first = self.request_review()
+        self.accept_review(first.message_id)
+        changed = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="changes_requested",
+            body="Medium: update the implementation.",
+            idempotency_key="changes-before-new-request",
+        )
+        self.messages.mark_read(changed.message_id, 1)
+        self.reader.current = pull_request(
+            checks="FAILURE", checks_failed=True, head_sha="b" * 40
+        )
+        self.watcher.poll_once()
+        red = self.con.execute(
+            "SELECT message_id FROM sprint_messages WHERE to_participant_id=? "
+            "AND idempotency_key LIKE 'pr-transition:%' "
+            "ORDER BY message_id DESC LIMIT 1",
+            (self.developer_id,),
+        ).fetchone()
+        self.messages.mark_read(int(red["message_id"]), 1)
+        self.reader.current = pull_request(
+            checks="SUCCESS", checks_failed=False, head_sha="b" * 40
+        )
+        self.watcher.poll_once()
+        pending = self.request_review("review-pending-second-cycle")
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "accepted request"
+        ):
+            self.loop.record_review(
+                self.sprint_id,
+                self.registered_pr_id,
+                2,
+                verdict="approved",
+                body="must not skip second acceptance",
+                idempotency_key="premature-second-approval",
+            )
+
+        self.assertEqual(
+            "pending",
+            self.con.execute(
+                "SELECT disposition FROM sprint_messages WHERE message_id=?",
+                (pending.message_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            "in_review",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+
+    def test_approval_rejects_a_head_that_changed_after_review_acceptance(self):
+        handoff = self.request_review()
+        self.accept_review(handoff.message_id)
+        self.reader.current = pull_request(
+            checks="PENDING", checks_failed=False, head_sha="b" * 40
+        )
+        self.watcher.poll_once()
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "request is stale"
+        ):
+            self.loop.record_review(
+                self.sprint_id,
+                self.registered_pr_id,
+                2,
+                verdict="approved",
+                body="must re-request on the changed head",
+                idempotency_key="stale-review-head",
+            )
+
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_messages "
+                "WHERE idempotency_key='stale-review-head'"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            self.developer_conversation_id,
+            self.con.execute(
+                "SELECT current_conversation_id FROM sprint_participants "
+                "WHERE participant_id=?",
+                (self.developer_id,),
+            ).fetchone()[0],
+        )
+
+
+class MergeGateAndAdvanceTest(SprintReviewLoopCase):
+    def test_merge_gate_rechecks_live_green_and_exact_approved_head(self):
+        approved = self.approve()
+        authorization = self.loop.authorize_merge(
+            self.sprint_id, self.registered_pr_id, 1
+        )
+        self.assertEqual((42, "a" * 40), (authorization.pr_number, authorization.head_sha))
+
+        self.reader.current = pull_request(
+            checks="PENDING", checks_failed=False, head_sha="a" * 40
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "green at merge time"
+        ):
+            self.loop.authorize_merge(self.sprint_id, self.registered_pr_id, 1)
+
+        self.reader.current = pull_request(
+            checks="SUCCESS", checks_failed=False, head_sha="b" * 40
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "approval is stale"
+        ):
+            self.loop.authorize_merge(self.sprint_id, self.registered_pr_id, 1)
+        self.assertEqual(
+            "merge_ready",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (approved.work_unit_id,),
+            ).fetchone()[0],
+        )
+
+    def test_observed_merge_completes_board_and_assigns_next_in_persistent_lane(self):
+        approved = self.approve()
+        self.messages.mark_read(approved.message_id, 1)
+        document = self.con.execute(
+            "SELECT document_id FROM sprint_specs WHERE sprint_id=?",
+            (self.sprint_id,),
+        ).fetchone()[0]
+        feature = self.con.execute(
+            "SELECT feature_id FROM sprints WHERE sprint_id=?",
+            (self.sprint_id,),
+        ).fetchone()[0]
+        task_id = self.con.execute(
+            "INSERT INTO spec_tasks (feature_id,document_id,seq,title) "
+            "VALUES (?,?,99,'Next unit')",
+            (feature, document),
+        ).lastrowid
+        self.con.commit()
+        next_unit = sprint_domain.SprintWorkUnitStore(self.con).create(
+            self.sprint_id,
+            3,
+            assigned_shell_id=1,
+            reviewer_shell_id=2,
+            title="Next unit",
+            expected_output="Continue in the persistent lane",
+            task_ids=(task_id,),
+            dependency_ids=(self.unit_id,),
+        )
+
+        self.reader.current = pull_request(
+            state="MERGED", checks="SUCCESS", checks_failed=False, head_sha="a" * 40
+        )
+        self.watcher.poll_once()
+
+        self.assertEqual(
+            [(self.unit_id, "completed"), (next_unit, "ready")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT work_unit_id,disposition FROM sprint_work_units "
+                    "WHERE work_unit_id IN (?,?) ORDER BY work_unit_id",
+                    (self.unit_id, next_unit),
+                )
+            ],
+        )
+        current = self.con.execute(
+            "SELECT persistent_conversation_id,current_conversation_id "
+            "FROM sprint_participants WHERE participant_id=?",
+            (self.developer_id,),
+        ).fetchone()
+        self.assertEqual(self.developer_conversation_id, current[0])
+        self.assertEqual(current[0], current[1])
+        assignment = self.con.execute(
+            "SELECT message_id FROM sprint_messages WHERE work_unit_id=? "
+            "AND message_kind='work_assignment'",
+            (next_unit,),
+        ).fetchone()
+        self.assertIsNotNone(assignment)
+        lease = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).claim_next("stage6-next")
+        self.assertEqual(self.developer_conversation_id, lease.target_conversation_id)
+        self.assertEqual(
+            ["work_unit.completed", "work_unit.ready", "pr.transition"],
+            [
+                row[0]
+                for row in self.con.execute(
+                    "SELECT event_type FROM sprint_events "
+                    "ORDER BY event_id DESC LIMIT 3"
+                )
+            ][::-1],
+        )
+
+
+class CarriedLowClosureTest(SprintReviewLoopCase):
+    def test_registration_notifies_live_watcher_once_after_commit(self):
+        store = sprint_pr_watcher.SprintPRRegistrationStore(self.con)
+        with mock.patch.object(
+            sprint_pr_watcher, "notify_commit", return_value=True
+        ) as notify:
+            created = store.register(
+                self.sprint_id,
+                owner_shell_id=1,
+                repository="acme/other",
+                pr_number=43,
+                work_unit_ids=(self.unit_id,),
+            )
+            replay = store.register(
+                self.sprint_id,
+                owner_shell_id=1,
+                repository="acme/other",
+                pr_number=43,
+                work_unit_ids=(self.unit_id,),
+            )
+
+        self.assertTrue(created.created)
+        self.assertFalse(replay.created)
+        notify.assert_called_once_with()
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_registered_prs "
+                "WHERE repository='acme/other' AND pr_number=43"
+            ).fetchone()[0],
+        )
+
+    def test_paused_sprint_wake_cannot_be_claimed_for_delivery(self):
+        sent = self.messages.send(
+            self.sprint_id,
+            to_participant_id=self.developer_id,
+            from_participant_id=self.planner_id,
+            work_unit_id=self.unit_id,
+            message_kind="notification",
+            body="active before pause",
+            idempotency_key="pause-race",
+            active=True,
+        )
+        self.lifecycle.transition(
+            self.sprint_id,
+            "paused",
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="integrity check",
+        )
+
+        service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
+        self.assertIsNone(service.claim_next("paused-delivery"))
+        wake = self.con.execute(
+            "SELECT state,attempt_count,claim_owner FROM sprint_wake_outbox "
+            "WHERE wake_id=?",
+            (sent.wake_id,),
+        ).fetchone()
+        self.assertEqual(("pending", 0, None), tuple(wake))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- compose green readiness, actionable review requests, and accepted Reviewer outcomes over existing Sprint records
- route changes-requested and approved outcomes into fresh linked fix/merge conversations, with watcher wakes following the current pointer
- re-read GitHub for live-green, exact-approved-head merge authorization; project observed merges into completion and persistent-lane next assignment
- activate the registered-PR watcher notifier and pin paused-Sprint wake claims as the two carried Low closures

## Design judgement

No new schema: work-unit dispositions, sprint messages/judgments/events, participant conversation pointers, and registered-PR transitions remain the single owners. GitHub is read outside SQLite; armed grant, ownership, approved head, and lane state are revalidated inside the short commit.

## Verification

- focused Stage 2–6/removal/startup: 103 passed, 203 subtests
- full suite: 1,342 passed, 1 skipped, 745 subtests
- render-check, py_compile, changed-file Ruff, JSON parse, and git diff --check green
- ./sc verify refuses linked worktrees by design (subfloor#769 / SC-019); no live-instance state touched

## Sprint protocol

Sprint 51 decision #38 applies: no PR watch registration and no dev self-merge; PLN1 merges after REV2 review-clean + green.