### PR TITLE
feat: add Sprint pause and recovery

### DIFF
--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -810,44 +810,59 @@ class BrokerStore:
                 con,
                 "conversation.broker.request_interrupt",
             ):
-                row = con.execute(
-                    "SELECT conversation_id,trigger_message_id,state "
-                    "FROM conversation_runs WHERE run_id=?",
-                    (run_id,),
-                ).fetchone()
-                if row is None:
-                    raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
-                if row["state"] not in LIVE_RUN_STATES:
-                    raise BrokerError(
-                        "CONVERSATION_RUN_NOT_ACTIVE",
-                        f"run {run_id} is {row['state']}",
-                    )
-                exists = con.execute(
-                    "SELECT 1 FROM conversation_events "
-                    "WHERE run_id=? AND event_type='run.interrupt.requested'",
-                    (run_id,),
-                ).fetchone()
-                if exists is None:
-                    self._append_event(
-                        con,
-                        conversation_id=row["conversation_id"],
-                        event_type="run.interrupt.requested",
-                        payload={"requested_at": now},
-                        message_id=row["trigger_message_id"],
-                        run_id=run_id,
-                    )
-                    con.execute(
-                        "UPDATE conversations SET last_activity_at=?,"
-                        "version=version+1 WHERE conversation_id=?",
-                        (now, row["conversation_id"]),
-                    )
-                conversation_id = row["conversation_id"]
-                created = exists is None
+                created, conversation_id = self.request_interrupt_in_transaction(
+                    con,
+                    run_id,
+                    requested_at=now,
+                )
         finally:
             con.close()
         if created:
             conversation_events.notify(conversation_id)
         return created
