### PR TITLE
test: prove Sprint v2 serial and parallel composition

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -28,6 +28,7 @@ import io
 import ipaddress
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -68,6 +69,7 @@ import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, sp
 import sprint_close  # noqa: E402  (Sprints v2 conformance + report evidence)
 import sprint_domain  # noqa: E402  (Sprints v2 work dispatch authority)
 import sprint_liveness  # noqa: E402  (Sprints v2 one-shot monitor surface)
+import sprint_recovery  # noqa: E402  (Sprints v2 pause/resume reconciliation)
 import sprint_review_loop  # noqa: E402  (Sprints v2 Dev/Review command surface)
 import sprint_runtime  # noqa: E402  (armed-only Sprint dispatch + wake delivery)
 sys.path.insert(0, str(ENGINE / "api"))
@@ -1837,6 +1839,17 @@ class Handler(BaseHTTPRequestHandler):
             raise ValueError(f"{name} must be a positive integer")
         return value
 
+    @classmethod
+    def _sprint_integer_list(cls, body: dict, name: str) -> list[int]:
+        values = body.get(name)
+        if not isinstance(values, list) or not values:
+            raise ValueError(f"{name} must be a non-empty array")
+        return list(
+            dict.fromkeys(
+                cls._sprint_integer({name: item}, name) for item in values
+            )
+        )
+
     def _sprint_error(self, exc: Exception):
         if isinstance(exc, sprint_domain.SprintAuthorityError):
             return self._send(403, {"error": str(exc)})
@@ -1860,6 +1873,234 @@ class Handler(BaseHTTPRequestHandler):
             raise sprint_domain.SprintAuthorityError(
                 "only the owning Planner may trigger Sprint dispatch or monitoring"
             )
+
+    @staticmethod
+    def _sprint_planner_proxy(con, sprint_id: int, shell_id: int) -> int:
+        row = con.execute(
+            "SELECT sp.originating_planner_shell_id,caller.flavor "
+            "FROM sprints sp JOIN shells caller ON caller.shell_id=? "
+            "WHERE sp.sprint_id=?",
+            (shell_id, sprint_id),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown Sprint: {sprint_id}")
+        planner_shell_id = int(row["originating_planner_shell_id"])
+        if shell_id != planner_shell_id and row["flavor"] != "admin":
+            raise sprint_domain.SprintAuthorityError(
+                "only the owning Planner or FnB may change the Sprint plan"
+            )
+        return planner_shell_id
+
+    @staticmethod
+    def _sprint_actor(
+        con, sprint_id: int, shell_id: int
+    ) -> sprint_domain.LifecycleActor:
+        row = con.execute(
+            "SELECT caller.flavor,sp.originating_planner_shell_id,"
+            "EXISTS(SELECT 1 FROM sprint_participants p "
+            "WHERE p.sprint_id=sp.sprint_id "
+            "AND p.shell_id=caller.shell_id) participates "
+            "FROM sprints sp JOIN shells caller ON caller.shell_id=? "
+            "WHERE sp.sprint_id=?",
+            (shell_id, sprint_id),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown Sprint: {sprint_id}")
+        if row["flavor"] == "admin":
+            return sprint_domain.LifecycleActor("fnb", shell_id)
+        if int(row["originating_planner_shell_id"]) == shell_id:
+            return sprint_domain.LifecycleActor("planner", shell_id)
+        if row["participates"]:
+            return sprint_domain.LifecycleActor("participant", shell_id)
+        raise sprint_domain.SprintAuthorityError(
+            "only a Sprint participant or FnB may change lifecycle"
+        )
+
+    def _declare_sprint(self, con, shell_id: int, body: dict) -> int:
+        feature_id = self._sprint_integer(body, "feature_id")
+        approval_ids = self._sprint_integer_list(body, "spec_approval_ids")
+        participants = body.get("participants")
+        if not isinstance(participants, list) or not participants:
+            raise ValueError("participants must be a non-empty array")
+        if body.get("merge_grant_enabled") is not True:
+            raise sprint_domain.SprintInvariantError(
+                "declaration requires an explicit Sprint merge grant"
+            )
+
+        caller = con.execute(
+            "SELECT flavor FROM shells WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+            (shell_id,),
+        ).fetchone()
+        requested_planner = body.get("planner_shell_id")
+        planner_shell_id = (
+            shell_id
+            if requested_planner is None
+            else self._sprint_integer(body, "planner_shell_id")
+        )
+        if caller is None or (
+            caller["flavor"] != "admin"
+            and (caller["flavor"] != "planner" or planner_shell_id != shell_id)
+        ):
+            raise sprint_domain.SprintAuthorityError(
+                "only the originating Planner or FnB may declare a Sprint"
+            )
+        planner = con.execute(
+            "SELECT 1 FROM shells WHERE shell_id=? AND flavor='planner' "
+            "AND COALESCE(is_deleted,0)=0",
+            (planner_shell_id,),
+        ).fetchone()
+        if planner is None:
+            raise sprint_domain.SprintInvariantError(
+                "originating Planner must be an active Planner shell"
+            )
+
+        normalized: list[dict] = []
+        seen_shells: set[int] = set()
+        for participant in participants:
+            if not isinstance(participant, dict):
+                raise ValueError("each participant must be an object")
+            participant_shell_id = self._sprint_integer(
+                participant, "shell_id"
+            )
+            role = participant.get("role")
+            harness = participant.get("harness")
+            if role not in {"planner", "developer", "reviewer"}:
+                raise ValueError(
+                    "participant role must be planner, developer, or reviewer"
+                )
+            if not isinstance(harness, str) or not harness.strip():
+                raise ValueError("participant harness is required")
+            if participant_shell_id in seen_shells:
+                raise ValueError("participant shells must be unique")
+            seen_shells.add(participant_shell_id)
+            normalized.append(
+                {
+                    "shell_id": participant_shell_id,
+                    "role": role,
+                    "harness": harness.strip(),
+                    "model": participant.get("model"),
+                    "effort": participant.get("effort"),
+                    "route": participant.get("route"),
+                }
+            )
+        if not any(
+            item["shell_id"] == planner_shell_id and item["role"] == "planner"
+            for item in normalized
+        ):
+            raise sprint_domain.SprintInvariantError(
+                "originating Planner must be a Planner participant"
+            )
+
+        with db_driver.write_transaction(con, "sprint.declare"):
+            if con.execute(
+                "SELECT 1 FROM roadmap WHERE feature_id=?", (feature_id,)
+            ).fetchone() is None:
+                raise KeyError(f"unknown feature: {feature_id}")
+            approval_rows = []
+            for approval_id in approval_ids:
+                approval = con.execute(
+                    "SELECT a.document_id,a.revision_sha256,a.verdict,d.feature_id,"
+                    "d.kind,d.body FROM sprint_spec_approvals a "
+                    "JOIN documents d ON d.document_id=a.document_id "
+                    "WHERE a.approval_id=?",
+                    (approval_id,),
+                ).fetchone()
+                if approval is None:
+                    raise KeyError(f"unknown Sprint spec approval: {approval_id}")
+                current_revision = hashlib.sha256(
+                    approval["body"].encode()
+                ).hexdigest()
+                if (
+                    approval["verdict"] != "pass"
+                    or approval["kind"] != "spec"
+                    or int(approval["feature_id"]) != feature_id
+                    or approval["revision_sha256"] != current_revision
+                ):
+                    raise sprint_domain.SprintInvariantError(
+                        "declaration requires current passing approvals for its feature"
+                    )
+                approval_rows.append((approval_id, approval))
+            active_shells = {
+                int(row["shell_id"]): str(row["flavor"])
+                for row in con.execute(
+                    "SELECT shell_id,flavor FROM shells "
+                    "WHERE COALESCE(is_deleted,0)=0"
+                )
+            }
+            if not seen_shells.issubset(active_shells.keys()):
+                raise sprint_domain.SprintInvariantError(
+                    "Sprint participants must be active shells"
+                )
+            expected_flavors = {
+                "planner": "planner",
+                "developer": "dev",
+                "reviewer": "reviewer",
+            }
+            if any(
+                active_shells[item["shell_id"]] != expected_flavors[item["role"]]
+                for item in normalized
+            ):
+                raise sprint_domain.SprintInvariantError(
+                    "Sprint participant roles must match their shell flavors"
+                )
+            sprint_id = int(
+                con.execute(
+                    "INSERT INTO sprints "
+                    "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                    "VALUES (?,?,1)",
+                    (feature_id, planner_shell_id),
+                ).lastrowid
+            )
+            con.executemany(
+                "INSERT INTO sprint_specs "
+                "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+                "VALUES (?,?,?,?)",
+                (
+                    (
+                        sprint_id,
+                        approval["document_id"],
+                        approval["revision_sha256"],
+                        approval_id,
+                    )
+                    for approval_id, approval in approval_rows
+                ),
+            )
+            con.executemany(
+                "INSERT INTO sprint_participants "
+                "(sprint_id,shell_id,role,harness,model,effort,route) "
+                "VALUES (?,?,?,?,?,?,?)",
+                (
+                    (
+                        sprint_id,
+                        item["shell_id"],
+                        item["role"],
+                        item["harness"],
+                        item["model"],
+                        item["effort"],
+                        item["route"],
+                    )
+                    for item in normalized
+                ),
+            )
+            con.execute(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+                "VALUES (?,'sprint.declared',?,?,?)",
+                (
+                    sprint_id,
+                    "fnb" if caller["flavor"] == "admin" else "planner",
+                    shell_id,
+                    json.dumps(
+                        {
+                            "feature_id": feature_id,
+                            "spec_approval_ids": approval_ids,
+                            "participant_shell_ids": sorted(seen_shells),
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+        return sprint_id
 
     def _sprint_get(self, path: str):
         shell_id = self._require_shell_auth()
@@ -1897,7 +2138,129 @@ class Handler(BaseHTTPRequestHandler):
             return
         con = db()
         try:
+            if path == "/_sc/sprint/declare":
+                sprint_id = self._declare_sprint(con, shell_id, body)
+                return self._send(201, {"sprint_id": sprint_id})
             sprint_id = self._sprint_integer(body, "sprint_id")
+            if path == "/_sc/sprint/plan-unit":
+                planner_shell_id = self._sprint_planner_proxy(
+                    con, sprint_id, shell_id
+                )
+                unit_id = sprint_domain.SprintWorkUnitStore(con).create(
+                    sprint_id,
+                    planner_shell_id,
+                    assigned_shell_id=self._sprint_integer(
+                        body, "assigned_shell_id"
+                    ),
+                    reviewer_shell_id=self._sprint_integer(
+                        body, "reviewer_shell_id"
+                    ),
+                    title=body.get("title") or "",
+                    expected_output=body.get("expected_output") or "",
+                    task_ids=self._sprint_integer_list(body, "task_ids"),
+                    planned_wave=int(body.get("planned_wave", 0)),
+                    dependency_ids=(
+                        self._sprint_integer_list(body, "dependency_ids")
+                        if body.get("dependency_ids")
+                        else ()
+                    ),
+                )
+                return self._send(201, {"work_unit_id": unit_id})
+            if path == "/_sc/sprint/arm":
+                planner_shell_id = self._sprint_planner_proxy(
+                    con, sprint_id, shell_id
+                )
+                try:
+                    wake_ids = sprint_domain.SprintLifecycleStore(con).arm(
+                        sprint_id, planner_shell_id
+                    )
+                except sqlite3.IntegrityError as exc:
+                    if "idx_sprints_single_armed" not in str(exc):
+                        raise
+                    raise sprint_domain.SprintInvariantError(
+                        "another Sprint is already armed"
+                    ) from exc
+                return self._send(200, {"wake_ids": wake_ids})
+            if path == "/_sc/sprint/register-pr":
+                receipt = sprint_pr_watcher.SprintPRWatcher(
+                    con, repo_root=REPO_ROOT
+                ).register(
+                    sprint_id,
+                    owner_shell_id=shell_id,
+                    repository=body.get("repository") or "",
+                    pr_number=self._sprint_integer(body, "pr_number"),
+                    work_unit_ids=self._sprint_integer_list(
+                        body, "work_unit_ids"
+                    ),
+                )
+                return self._send(201 if receipt.created else 200, {
+                    "registered_pr_id": receipt.registered_pr_id,
+                    "created": receipt.created,
+                })
+            if path == "/_sc/sprint/pause":
+                receipt = sprint_recovery.SprintRecoveryCoordinator(
+                    con, repo_root=REPO_ROOT
+                ).pause(
+                    sprint_id,
+                    self._sprint_actor(con, sprint_id, shell_id),
+                    reason=body.get("reason") or "",
+                )
+                return self._send(200, {
+                    "changed": receipt.changed,
+                    "report_id": receipt.report_id,
+                    "interrupt_run_ids": list(receipt.interrupt_run_ids),
+                    "notification_conversation_ids": list(
+                        receipt.notification_conversation_ids
+                    ),
+                })
+            if path == "/_sc/sprint/resume":
+                receipt = sprint_recovery.SprintRecoveryCoordinator(
+                    con, repo_root=REPO_ROOT
+                ).resume(
+                    sprint_id,
+                    self._sprint_actor(con, sprint_id, shell_id),
+                    reason=body.get("reason"),
+                )
+                return self._send(200, {
+                    "changed": receipt.changed,
+                    "dispatched_wake_ids": list(receipt.dispatched_wake_ids),
+                    "projected_work_unit_ids": list(
+                        receipt.projected_work_unit_ids
+                    ),
+                    "resolved_review_message_ids": list(
+                        receipt.resolved_review_message_ids
+                    ),
+                    "spec_drift_document_ids": list(
+                        receipt.spec_drift_document_ids
+                    ),
+                    "anomalies": list(receipt.anomalies),
+                })
+            if path == "/_sc/sprint/complete":
+                changed = sprint_domain.SprintLifecycleStore(con).transition(
+                    sprint_id,
+                    "completed",
+                    self._sprint_actor(con, sprint_id, shell_id),
+                    reason=body.get("reason"),
+                    terminal_outcome=body.get("terminal_outcome"),
+                )
+                return self._send(200, {"changed": changed})
+            if path == "/_sc/sprint/abort":
+                receipt = sprint_recovery.SprintRecoveryCoordinator(
+                    con, repo_root=REPO_ROOT
+                ).abort(
+                    sprint_id,
+                    self._sprint_actor(con, sprint_id, shell_id),
+                    reason=body.get("reason") or "",
+                    terminal_outcome=body.get("terminal_outcome") or "aborted",
+                )
+                return self._send(200, {
+                    "changed": receipt.changed,
+                    "report_id": receipt.report_id,
+                    "interrupt_run_ids": list(receipt.interrupt_run_ids),
+                    "notification_conversation_ids": list(
+                        receipt.notification_conversation_ids
+                    ),
+                })
             if path == "/_sc/sprint/review-request":
                 receipt = sprint_review_loop.SprintReviewLoopStore(
                     con, repo_root=REPO_ROOT

--- a/.super-coder/assets/skills/sprint_close/SKILL.md
+++ b/.super-coder/assets/skills/sprint_close/SKILL.md
@@ -99,5 +99,10 @@ or FnB authority. Terminal state stops Sprint services and removes live pills
 while retaining conversations, messages, events, PR evidence, reports, and
 follow-ups.
 
+```text
+sc sprint complete --sprint <id> --reason <summary> --outcome <outcome>
+sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
+```
+
 Hand the FnB the final report id, follow-up list, integrated SHA, and evidence
 links. Stop after the terminal transition; Sprint-scoped authority is over.

--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -39,6 +39,11 @@ until it is green. The watcher supplies red/green facts; do not write PR state
 yourself. On red, diagnose and fix the PR. On green, judge readiness rather
 than forwarding mechanically.
 
+```text
+sc sprint register-pr --sprint <id> --repository <owner/name> \
+  --pr <number> --work-unit <id>
+```
+
 ## Review handoff
 
 Put the readiness claim in a file, then use one stable retry key:
@@ -77,6 +82,10 @@ Pause immediately when integrity is threatened: broken base, destructive
 ambiguity, unavailable GitHub, untrustworthy runners, provider exhaustion, or
 an unrecoverable environment. State the short reason first; detailed judgment
 can follow after pause is durable.
+
+```text
+sc sprint pause --sprint <id> --reason <integrity-threat>
+```
 
 Stop when the unit is merged and reported, declined, paused awaiting recovery,
 or returned to review. Ask the Planner for later work only after the current

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -74,6 +74,11 @@ messages, pending wakes, work units, registered PRs, capacity, and spec drift.
 Drift informs; it never silently blocks resume. Record the exact revision facts
 and choose continue, re-plan, or abort.
 
+```text
+sc sprint pause --sprint <id> --reason <integrity-threat>
+sc sprint resume --sprint <id> [--reason <reconciliation-judgment>]
+```
+
 Abort only when continuing would be dishonest or unsafe. It is terminal and
 deletes nothing.
 

--- a/.super-coder/assets/skills/sprint_prep/SKILL.md
+++ b/.super-coder/assets/skills/sprint_prep/SKILL.md
@@ -63,6 +63,22 @@ For every participant, record role, route, model, effective effort, persistent
 conversation ownership, and fallback facts the plan actually depends on. Never
 pretend a native session can resume across harnesses.
 
+Declare the prepared envelope from a JSON array of participant objects, then
+add each editing lane from existing spec tasks:
+
+```text
+sc sprint declare --feature <feature-id> \
+  --spec-approval <approval-id> --participants-file <path> --merge-grant
+sc sprint plan-unit --sprint <id> \
+  --developer-shell <id> --reviewer-shell <id> --title <title> \
+  --expected-output-file <path> --task <task-id> \
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>]
+```
+
+The participant file contains `shell_id`, `role`, and `harness`, with optional
+`model`, `effort`, and `route`. FnB may add `--planner-shell <id>` when declaring
+for the originating Planner. Keep the Sprint prepared while shaping the plan.
+
 ## Final arming check
 
 Immediately before arming, re-read the spec revision hashes, QAQC records,
@@ -73,6 +89,10 @@ arming transaction; external harness and GitHub work occurs after it commits.
 Arming succeeds only when the first assignments and wake intents are durable.
 A process crash after commit is outbox recovery; a crash before commit exposes
 no partial Sprint.
+
+```text
+sc sprint arm --sprint <id>
+```
 
 ## Handoff
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3814,6 +3814,11 @@ or FnB authority. Terminal state stops Sprint services and removes live pills
 while retaining conversations, messages, events, PR evidence, reports, and
 follow-ups.
 
+```text
+sc sprint complete --sprint <id> --reason <summary> --outcome <outcome>
+sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
+```
+
 Hand the FnB the final report id, follow-up list, integrated SHA, and evidence
 links. Stop after the terminal transition; Sprint-scoped authority is over.',
   0
@@ -3863,6 +3868,11 @@ until it is green. The watcher supplies red/green facts; do not write PR state
 yourself. On red, diagnose and fix the PR. On green, judge readiness rather
 than forwarding mechanically.
 
+```text
+sc sprint register-pr --sprint <id> --repository <owner/name> \
+  --pr <number> --work-unit <id>
+```
+
 ## Review handoff
 
 Put the readiness claim in a file, then use one stable retry key:
@@ -3901,6 +3911,10 @@ Pause immediately when integrity is threatened: broken base, destructive
 ambiguity, unavailable GitHub, untrustworthy runners, provider exhaustion, or
 an unrecoverable environment. State the short reason first; detailed judgment
 can follow after pause is durable.
+
+```text
+sc sprint pause --sprint <id> --reason <integrity-threat>
+```
 
 Stop when the unit is merged and reported, declined, paused awaiting recovery,
 or returned to review. Ask the Planner for later work only after the current
@@ -3987,6 +4001,11 @@ messages, pending wakes, work units, registered PRs, capacity, and spec drift.
 Drift informs; it never silently blocks resume. Record the exact revision facts
 and choose continue, re-plan, or abort.
 
+```text
+sc sprint pause --sprint <id> --reason <integrity-threat>
+sc sprint resume --sprint <id> [--reason <reconciliation-judgment>]
+```
+
 Abort only when continuing would be dishonest or unsafe. It is terminal and
 deletes nothing.
 
@@ -4070,6 +4089,22 @@ For every participant, record role, route, model, effective effort, persistent
 conversation ownership, and fallback facts the plan actually depends on. Never
 pretend a native session can resume across harnesses.
 
+Declare the prepared envelope from a JSON array of participant objects, then
+add each editing lane from existing spec tasks:
+
+```text
+sc sprint declare --feature <feature-id> \
+  --spec-approval <approval-id> --participants-file <path> --merge-grant
+sc sprint plan-unit --sprint <id> \
+  --developer-shell <id> --reviewer-shell <id> --title <title> \
+  --expected-output-file <path> --task <task-id> \
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>]
+```
+
+The participant file contains `shell_id`, `role`, and `harness`, with optional
+`model`, `effort`, and `route`. FnB may add `--planner-shell <id>` when declaring
+for the originating Planner. Keep the Sprint prepared while shaping the plan.
+
 ## Final arming check
 
 Immediately before arming, re-read the spec revision hashes, QAQC records,
@@ -4080,6 +4115,10 @@ arming transaction; external harness and GitHub work occurs after it commits.
 Arming succeeds only when the first assignments and wake intents are durable.
 A process crash after commit is outbox recovery; a crash before commit exposes
 no partial Sprint.
+
+```text
+sc sprint arm --sprint <id>
+```
 
 ## Handoff
 

--- a/.super-coder/migrations/0151_seed_sprint_v2_skills.sql
+++ b/.super-coder/migrations/0151_seed_sprint_v2_skills.sql
@@ -105,6 +105,11 @@ or FnB authority. Terminal state stops Sprint services and removes live pills
 while retaining conversations, messages, events, PR evidence, reports, and
 follow-ups.
 
+```text
+sc sprint complete --sprint <id> --reason <summary> --outcome <outcome>
+sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
+```
+
 Hand the FnB the final report id, follow-up list, integrated SHA, and evidence
 links. Stop after the terminal transition; Sprint-scoped authority is over.',
   0
@@ -155,6 +160,11 @@ until it is green. The watcher supplies red/green facts; do not write PR state
 yourself. On red, diagnose and fix the PR. On green, judge readiness rather
 than forwarding mechanically.
 
+```text
+sc sprint register-pr --sprint <id> --repository <owner/name> \
+  --pr <number> --work-unit <id>
+```
+
 ## Review handoff
 
 Put the readiness claim in a file, then use one stable retry key:
@@ -193,6 +203,10 @@ Pause immediately when integrity is threatened: broken base, destructive
 ambiguity, unavailable GitHub, untrustworthy runners, provider exhaustion, or
 an unrecoverable environment. State the short reason first; detailed judgment
 can follow after pause is durable.
+
+```text
+sc sprint pause --sprint <id> --reason <integrity-threat>
+```
 
 Stop when the unit is merged and reported, declined, paused awaiting recovery,
 or returned to review. Ask the Planner for later work only after the current
@@ -280,6 +294,11 @@ messages, pending wakes, work units, registered PRs, capacity, and spec drift.
 Drift informs; it never silently blocks resume. Record the exact revision facts
 and choose continue, re-plan, or abort.
 
+```text
+sc sprint pause --sprint <id> --reason <integrity-threat>
+sc sprint resume --sprint <id> [--reason <reconciliation-judgment>]
+```
+
 Abort only when continuing would be dishonest or unsafe. It is terminal and
 deletes nothing.
 
@@ -364,6 +383,22 @@ For every participant, record role, route, model, effective effort, persistent
 conversation ownership, and fallback facts the plan actually depends on. Never
 pretend a native session can resume across harnesses.
 
+Declare the prepared envelope from a JSON array of participant objects, then
+add each editing lane from existing spec tasks:
+
+```text
+sc sprint declare --feature <feature-id> \
+  --spec-approval <approval-id> --participants-file <path> --merge-grant
+sc sprint plan-unit --sprint <id> \
+  --developer-shell <id> --reviewer-shell <id> --title <title> \
+  --expected-output-file <path> --task <task-id> \
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>]
+```
+
+The participant file contains `shell_id`, `role`, and `harness`, with optional
+`model`, `effort`, and `route`. FnB may add `--planner-shell <id>` when declaring
+for the originating Planner. Keep the Sprint prepared while shaping the plan.
+
 ## Final arming check
 
 Immediately before arming, re-read the spec revision hashes, QAQC records,
@@ -374,6 +409,10 @@ arming transaction; external harness and GitHub work occurs after it commits.
 Arming succeeds only when the first assignments and wake intents are durable.
 A process crash after commit is outbox recovery; a crash before commit exposes
 no partial Sprint.
+
+```text
+sc sprint arm --sprint <id>
+```
 
 ## Handoff
 

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Authenticated shell-facing commands for the Sprints v2 loop."""
+
 from __future__ import annotations
 
 import argparse
@@ -34,8 +35,109 @@ def _json_array(path: str) -> list[dict]:
     return value
 
 
+def _integer_list(values: list[int] | None) -> list[int]:
+    return list(dict.fromkeys(values or ()))
+
+
 def _post(path: str, payload: dict, *, idempotent: bool = False) -> dict:
     return mem._api("POST", path, payload, idempotent=idempotent)
+
+
+def cmd_declare(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/declare",
+        {
+            "feature_id": args.feature,
+            "planner_shell_id": args.planner_shell,
+            "spec_approval_ids": _integer_list(args.spec_approval),
+            "participants": _json_array(args.participants_file),
+            "merge_grant_enabled": args.merge_grant,
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_plan_unit(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/plan-unit",
+        {
+            "sprint_id": args.sprint,
+            "assigned_shell_id": args.developer_shell,
+            "reviewer_shell_id": args.reviewer_shell,
+            "title": args.title,
+            "expected_output": _text(args.expected_output_file, "expected output"),
+            "task_ids": _integer_list(args.task),
+            "planned_wave": args.wave,
+            "dependency_ids": _integer_list(args.depends_on),
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_arm(args: argparse.Namespace) -> int:
+    result = _post("/_sc/sprint/arm", {"sprint_id": args.sprint})
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_register_pr(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/register-pr",
+        {
+            "sprint_id": args.sprint,
+            "repository": args.repository,
+            "pr_number": args.pr,
+            "work_unit_ids": [args.work_unit],
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_pause(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/pause",
+        {"sprint_id": args.sprint, "reason": args.reason},
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/resume",
+        {"sprint_id": args.sprint, "reason": args.reason},
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_complete(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/complete",
+        {
+            "sprint_id": args.sprint,
+            "reason": args.reason,
+            "terminal_outcome": args.outcome,
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_abort(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/abort",
+        {
+            "sprint_id": args.sprint,
+            "reason": args.reason,
+            "terminal_outcome": args.outcome,
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
 
 
 def cmd_request_review(args: argparse.Namespace) -> int:
@@ -114,9 +216,7 @@ def cmd_record_conformance(args: argparse.Namespace) -> int:
 
 
 def cmd_compile_report(args: argparse.Namespace) -> int:
-    result = mem._api(
-        "GET", f"/_sc/sprint/{args.sprint}/report?limit={args.limit}"
-    )
+    result = mem._api("GET", f"/_sc/sprint/{args.sprint}/report?limit={args.limit}")
     print(json.dumps(result["evidence_packet"], indent=2, sort_keys=True))
     return 0
 
@@ -131,7 +231,73 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
-    request = sub.add_parser("request-review", help="Developer hands a green PR to Review")
+    declare = sub.add_parser(
+        "declare", help="Planner creates one editable prepared Sprint envelope"
+    )
+    declare.add_argument("--feature", type=int, required=True)
+    declare.add_argument(
+        "--planner-shell",
+        type=int,
+        help="originating Planner; defaults to the authenticated caller",
+    )
+    declare.add_argument("--spec-approval", type=int, action="append", required=True)
+    declare.add_argument("--participants-file", required=True)
+    declare.add_argument("--merge-grant", action="store_true", required=True)
+    declare.set_defaults(fn=cmd_declare)
+
+    plan = sub.add_parser(
+        "plan-unit", help="Planner groups existing spec tasks into one editing lane"
+    )
+    plan.add_argument("--sprint", type=int, required=True)
+    plan.add_argument("--developer-shell", type=int, required=True)
+    plan.add_argument("--reviewer-shell", type=int, required=True)
+    plan.add_argument("--title", required=True)
+    plan.add_argument("--expected-output-file", required=True)
+    plan.add_argument("--task", type=int, action="append", required=True)
+    plan.add_argument("--wave", type=int, default=0)
+    plan.add_argument("--depends-on", type=int, action="append")
+    plan.set_defaults(fn=cmd_plan_unit)
+
+    arm = sub.add_parser("arm", help="Planner atomically arms an eligible plan")
+    arm.add_argument("--sprint", type=int, required=True)
+    arm.set_defaults(fn=cmd_arm)
+
+    register = sub.add_parser(
+        "register-pr", help="Developer registers one PR to its owning work unit"
+    )
+    register.add_argument("--sprint", type=int, required=True)
+    register.add_argument("--repository", required=True)
+    register.add_argument("--pr", type=int, required=True)
+    register.add_argument("--work-unit", type=int, required=True)
+    register.set_defaults(fn=cmd_register_pr)
+
+    pause = sub.add_parser("pause", help="Participant or FnB pauses for integrity")
+    pause.add_argument("--sprint", type=int, required=True)
+    pause.add_argument("--reason", required=True)
+    pause.set_defaults(fn=cmd_pause)
+
+    resume = sub.add_parser("resume", help="Planner or FnB reconciles and re-arms")
+    resume.add_argument("--sprint", type=int, required=True)
+    resume.add_argument("--reason")
+    resume.set_defaults(fn=cmd_resume)
+
+    complete = sub.add_parser("complete", help="Planner or FnB closes successfully")
+    complete.add_argument("--sprint", type=int, required=True)
+    complete.add_argument("--reason", required=True)
+    complete.add_argument("--outcome", required=True)
+    complete.set_defaults(fn=cmd_complete)
+
+    abort = sub.add_parser(
+        "abort", help="Planner or FnB stops without deleting history"
+    )
+    abort.add_argument("--sprint", type=int, required=True)
+    abort.add_argument("--reason", required=True)
+    abort.add_argument("--outcome", default="aborted")
+    abort.set_defaults(fn=cmd_abort)
+
+    request = sub.add_parser(
+        "request-review", help="Developer hands a green PR to Review"
+    )
     request.add_argument("--sprint", type=int, required=True)
     request.add_argument("--registered-pr", type=int, required=True)
     request.add_argument("--readiness-file", required=True)

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -37,7 +37,9 @@
     "tests/test_sprint_review_loop.py",
     "tests/test_sprint_close.py",
     "tests/test_sprint_cli.py",
-    "tests/test_sprint_skills.py"
+    "tests/test_sprint_skills.py",
+    "tests/test_sprint_live_proof.py",
+    "tests/fixtures/sprint_v2_acceptance.json"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/fixtures/sprint_v2_acceptance.json
+++ b/tests/fixtures/sprint_v2_acceptance.json
@@ -1,0 +1,127 @@
+{
+  "spec_document_id": 46,
+  "scenarios": [
+    {
+      "scenario": "Crash after message commit but before wake dispatch",
+      "file": "tests/test_sprint_message_delivery.py",
+      "test": "test_message_and_active_wake_commit_or_roll_back_together"
+    },
+    {
+      "scenario": "Duplicate wake delivery and messages coalescing behind an active turn",
+      "file": "tests/test_sprint_message_delivery.py",
+      "test": "test_messages_behind_delivering_wake_coalesce_once"
+    },
+    {
+      "scenario": "Three failed wake attempts cause automatic pause",
+      "file": "tests/test_sprint_message_delivery.py",
+      "test": "test_third_delivery_failure_auto_pauses_and_stops_claiming"
+    },
+    {
+      "scenario": "Browser messaging during an active participant turn queues without interruption",
+      "file": "tests/test_conversation_api.py",
+      "test": "test_message_stacked_during_run_queues_without_interrupting"
+    },
+    {
+      "scenario": "GitHub outage, rate pressure, unchanged polls, and recovery stay durable",
+      "file": "tests/test_sprint_pr_watcher.py",
+      "test": "test_failure_is_durable_backs_off_and_never_invents_state"
+    },
+    {
+      "scenario": "First red and later green occurrences wake the Developer exactly once",
+      "file": "tests/test_sprint_pr_watcher.py",
+      "test": "test_red_green_red_occurrences_wake_once_each_and_coalesce"
+    },
+    {
+      "scenario": "PR change while paused is reconciled once after resume",
+      "file": "tests/test_sprint_pr_watcher.py",
+      "test": "test_paused_change_is_observed_once_after_resume"
+    },
+    {
+      "scenario": "Quota exhaustion after acceptance escalates immediately",
+      "file": "tests/test_sprint_liveness.py",
+      "test": "test_fresh_exhausted_worker_quota_escalates_on_first_evaluation"
+    },
+    {
+      "scenario": "Healthy long-running process permits one nudge without escalation",
+      "file": "tests/test_sprint_liveness.py",
+      "test": "test_supporting_process_health_allows_one_nudge_but_defers_escalation"
+    },
+    {
+      "scenario": "Continued silence after a nudge emits exactly one Planner escalation",
+      "file": "tests/test_sprint_liveness.py",
+      "test": "test_grace_nudge_escalation_and_restart_dedup"
+    },
+    {
+      "scenario": "Missing process or expired lease escalates as proven failure",
+      "file": "tests/test_sprint_liveness.py",
+      "test": "test_proven_failure_escalates_immediately_without_nudging_worker"
+    },
+    {
+      "scenario": "Pause during an active Developer turn persists interrupt intent",
+      "file": "tests/test_sprint_recovery.py",
+      "test": "test_participant_pause_atomically_persists_report_interrupt_and_notice"
+    },
+    {
+      "scenario": "Parallel Developers may finish out of planned order",
+      "file": "tests/test_sprint_live_proof.py",
+      "test": "test_parallel_sprint_completes_out_of_order_without_lane_overlap"
+    },
+    {
+      "scenario": "Review rejection, fresh correction conversation, approval, and merge",
+      "file": "tests/test_sprint_live_proof.py",
+      "test": "test_serial_sprint_runs_correction_merge_dispatch_and_close"
+    },
+    {
+      "scenario": "Mid-Sprint spec edit is surfaced during resume",
+      "file": "tests/test_sprint_recovery.py",
+      "test": "test_resume_records_drift_and_github_failure_without_blocking"
+    },
+    {
+      "scenario": "FnB authority can compile evidence when the Planner is unavailable",
+      "file": "tests/test_sprint_close.py",
+      "test": "test_only_planner_or_admin_compiles_and_participants_read_timeline"
+    },
+    {
+      "scenario": "Restart preserves every non-terminal lifecycle state",
+      "file": "tests/test_sprint_recovery.py",
+      "test": "test_restart_recovers_prepared_armed_and_paused_without_state_drift"
+    },
+    {
+      "scenario": "Conversation and watcher writes share SQLite without lock loss",
+      "file": "tests/test_sprint_live_proof.py",
+      "test": "test_conversation_and_watcher_writes_share_wal_without_lock_loss"
+    }
+  ],
+  "invariant_sweep": [
+    {
+      "invariant": "single armed Sprint",
+      "file": "tests/test_sprint_v2_domain.py",
+      "test": "test_single_armed_invariant_rolls_back_second_release"
+    },
+    {
+      "invariant": "one editing lane per Developer",
+      "file": "tests/test_sprint_work_dispatch.py",
+      "test": "test_dependencies_block_and_each_developer_gets_one_editing_lane"
+    },
+    {
+      "invariant": "one owning work unit per registered PR",
+      "file": "tests/test_sprint_pr_watcher.py",
+      "test": "test_registration_rejects_multiple_work_units_without_side_effects"
+    },
+    {
+      "invariant": "role and merge authority gates leave no side effects",
+      "file": "tests/test_sprint_review_loop.py",
+      "test": "test_non_green_and_wrong_developer_leave_no_review_evidence"
+    },
+    {
+      "invariant": "pause reconciliation projects merge before downstream release",
+      "file": "tests/test_sprint_recovery.py",
+      "test": "test_resume_projects_observed_merge_before_releasing_downstream"
+    },
+    {
+      "invariant": "closed without merge resolves review liveness",
+      "file": "tests/test_sprint_recovery.py",
+      "test": "test_closed_without_merge_resolves_every_review_expectation"
+    }
+  ]
+}

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -1,4 +1,5 @@
 """Authenticated end-to-end gates for the shell-facing Sprint commands."""
+
 from __future__ import annotations
 
 import contextlib
@@ -27,6 +28,7 @@ from github_pull_requests import PullRequest  # noqa: E402
 from test_sprint_v2_domain import apply_schema  # noqa: E402
 
 TOKENS = {
+    "admin": "admin-token",
     "developer": "dev-token",
     "reviewer": "review-token",
     "planner": "planner-token",
@@ -69,6 +71,7 @@ class SprintCliApiTest(unittest.TestCase):
                 (2, "Reviewer", "REV1", "reviewer", "prompt", TOKENS["reviewer"]),
                 (3, "Planner", "PLN1", "planner", "prompt", TOKENS["planner"]),
                 (4, "Developer 2", "DEV2", "dev", "prompt", "dev2-token"),
+                (5, "FnB", "FNB", "admin", "prompt", TOKENS["admin"]),
             ),
         )
         feature_id = int(
@@ -135,9 +138,7 @@ class SprintCliApiTest(unittest.TestCase):
             ).lastrowid
         )
         con.commit()
-        initial_wake = sprint_domain.SprintLifecycleStore(con).arm(
-            cls.sprint_id, 3
-        )[0]
+        initial_wake = sprint_domain.SprintLifecycleStore(con).arm(cls.sprint_id, 3)[0]
         initial_message = int(
             con.execute(
                 "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",
@@ -201,6 +202,400 @@ class SprintCliApiTest(unittest.TestCase):
         with contextlib.redirect_stdout(output):
             self.assertEqual(0, sprint_cli.main(list(argv)))
         return json.loads(output.getvalue())
+
+    def seed_declaration(self, suffix: str) -> tuple[int, int, int]:
+        con = sqlite3.connect(self.db)
+        try:
+            feature_id = int(
+                con.execute(
+                    "INSERT INTO roadmap (title,roadmap_status) VALUES (?,?)",
+                    (f"Declared feature {suffix}", "in_progress"),
+                ).lastrowid
+            )
+            body = f"declared spec {suffix}"
+            document_id = int(
+                con.execute(
+                    "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                    "VALUES (?,'spec',1,?,?)",
+                    (feature_id, f"Spec {suffix}", body),
+                ).lastrowid
+            )
+            approval_id = int(
+                con.execute(
+                    "INSERT INTO sprint_spec_approvals "
+                    "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+                    "VALUES (?,?,2,'pass')",
+                    (document_id, hashlib.sha256(body.encode()).hexdigest()),
+                ).lastrowid
+            )
+            task_id = int(
+                con.execute(
+                    "INSERT INTO spec_tasks (feature_id,document_id,seq,title) "
+                    "VALUES (?,?,0,?)",
+                    (feature_id, document_id, f"Task {suffix}"),
+                ).lastrowid
+            )
+            con.commit()
+            return feature_id, approval_id, task_id
+        finally:
+            con.close()
+
+    def participants_file(self) -> str:
+        return self.write(
+            json.dumps(
+                [
+                    {"shell_id": 3, "role": "planner", "harness": "codex"},
+                    {"shell_id": 1, "role": "developer", "harness": "codex"},
+                    {"shell_id": 2, "role": "reviewer", "harness": "kimi"},
+                ]
+            )
+        )
+
+    def use_isolated_db(self) -> None:
+        original_db = self.db
+        original_server_db = server.DB_PATH
+        with tempfile.NamedTemporaryFile(
+            dir=self.tmp, suffix=".db", delete=False
+        ) as handle:
+            isolated = Path(handle.name)
+        con = sqlite3.connect(isolated)
+        try:
+            apply_schema(con)
+            con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+            con.executemany(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id,api_key) "
+                "VALUES (?,?,?,?,?,1,?)",
+                (
+                    (1, "Developer", "DEV1", "dev", "prompt", TOKENS["developer"]),
+                    (2, "Reviewer", "REV1", "reviewer", "prompt", TOKENS["reviewer"]),
+                    (3, "Planner", "PLN1", "planner", "prompt", TOKENS["planner"]),
+                    (5, "FnB", "FNB", "admin", "prompt", TOKENS["admin"]),
+                ),
+            )
+            con.commit()
+        finally:
+            con.close()
+        self.db = isolated
+        server.DB_PATH = isolated
+        self.addCleanup(setattr, self, "db", original_db)
+        self.addCleanup(setattr, server, "DB_PATH", original_server_db)
+
+    def test_declare_plan_lifecycle_and_registration_surfaces(self):
+        self.use_isolated_db()
+        feature_id, approval_id, task_id = self.seed_declaration("lifecycle")
+        declaration = self.run_cli(
+            TOKENS["planner"],
+            "declare",
+            "--feature",
+            str(feature_id),
+            "--spec-approval",
+            str(approval_id),
+            "--participants-file",
+            self.participants_file(),
+            "--merge-grant",
+        )
+        sprint_id = declaration["sprint_id"]
+        unit = self.run_cli(
+            TOKENS["planner"],
+            "plan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--developer-shell",
+            "1",
+            "--reviewer-shell",
+            "2",
+            "--title",
+            "Shell-driven lane",
+            "--expected-output-file",
+            self.write("One merged fixture PR."),
+            "--task",
+            str(task_id),
+        )
+        armed = self.run_cli(TOKENS["planner"], "arm", "--sprint", str(sprint_id))
+        self.assertEqual(1, len(armed["wake_ids"]))
+
+        with mock.patch.object(
+            server.sprint_pr_watcher,
+            "GitHubPullRequestReader",
+            return_value=Reader(),
+        ):
+            registration = self.run_cli(
+                TOKENS["developer"],
+                "register-pr",
+                "--sprint",
+                str(sprint_id),
+                "--repository",
+                "acme/repo",
+                "--pr",
+                "84",
+                "--work-unit",
+                str(unit["work_unit_id"]),
+            )
+        self.assertTrue(registration["created"])
+
+        paused = self.run_cli(
+            TOKENS["developer"],
+            "pause",
+            "--sprint",
+            str(sprint_id),
+            "--reason",
+            "exercise participant pause",
+        )
+        self.assertTrue(paused["changed"])
+        self.assertIsInstance(paused["report_id"], int)
+        with mock.patch.object(
+            server.sprint_recovery,
+            "GitHubPullRequestReader",
+            return_value=Reader(),
+        ):
+            resumed = self.run_cli(
+                TOKENS["planner"],
+                "resume",
+                "--sprint",
+                str(sprint_id),
+                "--reason",
+                "fixture is healthy",
+            )
+        self.assertTrue(resumed["changed"])
+        completed = self.run_cli(
+            TOKENS["planner"],
+            "complete",
+            "--sprint",
+            str(sprint_id),
+            "--reason",
+            "proof complete",
+            "--outcome",
+            "accepted",
+        )
+        self.assertTrue(completed["changed"])
+
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                ("completed", "accepted"),
+                con.execute(
+                    "SELECT lifecycle,terminal_outcome FROM sprints WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone(),
+            )
+            self.assertEqual(
+                [("sprint.declared",), ("work_unit.created",)],
+                con.execute(
+                    "SELECT event_type FROM sprint_events WHERE sprint_id=? "
+                    "ORDER BY event_id LIMIT 2",
+                    (sprint_id,),
+                ).fetchall(),
+            )
+        finally:
+            con.close()
+
+    def test_admin_declares_for_planner_and_aborts_without_deleting_history(self):
+        self.use_isolated_db()
+        feature_id, approval_id, task_id = self.seed_declaration("abort")
+        declaration = self.run_cli(
+            TOKENS["admin"],
+            "declare",
+            "--feature",
+            str(feature_id),
+            "--planner-shell",
+            "3",
+            "--spec-approval",
+            str(approval_id),
+            "--participants-file",
+            self.participants_file(),
+            "--merge-grant",
+        )
+        sprint_id = declaration["sprint_id"]
+        unit_id = self.run_cli(
+            TOKENS["admin"],
+            "plan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--developer-shell",
+            "1",
+            "--reviewer-shell",
+            "2",
+            "--title",
+            "FnB-planned lane",
+            "--expected-output-file",
+            self.write("History survives armed abort."),
+            "--task",
+            str(task_id),
+        )["work_unit_id"]
+        armed = self.run_cli(TOKENS["admin"], "arm", "--sprint", str(sprint_id))
+        self.assertEqual(1, len(armed["wake_ids"]))
+        aborted = self.run_cli(
+            TOKENS["admin"],
+            "abort",
+            "--sprint",
+            str(sprint_id),
+            "--reason",
+            "fixture cancellation",
+        )
+        self.assertTrue(aborted["changed"])
+        self.assertIsInstance(aborted["report_id"], int)
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                ("aborted", "aborted"),
+                con.execute(
+                    "SELECT lifecycle,terminal_outcome FROM sprints WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone(),
+            )
+            self.assertEqual(
+                (3, "ready"),
+                con.execute(
+                    "SELECT COUNT(*),u.disposition FROM sprint_participants p "
+                    "JOIN sprint_work_units u ON u.sprint_id=p.sprint_id "
+                    "WHERE p.sprint_id=? AND u.work_unit_id=?",
+                    (sprint_id, unit_id),
+                ).fetchone(),
+            )
+        finally:
+            con.close()
+
+    def test_arm_reports_single_armed_conflict_and_rolls_back_release(self):
+        feature_id, approval_id, task_id = self.seed_declaration("single-armed")
+        sprint_id = self.run_cli(
+            TOKENS["planner"],
+            "declare",
+            "--feature",
+            str(feature_id),
+            "--spec-approval",
+            str(approval_id),
+            "--participants-file",
+            self.participants_file(),
+            "--merge-grant",
+        )["sprint_id"]
+        unit_id = self.run_cli(
+            TOKENS["planner"],
+            "plan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--developer-shell",
+            "1",
+            "--reviewer-shell",
+            "2",
+            "--title",
+            "Blocked second Sprint",
+            "--expected-output-file",
+            self.write("No assignment may escape."),
+            "--task",
+            str(task_id),
+        )["work_unit_id"]
+        with self.assertRaisesRegex(SystemExit, "HTTP 409.*already armed"):
+            self.run_cli(TOKENS["planner"], "arm", "--sprint", str(sprint_id))
+
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                ("prepared", "planned", 0),
+                con.execute(
+                    "SELECT s.lifecycle,u.disposition,"
+                    "(SELECT COUNT(*) FROM sprint_messages WHERE sprint_id=s.sprint_id) "
+                    "FROM sprints s JOIN sprint_work_units u USING(sprint_id) "
+                    "WHERE s.sprint_id=? AND u.work_unit_id=?",
+                    (sprint_id, unit_id),
+                ).fetchone(),
+            )
+        finally:
+            con.close()
+
+    def test_new_surface_rejects_cross_role_without_side_effects(self):
+        self.use_isolated_db()
+        feature_id, approval_id, task_id = self.seed_declaration("authority")
+        declare_argv = (
+            "declare",
+            "--feature",
+            str(feature_id),
+            "--spec-approval",
+            str(approval_id),
+            "--participants-file",
+            self.participants_file(),
+            "--merge-grant",
+        )
+        with self.assertRaisesRegex(SystemExit, "HTTP 403.*originating Planner"):
+            self.run_cli(TOKENS["developer"], *declare_argv)
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                0, con.execute("SELECT COUNT(*) FROM sprints").fetchone()[0]
+            )
+        finally:
+            con.close()
+
+        sprint_id = self.run_cli(TOKENS["planner"], *declare_argv)["sprint_id"]
+        plan_argv = (
+            "plan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--developer-shell",
+            "1",
+            "--reviewer-shell",
+            "2",
+            "--title",
+            "Authority lane",
+            "--expected-output-file",
+            self.write("No unauthorized writes."),
+            "--task",
+            str(task_id),
+        )
+        with self.assertRaisesRegex(SystemExit, "HTTP 403.*owning Planner"):
+            self.run_cli(TOKENS["developer"], *plan_argv)
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                0,
+                con.execute(
+                    "SELECT COUNT(*) FROM sprint_work_units WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone()[0],
+            )
+        finally:
+            con.close()
+
+        unit_id = self.run_cli(TOKENS["planner"], *plan_argv)["work_unit_id"]
+        with self.assertRaisesRegex(SystemExit, "HTTP 403.*owning Planner"):
+            self.run_cli(TOKENS["reviewer"], "arm", "--sprint", str(sprint_id))
+        self.run_cli(TOKENS["planner"], "arm", "--sprint", str(sprint_id))
+        with self.assertRaisesRegex(SystemExit, "HTTP 409.*Developer participant"):
+            self.run_cli(
+                TOKENS["reviewer"],
+                "register-pr",
+                "--sprint",
+                str(sprint_id),
+                "--repository",
+                "acme/repo",
+                "--pr",
+                "85",
+                "--work-unit",
+                str(unit_id),
+            )
+        with self.assertRaisesRegex(SystemExit, "HTTP 403.*cannot transition"):
+            self.run_cli(
+                TOKENS["reviewer"],
+                "complete",
+                "--sprint",
+                str(sprint_id),
+                "--reason",
+                "unauthorized",
+                "--outcome",
+                "accepted",
+            )
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                ("armed", 0),
+                con.execute(
+                    "SELECT lifecycle,(SELECT COUNT(*) FROM sprint_registered_prs) "
+                    "FROM sprints WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone(),
+            )
+        finally:
+            con.close()
 
     def test_real_review_merge_dispatch_monitor_and_close_surfaces(self):
         request = self.run_cli(
@@ -269,8 +664,7 @@ class SprintCliApiTest(unittest.TestCase):
             self.assertEqual(
                 "ready",
                 con.execute(
-                    "SELECT disposition FROM sprint_work_units "
-                    "WHERE work_unit_id=?",
+                    "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
                     (self.dispatch_unit_id,),
                 ).fetchone()[0],
             )

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -2,29 +2,46 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import io
 import json
 import sqlite3
 import sys
 import tempfile
 import threading
 import unittest
+from http.server import ThreadingHTTPServer
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 ACCEPTANCE = ROOT / "tests" / "fixtures" / "sprint_v2_acceptance.json"
-sys.path[:0] = [str(ENGINE / "scripts"), str(ROOT / "tests")]
+sys.path[:0] = [
+    str(ENGINE / "scripts"),
+    str(ENGINE / "api"),
+    str(ROOT / "tests"),
+]
 
 import db_driver
-import sprint_close
+import mem
+import server
+import sprint_cli
 import sprint_domain
 import sprint_message_delivery
 import sprint_pr_watcher
-import sprint_review_loop
 import sprint_runtime
 from github_pull_requests import PullRequest
 from test_sprint_v2_domain import apply_schema
+
+TOKENS = {
+    1: "live-dev-1",
+    2: "live-review-1",
+    3: "live-planner",
+    4: "live-dev-2",
+    5: "live-review-2",
+}
 
 
 class ScenarioGitHub:
@@ -47,7 +64,7 @@ class ScenarioGitHub:
         pull_request = PullRequest(
             number=number,
             head_ref=f"live-proof/pr-{number}",
-            base_ref="main",
+            base_ref="live-proof/base",
             head_sha=head,
             state=state,
             merged_at="2026-08-01T00:00:00Z" if state == "MERGED" else None,
@@ -71,6 +88,18 @@ class ScenarioGitHub:
 
 
 class SprintLiveProof(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+        mem.SC_API_BASE = f"http://127.0.0.1:{cls.httpd.server_address[1]}"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp_dir.cleanup)
@@ -85,19 +114,51 @@ class SprintLiveProof(unittest.TestCase):
         self.con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
         self.con.executemany(
             "INSERT INTO shells "
-            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
-            "VALUES (?,?,?,?,?,1)",
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id,api_key) "
+            "VALUES (?,?,?,?,?,1,?)",
             (
-                (1, "Developer one", "DEV1", "dev", "prompt"),
-                (2, "Reviewer one", "REV1", "reviewer", "prompt"),
-                (3, "Planner", "PLN1", "planner", "prompt"),
-                (4, "Developer two", "DEV2", "dev", "prompt"),
-                (5, "Reviewer two", "REV2", "reviewer", "prompt"),
+                (1, "Developer one", "DEV1", "dev", "prompt", TOKENS[1]),
+                (2, "Reviewer one", "REV1", "reviewer", "prompt", TOKENS[2]),
+                (3, "Planner", "PLN1", "planner", "prompt", TOKENS[3]),
+                (4, "Developer two", "DEV2", "dev", "prompt", TOKENS[4]),
+                (5, "Reviewer two", "REV2", "reviewer", "prompt", TOKENS[5]),
             ),
         )
         self.con.commit()
+        server.DB_PATH = self.db_path
         self.github = ScenarioGitHub()
         self.reader_factory = lambda _repository: self.github
+        self.input_counter = 0
+
+    def write_input(self, body: str) -> str:
+        path = Path(self.temp_dir.name) / f"input-{self.input_counter}.txt"
+        self.input_counter += 1
+        path.write_text(body)
+        return str(path)
+
+    def run_cli(self, shell_id: int, *argv: str) -> dict:
+        mem.SC_API_TOKEN = TOKENS[shell_id]
+        output = io.StringIO()
+        with (
+            mock.patch.object(
+                server.sprint_pr_watcher,
+                "GitHubPullRequestReader",
+                return_value=self.github,
+            ),
+            mock.patch.object(
+                server.sprint_review_loop,
+                "GitHubPullRequestReader",
+                return_value=self.github,
+            ),
+            mock.patch.object(
+                server.sprint_recovery,
+                "GitHubPullRequestReader",
+                return_value=self.github,
+            ),
+            contextlib.redirect_stdout(output),
+        ):
+            self.assertEqual(0, sprint_cli.main(list(argv)))
+        return json.loads(output.getvalue())
 
     def prepare(
         self,
@@ -127,31 +188,6 @@ class SprintLiveProof(unittest.TestCase):
                 (document_id, revision),
             ).lastrowid
         )
-        sprint_id = int(
-            self.con.execute(
-                "INSERT INTO sprints "
-                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
-                "VALUES (?,3,1)",
-                (feature_id,),
-            ).lastrowid
-        )
-        self.con.execute(
-            "INSERT INTO sprint_specs "
-            "(sprint_id,document_id,bound_revision_sha256,approval_id) "
-            "VALUES (?,?,?,?)",
-            (sprint_id, document_id, revision, approval_id),
-        )
-        self.con.executemany(
-            "INSERT INTO sprint_participants "
-            "(sprint_id,shell_id,role,harness,model,effort) VALUES (?,?,?,?,?,?)",
-            (
-                (sprint_id, 3, "planner", "codex", "planner-model", "high"),
-                (sprint_id, 1, "developer", "codex", "dev-model", "high"),
-                (sprint_id, 2, "reviewer", "kimi", "review-model", "high"),
-                (sprint_id, 4, "developer", "codex", "dev-model", "high"),
-                (sprint_id, 5, "reviewer", "kimi", "review-model", "high"),
-            ),
-        )
         task_ids = [
             int(
                 self.con.execute(
@@ -163,23 +199,80 @@ class SprintLiveProof(unittest.TestCase):
             for index in range(len(lanes))
         ]
         self.con.commit()
-
-        units = sprint_domain.SprintWorkUnitStore(self.con)
+        declaration = self.run_cli(
+            3,
+            "declare",
+            "--feature",
+            str(feature_id),
+            "--spec-approval",
+            str(approval_id),
+            "--participants-file",
+            self.write_input(
+                json.dumps(
+                    [
+                        {
+                            "shell_id": 3,
+                            "role": "planner",
+                            "harness": "codex",
+                            "model": "planner-model",
+                            "effort": "high",
+                        },
+                        {
+                            "shell_id": 1,
+                            "role": "developer",
+                            "harness": "codex",
+                            "model": "dev-model",
+                            "effort": "high",
+                        },
+                        {
+                            "shell_id": 2,
+                            "role": "reviewer",
+                            "harness": "kimi",
+                            "model": "review-model",
+                            "effort": "high",
+                        },
+                        {
+                            "shell_id": 4,
+                            "role": "developer",
+                            "harness": "codex",
+                            "model": "dev-model",
+                            "effort": "high",
+                        },
+                        {
+                            "shell_id": 5,
+                            "role": "reviewer",
+                            "harness": "kimi",
+                            "model": "review-model",
+                            "effort": "high",
+                        },
+                    ]
+                )
+            ),
+            "--merge-grant",
+        )
+        sprint_id = declaration["sprint_id"]
         unit_ids: list[int] = []
         for index, (developer, reviewer, dependency_indexes) in enumerate(lanes):
-            unit_ids.append(
-                units.create(
-                    sprint_id,
-                    3,
-                    assigned_shell_id=developer,
-                    reviewer_shell_id=reviewer,
-                    title=f"Live lane {index + 1}",
-                    expected_output=f"Merged live lane {index + 1}",
-                    task_ids=(task_ids[index],),
-                    planned_wave=0,
-                    dependency_ids=tuple(unit_ids[item] for item in dependency_indexes),
-                )
-            )
+            argv = [
+                "plan-unit",
+                "--sprint",
+                str(sprint_id),
+                "--developer-shell",
+                str(developer),
+                "--reviewer-shell",
+                str(reviewer),
+                "--title",
+                f"Live lane {index + 1}",
+                "--expected-output-file",
+                self.write_input(f"Merged live lane {index + 1}"),
+                "--task",
+                str(task_ids[index]),
+                "--wave",
+                "0",
+            ]
+            for dependency_index in dependency_indexes:
+                argv.extend(("--depends-on", str(unit_ids[dependency_index])))
+            unit_ids.append(self.run_cli(3, *argv)["work_unit_id"])
         return sprint_id, document_id, unit_ids
 
     def watcher(self) -> sprint_pr_watcher.SprintPRWatcher:
@@ -234,66 +327,95 @@ class SprintLiveProof(unittest.TestCase):
         request_changes: bool = False,
     ) -> int:
         self.github.set(pr_number, "OPEN")
-        registration = watcher.register(
-            sprint_id,
-            owner_shell_id=developer,
-            repository="acme/live-proof",
-            pr_number=pr_number,
-            work_unit_ids=(unit_id,),
-        )
-        loop = sprint_review_loop.SprintReviewLoopStore(
-            self.con,
-            repo_root=ROOT,
-            reader_factory=self.reader_factory,
+        registration = self.run_cli(
+            developer,
+            "register-pr",
+            "--sprint",
+            str(sprint_id),
+            "--repository",
+            "acme/live-proof",
+            "--pr",
+            str(pr_number),
+            "--work-unit",
+            str(unit_id),
         )
         messages = sprint_message_delivery.SprintMessageStore(self.con)
 
-        handoff = loop.request_review(
-            sprint_id,
-            registration.registered_pr_id,
+        handoff = self.run_cli(
             developer,
-            readiness=f"PR {pr_number} is green and ready.",
-            idempotency_key=f"proof:{pr_number}:review:1",
+            "request-review",
+            "--sprint",
+            str(sprint_id),
+            "--registered-pr",
+            str(registration["registered_pr_id"]),
+            "--readiness-file",
+            self.write_input(f"PR {pr_number} is green and ready."),
+            "--key",
+            f"proof:{pr_number}:review:1",
         )
-        self.assertEqual("accepted", messages.mark_read(handoff.message_id, reviewer))
+        self.assertEqual(
+            "accepted", messages.mark_read(handoff["message_id"], reviewer)
+        )
         if request_changes:
-            outcome = loop.record_review(
-                sprint_id,
-                registration.registered_pr_id,
+            outcome = self.run_cli(
                 reviewer,
-                verdict="changes_requested",
-                body="Exercise the correction loop before approval.",
-                idempotency_key=f"proof:{pr_number}:changes",
+                "record-review",
+                "--sprint",
+                str(sprint_id),
+                "--registered-pr",
+                str(registration["registered_pr_id"]),
+                "--verdict",
+                "changes_requested",
+                "--body-file",
+                self.write_input("Exercise the correction loop before approval."),
+                "--key",
+                f"proof:{pr_number}:changes",
             )
-            self.assertEqual("fixing", outcome.disposition)
+            self.assertEqual("fixing", outcome["disposition"])
             self.github.set(pr_number, "OPEN", checks="FAILURE")
             self.assertTrue(watcher.poll_once())
             self.github.set(pr_number, "OPEN")
             self.assertTrue(watcher.poll_once())
-            handoff = loop.request_review(
-                sprint_id,
-                registration.registered_pr_id,
+            handoff = self.run_cli(
                 developer,
-                readiness=f"PR {pr_number} correction is green.",
-                idempotency_key=f"proof:{pr_number}:review:2",
+                "request-review",
+                "--sprint",
+                str(sprint_id),
+                "--registered-pr",
+                str(registration["registered_pr_id"]),
+                "--readiness-file",
+                self.write_input(f"PR {pr_number} correction is green."),
+                "--key",
+                f"proof:{pr_number}:review:2",
             )
             self.assertEqual(
-                "accepted", messages.mark_read(handoff.message_id, reviewer)
+                "accepted", messages.mark_read(handoff["message_id"], reviewer)
             )
 
-        approval = loop.record_review(
-            sprint_id,
-            registration.registered_pr_id,
+        approval = self.run_cli(
             reviewer,
-            verdict="approved",
-            body="No Medium-or-higher findings remain.",
-            idempotency_key=f"proof:{pr_number}:approved",
+            "record-review",
+            "--sprint",
+            str(sprint_id),
+            "--registered-pr",
+            str(registration["registered_pr_id"]),
+            "--verdict",
+            "approved",
+            "--body-file",
+            self.write_input("No Medium-or-higher findings remain."),
+            "--key",
+            f"proof:{pr_number}:approved",
         )
-        self.assertEqual("merge_ready", approval.disposition)
-        authorization = loop.authorize_merge(
-            sprint_id, registration.registered_pr_id, developer
+        self.assertEqual("merge_ready", approval["disposition"])
+        authorization = self.run_cli(
+            developer,
+            "authorize-merge",
+            "--sprint",
+            str(sprint_id),
+            "--registered-pr",
+            str(registration["registered_pr_id"]),
         )
-        self.assertEqual(f"{pr_number:040x}", authorization.head_sha)
+        self.assertEqual(f"{pr_number:040x}", authorization["head_sha"])
         self.github.set(pr_number, "MERGED")
         self.assertTrue(watcher.poll_once())
         self.assertEqual(
@@ -303,28 +425,41 @@ class SprintLiveProof(unittest.TestCase):
                 (unit_id,),
             ).fetchone()[0],
         )
-        return registration.registered_pr_id
+        return registration["registered_pr_id"]
 
     def close(self, sprint_id: int, document_id: int) -> dict:
-        close = sprint_close.SprintCloseStore(self.con)
-        receipt = close.record_conformance(
-            sprint_id,
+        receipt = self.run_cli(
             2,
-            body="Integrated live proof matches its bound contract.",
-            findings=(),
-            idempotency_key=f"proof:{sprint_id}:conformance",
+            "record-conformance",
+            "--sprint",
+            str(sprint_id),
+            "--body-file",
+            self.write_input("Integrated live proof matches its bound contract."),
+            "--findings-file",
+            self.write_input("[]"),
+            "--key",
+            f"proof:{sprint_id}:conformance",
         )
-        self.assertEqual((), receipt.followup_ids)
-        self.assertTrue(
-            sprint_domain.SprintLifecycleStore(self.con).transition(
-                sprint_id,
-                "completed",
-                sprint_domain.LifecycleActor("planner", 3),
-                reason="delivery and conformance complete",
-                terminal_outcome="accepted",
-            )
+        self.assertEqual([], receipt["followup_ids"])
+        completed = self.run_cli(
+            3,
+            "complete",
+            "--sprint",
+            str(sprint_id),
+            "--reason",
+            "delivery and conformance complete",
+            "--outcome",
+            "accepted",
         )
-        packet = close.compile_evidence_packet(sprint_id, 3)
+        self.assertTrue(completed["changed"])
+        packet = self.run_cli(
+            3,
+            "compile-report",
+            "--sprint",
+            str(sprint_id),
+            "--limit",
+            "50",
+        )
         self.assertEqual("completed", packet["scope"]["lifecycle"])
         self.assertEqual(
             document_id, packet["spec_revisions"]["bound"][0]["document_id"]
@@ -335,7 +470,7 @@ class SprintLiveProof(unittest.TestCase):
 
     def test_serial_sprint_runs_correction_merge_dispatch_and_close(self) -> None:
         sprint_id, document_id, units = self.prepare(((1, 2, ()), (1, 2, (0,))))
-        initial_wakes = sprint_domain.SprintLifecycleStore(self.con).arm(sprint_id, 3)
+        initial_wakes = self.run_cli(3, "arm", "--sprint", str(sprint_id))["wake_ids"]
         self.assertEqual(1, len(initial_wakes))
         self.assertEqual(
             [(units[0], "ready"), (units[1], "planned")],
@@ -409,7 +544,7 @@ class SprintLiveProof(unittest.TestCase):
 
     def test_parallel_sprint_completes_out_of_order_without_lane_overlap(self) -> None:
         sprint_id, document_id, units = self.prepare(((1, 2, ()), (4, 5, ())))
-        initial_wakes = sprint_domain.SprintLifecycleStore(self.con).arm(sprint_id, 3)
+        initial_wakes = self.run_cli(3, "arm", "--sprint", str(sprint_id))["wake_ids"]
         self.assertEqual(2, len(initial_wakes))
         self.deliver_browser_turns()
         self.accept_assignment(units[0], 1)

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -1,0 +1,557 @@
+"""Stage 10 compositional proof for serial and parallel Sprints v2 runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+ACCEPTANCE = ROOT / "tests" / "fixtures" / "sprint_v2_acceptance.json"
+sys.path[:0] = [str(ENGINE / "scripts"), str(ROOT / "tests")]
+
+import db_driver
+import sprint_close
+import sprint_domain
+import sprint_message_delivery
+import sprint_pr_watcher
+import sprint_review_loop
+import sprint_runtime
+from github_pull_requests import PullRequest
+from test_sprint_v2_domain import apply_schema
+
+
+class ScenarioGitHub:
+    """Mutable GitHub boundary used to drive production watcher transitions."""
+
+    def __init__(self) -> None:
+        self.pull_requests: dict[int, PullRequest] = {}
+        self.get_calls: list[int] = []
+        self.list_calls = 0
+
+    def set(
+        self,
+        number: int,
+        state: str,
+        *,
+        checks: str | None = "SUCCESS",
+        head_sha: str | None = None,
+    ) -> PullRequest:
+        head = head_sha or f"{number:040x}"
+        pull_request = PullRequest(
+            number=number,
+            head_ref=f"live-proof/pr-{number}",
+            base_ref="main",
+            head_sha=head,
+            state=state,
+            merged_at="2026-08-01T00:00:00Z" if state == "MERGED" else None,
+            merge_sha=f"{number + 10000:040x}" if state == "MERGED" else None,
+            title=f"Live proof PR {number}",
+            url=f"https://github.com/acme/live-proof/pull/{number}",
+            review_decision="APPROVED" if state in {"OPEN", "MERGED"} else None,
+            checks=checks,
+            checks_failed=checks == "FAILURE",
+        )
+        self.pull_requests[number] = pull_request
+        return pull_request
+
+    def get(self, number: int) -> PullRequest:
+        self.get_calls.append(number)
+        return self.pull_requests[number]
+
+    def list(self) -> list[PullRequest]:
+        self.list_calls += 1
+        return [self.pull_requests[number] for number in sorted(self.pull_requests)]
+
+
+class SprintLiveProof(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.db_path = Path(self.temp_dir.name) / "sprint-live-proof.db"
+        seed = sqlite3.connect(self.db_path)
+        try:
+            apply_schema(seed)
+        finally:
+            seed.close()
+        self.con = db_driver.connect(self.db_path)
+        self.addCleanup(self.con.close)
+        self.con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        self.con.executemany(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (?,?,?,?,?,1)",
+            (
+                (1, "Developer one", "DEV1", "dev", "prompt"),
+                (2, "Reviewer one", "REV1", "reviewer", "prompt"),
+                (3, "Planner", "PLN1", "planner", "prompt"),
+                (4, "Developer two", "DEV2", "dev", "prompt"),
+                (5, "Reviewer two", "REV2", "reviewer", "prompt"),
+            ),
+        )
+        self.con.commit()
+        self.github = ScenarioGitHub()
+        self.reader_factory = lambda _repository: self.github
+
+    def prepare(
+        self,
+        lanes: tuple[tuple[int, int, tuple[int, ...]], ...],
+    ) -> tuple[int, int, list[int]]:
+        """Seed one eligible declaration, then create lanes through the store."""
+        feature_id = int(
+            self.con.execute(
+                "INSERT INTO roadmap (title,roadmap_status) "
+                "VALUES ('Live proof feature','in_progress')"
+            ).lastrowid
+        )
+        body = "Sprints v2 live proof contract"
+        document_id = int(
+            self.con.execute(
+                "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                "VALUES (?,'spec',1,'Live proof spec',?)",
+                (feature_id, body),
+            ).lastrowid
+        )
+        revision = hashlib.sha256(body.encode()).hexdigest()
+        approval_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_spec_approvals "
+                "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+                "VALUES (?,?,2,'pass')",
+                (document_id, revision),
+            ).lastrowid
+        )
+        sprint_id = int(
+            self.con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_specs "
+            "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+            "VALUES (?,?,?,?)",
+            (sprint_id, document_id, revision, approval_id),
+        )
+        self.con.executemany(
+            "INSERT INTO sprint_participants "
+            "(sprint_id,shell_id,role,harness,model,effort) VALUES (?,?,?,?,?,?)",
+            (
+                (sprint_id, 3, "planner", "codex", "planner-model", "high"),
+                (sprint_id, 1, "developer", "codex", "dev-model", "high"),
+                (sprint_id, 2, "reviewer", "kimi", "review-model", "high"),
+                (sprint_id, 4, "developer", "codex", "dev-model", "high"),
+                (sprint_id, 5, "reviewer", "kimi", "review-model", "high"),
+            ),
+        )
+        task_ids = [
+            int(
+                self.con.execute(
+                    "INSERT INTO spec_tasks "
+                    "(feature_id,document_id,seq,title) VALUES (?,?,?,?)",
+                    (feature_id, document_id, index, f"Live task {index}"),
+                ).lastrowid
+            )
+            for index in range(len(lanes))
+        ]
+        self.con.commit()
+
+        units = sprint_domain.SprintWorkUnitStore(self.con)
+        unit_ids: list[int] = []
+        for index, (developer, reviewer, dependency_indexes) in enumerate(lanes):
+            unit_ids.append(
+                units.create(
+                    sprint_id,
+                    3,
+                    assigned_shell_id=developer,
+                    reviewer_shell_id=reviewer,
+                    title=f"Live lane {index + 1}",
+                    expected_output=f"Merged live lane {index + 1}",
+                    task_ids=(task_ids[index],),
+                    planned_wave=0,
+                    dependency_ids=tuple(unit_ids[item] for item in dependency_indexes),
+                )
+            )
+        return sprint_id, document_id, unit_ids
+
+    def watcher(self) -> sprint_pr_watcher.SprintPRWatcher:
+        return sprint_pr_watcher.SprintPRWatcher(
+            self.con,
+            repo_root=ROOT,
+            reader_factory=self.reader_factory,
+        )
+
+    def deliver_browser_turns(self) -> None:
+        runtime = sprint_runtime.SprintRuntimeService(
+            self.db_path,
+            pulse_seconds=1,
+        )
+        self.assertTrue(runtime.pulse_once())
+
+    def assignment_message(self, unit_id: int) -> int:
+        row = self.con.execute(
+            "SELECT message_id FROM sprint_messages "
+            "WHERE work_unit_id=? AND message_kind='work_assignment' "
+            "ORDER BY message_id DESC LIMIT 1",
+            (unit_id,),
+        ).fetchone()
+        self.assertIsNotNone(row)
+        return int(row[0])
+
+    def accept_assignment(self, unit_id: int, developer: int) -> None:
+        message_id = self.assignment_message(unit_id)
+        self.assertEqual(
+            "accepted",
+            sprint_message_delivery.SprintMessageStore(self.con).mark_read(
+                message_id, developer
+            ),
+        )
+        self.assertEqual(
+            "active",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (unit_id,),
+            ).fetchone()[0],
+        )
+
+    def review_and_merge(
+        self,
+        watcher: sprint_pr_watcher.SprintPRWatcher,
+        *,
+        sprint_id: int,
+        unit_id: int,
+        developer: int,
+        reviewer: int,
+        pr_number: int,
+        request_changes: bool = False,
+    ) -> int:
+        self.github.set(pr_number, "OPEN")
+        registration = watcher.register(
+            sprint_id,
+            owner_shell_id=developer,
+            repository="acme/live-proof",
+            pr_number=pr_number,
+            work_unit_ids=(unit_id,),
+        )
+        loop = sprint_review_loop.SprintReviewLoopStore(
+            self.con,
+            repo_root=ROOT,
+            reader_factory=self.reader_factory,
+        )
+        messages = sprint_message_delivery.SprintMessageStore(self.con)
+
+        handoff = loop.request_review(
+            sprint_id,
+            registration.registered_pr_id,
+            developer,
+            readiness=f"PR {pr_number} is green and ready.",
+            idempotency_key=f"proof:{pr_number}:review:1",
+        )
+        self.assertEqual("accepted", messages.mark_read(handoff.message_id, reviewer))
+        if request_changes:
+            outcome = loop.record_review(
+                sprint_id,
+                registration.registered_pr_id,
+                reviewer,
+                verdict="changes_requested",
+                body="Exercise the correction loop before approval.",
+                idempotency_key=f"proof:{pr_number}:changes",
+            )
+            self.assertEqual("fixing", outcome.disposition)
+            self.github.set(pr_number, "OPEN", checks="FAILURE")
+            self.assertTrue(watcher.poll_once())
+            self.github.set(pr_number, "OPEN")
+            self.assertTrue(watcher.poll_once())
+            handoff = loop.request_review(
+                sprint_id,
+                registration.registered_pr_id,
+                developer,
+                readiness=f"PR {pr_number} correction is green.",
+                idempotency_key=f"proof:{pr_number}:review:2",
+            )
+            self.assertEqual(
+                "accepted", messages.mark_read(handoff.message_id, reviewer)
+            )
+
+        approval = loop.record_review(
+            sprint_id,
+            registration.registered_pr_id,
+            reviewer,
+            verdict="approved",
+            body="No Medium-or-higher findings remain.",
+            idempotency_key=f"proof:{pr_number}:approved",
+        )
+        self.assertEqual("merge_ready", approval.disposition)
+        authorization = loop.authorize_merge(
+            sprint_id, registration.registered_pr_id, developer
+        )
+        self.assertEqual(f"{pr_number:040x}", authorization.head_sha)
+        self.github.set(pr_number, "MERGED")
+        self.assertTrue(watcher.poll_once())
+        self.assertEqual(
+            "completed",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (unit_id,),
+            ).fetchone()[0],
+        )
+        return registration.registered_pr_id
+
+    def close(self, sprint_id: int, document_id: int) -> dict:
+        close = sprint_close.SprintCloseStore(self.con)
+        receipt = close.record_conformance(
+            sprint_id,
+            2,
+            body="Integrated live proof matches its bound contract.",
+            findings=(),
+            idempotency_key=f"proof:{sprint_id}:conformance",
+        )
+        self.assertEqual((), receipt.followup_ids)
+        self.assertTrue(
+            sprint_domain.SprintLifecycleStore(self.con).transition(
+                sprint_id,
+                "completed",
+                sprint_domain.LifecycleActor("planner", 3),
+                reason="delivery and conformance complete",
+                terminal_outcome="accepted",
+            )
+        )
+        packet = close.compile_evidence_packet(sprint_id, 3)
+        self.assertEqual("completed", packet["scope"]["lifecycle"])
+        self.assertEqual(
+            document_id, packet["spec_revisions"]["bound"][0]["document_id"]
+        )
+        self.assertEqual([], packet["unresolved_work"]["work_units"]["items"])
+        self.assertEqual([], packet["unresolved_work"]["followups"]["items"])
+        return packet
+
+    def test_serial_sprint_runs_correction_merge_dispatch_and_close(self) -> None:
+        sprint_id, document_id, units = self.prepare(((1, 2, ()), (1, 2, (0,))))
+        initial_wakes = sprint_domain.SprintLifecycleStore(self.con).arm(sprint_id, 3)
+        self.assertEqual(1, len(initial_wakes))
+        self.assertEqual(
+            [(units[0], "ready"), (units[1], "planned")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT work_unit_id,disposition FROM sprint_work_units "
+                    "WHERE sprint_id=? ORDER BY work_unit_id",
+                    (sprint_id,),
+                )
+            ],
+        )
+        self.deliver_browser_turns()
+        self.accept_assignment(units[0], 1)
+        watcher = self.watcher()
+        self.review_and_merge(
+            watcher,
+            sprint_id=sprint_id,
+            unit_id=units[0],
+            developer=1,
+            reviewer=2,
+            pr_number=1001,
+            request_changes=True,
+        )
+        self.assertEqual(
+            "ready",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (units[1],),
+            ).fetchone()[0],
+        )
+        self.deliver_browser_turns()
+        self.accept_assignment(units[1], 1)
+        self.review_and_merge(
+            watcher,
+            sprint_id=sprint_id,
+            unit_id=units[1],
+            developer=1,
+            reviewer=2,
+            pr_number=1002,
+        )
+        packet = self.close(sprint_id, document_id)
+
+        event_types = [
+            row[0]
+            for row in self.con.execute(
+                "SELECT event_type FROM sprint_events WHERE sprint_id=? ORDER BY event_id",
+                (sprint_id,),
+            )
+        ]
+        self.assertEqual(2, event_types.count("work_unit.completed"))
+        self.assertEqual(2, event_types.count("merge.authorized"))
+        self.assertEqual(1, event_types.count("review.changes_requested"))
+        self.assertEqual(2, event_types.count("review.approved"))
+        self.assertEqual("lifecycle.completed", event_types[-1])
+        self.assertEqual(2, packet["pr_outcomes"]["total"])
+        self.assertEqual(
+            ["work", "fix", "merge", "merge"],
+            [
+                row[0]
+                for row in self.con.execute(
+                    "SELECT link.purpose FROM sprint_participant_conversations link "
+                    "JOIN sprint_participants p "
+                    "ON p.participant_id=link.sprint_participant_id "
+                    "WHERE p.sprint_id=? AND p.shell_id=1 "
+                    "ORDER BY link.participant_conversation_id",
+                    (sprint_id,),
+                )
+            ],
+        )
+
+    def test_parallel_sprint_completes_out_of_order_without_lane_overlap(self) -> None:
+        sprint_id, document_id, units = self.prepare(((1, 2, ()), (4, 5, ())))
+        initial_wakes = sprint_domain.SprintLifecycleStore(self.con).arm(sprint_id, 3)
+        self.assertEqual(2, len(initial_wakes))
+        self.deliver_browser_turns()
+        self.accept_assignment(units[0], 1)
+        self.accept_assignment(units[1], 4)
+        watcher = self.watcher()
+
+        self.review_and_merge(
+            watcher,
+            sprint_id=sprint_id,
+            unit_id=units[1],
+            developer=4,
+            reviewer=5,
+            pr_number=2002,
+        )
+        self.assertEqual(
+            "active",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (units[0],),
+            ).fetchone()[0],
+        )
+        self.review_and_merge(
+            watcher,
+            sprint_id=sprint_id,
+            unit_id=units[0],
+            developer=1,
+            reviewer=2,
+            pr_number=2001,
+        )
+        packet = self.close(sprint_id, document_id)
+
+        completions = [
+            json.loads(row[0])["work_unit_id"]
+            for row in self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='work_unit.completed' ORDER BY event_id",
+                (sprint_id,),
+            )
+        ]
+        self.assertEqual([units[1], units[0]], completions)
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_liveness_expectations "
+                "WHERE sprint_id=? AND resolved_at IS NULL",
+                (sprint_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(2, packet["planned_vs_actual"]["total"])
+        self.assertEqual(2, packet["pr_outcomes"]["total"])
+
+    def test_conversation_and_watcher_writes_share_wal_without_lock_loss(self) -> None:
+        sprint_id, _document_id, units = self.prepare(((1, 2, ()),))
+        sprint_domain.SprintLifecycleStore(self.con).arm(sprint_id, 3)
+        self.accept_assignment(units[0], 1)
+        self.github.set(3001, "OPEN", checks="PENDING")
+        watcher = self.watcher()
+        watcher.register(
+            sprint_id,
+            owner_shell_id=1,
+            repository="acme/live-proof",
+            pr_number=3001,
+            work_unit_ids=(units[0],),
+        )
+        self.github.set(3001, "OPEN")
+        conversation_id = str(
+            self.con.execute(
+                "SELECT current_conversation_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=1",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+        barrier = threading.Barrier(2)
+        failures: list[BaseException] = []
+
+        def conversation_write() -> None:
+            try:
+                barrier.wait()
+                sprint_runtime.enqueue_conversation_turn(
+                    self.db_path,
+                    conversation_id,
+                    sprint_message_delivery.FIXED_WAKE_PROMPT,
+                    "live-proof:concurrent-conversation",
+                )
+            except BaseException as exc:  # noqa: BLE001 - asserted below
+                failures.append(exc)
+
+        def watcher_write() -> None:
+            con = db_driver.connect(self.db_path)
+            try:
+                barrier.wait()
+                sprint_pr_watcher.SprintPRWatcher(
+                    con,
+                    repo_root=ROOT,
+                    reader_factory=self.reader_factory,
+                ).poll_once()
+            except BaseException as exc:  # noqa: BLE001 - asserted below
+                failures.append(exc)
+            finally:
+                con.close()
+
+        threads = [
+            threading.Thread(target=conversation_write),
+            threading.Thread(target=watcher_write),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual([], failures)
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM conversation_messages "
+                "WHERE idempotency_key='live-proof:concurrent-conversation'"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            [("pending",), ("green",)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT normalized_state FROM sprint_pr_transitions "
+                    "ORDER BY transition_id"
+                )
+            ],
+        )
+
+    def test_adversarial_acceptance_manifest_references_real_gates(self) -> None:
+        manifest = json.loads(ACCEPTANCE.read_text())
+        self.assertEqual(46, manifest["spec_document_id"])
+        self.assertEqual(18, len(manifest["scenarios"]))
+        self.assertEqual(6, len(manifest["invariant_sweep"]))
+        entries = manifest["scenarios"] + manifest["invariant_sweep"]
+        identities = {(entry["file"], entry["test"]) for entry in entries}
+        self.assertEqual(len(entries), len(identities))
+        for entry in entries:
+            with self.subTest(entry=entry.get("scenario") or entry["invariant"]):
+                source = ROOT.joinpath(entry["file"]).read_text()
+                self.assertIn(f"def {entry['test']}", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -1,4 +1,5 @@
 """Stage 9 gates for the five Sprints v2 engine skills."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -80,6 +81,14 @@ class SprintSkillTest(unittest.TestCase):
 
     def test_skills_use_only_the_shipped_shell_command_surface(self):
         expected = {
+            "declare",
+            "plan-unit",
+            "arm",
+            "register-pr",
+            "pause",
+            "resume",
+            "complete",
+            "abort",
             "request-review",
             "record-review",
             "authorize-merge",


### PR DESCRIPTION
## Scope

Sprint 51 unit 10 now proves the Sprints v2 loop through the authenticated shell/API surface rather than direct store orchestration.

- Adds `declare`, `plan-unit`, `arm`, `register-pr`, `pause`, `resume`, `complete`, and `abort` commands over the existing production stores.
- Enforces originating-Planner/FnB lifecycle authority, Developer PR ownership, participant pause authority, exact passing spec approvals, role/flavor matching, and single-armed rollback.
- Updates the four owning role skills and both generated skill seeds with the command contract.
- Drives one serial and one parallel Sprint through real HTTP bearer identities, browser-conversation wakes, review correction/approval, live merge authorization, merge observation, conformance, report compilation, and terminal completion.
- Retains the 18-scenario adversarial acceptance manifest, six invariant sweep, and concurrent conversation/watcher WAL race.

## R6 real-GitHub evidence

The external proof used disposable PRs #870 and #871, both targeting `fixture/s2-u10-20260801-0022-base`—never `main`.

- The production surface declared/planned/armed two lanes, registered both real PRs, observed their hosted green checks, recorded review approvals, and authorized exact heads: #870 `9edf816…`; #871 `1a91220…`.
- #871 was exact-head squash-merged only into the throwaway base. #870 was closed without merge.
- Both PR head branches, the base branch, local fixture branches/worktree, and temporary proof harness were deleted.
- `origin/main` remained unchanged at `b7e77d7` throughout cleanup.

The first fixture names deliberately tripped the R1 removal inventory. They were made semantically neutral; no guard was weakened and both hosted fixture runs then passed tests, verify, and render-check.

## Verification

- Exact head `6aed99e`: 1,386 passed, 1 skipped, 774 subtests.
- Sprint/server/removal seam: 159 passed, 265 subtests before the final authority regression; the exact-head full suite includes that added case.
- Hosted PR #869: all 6 checks green (tests, verify, render-check, CodeQL aggregate + both analyses).
- `./sc render-check`, critical Ruff rules, `py_compile`, and `git diff --check`: green.
- Local `./sc verify` remains unavailable from linked worktrees by design; hosted verify is green (existing #769).

## Judgments and follow-up

- R1 allowlist discipline is preserved: only the unit-10 proof test/acceptance artifact are added; v1 negative assertions remain unchanged.
- Real-provider egress stays stubbed only at the broker boundary in the isolated browser proof, per ruling #595; all DB/conversation/watcher/review/lifecycle paths are production implementations.
- Side defect #872 records `./sc seed-skills` resolving the shared checkout from a linked worktree and its uninitialized-live-DB failure. The branch seed was regenerated directly and verified by migration replay.