+
+    @staticmethod
+    def request_interrupt_in_transaction(
+        con,
+        run_id: int,
+        *,
+        requested_at: str,
+    ) -> tuple[bool, str]:
+        """Persist one interrupt intent inside an existing owner transaction."""
+        if not con.in_transaction:
+            raise RuntimeError("interrupt intent requires an active transaction")
+        row = con.execute(
+            "SELECT conversation_id,trigger_message_id,state "
+            "FROM conversation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+        if row["state"] not in LIVE_RUN_STATES:
+            raise BrokerError(
+                "CONVERSATION_RUN_NOT_ACTIVE",
+                f"run {run_id} is {row['state']}",
+            )
+        exists = con.execute(
+            "SELECT 1 FROM conversation_events "
+            "WHERE run_id=? AND event_type='run.interrupt.requested'",
+            (run_id,),
+        ).fetchone()
+        if exists is None:
+            BrokerStore._append_event(
+                con,
+                conversation_id=row["conversation_id"],
+                event_type="run.interrupt.requested",
+                payload={"requested_at": requested_at},
+                message_id=row["trigger_message_id"],
+                run_id=run_id,
+            )
+            con.execute(
+                "UPDATE conversations SET last_activity_at=?,"
+                "version=version+1 WHERE conversation_id=?",
+                (requested_at, row["conversation_id"]),
+            )
+        return exists is None, str(row["conversation_id"])
 
     def heartbeat_service(self, interval_seconds: int) -> None:
         con = self.connect()

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -13,6 +13,8 @@ import sqlite3
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
+import conversation_broker
+import conversation_events
 import db_driver
 import sprint_participant_chats
 
@@ -57,6 +59,32 @@ class LifecycleActor:
             raise ValueError(f"{self.kind} actor requires shell_id")
 
 
+@dataclass(frozen=True)
+class PauseReceipt:
+    changed: bool
+    report_id: int | None
+    interrupt_run_ids: tuple[int, ...]
+    notification_conversation_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResumeReceipt:
+    changed: bool
+    dispatched_wake_ids: tuple[int, ...]
+    projected_work_unit_ids: tuple[int, ...]
+    resolved_review_message_ids: tuple[int, ...]
+    spec_drift_document_ids: tuple[int, ...]
+    anomalies: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AbortReceipt:
+    changed: bool
+    report_id: int | None
+    interrupt_run_ids: tuple[int, ...]
+    notification_conversation_ids: tuple[str, ...]
+
+
 def transition_allowed(current: str, target: str) -> bool:
     return (
         current in SPRINT_TRANSITIONS
@@ -68,9 +96,17 @@ def transition_allowed(current: str, target: str) -> bool:
 class SprintLifecycleStore:
     """Transactional lifecycle operations over one engine DB connection."""
 
-    def __init__(self, con: sqlite3.Connection) -> None:
+    def __init__(
+        self,
+        con: sqlite3.Connection,
+        *,
+        interrupt_run: Callable[[int], bool] | None = None,
+        notify_commit: Callable[[], bool] | None = None,
+    ) -> None:
         self.con = con
         self.con.row_factory = sqlite3.Row
+        self.interrupt_run = interrupt_run or conversation_broker.interrupt_run
+        self.notify_commit = notify_commit or conversation_broker.notify_commit
 
     def armed_sprint_id(self) -> int | None:
         row = self.con.execute(
@@ -129,6 +165,17 @@ class SprintLifecycleStore:
         terminal_outcome: str | None = None,
     ) -> bool:
         """Apply one authorized edge; same-state requests are idempotent."""
+        if target == "paused":
+            return self.pause(sprint_id, actor, reason=reason or "unspecified").changed
+        if target == "armed":
+            return self.resume(sprint_id, actor, reason=reason).changed
+        if target == "aborted":
+            return self.abort(
+                sprint_id,
+                actor,
+                reason=reason or terminal_outcome or "aborted",
+                terminal_outcome=terminal_outcome,
+            ).changed
         with db_driver.write_transaction(self.con, "sprint.transition"):
             sprint = self._sprint(sprint_id)
             current = str(sprint["lifecycle"])
@@ -158,6 +205,203 @@ class SprintLifecycleStore:
             )
         return True
 
+    def pause(
+        self,
+        sprint_id: int,
+        actor: LifecycleActor,
+        *,
+        reason: str,
+        detail: dict | None = None,
+    ) -> PauseReceipt:
+        """Atomically pause, persist intent/report/reason, and notify Planner."""
+        reason = self._required_text(reason, "pause reason", 1000)
+        with db_driver.write_transaction(self.con, "sprint.pause"):
+            sprint = self._sprint(sprint_id)
+            current = str(sprint["lifecycle"])
+            if current == "paused":
+                return PauseReceipt(False, None, (), ())
+            self._require_edge(current, "paused")
+            self._authorize(sprint, "paused", actor)
+            receipt = self._pause_in_transaction(
+                sprint,
+                actor,
+                reason=reason,
+                detail=detail or {},
+            )
+        self._signal_interrupts_and_notifications(receipt)
+        return receipt
+
+    def resume(
+        self,
+        sprint_id: int,
+        actor: LifecycleActor,
+        *,
+        reason: str | None = None,
+        reconcile_in_transaction: Callable[[sqlite3.Connection], None] | None = None,
+        external_anomalies: Iterable[str] = (),
+    ) -> ResumeReceipt:
+        """Reconcile durable and supplied evidence before publishing re-arming."""
+        anomalies = tuple(
+            self._required_text(item, "reconciliation anomaly", 2000)
+            for item in external_anomalies
+        )
+        all_anomalies = anomalies
+        notice_conversations: tuple[str, ...] = ()
+        with db_driver.write_transaction(self.con, "sprint.resume"):
+            sprint = self._sprint(sprint_id)
+            current = str(sprint["lifecycle"])
+            if current == "armed":
+                return ResumeReceipt(False, (), (), (), (), anomalies)
+            if current == "prepared":
+                raise SprintInvariantError(
+                    "prepared Sprints must use arm() so plan release is atomic"
+                )
+            self._require_edge(current, "armed")
+            self._authorize(sprint, "armed", actor)
+
+            # Armed is not externally visible until this transaction commits.
+            # That permits active reconciliation notifications to be created
+            # before dispatch without exposing a half-reconciled Sprint.
+            self._update_lifecycle(
+                sprint_id,
+                current=current,
+                target="armed",
+                outcome=None,
+            )
+            if reconcile_in_transaction is not None:
+                reconcile_in_transaction(self.con)
+            projected, resolved = self._reconcile_registered_prs_in_transaction(
+                sprint_id
+            )
+            drift = self._spec_drift(sprint_id)
+            all_anomalies = tuple(
+                dict.fromkeys((*anomalies, *self._local_reconciliation_anomalies(sprint_id)))
+            )
+            evidence = self._reconciliation_evidence(
+                sprint_id,
+                trigger="resume",
+                projected_work_unit_ids=projected,
+                resolved_review_message_ids=resolved,
+                spec_drift=drift,
+                anomalies=all_anomalies,
+            )
+            self._event(
+                sprint_id,
+                "lifecycle.reconciled",
+                actor,
+                evidence,
+            )
+            if drift or all_anomalies:
+                _, notice_conversations = self._queue_planner_notice(
+                    sprint_id,
+                    body=(
+                        f"Sprint {sprint_id} resumed with reconciliation evidence: "
+                        f"{len(drift)} spec drift item(s), "
+                        f"{len(all_anomalies)} anomaly item(s)."
+                    ),
+                    idempotency_key=(
+                        f"sprint-resume:{sprint_id}:v{int(sprint['version']) + 1}"
+                    ),
+                )
+            planner = self._planner_participant_id(sprint_id)
+            dispatched = tuple(
+                SprintWorkUnitStore(self.con)._dispatch_ready_locked(
+                    sprint_id,
+                    planner_participant_id=planner,
+                )
+            )
+            self._event(
+                sprint_id,
+                "lifecycle.armed",
+                actor,
+                {
+                    "from": current,
+                    "reason": reason,
+                    "reconciled": True,
+                    "dispatched_wake_ids": list(dispatched),
+                },
+            )
+        self._signal_notifications(notice_conversations)
+        return ResumeReceipt(
+            True,
+            dispatched,
+            tuple(projected),
+            tuple(resolved),
+            tuple(sorted(drift)),
+            all_anomalies,
+        )
+
+    def abort(
+        self,
+        sprint_id: int,
+        actor: LifecycleActor,
+        *,
+        reason: str,
+        terminal_outcome: str | None,
+    ) -> AbortReceipt:
+        """Abort from prepared/armed/paused without deleting Sprint history."""
+        reason = self._required_text(reason, "abort reason", 2000)
+        outcome = self._required_text(
+            terminal_outcome or "aborted",
+            "abort outcome",
+            500,
+        )
+        with db_driver.write_transaction(self.con, "sprint.abort"):
+            sprint = self._sprint(sprint_id)
+            current = str(sprint["lifecycle"])
+            if current == "aborted":
+                return AbortReceipt(False, None, (), ())
+            self._require_edge(current, "aborted")
+            self._authorize(sprint, "aborted", actor)
+            run_ids, run_conversations = self._persist_interrupt_intents(sprint_id)
+            self._update_lifecycle(
+                sprint_id,
+                current=current,
+                target="aborted",
+                outcome=outcome,
+            )
+            report_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_reports "
+                    "(sprint_id,report_kind,author_shell_id,body) "
+                    "VALUES (?,'abort',?,?)",
+                    (
+                        sprint_id,
+                        actor.shell_id,
+                        json.dumps(
+                            self._abort_report(sprint_id, current, reason, outcome),
+                            sort_keys=True,
+                        ),
+                    ),
+                ).lastrowid
+            )
+            _, notice_conversations = self._queue_planner_notice(
+                sprint_id,
+                body=f"Sprint {sprint_id} aborted: {reason}",
+                idempotency_key=(
+                    f"sprint-abort:{sprint_id}:v{int(sprint['version']) + 1}"
+                ),
+            )
+            self._event(
+                sprint_id,
+                "lifecycle.aborted",
+                actor,
+                {
+                    "from": current,
+                    "reason": reason,
+                    "report_id": report_id,
+                    "interrupt_run_ids": list(run_ids),
+                },
+            )
+            receipt = AbortReceipt(
+                True,
+                report_id,
+                run_ids,
+                tuple(sorted(set(run_conversations) | set(notice_conversations))),
+            )
+        self._signal_interrupts_and_notifications(receipt)
+        return receipt
+
     def record_wake_failure(
         self,
         wake_id: int,
@@ -171,6 +415,7 @@ class SprintLifecycleStore:
         if not error:
             raise ValueError("wake failure requires an error")
         error = error[:16384]
+        pause_receipt: PauseReceipt | None = None
         with db_driver.write_transaction(self.con, "sprint.wake_failure"):
             row = self.con.execute(
                 "SELECT wake_id,sprint_id,state,attempt_count,claim_owner "
@@ -214,36 +459,590 @@ class SprintLifecycleStore:
             if terminal:
                 sprint = self._sprint(int(row["sprint_id"]))
                 if sprint["lifecycle"] == "armed":
-                    self._update_lifecycle(
-                        int(row["sprint_id"]),
-                        current="armed",
-                        target="paused",
-                        outcome=None,
-                    )
-                    body = json.dumps(
-                        {
-                            "reason": "wake_delivery_exhausted",
+                    pause_receipt = self._pause_in_transaction(
+                        sprint,
+                        LifecycleActor("system"),
+                        reason="wake_delivery_exhausted",
+                        detail={
                             "wake_id": wake_id,
                             "attempts": 3,
                             "last_error": error,
                         },
-                        sort_keys=True,
                     )
-                    self.con.execute(
-                        "INSERT INTO sprint_reports "
-                        "(sprint_id,report_kind,body) VALUES (?,'pause',?)",
-                        (int(row["sprint_id"]), body),
-                    )
-                    self._event(
-                        int(row["sprint_id"]),
-                        "lifecycle.paused",
-                        LifecycleActor("system"),
-                        {
-                            "reason": "wake_delivery_exhausted",
-                            "wake_id": wake_id,
-                        },
-                    )
+        if pause_receipt is not None:
+            self._signal_interrupts_and_notifications(pause_receipt)
         return attempt
+
+    def recover_on_startup(
+        self, sprint_id: int | None = None
+    ) -> tuple[tuple[int, str], ...]:
+        """Reassert durable non-terminal recovery facts without changing state."""
+        sql = (
+            "SELECT sprint_id,lifecycle FROM sprints "
+            "WHERE lifecycle IN ('prepared','armed','paused')"
+        )
+        params: tuple[int, ...] = ()
+        if sprint_id is not None:
+            sql += " AND sprint_id=?"
+            params = (sprint_id,)
+        rows = self.con.execute(sql + " ORDER BY sprint_id", params).fetchall()
+        recovered: list[tuple[int, str]] = []
+        for row in rows:
+            sprint_id = int(row["sprint_id"])
+            lifecycle = str(row["lifecycle"])
+            run_ids: tuple[int, ...] = ()
+            conversations: tuple[str, ...] = ()
+            if lifecycle in {"armed", "paused"}:
+                with db_driver.write_transaction(
+                    self.con, "sprint.recover.startup"
+                ):
+                    if lifecycle == "paused":
+                        run_ids, conversations = self._persist_interrupt_intents(
+                            sprint_id
+                        )
+                    else:
+                        self._reconcile_registered_prs_in_transaction(sprint_id)
+            if run_ids or conversations:
+                self._signal_interrupts_and_notifications(
+                    PauseReceipt(True, None, run_ids, conversations)
+                )
+            recovered.append((sprint_id, lifecycle))
+        return tuple(recovered)
+
+    def _pause_in_transaction(
+        self,
+        sprint: sqlite3.Row,
+        actor: LifecycleActor,
+        *,
+        reason: str,
+        detail: dict,
+    ) -> PauseReceipt:
+        if not self.con.in_transaction:
+            raise RuntimeError("pause requires an active transaction")
+        sprint_id = int(sprint["sprint_id"])
+        current = str(sprint["lifecycle"])
+        self._require_edge(current, "paused")
+        self._authorize(sprint, "paused", actor)
+        run_ids, run_conversations = self._persist_interrupt_intents(sprint_id)
+        template = self._pause_report(sprint_id, current, reason, actor, detail)
+        self._update_lifecycle(
+            sprint_id,
+            current=current,
+            target="paused",
+            outcome=None,
+        )
+        report_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_reports "
+                "(sprint_id,report_kind,author_shell_id,body) "
+                "VALUES (?,'pause',?,?)",
+                (sprint_id, actor.shell_id, json.dumps(template, sort_keys=True)),
+            ).lastrowid
+        )
+        _, notice_conversations = self._queue_planner_notice(
+            sprint_id,
+            body=f"Sprint {sprint_id} paused: {reason}",
+            idempotency_key=(
+                f"sprint-pause:{sprint_id}:v{int(sprint['version']) + 1}"
+            ),
+        )
+        self._event(
+            sprint_id,
+            "lifecycle.paused",
+            actor,
+            {
+                "from": current,
+                "reason": reason,
+                "report_id": report_id,
+                "interrupt_run_ids": list(run_ids),
+                **detail,
+            },
+        )
+        return PauseReceipt(
+            True,
+            report_id,
+            run_ids,
+            tuple(sorted(set(run_conversations) | set(notice_conversations))),
+        )
+
+    def _persist_interrupt_intents(
+        self, sprint_id: int
+    ) -> tuple[tuple[int, ...], tuple[str, ...]]:
+        if not self.con.in_transaction:
+            raise RuntimeError("interrupt persistence requires an active transaction")
+        rows = self.con.execute(
+            "SELECT DISTINCT r.run_id FROM conversation_runs r "
+            "JOIN sprint_participant_conversations pc "
+            "ON pc.conversation_id=r.conversation_id "
+            "JOIN sprint_participants p "
+            "ON p.participant_id=pc.sprint_participant_id "
+            "WHERE p.sprint_id=? AND r.state IN ('leased','starting','running') "
+            "ORDER BY r.run_id",
+            (sprint_id,),
+        ).fetchall()
+        now = str(self.con.execute("SELECT datetime('now')").fetchone()[0])
+        run_ids: list[int] = []
+        conversations: list[str] = []
+        for row in rows:
+            run_id = int(row["run_id"])
+            _, conversation_id = (
+                conversation_broker.BrokerStore.request_interrupt_in_transaction(
+                    self.con,
+                    run_id,
+                    requested_at=now,
+                )
+            )
+            run_ids.append(run_id)
+            conversations.append(conversation_id)
+        return tuple(run_ids), tuple(sorted(set(conversations)))
+
+    def _pause_report(
+        self,
+        sprint_id: int,
+        lifecycle_before: str,
+        reason: str,
+        actor: LifecycleActor,
+        detail: dict,
+    ) -> dict:
+        active_turns = [
+            dict(row)
+            for row in self.con.execute(
+                "SELECT r.run_id,r.conversation_id,r.state,r.lease_owner,"
+                "r.heartbeat_at,r.lease_expires_at FROM conversation_runs r "
+                "JOIN sprint_participant_conversations pc "
+                "ON pc.conversation_id=r.conversation_id "
+                "JOIN sprint_participants p "
+                "ON p.participant_id=pc.sprint_participant_id "
+                "WHERE p.sprint_id=? AND r.state IN ('leased','starting','running') "
+                "ORDER BY r.run_id",
+                (sprint_id,),
+            )
+        ]
+        work_units = [
+            dict(row)
+            for row in self.con.execute(
+                "SELECT work_unit_id,assigned_shell_id,reviewer_shell_id,title,"
+                "planned_wave,disposition FROM sprint_work_units "
+                "WHERE sprint_id=? ORDER BY work_unit_id",
+                (sprint_id,),
+            )
+        ]
+        prs = [
+            dict(row)
+            for row in self.con.execute(
+                "SELECT pr.registered_pr_id,pr.repository,pr.pr_number,"
+                "t.normalized_state,t.observed_head_sha,t.observed_at "
+                "FROM sprint_registered_prs pr LEFT JOIN sprint_pr_transitions t "
+                "ON t.transition_id=(SELECT MAX(latest.transition_id) "
+                "FROM sprint_pr_transitions latest "
+                "WHERE latest.registered_pr_id=pr.registered_pr_id) "
+                "WHERE pr.sprint_id=? ORDER BY pr.registered_pr_id",
+                (sprint_id,),
+            )
+        ]
+        anomalies = [
+            {"event_type": row["event_type"], "payload": json.loads(row["payload"])}
+            for row in self.con.execute(
+                "SELECT event_type,payload FROM sprint_events WHERE sprint_id=? "
+                "AND (event_type LIKE '%failed%' OR event_type LIKE '%error%' "
+                "OR event_type LIKE '%unknown%' OR event_type LIKE '%escalat%') "
+                "ORDER BY event_id DESC LIMIT 20",
+                (sprint_id,),
+            )
+        ]
+        return {
+            "reason": reason,
+            "actor": {"kind": actor.kind, "shell_id": actor.shell_id},
+            "lifecycle_before": lifecycle_before,
+            "detail": detail,
+            "deterministic": {
+                "active_turns": active_turns,
+                "work_units": work_units,
+                "registered_prs": prs,
+                "recent_anomalies": anomalies,
+            },
+            "integrity_threat": "",
+            "judgment": "",
+            "recommendation": "",
+        }
+
+    def _abort_report(
+        self,
+        sprint_id: int,
+        lifecycle_before: str,
+        reason: str,
+        outcome: str,
+    ) -> dict:
+        rows = self.con.execute(
+            "SELECT work_unit_id,title,disposition FROM sprint_work_units "
+            "WHERE sprint_id=? ORDER BY work_unit_id",
+            (sprint_id,),
+        ).fetchall()
+        completed = [dict(row) for row in rows if row["disposition"] == "completed"]
+        outstanding = [
+            dict(row) for row in rows if row["disposition"] != "completed"
+        ]
+        return {
+            "reason": reason,
+            "terminal_outcome": outcome,
+            "lifecycle_before": lifecycle_before,
+            "completed_work": completed,
+            "outstanding_work": outstanding,
+            "recovery_disposition": "",
+        }
+
+    def _reconcile_registered_prs_in_transaction(
+        self, sprint_id: int
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        if not self.con.in_transaction:
+            raise RuntimeError("PR reconciliation requires an active transaction")
+        rows = self.con.execute(
+            "SELECT pr.registered_pr_id,t.transition_key,t.normalized_state "
+            "FROM sprint_registered_prs pr JOIN sprint_pr_transitions t "
+            "ON t.transition_id=(SELECT MAX(latest.transition_id) "
+            "FROM sprint_pr_transitions latest "
+            "WHERE latest.registered_pr_id=pr.registered_pr_id) "
+            "WHERE pr.sprint_id=? ORDER BY pr.registered_pr_id",
+            (sprint_id,),
+        ).fetchall()
+        projected: list[int] = []
+        resolved: list[int] = []
+        units = SprintWorkUnitStore(self.con)
+        for row in rows:
+            registered_pr_id = int(row["registered_pr_id"])
+            unit_ids = tuple(
+                int(item[0])
+                for item in self.con.execute(
+                    "SELECT work_unit_id FROM sprint_pr_work_units "
+                    "WHERE registered_pr_id=? ORDER BY work_unit_id",
+                    (registered_pr_id,),
+                )
+            )
+            if row["normalized_state"] == "merged":
+                incomplete = tuple(
+                    int(item[0])
+                    for item in self.con.execute(
+                        "SELECT work_unit_id FROM sprint_work_units "
+                        "WHERE work_unit_id IN ("
+                        + ",".join("?" for _ in unit_ids)
+                        + ") AND disposition<>'completed' ORDER BY work_unit_id",
+                        unit_ids,
+                    )
+                ) if unit_ids else ()
+                if incomplete:
+                    units.complete_from_merge_in_transaction(
+                        sprint_id,
+                        unit_ids,
+                        transition_key=str(row["transition_key"]),
+                        dispatch=False,
+                    )
+                    projected.extend(incomplete)
+            elif row["normalized_state"] == "closed":
+                for unit_id in unit_ids:
+                    resolved.extend(
+                        self._resolve_review_expectations_in_transaction(
+                            unit_id,
+                            "registered_pr.closed_without_merge",
+                        )
+                    )
+        return tuple(sorted(set(projected))), tuple(sorted(set(resolved)))
+
+    def _resolve_review_expectations_in_transaction(
+        self, work_unit_id: int, resolution: str
+    ) -> tuple[int, ...]:
+        rows = self.con.execute(
+            "SELECT e.message_id FROM sprint_liveness_expectations e "
+            "JOIN sprint_messages m ON m.message_id=e.message_id "
+            "WHERE m.work_unit_id=? AND m.message_kind='review_request' "
+            "AND e.resolved_at IS NULL ORDER BY e.message_id",
+            (work_unit_id,),
+        ).fetchall()
+        message_ids = tuple(int(row[0]) for row in rows)
+        if message_ids:
+            marks = ",".join("?" for _ in message_ids)
+            self.con.execute(
+                "UPDATE sprint_liveness_expectations SET resolved_at=datetime('now'),"
+                "resolution=?,next_evaluation_at=NULL "
+                f"WHERE message_id IN ({marks}) AND resolved_at IS NULL",
+                (resolution, *message_ids),
+            )
+        return message_ids
+
+    def _spec_drift(self, sprint_id: int) -> dict[int, dict[str, str]]:
+        drift: dict[int, dict[str, str]] = {}
+        rows = self.con.execute(
+            "SELECT ss.document_id,ss.bound_revision_sha256,d.body "
+            "FROM sprint_specs ss JOIN documents d USING (document_id) "
+            "WHERE ss.sprint_id=? ORDER BY ss.document_id",
+            (sprint_id,),
+        ).fetchall()
+        for row in rows:
+            current = hashlib.sha256((row["body"] or "").encode()).hexdigest()
+            if current != row["bound_revision_sha256"]:
+                drift[int(row["document_id"])] = {
+                    "bound_revision_sha256": str(row["bound_revision_sha256"]),
+                    "current_revision_sha256": current,
+                }
+        return drift
+
+    def _local_reconciliation_anomalies(self, sprint_id: int) -> tuple[str, ...]:
+        anomalies = [
+            f"participant {row['participant_id']} ({row['role']}) has no usable capacity"
+            for row in self.con.execute(
+                "SELECT p.participant_id,p.role FROM sprint_participants p "
+                "JOIN shells sh USING (shell_id) WHERE p.sprint_id=? "
+                "AND (sh.is_deleted<>0 OR p.current_conversation_id IS NULL) "
+                "ORDER BY p.participant_id",
+                (sprint_id,),
+            )
+        ]
+        anomalies.extend(
+            f"wake {row['wake_id']} targets a participant without a current conversation"
+            for row in self.con.execute(
+                "SELECT w.wake_id FROM sprint_wake_outbox w "
+                "JOIN sprint_participants p ON p.participant_id=w.participant_id "
+                "WHERE w.sprint_id=? AND w.state IN ('pending','delivering') "
+                "AND p.current_conversation_id IS NULL ORDER BY w.wake_id",
+                (sprint_id,),
+            )
+        )
+        return tuple(anomalies)
+
+    def _reconciliation_evidence(
+        self,
+        sprint_id: int,
+        *,
+        trigger: str,
+        projected_work_unit_ids: Iterable[int],
+        resolved_review_message_ids: Iterable[int],
+        spec_drift: dict[int, dict[str, str]],
+        anomalies: Iterable[str],
+    ) -> dict:
+        return {
+            "trigger": trigger,
+            "native_runs": [
+                dict(row)
+                for row in self.con.execute(
+                    "SELECT r.run_id,r.state,r.heartbeat_at,r.lease_expires_at,"
+                    "EXISTS(SELECT 1 FROM conversation_events e "
+                    "WHERE e.run_id=r.run_id "
+                    "AND e.event_type='run.interrupt.requested') interrupt_requested "
+                    "FROM conversation_runs r "
+                    "JOIN sprint_participant_conversations pc "
+                    "ON pc.conversation_id=r.conversation_id "
+                    "JOIN sprint_participants p "
+                    "ON p.participant_id=pc.sprint_participant_id "
+                    "WHERE p.sprint_id=? ORDER BY r.run_id",
+                    (sprint_id,),
+                )
+            ],
+            "unread_message_ids": [
+                int(row[0])
+                for row in self.con.execute(
+                    "SELECT message_id FROM sprint_messages WHERE sprint_id=? "
+                    "AND read_at IS NULL ORDER BY message_id",
+                    (sprint_id,),
+                )
+            ],
+            "pending_wakes": [
+                dict(row)
+                for row in self.con.execute(
+                    "SELECT wake_id,participant_id,state,attempt_count,available_at,"
+                    "lease_expires_at FROM sprint_wake_outbox WHERE sprint_id=? "
+                    "AND state IN ('pending','delivering') ORDER BY wake_id",
+                    (sprint_id,),
+                )
+            ],
+            "work_units": [
+                dict(row)
+                for row in self.con.execute(
+                    "SELECT work_unit_id,assigned_shell_id,disposition "
+                    "FROM sprint_work_units WHERE sprint_id=? ORDER BY work_unit_id",
+                    (sprint_id,),
+                )
+            ],
+            "registered_prs": [
+                dict(row)
+                for row in self.con.execute(
+                    "SELECT pr.registered_pr_id,pr.repository,pr.pr_number,"
+                    "t.normalized_state,t.observed_head_sha "
+                    "FROM sprint_registered_prs pr LEFT JOIN sprint_pr_transitions t "
+                    "ON t.transition_id=(SELECT MAX(latest.transition_id) "
+                    "FROM sprint_pr_transitions latest "
+                    "WHERE latest.registered_pr_id=pr.registered_pr_id) "
+                    "WHERE pr.sprint_id=? ORDER BY pr.registered_pr_id",
+                    (sprint_id,),
+                )
+            ],
+            "participant_capacity": [
+                dict(row)
+                for row in self.con.execute(
+                    "SELECT p.participant_id,p.shell_id,p.role,p.disposition,"
+                    "CASE WHEN sh.is_deleted=0 AND p.current_conversation_id IS NOT NULL "
+                    "THEN 1 ELSE 0 END available "
+                    "FROM sprint_participants p JOIN shells sh USING (shell_id) "
+                    "WHERE p.sprint_id=? ORDER BY p.participant_id",
+                    (sprint_id,),
+                )
+            ],
+            "projected_work_unit_ids": list(projected_work_unit_ids),
+            "resolved_review_message_ids": list(resolved_review_message_ids),
+            "spec_drift": {str(key): value for key, value in spec_drift.items()},
+            "anomalies": list(anomalies),
+        }
+
+    def _planner_participant_id(self, sprint_id: int) -> int:
+        row = self.con.execute(
+            "SELECT participant_id FROM sprint_participants "
+            "WHERE sprint_id=? AND role='planner'",
+            (sprint_id,),
+        ).fetchone()
+        if row is None:
+            raise SprintInvariantError("Sprint has no Planner participant")
+        return int(row[0])
+
+    def _queue_planner_notice(
+        self,
+        sprint_id: int,
+        *,
+        body: str,
+        idempotency_key: str,
+    ) -> tuple[int, tuple[str, ...]]:
+        participant_id = self._planner_participant_id(sprint_id)
+        participant = self.con.execute(
+            "SELECT current_conversation_id FROM sprint_participants "
+            "WHERE participant_id=?",
+            (participant_id,),
+        ).fetchone()
+        existing = self.con.execute(
+            "SELECT message_id FROM sprint_messages WHERE idempotency_key=?",
+            (idempotency_key,),
+        ).fetchone()
+        if existing is None:
+            message_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_messages "
+                    "(sprint_id,to_participant_id,message_kind,body,actionable,"
+                    "idempotency_key) VALUES (?,?,'notification',?,0,?)",
+                    (sprint_id, participant_id, body, idempotency_key),
+                ).lastrowid
+            )
+        else:
+            message_id = int(existing[0])
+        conversation_id = participant["current_conversation_id"]
+        if conversation_id is None:
+            return message_id, ()
+        conversation = self.con.execute(
+            "SELECT state FROM conversations WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()
+        if conversation is None or conversation["state"] == "closed":
+            return message_id, ()
+        prompt = f"{body}\n\nCheck the Sprint inbox and recovery evidence."
+        prompt_key = f"{idempotency_key}:planner-conversation"
+        queued = self.con.execute(
+            "SELECT message_id FROM conversation_messages "
+            "WHERE conversation_id=? AND idempotency_key=?",
+            (conversation_id, prompt_key),
+        ).fetchone()
+        if queued is None:
+            conversation_message_id = int(
+                self.con.execute(
+                    "INSERT INTO conversation_messages "
+                    "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                    "idempotency_key,request_hash,state) "
+                    "VALUES (?,'engine','sprint-recovery','prompt',?,?,?,'queued')",
+                    (
+                        conversation_id,
+                        prompt,
+                        prompt_key,
+                        hashlib.sha256(prompt.encode()).hexdigest(),
+                    ),
+                ).lastrowid
+            )
+            self.con.execute(
+                "INSERT INTO conversation_outbox (conversation_id,message_id) "
+                "VALUES (?,?)",
+                (conversation_id, conversation_message_id),
+            )
+            sequence = int(
+                self.con.execute(
+                    "SELECT COALESCE(MAX(sequence),0)+1 "
+                    "FROM conversation_events WHERE conversation_id=?",
+                    (conversation_id,),
+                ).fetchone()[0]
+            )
+            self.con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id) "
+                "VALUES (?,?,'message.accepted',?,?)",
+                (
+                    conversation_id,
+                    sequence,
+                    json.dumps(
+                        {
+                            "message_id": conversation_message_id,
+                            "queue_state": "queued",
+                            "source": "sprint_recovery",
+                        },
+                        sort_keys=True,
+                    ),
+                    conversation_message_id,
+                ),
+            )
+            target_state = (
+                conversation["state"]
+                if conversation["state"] in {"queued", "running"}
+                else "queued"
+            )
+            self.con.execute(
+                "UPDATE conversations SET state=?,last_activity_at=datetime('now'),"
+                "version=version+1 WHERE conversation_id=?",
+                (target_state, conversation_id),
+            )
+        return message_id, (str(conversation_id),)
+
+    def _signal_interrupts_and_notifications(
+        self, receipt: PauseReceipt | AbortReceipt
+    ) -> None:
+        self._signal_notifications(receipt.notification_conversation_ids)
+        for run_id in receipt.interrupt_run_ids:
+            try:
+                self.interrupt_run(run_id)
+            except Exception as exc:  # noqa: BLE001 - intent remains retryable
+                with db_driver.write_transaction(
+                    self.con, "sprint.pause.interrupt_delivery"
+                ):
+                    sprint_id = self.con.execute(
+                        "SELECT p.sprint_id FROM conversation_runs r "
+                        "JOIN sprint_participant_conversations pc "
+                        "ON pc.conversation_id=r.conversation_id "
+                        "JOIN sprint_participants p "
+                        "ON p.participant_id=pc.sprint_participant_id "
+                        "WHERE r.run_id=?",
+                        (run_id,),
+                    ).fetchone()[0]
+                    self._event(
+                        int(sprint_id),
+                        "pause.interrupt_delivery_failed",
+                        LifecycleActor("system"),
+                        {"run_id": run_id, "error": str(exc)[:2000]},
+                    )
+
+    def _signal_notifications(self, conversation_ids: Iterable[str]) -> None:
+        for conversation_id in sorted(set(conversation_ids)):
+            conversation_events.notify(conversation_id)
+        if tuple(conversation_ids):
+            self.notify_commit()
+
+    @staticmethod
+    def _required_text(value: str, label: str, limit: int) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError(f"{label} is empty")
+        if len(value) > limit:
+            raise ValueError(f"{label} exceeds {limit} characters")
+        return value
 
     def _sprint(self, sprint_id: int) -> sqlite3.Row:
         row = self.con.execute(
@@ -648,6 +1447,7 @@ class SprintWorkUnitStore:
         work_unit_ids: Iterable[int],
         *,
         transition_key: str,
+        dispatch: bool = True,
     ) -> list[int]:
         """Project an observed merge, then release newly ready work atomically."""
         if not self.con.in_transaction:
@@ -662,7 +1462,7 @@ class SprintWorkUnitStore:
         ).fetchone()
         if sprint is None:
             raise KeyError(f"unknown Sprint: {sprint_id}")
-        if sprint["lifecycle"] != "armed":
+        if sprint["lifecycle"] not in {"armed", "paused"}:
             return []
         placeholders = ",".join("?" for _ in unit_ids)
         units = self.con.execute(
@@ -709,7 +1509,7 @@ class SprintWorkUnitStore:
                 },
                 actor_kind="system",
             )
-        if not changed:
+        if not changed or not dispatch or sprint["lifecycle"] != "armed":
             return []
         planner = self._require_participant(
             sprint_id,
@@ -1026,6 +1826,7 @@ class ArmedServiceSwitch:
         self.callbacks = tuple(callbacks)
 
     def recover_on_startup(self) -> bool:
+        self.store.recover_on_startup()
         return self._run("startup")
 
     def tick(self) -> bool:

--- a/.super-coder/scripts/sprint_liveness.py
+++ b/.super-coder/scripts/sprint_liveness.py
@@ -599,6 +599,36 @@ class SprintLivenessMonitor:
             ).rowcount
         return changed == 1
 
+    def resolve_review_requests_for_work_unit_in_transaction(
+        self,
+        work_unit_id: int,
+        resolution: str,
+    ) -> tuple[int, ...]:
+        """Resolve every live review expectation owned by one editing lane."""
+        if not self.con.in_transaction:
+            raise RuntimeError("liveness resolution requires an active transaction")
+        resolution = resolution.strip()
+        if not resolution:
+            raise ValueError("liveness expectation resolution is empty")
+        rows = self.con.execute(
+            "SELECT e.message_id FROM sprint_liveness_expectations e "
+            "JOIN sprint_messages m ON m.message_id=e.message_id "
+            "WHERE m.work_unit_id=? AND m.message_kind='review_request' "
+            "AND e.resolved_at IS NULL ORDER BY e.message_id",
+            (work_unit_id,),
+        ).fetchall()
+        message_ids = tuple(int(row[0]) for row in rows)
+        if not message_ids:
+            return ()
+        marks = ",".join("?" for _ in message_ids)
+        self.con.execute(
+            "UPDATE sprint_liveness_expectations SET resolved_at=?,resolution=?,"
+            "next_evaluation_at=NULL "
+            f"WHERE message_id IN ({marks}) AND resolved_at IS NULL",
+            (_stamp(self.now()), resolution, *message_ids),
+        )
+        return message_ids
+
     def _apply(
         self, message_id: int, snapshot: EvidenceSnapshot, now: datetime
     ) -> EvaluationOutcome | None:

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 import db_driver
+import sprint_liveness
 from github_pull_requests import (
     GitHubPullRequestReader,
     GitHubReadError,
@@ -50,6 +51,7 @@ class TransitionReceipt:
     transition_id: int
     normalized_state: str
     transition_key: str
+    resolved_review_message_ids: tuple[int, ...] = ()
 
 
 @dataclass
@@ -225,6 +227,7 @@ class SprintPRWatcher:
         self.monotonic = monotonic
         self.registration = SprintPRRegistrationStore(con)
         self.messages = SprintMessageStore(con)
+        self.liveness = sprint_liveness.SprintLivenessMonitor(con)
         self.review_loop = SprintReviewLoopStore(
             con,
             repo_root=self.repo_root,
@@ -334,7 +337,6 @@ class SprintPRWatcher:
         pull_request: PullRequest,
         trigger: str,
     ) -> TransitionReceipt | None:
-        registered_pr_id = int(registered["registered_pr_id"])
         if pull_request.number != int(registered["pr_number"]):
             self._poll_failed(
                 registered,
@@ -342,6 +344,37 @@ class SprintPRWatcher:
                 GitHubReadError("GitHub returned a different PR identity"),
             )
             return None
+        with db_driver.write_transaction(self.con, "sprint.pr.observe"):
+            receipt = self.observe_in_transaction(
+                int(registered["registered_pr_id"]),
+                pull_request,
+                trigger=trigger,
+            )
+        if receipt is not None:
+            self._backoff.pop(int(registered["registered_pr_id"]), None)
+        return receipt
+
+    def observe_in_transaction(
+        self,
+        registered_pr_id: int,
+        pull_request: PullRequest,
+        *,
+        trigger: str,
+        dispatch: bool = True,
+    ) -> TransitionReceipt | None:
+        """Apply a pre-read observation inside an owner reconciliation commit."""
+        if not self.con.in_transaction:
+            raise RuntimeError("PR observation requires an active transaction")
+        registered = self.con.execute(
+            "SELECT registered_pr_id,sprint_id,repository,pr_number "
+            "FROM sprint_registered_prs WHERE registered_pr_id=?",
+            (registered_pr_id,),
+        ).fetchone()
+        if registered is None:
+            raise KeyError(f"unknown registered PR: {registered_pr_id}")
+        registered_pr_id = int(registered["registered_pr_id"])
+        if pull_request.number != int(registered["pr_number"]):
+            raise GitHubReadError("GitHub returned a different PR identity")
         state = normalize_state(pull_request)
         evidence = {
             "base_ref": pull_request.base_ref,
@@ -355,66 +388,75 @@ class SprintPRWatcher:
             "trigger": trigger,
             "url": pull_request.url,
         }
-        with db_driver.write_transaction(self.con, "sprint.pr.observe"):
-            current = self.con.execute(
-                "SELECT p.*,s.lifecycle FROM sprint_registered_prs p "
-                "JOIN sprints s USING (sprint_id) "
-                "WHERE p.registered_pr_id=?",
-                (registered_pr_id,),
-            ).fetchone()
-            if current is None or current["lifecycle"] != "armed":
-                return None
-            latest = self.con.execute(
-                "SELECT transition_key,normalized_state "
-                "FROM sprint_pr_transitions WHERE registered_pr_id=? "
-                "ORDER BY transition_id DESC LIMIT 1",
-                (registered_pr_id,),
-            ).fetchone()
-            if latest is not None and latest["normalized_state"] == state:
-                self._backoff.pop(registered_pr_id, None)
-                return None
-            parent_key = latest["transition_key"] if latest is not None else "root"
-            transition_key = hashlib.sha256(
-                f"{registered_pr_id}:{parent_key}:{state}".encode()
-            ).hexdigest()
-            transition_id = int(
-                self.con.execute(
-                    "INSERT INTO sprint_pr_transitions "
-                    "(registered_pr_id,normalized_state,transition_key,"
-                    "observed_head_sha,evidence) VALUES (?,?,?,?,?)",
-                    (
-                        registered_pr_id,
-                        state,
-                        transition_key,
-                        pull_request.head_sha,
-                        json.dumps(evidence, sort_keys=True),
-                    ),
-                ).lastrowid
-            )
-            self._route_transition(current, transition_key, state, pull_request)
-            if state == "merged":
-                self.review_loop.observe_merge_in_transaction(
-                    registered_pr_id,
-                    transition_key=transition_key,
-                )
+        current = self.con.execute(
+            "SELECT p.*,s.lifecycle FROM sprint_registered_prs p "
+            "JOIN sprints s USING (sprint_id) "
+            "WHERE p.registered_pr_id=?",
+            (registered_pr_id,),
+        ).fetchone()
+        if current is None or current["lifecycle"] != "armed":
+            return None
+        latest = self.con.execute(
+            "SELECT transition_key,normalized_state "
+            "FROM sprint_pr_transitions WHERE registered_pr_id=? "
+            "ORDER BY transition_id DESC LIMIT 1",
+            (registered_pr_id,),
+        ).fetchone()
+        if latest is not None and latest["normalized_state"] == state:
+            self._backoff.pop(registered_pr_id, None)
+            return None
+        parent_key = latest["transition_key"] if latest is not None else "root"
+        transition_key = hashlib.sha256(
+            f"{registered_pr_id}:{parent_key}:{state}".encode()
+        ).hexdigest()
+        transition_id = int(
             self.con.execute(
-                "INSERT INTO sprint_events "
-                "(sprint_id,event_type,actor_kind,payload) "
-                "VALUES (?,'pr.transition','system',?)",
+                "INSERT INTO sprint_pr_transitions "
+                "(registered_pr_id,normalized_state,transition_key,"
+                "observed_head_sha,evidence) VALUES (?,?,?,?,?)",
                 (
-                    current["sprint_id"],
-                    json.dumps(
-                        {
-                            "normalized_state": state,
-                            "registered_pr_id": registered_pr_id,
-                            "transition_id": transition_id,
-                        },
-                        sort_keys=True,
-                    ),
+                    registered_pr_id,
+                    state,
+                    transition_key,
+                    pull_request.head_sha,
+                    json.dumps(evidence, sort_keys=True),
                 ),
+            ).lastrowid
+        )
+        resolved_review_message_ids = self._route_transition(
+            current,
+            transition_key,
+            state,
+            pull_request,
+        )
+        if state == "merged":
+            self.review_loop.observe_merge_in_transaction(
+                registered_pr_id,
+                transition_key=transition_key,
+                dispatch=dispatch,
             )
-        self._backoff.pop(registered_pr_id, None)
-        return TransitionReceipt(transition_id, state, transition_key)
+        self.con.execute(
+            "INSERT INTO sprint_events "
+            "(sprint_id,event_type,actor_kind,payload) "
+            "VALUES (?,'pr.transition','system',?)",
+            (
+                current["sprint_id"],
+                json.dumps(
+                    {
+                        "normalized_state": state,
+                        "registered_pr_id": registered_pr_id,
+                        "transition_id": transition_id,
+                    },
+                    sort_keys=True,
+                ),
+            ),
+        )
+        return TransitionReceipt(
+            transition_id,
+            state,
+            transition_key,
+            resolved_review_message_ids,
+        )
 
     def _route_transition(
         self,
@@ -422,7 +464,7 @@ class SprintPRWatcher:
         transition_key: str,
         state: str,
         pull_request: PullRequest,
-    ) -> None:
+    ) -> tuple[int, ...]:
         sprint_id = int(registered["sprint_id"])
         registered_pr_id = int(registered["registered_pr_id"])
         unit_rows = self.con.execute(
@@ -435,6 +477,14 @@ class SprintPRWatcher:
         work_unit_id = (
             int(unit_rows[0]["work_unit_id"]) if len(unit_rows) == 1 else None
         )
+        resolved_review_message_ids: tuple[int, ...] = ()
+        if state == "closed" and work_unit_id is not None:
+            resolved_review_message_ids = (
+                self.liveness.resolve_review_requests_for_work_unit_in_transaction(
+                    work_unit_id,
+                    "registered_pr.closed_without_merge",
+                )
+            )
         recipients: dict[int, bool] = {
             int(registered["owner_participant_id"]): state in {"red", "green"}
         }
@@ -478,6 +528,7 @@ class SprintPRWatcher:
                     f"pr-transition:{transition_key}:participant:{participant_id}"
                 ),
             )
+        return resolved_review_message_ids
 
     def _poll_failed(
         self,

--- a/.super-coder/scripts/sprint_recovery.py
+++ b/.super-coder/scripts/sprint_recovery.py
@@ -1,0 +1,207 @@
+"""Pause, resume, abort, and restart coordination for Sprints v2."""
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+import conversation_broker
+from github_pull_requests import GitHubPullRequestReader, PullRequest
+from sprint_domain import (
+    AbortReceipt,
+    LifecycleActor,
+    PauseReceipt,
+    ResumeReceipt,
+    SprintLifecycleStore,
+)
+from sprint_pr_watcher import SprintPRWatcher
+
+
+@dataclass(frozen=True)
+class _ObservedPR:
+    registered_pr_id: int
+    pull_request: PullRequest
+
+
+class SprintRecoveryCoordinator:
+    """Keep external reads outside SQLite and commit one reconciled resume."""
+
+    def __init__(
+        self,
+        con: sqlite3.Connection,
+        *,
+        repo_root: str | Path,
+        reader_factory: Callable[[str], Any] | None = None,
+        interrupt_run: Callable[[int], bool] | None = None,
+        notify_commit: Callable[[], bool] | None = None,
+        native_reconciler: Callable[[tuple[int, ...]], tuple[str, ...]] | None = None,
+    ) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+        self.repo_root = Path(repo_root)
+        self.reader_factory = reader_factory or (
+            lambda repository: GitHubPullRequestReader(
+                self.repo_root,
+                repository=repository,
+            )
+        )
+        self.native_reconciler = native_reconciler or self._reconcile_native_runs
+        self.lifecycle = SprintLifecycleStore(
+            con,
+            interrupt_run=interrupt_run,
+            notify_commit=notify_commit,
+        )
+        self.watcher = SprintPRWatcher(
+            con,
+            repo_root=self.repo_root,
+            reader_factory=self.reader_factory,
+        )
+
+    def pause(
+        self,
+        sprint_id: int,
+        actor: LifecycleActor,
+        *,
+        reason: str,
+        detail: dict | None = None,
+    ) -> PauseReceipt:
+        return self.lifecycle.pause(
+            sprint_id,
+            actor,
+            reason=reason,
+            detail=detail,
+        )
+
+    def resume(
+        self,
+        sprint_id: int,
+        actor: LifecycleActor,
+        *,
+        reason: str | None = None,
+    ) -> ResumeReceipt:
+        native_run_ids = tuple(
+            int(row[0])
+            for row in self.con.execute(
+                "SELECT DISTINCT r.run_id FROM conversation_runs r "
+                "JOIN sprint_participant_conversations pc "
+                "ON pc.conversation_id=r.conversation_id "
+                "JOIN sprint_participants p "
+                "ON p.participant_id=pc.sprint_participant_id "
+                "WHERE p.sprint_id=? AND r.state IN ('leased','starting','running') "
+                "ORDER BY r.run_id",
+                (sprint_id,),
+            )
+        )
+        native_anomalies = self.native_reconciler(native_run_ids)
+        observations, pr_anomalies = self._read_registered_prs(sprint_id)
+        anomalies = (*native_anomalies, *pr_anomalies)
+        resolved_review_message_ids: list[int] = []
+
+        def reconcile(_con: sqlite3.Connection) -> None:
+            for observation in observations:
+                receipt = self.watcher.observe_in_transaction(
+                    observation.registered_pr_id,
+                    observation.pull_request,
+                    trigger="resume",
+                    dispatch=False,
+                )
+                if receipt is not None:
+                    resolved_review_message_ids.extend(
+                        receipt.resolved_review_message_ids
+                    )
+
+        receipt = self.lifecycle.resume(
+            sprint_id,
+            actor,
+            reason=reason,
+            reconcile_in_transaction=reconcile,
+            external_anomalies=anomalies,
+        )
+        return replace(
+            receipt,
+            resolved_review_message_ids=tuple(
+                sorted(
+                    set(receipt.resolved_review_message_ids)
+                    | set(resolved_review_message_ids)
+                )
+            ),
+        )
+
+    @staticmethod
+    def _reconcile_native_runs(run_ids: tuple[int, ...]) -> tuple[str, ...]:
+        if not run_ids:
+            return ()
+        broker = conversation_broker.service()
+        if broker is None or not broker.is_alive():
+            return (
+                (
+                    "native-run reconciliation deferred: conversation broker "
+                    "unavailable for run(s) "
+                    f"{','.join(str(run_id) for run_id in run_ids)}"
+                ),
+            )
+        broker.notify()
+        return ()
+
+    def abort(
+        self,
+        sprint_id: int,
+        actor: LifecycleActor,
+        *,
+        reason: str,
+        terminal_outcome: str = "aborted",
+    ) -> AbortReceipt:
+        return self.lifecycle.abort(
+            sprint_id,
+            actor,
+            reason=reason,
+            terminal_outcome=terminal_outcome,
+        )
+
+    def recover_on_startup(self, sprint_id: int) -> str:
+        """Recover one non-terminal state; only armed state performs PR reads."""
+        row = self.con.execute(
+            "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+            (sprint_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown Sprint: {sprint_id}")
+        lifecycle = str(row["lifecycle"])
+        if lifecycle not in {"prepared", "armed", "paused"}:
+            return lifecycle
+        self.lifecycle.recover_on_startup(sprint_id)
+        if lifecycle == "armed":
+            self.watcher.poll_once(startup=True)
+        return lifecycle
+
+    def _read_registered_prs(
+        self,
+        sprint_id: int,
+    ) -> tuple[tuple[_ObservedPR, ...], tuple[str, ...]]:
+        rows = self.con.execute(
+            "SELECT registered_pr_id,repository,pr_number "
+            "FROM sprint_registered_prs WHERE sprint_id=? "
+            "ORDER BY registered_pr_id",
+            (sprint_id,),
+        ).fetchall()
+        observations: list[_ObservedPR] = []
+        anomalies: list[str] = []
+        for row in rows:
+            repository = str(row["repository"])
+            pr_number = int(row["pr_number"])
+            try:
+                pull_request = self.reader_factory(repository).get(pr_number)
+                if pull_request.number != pr_number:
+                    raise RuntimeError("GitHub returned a different PR identity")
+            except Exception as exc:  # noqa: BLE001 - external faults inform
+                anomalies.append(
+                    f"{repository}#{pr_number} reconciliation failed: "
+                    f"{str(exc).strip() or exc.__class__.__name__}"
+                )
+                continue
+            observations.append(
+                _ObservedPR(int(row["registered_pr_id"]), pull_request)
+            )
+        return tuple(observations), tuple(anomalies)

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -272,6 +272,7 @@ class SprintReviewLoopStore:
         registered_pr_id: int,
         *,
         transition_key: str,
+        dispatch: bool = True,
     ) -> list[int]:
         if not self.con.in_transaction:
             raise RuntimeError("merge observation requires an active transaction")
@@ -293,6 +294,7 @@ class SprintReviewLoopStore:
             int(row["sprint_id"]),
             unit_ids,
             transition_key=transition_key,
+            dispatch=dispatch,
         )
 
     def _lane(self, sprint_id: int, registered_pr_id: int) -> sqlite3.Row:

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -10,6 +10,7 @@
     ".super-coder/scripts/sprint_participant_chats.py",
     ".super-coder/scripts/sprint_runtime.py",
     ".super-coder/scripts/sprint_pr_watcher.py",
+    ".super-coder/scripts/sprint_recovery.py",
     ".super-coder/scripts/sprint_review_loop.py",
     ".super-coder/migrations/0144_remove_sprint_v1.sql",
     "tests/fixtures/sprint_removal/build_pre_removal_fixture.py",
@@ -23,6 +24,7 @@
     "tests/test_sprint_participant_chats.py",
     "tests/test_sprint_work_dispatch.py",
     "tests/test_sprint_pr_watcher.py",
+    "tests/test_sprint_recovery.py",
     "tests/test_sprint_review_loop.py"
   ],
   "baseline_migration_ledger": {

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -1,0 +1,556 @@
+"""Stage 8 gates for Sprint pause, resume, abort, and restart recovery."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path[:0] = [str(SCRIPTS), str(ROOT / "tests")]
+
+import sprint_domain
+import sprint_recovery
+from github_pull_requests import GitHubReadError
+from test_sprint_pr_watcher import SprintPRWatcherCase, pull_request
+from test_sprint_review_loop import SprintReviewLoopCase
+from test_sprint_v2_domain import SprintDomainCase
+
+
+class SprintRecoveryCase(SprintPRWatcherCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.interrupts: list[int] = []
+        self.notifications = 0
+
+    def coordinator(self) -> sprint_recovery.SprintRecoveryCoordinator:
+        def interrupt(run_id: int) -> bool:
+            self.assertFalse(self.con.in_transaction)
+            self.assertEqual(
+                "paused",
+                self.con.execute(
+                    "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                    (self.sprint_id,),
+                ).fetchone()[0],
+            )
+            self.interrupts.append(run_id)
+            return True
+
+        def notify() -> bool:
+            self.notifications += 1
+            return True
+
+        return sprint_recovery.SprintRecoveryCoordinator(
+            self.con,
+            repo_root=ROOT,
+            reader_factory=lambda _repository: self.reader,
+            interrupt_run=interrupt,
+            notify_commit=notify,
+        )
+
+    def add_live_run(self, shell_id: int = 1) -> int:
+        participant = self.con.execute(
+            "SELECT current_conversation_id FROM sprint_participants "
+            "WHERE sprint_id=? AND shell_id=?",
+            (self.sprint_id, shell_id),
+        ).fetchone()
+        conversation_id = str(participant[0])
+        token = self.con.execute(
+            "SELECT COUNT(*)+1 FROM conversation_runs"
+        ).fetchone()[0]
+        message_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state) "
+                "VALUES (?,'engine','test','prompt','active Sprint turn',?,?,"
+                "'running')",
+                (conversation_id, f"active:{token}", f"active:{token}"),
+            ).lastrowid
+        )
+        run_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,state,lease_owner,"
+                "lease_expires_at,started_at,heartbeat_at) "
+                "VALUES (?,?,?,'running','test-broker','2999-01-01 00:00:00',"
+                "'2026-08-01 00:00:00','2026-08-01 00:00:00')",
+                (conversation_id, shell_id, message_id),
+            ).lastrowid
+        )
+        self.con.execute(
+            "UPDATE conversations SET state='queued' WHERE conversation_id=?",
+            (conversation_id,),
+        )
+        self.con.execute(
+            "UPDATE conversations SET state='running' WHERE conversation_id=?",
+            (conversation_id,),
+        )
+        self.con.commit()
+        return run_id
+
+    def test_participant_pause_atomically_persists_report_interrupt_and_notice(self):
+        self.register()
+        run_id = self.add_live_run()
+        coordinator = self.coordinator()
+
+        receipt = coordinator.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="GitHub state cannot be trusted",
+            detail={"provider": "github"},
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual((run_id,), receipt.interrupt_run_ids)
+        self.assertEqual([run_id], self.interrupts)
+        self.assertEqual(1, self.notifications)
+        self.assertEqual(
+            ("paused", "run.interrupt.requested"),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,e.event_type FROM sprints s "
+                    "JOIN conversation_events e ON e.run_id=? "
+                    "WHERE s.sprint_id=? "
+                    "AND e.event_type='run.interrupt.requested'",
+                    (run_id, self.sprint_id),
+                ).fetchone()
+            ),
+        )
+        report = json.loads(
+            self.con.execute(
+                "SELECT body FROM sprint_reports WHERE report_id=?",
+                (receipt.report_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual("GitHub state cannot be trusted", report["reason"])
+        self.assertEqual(
+            {"kind": "participant", "shell_id": 1}, report["actor"]
+        )
+        self.assertEqual([run_id], [row["run_id"] for row in report["deterministic"]["active_turns"]])
+        self.assertEqual(
+            [self.unit_id],
+            [row["work_unit_id"] for row in report["deterministic"]["work_units"]],
+        )
+        self.assertEqual(
+            ["red"],
+            [row["normalized_state"] for row in report["deterministic"]["registered_prs"]],
+        )
+        self.assertEqual("", report["integrity_threat"])
+        self.assertEqual("", report["judgment"])
+        self.assertEqual("", report["recommendation"])
+        self.assertEqual(
+            [(self.planner_id, 0, "Sprint 1 paused: GitHub state cannot be trusted")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT to_participant_id,actionable,body FROM sprint_messages "
+                    "WHERE idempotency_key LIKE 'sprint-pause:%'"
+                )
+            ],
+        )
+        self.assertEqual(
+            [("engine", "sprint-recovery", "queued")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT sender_kind,sender_ref,state FROM conversation_messages "
+                    "WHERE idempotency_key LIKE 'sprint-pause:%:planner-conversation'"
+                )
+            ],
+        )
+
+        replay = coordinator.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="GitHub state cannot be trusted",
+        )
+        self.assertFalse(replay.changed)
+        self.assertEqual(
+            (1, 1, 1),
+            tuple(
+                self.con.execute(
+                    "SELECT (SELECT COUNT(*) FROM sprint_reports WHERE report_kind='pause'),"
+                    "(SELECT COUNT(*) FROM conversation_events WHERE run_id=? "
+                    "AND event_type='run.interrupt.requested'),"
+                    "(SELECT COUNT(*) FROM sprint_messages "
+                    "WHERE idempotency_key LIKE 'sprint-pause:%')",
+                    (run_id,),
+                ).fetchone()
+            ),
+        )
+
+    def test_terminal_wake_failure_uses_the_same_pause_machinery(self):
+        run_id = self.add_live_run()
+        wake_id = int(self.send("auto-pause-wake").wake_id)
+        store = sprint_domain.SprintLifecycleStore(
+            self.con,
+            interrupt_run=lambda item: self.interrupts.append(item) or True,
+            notify_commit=lambda: True,
+        )
+
+        self.assertEqual(1, store.record_wake_failure(wake_id, "one"))
+        self.assertEqual(2, store.record_wake_failure(wake_id, "two"))
+        self.assertEqual(3, store.record_wake_failure(wake_id, "three"))
+
+        self.assertEqual([run_id], self.interrupts)
+        report = json.loads(
+            self.con.execute(
+                "SELECT body FROM sprint_reports WHERE sprint_id=? "
+                "AND report_kind='pause'",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual("wake_delivery_exhausted", report["reason"])
+        self.assertEqual(
+            {"attempts": 3, "last_error": "three", "wake_id": wake_id},
+            report["detail"],
+        )
+        self.assertEqual([run_id], [row["run_id"] for row in report["deterministic"]["active_turns"]])
+
+    def test_resume_projects_observed_merge_before_releasing_downstream(self):
+        registered = self.register()
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='merge_ready' "
+            "WHERE work_unit_id=?",
+            (self.unit_id,),
+        )
+        downstream = int(
+            self.con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output,planned_wave) "
+                "VALUES (?,1,2,'Downstream','Continue the lane',2)",
+                (self.sprint_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_work_unit_dependencies "
+            "(sprint_id,work_unit_id,depends_on_work_unit_id) VALUES (?,?,?)",
+            (self.sprint_id, downstream, self.unit_id),
+        )
+        self.con.commit()
+        coordinator = self.coordinator()
+        coordinator.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="merge observation race",
+        )
+        self.con.execute(
+            "INSERT INTO sprint_pr_transitions "
+            "(registered_pr_id,normalized_state,transition_key,observed_head_sha) "
+            "VALUES (?,'merged','paused-merge',?)",
+            (registered.registered_pr_id, "b" * 40),
+        )
+        self.con.commit()
+        self.reader.current = pull_request(state="MERGED", checks="SUCCESS", checks_failed=False)
+
+        receipt = coordinator.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="evidence reviewed",
+        )
+
+        self.assertEqual((self.unit_id,), receipt.projected_work_unit_ids)
+        self.assertEqual(1, len(receipt.dispatched_wake_ids))
+        self.assertEqual(
+            [(self.unit_id, "completed"), (downstream, "ready")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT work_unit_id,disposition FROM sprint_work_units "
+                    "WHERE work_unit_id IN (?,?) ORDER BY work_unit_id",
+                    (self.unit_id, downstream),
+                )
+            ],
+        )
+        self.assertEqual(
+            [(downstream, "work_assignment", "pending")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT work_unit_id,message_kind,disposition "
+                    "FROM sprint_messages WHERE work_unit_id=?",
+                    (downstream,),
+                )
+            ],
+        )
+
+    def test_resume_records_drift_and_github_failure_without_blocking(self):
+        self.register()
+        coordinator = self.coordinator()
+        coordinator.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="inspect drift",
+        )
+        document_id = int(
+            self.con.execute(
+                "SELECT document_id FROM sprint_specs WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.con.execute(
+            "UPDATE documents SET body='edited while paused' WHERE document_id=?",
+            (document_id,),
+        )
+        self.con.commit()
+        self.reader.current = GitHubReadError("github unavailable")
+
+        receipt = coordinator.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual((document_id,), receipt.spec_drift_document_ids)
+        self.assertEqual(
+            ("acme/repo#42 reconciliation failed: github unavailable",),
+            receipt.anomalies,
+        )
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+        payload = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='lifecycle.reconciled'",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual([str(document_id)], sorted(payload["spec_drift"]))
+        self.assertEqual(list(receipt.anomalies), payload["anomalies"])
+        self.assertEqual(
+            [(self.planner_id, 0)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT to_participant_id,actionable FROM sprint_messages "
+                    "WHERE idempotency_key LIKE 'sprint-resume:%'"
+                )
+            ],
+        )
+
+    def test_resume_surfaces_native_and_capacity_anomalies_without_blocking(self):
+        run_id = self.add_live_run()
+        coordinator = self.coordinator()
+        coordinator.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="participant capacity check",
+        )
+        self.con.execute("UPDATE shells SET is_deleted=1 WHERE shell_id=2")
+        self.con.commit()
+
+        receipt = coordinator.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+
+        self.assertEqual(
+            (
+                (
+                    "native-run reconciliation deferred: conversation broker "
+                    f"unavailable for run(s) {run_id}"
+                ),
+                f"participant {self.reviewer_id} (reviewer) has no usable capacity",
+            ),
+            receipt.anomalies,
+        )
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_messages "
+                "WHERE idempotency_key LIKE 'sprint-resume:%'",
+            ).fetchone()[0],
+        )
+
+
+class ClosedReviewRecoveryTest(SprintReviewLoopCase):
+    def test_closed_without_merge_resolves_every_review_expectation(self):
+        handoff = self.request_review()
+        self.accept_review(handoff.message_id)
+        lifecycle = sprint_domain.SprintLifecycleStore(
+            self.con,
+            interrupt_run=lambda _run_id: True,
+            notify_commit=lambda: True,
+        )
+        lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="PR ownership changed",
+        )
+        self.reader.current = pull_request(
+            state="CLOSED",
+            checks=None,
+            checks_failed=False,
+        )
+        coordinator = sprint_recovery.SprintRecoveryCoordinator(
+            self.con,
+            repo_root=ROOT,
+            reader_factory=lambda _repository: self.reader,
+            interrupt_run=lambda _run_id: True,
+            notify_commit=lambda: True,
+        )
+
+        receipt = coordinator.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+
+        self.assertEqual((handoff.message_id,), receipt.resolved_review_message_ids)
+        self.assertEqual(
+            ("registered_pr.closed_without_merge", None),
+            tuple(
+                self.con.execute(
+                    "SELECT resolution,next_evaluation_at "
+                    "FROM sprint_liveness_expectations WHERE message_id=?",
+                    (handoff.message_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            "in_review",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+            "closed PR resolution must not invent a review outcome",
+        )
+
+
+class LifecycleExitAndRestartTest(SprintDomainCase):
+    def coordinator(self) -> sprint_recovery.SprintRecoveryCoordinator:
+        def no_reader(_repository: str):
+            raise AssertionError("non-armed restart performed GitHub egress")
+
+        return sprint_recovery.SprintRecoveryCoordinator(
+            self.con,
+            repo_root=ROOT,
+            reader_factory=no_reader,
+            interrupt_run=lambda _run_id: True,
+            notify_commit=lambda: True,
+        )
+
+    def test_prepared_abort_records_stub_report_and_preserves_plan(self):
+        sprint_id, unit_id = self.create_sprint()
+        coordinator = self.coordinator()
+
+        receipt = coordinator.abort(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="Sprint will not arm",
+            terminal_outcome="discarded before arming",
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual(
+            ("aborted", "discarded before arming"),
+            tuple(
+                self.con.execute(
+                    "SELECT lifecycle,terminal_outcome FROM sprints "
+                    "WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone()
+            ),
+        )
+        report = json.loads(
+            self.con.execute(
+                "SELECT body FROM sprint_reports WHERE report_id=?",
+                (receipt.report_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual([], report["completed_work"])
+        self.assertEqual(
+            [(unit_id, "planned")],
+            [
+                (row["work_unit_id"], row["disposition"])
+                for row in report["outstanding_work"]
+            ],
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_work_units WHERE work_unit_id=?",
+                (unit_id,),
+            ).fetchone()[0],
+        )
+
+    def test_restart_recovers_prepared_armed_and_paused_without_state_drift(self):
+        sprint_id, _ = self.create_sprint()
+        coordinator = self.coordinator()
+
+        self.assertEqual("prepared", coordinator.recover_on_startup(sprint_id))
+        self.assertEqual(
+            "prepared",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()[0],
+        )
+        self.store.arm(sprint_id, 3)
+        armed = sprint_recovery.SprintRecoveryCoordinator(
+            self.con,
+            repo_root=ROOT,
+            reader_factory=lambda _repository: None,
+            interrupt_run=lambda _run_id: True,
+            notify_commit=lambda: True,
+        )
+        self.assertEqual("armed", armed.recover_on_startup(sprint_id))
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()[0],
+        )
+        self.store.pause(
+            sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="restart while paused",
+        )
+        self.assertEqual("paused", coordinator.recover_on_startup(sprint_id))
+        self.assertEqual(
+            "paused",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()[0],
+        )
+
+    def test_resume_cannot_bypass_prepared_arming_transaction(self):
+        sprint_id, _ = self.create_sprint()
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "prepared Sprints must use arm",
+        ):
+            self.store.resume(
+                sprint_id,
+                sprint_domain.LifecycleActor("planner", 3),
+            )
+        self.assertEqual(
+            ("prepared", 0, 0),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,"
+                    "(SELECT COUNT(*) FROM sprint_messages WHERE sprint_id=s.sprint_id),"
+                    "(SELECT COUNT(*) FROM sprint_events WHERE sprint_id=s.sprint_id) "
+                    "FROM sprints s WHERE s.sprint_id=?",
+                    (sprint_id,),
+                ).fetchone()
+            ),
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- centralize participant and system pause into one atomic lifecycle transaction with structured pause evidence, durable run interrupt intents, and active Planner notification
- reconcile GitHub PRs, observed-but-uncompleted merges, closed review expectations, native runs, pending work, participant capacity, and spec drift before resume dispatch
- add prepared/armed/paused restart recovery plus history-preserving prepared/armed/paused abort reports
- extend Stage 8 adversarial coverage and the v2 removal-manifest allowlist

## Judgements

- No migration: existing sprint_reports, sprint_events, conversation interrupt events, PR transitions, liveness expectations, and work-unit projections already own the facts. Decision #44 records this; adding a recovery table would duplicate truth.
- Resume publishes armed only at transaction commit, after supplied observations and local reconciliation have been applied but before ready work is dispatched.
- R1 is applied by extending the v2 allowlist without weakening any v1-removal guard.

## Verification

- focused Stage 1-8, broker, and removal seam: 126 passed
- full suite: 1,365 passed, 1 skipped
- exact committed head e41fa10: standalone sc verify passed
- render-check, py_compile, scoped Ruff, and git diff --check passed

## Notes

- No migration number claimed; unit 9 owns 0150 and 0151.
- Host-tool guidance mismatch encountered during verification is tracked separately in #866.