### PR TITLE
feat: complete Sprint shell surfaces

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -69,6 +69,7 @@ import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, sp
 import sprint_close  # noqa: E402  (Sprints v2 conformance + report evidence)
 import sprint_domain  # noqa: E402  (Sprints v2 work dispatch authority)
 import sprint_liveness  # noqa: E402  (Sprints v2 one-shot monitor surface)
+import sprint_message_delivery  # noqa: E402  (Sprints v2 inbox acceptance)
 import sprint_recovery  # noqa: E402  (Sprints v2 pause/resume reconciliation)
 import sprint_review_loop  # noqa: E402  (Sprints v2 Dev/Review command surface)
 import sprint_runtime  # noqa: E402  (armed-only Sprint dispatch + wake delivery)
@@ -2000,8 +2001,11 @@ class Handler(BaseHTTPRequestHandler):
             for approval_id in approval_ids:
                 approval = con.execute(
                     "SELECT a.document_id,a.revision_sha256,a.verdict,d.feature_id,"
-                    "d.kind,d.body FROM sprint_spec_approvals a "
+                    "d.kind,d.body,reviewer.flavor AS reviewer_flavor,"
+                    "COALESCE(reviewer.is_deleted,0) AS reviewer_deleted "
+                    "FROM sprint_spec_approvals a "
                     "JOIN documents d ON d.document_id=a.document_id "
+                    "JOIN shells reviewer ON reviewer.shell_id=a.reviewer_shell_id "
                     "WHERE a.approval_id=?",
                     (approval_id,),
                 ).fetchone()
@@ -2015,6 +2019,8 @@ class Handler(BaseHTTPRequestHandler):
                     or approval["kind"] != "spec"
                     or int(approval["feature_id"]) != feature_id
                     or approval["revision_sha256"] != current_revision
+                    or approval["reviewer_flavor"] != "reviewer"
+                    or approval["reviewer_deleted"]
                 ):
                     raise sprint_domain.SprintInvariantError(
                         "declaration requires current passing approvals for its feature"
@@ -2111,7 +2117,20 @@ class Handler(BaseHTTPRequestHandler):
         try:
             if len(parts) != 4:
                 return self._send(404, {"error": "not found"})
+            if parts[2] == "approvals":
+                approvals = sprint_domain.SprintSpecApprovalStore(
+                    con
+                ).for_document(int(parts[3]))
+                return self._send(200, {"approvals": approvals})
             sprint_id = int(parts[2])
+            if parts[3] == "inbox":
+                messages = sprint_message_delivery.SprintMessageStore(con).inbox(
+                    sprint_id, shell_id
+                )
+                return self._send(
+                    200,
+                    {"sprint_id": sprint_id, "messages": [dict(row) for row in messages]},
+                )
             store = sprint_close.SprintCloseStore(con)
             if parts[3] == "report":
                 query = parse_qs(urlparse(self.path).query)
@@ -2138,6 +2157,23 @@ class Handler(BaseHTTPRequestHandler):
             return
         con = db()
         try:
+            if path == "/_sc/sprint/qaqc":
+                receipt = sprint_domain.SprintSpecApprovalStore(con).record(
+                    self._sprint_integer(body, "document_id"),
+                    shell_id,
+                    verdict=body.get("verdict") or "",
+                    findings_document_id=(
+                        self._sprint_integer(body, "findings_document_id")
+                        if body.get("findings_document_id") is not None
+                        else None
+                    ),
+                )
+                return self._send(201 if receipt.created else 200, {
+                    "approval_id": receipt.approval_id,
+                    "revision_sha256": receipt.revision_sha256,
+                    "verdict": receipt.verdict,
+                    "created": receipt.created,
+                })
             if path == "/_sc/sprint/declare":
                 sprint_id = self._declare_sprint(con, shell_id, body)
                 return self._send(201, {"sprint_id": sprint_id})
@@ -2164,6 +2200,7 @@ class Handler(BaseHTTPRequestHandler):
                         if body.get("dependency_ids")
                         else ()
                     ),
+                    output_kind=body.get("output_kind") or "code",
                 )
                 return self._send(201, {"work_unit_id": unit_id})
             if path == "/_sc/sprint/arm":
@@ -2181,6 +2218,65 @@ class Handler(BaseHTTPRequestHandler):
                         "another Sprint is already armed"
                     ) from exc
                 return self._send(200, {"wake_ids": wake_ids})
+            if path == "/_sc/sprint/replan-unit":
+                planner_shell_id = self._sprint_planner_proxy(
+                    con, sprint_id, shell_id
+                )
+                changed = sprint_domain.SprintWorkUnitStore(con).replan(
+                    sprint_id,
+                    self._sprint_integer(body, "work_unit_id"),
+                    planner_shell_id,
+                    assigned_shell_id=self._sprint_integer(
+                        body, "assigned_shell_id"
+                    ),
+                    reviewer_shell_id=self._sprint_integer(
+                        body, "reviewer_shell_id"
+                    ),
+                    planned_wave=int(body.get("planned_wave", 0)),
+                    dependency_ids=(
+                        self._sprint_integer_list(body, "dependency_ids")
+                        if body.get("dependency_ids")
+                        else ()
+                    ),
+                    output_kind=body.get("output_kind"),
+                )
+                return self._send(200, {"changed": changed})
+            if path == "/_sc/sprint/complete-unit":
+                wake_ids = sprint_domain.SprintWorkUnitStore(con).complete(
+                    sprint_id,
+                    self._sprint_integer(body, "work_unit_id"),
+                    shell_id,
+                    result=body.get("result") or "",
+                )
+                return self._send(200, {"wake_ids": wake_ids})
+            if path == "/_sc/sprint/cancel-unit":
+                planner_shell_id = self._sprint_planner_proxy(
+                    con, sprint_id, shell_id
+                )
+                changed = sprint_domain.SprintWorkUnitStore(con).cancel(
+                    sprint_id,
+                    self._sprint_integer(body, "work_unit_id"),
+                    planner_shell_id,
+                    reason=body.get("reason") or "",
+                )
+                return self._send(200, {"changed": changed})
+            if path == "/_sc/sprint/inbox-read":
+                disposition = sprint_message_delivery.SprintMessageStore(
+                    con
+                ).mark_read(
+                    self._sprint_integer(body, "message_id"),
+                    shell_id,
+                    sprint_id=sprint_id,
+                )
+                return self._send(200, {"disposition": disposition})
+            if path == "/_sc/sprint/inbox-decline":
+                message_id = sprint_message_delivery.SprintMessageStore(con).decline(
+                    self._sprint_integer(body, "message_id"),
+                    shell_id,
+                    body.get("reason") or "",
+                    sprint_id=sprint_id,
+                )
+                return self._send(200, {"result_message_id": message_id})
             if path == "/_sc/sprint/register-pr":
                 receipt = sprint_pr_watcher.SprintPRWatcher(
                     con, repo_root=REPO_ROOT
@@ -2236,6 +2332,20 @@ class Handler(BaseHTTPRequestHandler):
                     "anomalies": list(receipt.anomalies),
                 })
             if path == "/_sc/sprint/complete":
+                report_body = body.get("final_report")
+                report_key = body.get("idempotency_key")
+                if (report_body is None) != (report_key is None):
+                    raise ValueError(
+                        "final_report and idempotency_key must be provided together"
+                    )
+                report = None
+                if report_body is not None:
+                    report = sprint_close.SprintCloseStore(con).record_final_report(
+                        sprint_id,
+                        shell_id,
+                        body=report_body,
+                        idempotency_key=report_key,
+                    )
                 changed = sprint_domain.SprintLifecycleStore(con).transition(
                     sprint_id,
                     "completed",
@@ -2243,7 +2353,11 @@ class Handler(BaseHTTPRequestHandler):
                     reason=body.get("reason"),
                     terminal_outcome=body.get("terminal_outcome"),
                 )
-                return self._send(200, {"changed": changed})
+                return self._send(200, {
+                    "changed": changed,
+                    "report_id": report.report_id if report else None,
+                    "report_created": report.created if report else False,
+                })
             if path == "/_sc/sprint/abort":
                 receipt = sprint_recovery.SprintRecoveryCoordinator(
                     con, repo_root=REPO_ROOT
@@ -2347,6 +2461,15 @@ class Handler(BaseHTTPRequestHandler):
                     "followup_ids": list(receipt.followup_ids),
                     "created": receipt.created,
                 })
+            if path == "/_sc/sprint/followup-disposition":
+                changed = sprint_close.SprintCloseStore(con).disposition_followup(
+                    sprint_id,
+                    self._sprint_integer(body, "followup_id"),
+                    shell_id,
+                    disposition=body.get("disposition") or "",
+                    resolution=body.get("resolution"),
+                )
+                return self._send(200, {"changed": changed})
             return self._send(404, {"error": "not found"})
         except Exception as exc:
             return self._sprint_error(exc)

--- a/.super-coder/assets/skills/sprint_close/SKILL.md
+++ b/.super-coder/assets/skills/sprint_close/SKILL.md
@@ -14,9 +14,11 @@ been chosen. Close-out supplies meaning; the compiler supplies facts.
 
 Before conformance, re-read work units, dependencies, registered PRs, checks,
 merge observations, task membership, pending actionable messages, and active
-native runs. Every planned unit must be completed/cancelled with an explicit
-disposition, and code units must have their real PR outcome. Do not infer task
-completion from PR state alone.
+native runs. Normally every planned unit is completed/cancelled with an
+explicit disposition, and code units have their real PR outcome. Close-out is
+advisory: the packet surfaces gaps but never prevents the owning Planner or FnB
+from making and reporting a completion judgment. Do not infer code completion
+from PR state alone.
 
 Boot an independent Reviewer into `sprint_rev` conformance mode with the bound
 spec revision hashes, integrated main SHA, and ratified judgment list. Do not
@@ -33,6 +35,16 @@ evidence rather than a silently reopened editing lane.
 
 Verify report id, follow-up ids, author identity, and idempotent replay before
 synthesis.
+
+FnB records one terminal disposition per follow-up. `accepted` acknowledges
+ship-as-is; `resolved` and `dismissed` require a resolution file.
+
+```text
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition accepted
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition resolved --resolution-file <path>
+```
 
 ## Compile bounded evidence
 
@@ -93,14 +105,16 @@ nothing.
 
 ## Terminal handoff
 
-Commit the final or abort report before the lifecycle transition. Complete only
-after conformance evidence and synthesis are durable; abort only under Planner
-or FnB authority. Terminal state stops Sprint services and removes live pills
-while retaining conversations, messages, events, PR evidence, reports, and
-follow-ups.
+Pass the final synthesis to `complete`; the surface commits the append-only
+`final` report before attempting the lifecycle transition. Omitting the report
+is permitted under advisory close-out, but the evidence packet records the gap.
+Abort only under Planner or FnB authority. Terminal state stops Sprint services
+and removes live pills while retaining conversations, messages, events, PR
+evidence, reports, and follow-ups.
 
 ```text
-sc sprint complete --sprint <id> --reason <summary> --outcome <outcome>
+sc sprint complete --sprint <id> --reason <summary> --outcome <outcome> \
+  --report-file <path> --key <stable-key>
 sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
 ```
 

--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -11,6 +11,12 @@ Use for an actionable work-unit assignment in an armed Sprint. Marking that
 Sprint message read is acceptance and starts work immediately. If you cannot
 accept, decline with a concrete reason; never leave it unread and waking.
 
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
 ## Orient and bound the lane
 
 Read the assignment, expected output, bound spec revision, dependencies,
@@ -33,6 +39,15 @@ Verification must exercise the unit's independent stage gate and realistic
 failure paths. A local exploratory number is not merge evidence. Record real CI
 failures, anomalous infrastructure failures, retries, review friction, and
 known departures for the final report.
+
+An explicitly planned report-only or no-code lane completes with its durable
+result instead of a PR. Code lanes cannot use this path; they complete only
+after merge authorization and observation.
+
+```text
+sc sprint complete-unit --sprint <id> --work-unit <id> \
+  --result-file <path>
+```
 
 Register the PR through the authoritative Sprint surface and retain ownership
 until it is green. The watcher supplies red/green facts; do not write PR state

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -17,6 +17,11 @@ participant routes, active conversations, registered PRs, unresolved
 expectations, and recent anomalies. Viewing a participant conversation is
 observation, not activity; never manufacture progress from browser presence.
 
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+```
+
 Release every dependency-ready lane through the production surface:
 
 ```text
@@ -50,6 +55,17 @@ sc sprint monitor --sprint <id>
 
 Do not poll this command on a schedule. It evaluates only due accepted
 expectations and its nudge/escalation identities are durable.
+
+Revise only a still-planned lane; name its complete new projection so the
+before/after event is reviewable. Cancel only an unreleased lane, with the
+reason retained as its terminal result:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  --developer-shell <id> --reviewer-shell <id> --wave <n> \
+  [--depends-on <work-unit-id>] [--output-kind code|report-only|no-code]
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reason>
+```
 
 ## Escalation judgment
 

--- a/.super-coder/assets/skills/sprint_prep/SKILL.md
+++ b/.super-coder/assets/skills/sprint_prep/SKILL.md
@@ -33,6 +33,17 @@ Read the feature, selected spec bodies, task ledgers, QAQC records, shell roster
 model routes, quota state, repository access, and worktree availability. Record
 the exact revision hash you inspected; a title or document id is not a revision.
 
+The Review shell records its verdict against the current exact body through the
+authenticated Sprint surface:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> --verdict pass \
+  [--findings-document <document-id>]
+```
+
+Use `fail` until every blocking finding is resolved. A body edit changes the
+revision hash and therefore needs a fresh signed record.
+
 Refuse arming when any of these is true:
 
 - a selected current revision lacks Review-shell QAQC approval;
@@ -72,7 +83,8 @@ sc sprint declare --feature <feature-id> \
 sc sprint plan-unit --sprint <id> \
   --developer-shell <id> --reviewer-shell <id> --title <title> \
   --expected-output-file <path> --task <task-id> \
-  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>]
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>] \
+  [--output-kind code|report-only|no-code]
 ```
 
 The participant file contains `shell_id`, `role`, and `harness`, with optional

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -10,6 +10,16 @@ common: false
 Use in one of two modes: a work-unit PR review during the loop, or the final
 whole-Sprint conformance pass. The evidence differs; independence does not.
 
+Read and accept the actionable request before beginning. During preparation,
+sign the exact current spec revision through the same authenticated surface:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
+
 ## Severity rubric
 
 This skill owns severity. The governing spec intentionally does not.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3729,9 +3729,11 @@ been chosen. Close-out supplies meaning; the compiler supplies facts.
 
 Before conformance, re-read work units, dependencies, registered PRs, checks,
 merge observations, task membership, pending actionable messages, and active
-native runs. Every planned unit must be completed/cancelled with an explicit
-disposition, and code units must have their real PR outcome. Do not infer task
-completion from PR state alone.
+native runs. Normally every planned unit is completed/cancelled with an
+explicit disposition, and code units have their real PR outcome. Close-out is
+advisory: the packet surfaces gaps but never prevents the owning Planner or FnB
+from making and reporting a completion judgment. Do not infer code completion
+from PR state alone.
 
 Boot an independent Reviewer into `sprint_rev` conformance mode with the bound
 spec revision hashes, integrated main SHA, and ratified judgment list. Do not
@@ -3748,6 +3750,16 @@ evidence rather than a silently reopened editing lane.
 
 Verify report id, follow-up ids, author identity, and idempotent replay before
 synthesis.
+
+FnB records one terminal disposition per follow-up. `accepted` acknowledges
+ship-as-is; `resolved` and `dismissed` require a resolution file.
+
+```text
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition accepted
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition resolved --resolution-file <path>
+```
 
 ## Compile bounded evidence
 
@@ -3808,14 +3820,16 @@ nothing.
 
 ## Terminal handoff
 
-Commit the final or abort report before the lifecycle transition. Complete only
-after conformance evidence and synthesis are durable; abort only under Planner
-or FnB authority. Terminal state stops Sprint services and removes live pills
-while retaining conversations, messages, events, PR evidence, reports, and
-follow-ups.
+Pass the final synthesis to `complete`; the surface commits the append-only
+`final` report before attempting the lifecycle transition. Omitting the report
+is permitted under advisory close-out, but the evidence packet records the gap.
+Abort only under Planner or FnB authority. Terminal state stops Sprint services
+and removes live pills while retaining conversations, messages, events, PR
+evidence, reports, and follow-ups.
 
 ```text
-sc sprint complete --sprint <id> --reason <summary> --outcome <outcome>
+sc sprint complete --sprint <id> --reason <summary> --outcome <outcome> \
+  --report-file <path> --key <stable-key>
 sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
 ```
 
@@ -3840,6 +3854,12 @@ Use for an actionable work-unit assignment in an armed Sprint. Marking that
 Sprint message read is acceptance and starts work immediately. If you cannot
 accept, decline with a concrete reason; never leave it unread and waking.
 
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
 ## Orient and bound the lane
 
 Read the assignment, expected output, bound spec revision, dependencies,
@@ -3862,6 +3882,15 @@ Verification must exercise the unit''s independent stage gate and realistic
 failure paths. A local exploratory number is not merge evidence. Record real CI
 failures, anomalous infrastructure failures, retries, review friction, and
 known departures for the final report.
+
+An explicitly planned report-only or no-code lane completes with its durable
+result instead of a PR. Code lanes cannot use this path; they complete only
+after merge authorization and observation.
+
+```text
+sc sprint complete-unit --sprint <id> --work-unit <id> \
+  --result-file <path>
+```
 
 Register the PR through the authoritative Sprint surface and retain ownership
 until it is green. The watcher supplies red/green facts; do not write PR state
@@ -3944,6 +3973,11 @@ participant routes, active conversations, registered PRs, unresolved
 expectations, and recent anomalies. Viewing a participant conversation is
 observation, not activity; never manufacture progress from browser presence.
 
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+```
+
 Release every dependency-ready lane through the production surface:
 
 ```text
@@ -3977,6 +4011,17 @@ sc sprint monitor --sprint <id>
 
 Do not poll this command on a schedule. It evaluates only due accepted
 expectations and its nudge/escalation identities are durable.
+
+Revise only a still-planned lane; name its complete new projection so the
+before/after event is reviewable. Cancel only an unreleased lane, with the
+reason retained as its terminal result:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  --developer-shell <id> --reviewer-shell <id> --wave <n> \
+  [--depends-on <work-unit-id>] [--output-kind code|report-only|no-code]
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reason>
+```
 
 ## Escalation judgment
 
@@ -4059,6 +4104,17 @@ Read the feature, selected spec bodies, task ledgers, QAQC records, shell roster
 model routes, quota state, repository access, and worktree availability. Record
 the exact revision hash you inspected; a title or document id is not a revision.
 
+The Review shell records its verdict against the current exact body through the
+authenticated Sprint surface:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> --verdict pass \
+  [--findings-document <document-id>]
+```
+
+Use `fail` until every blocking finding is resolved. A body edit changes the
+revision hash and therefore needs a fresh signed record.
+
 Refuse arming when any of these is true:
 
 - a selected current revision lacks Review-shell QAQC approval;
@@ -4098,7 +4154,8 @@ sc sprint declare --feature <feature-id> \
 sc sprint plan-unit --sprint <id> \
   --developer-shell <id> --reviewer-shell <id> --title <title> \
   --expected-output-file <path> --task <task-id> \
-  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>]
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>] \
+  [--output-kind code|report-only|no-code]
 ```
 
 The participant file contains `shell_id`, `role`, and `harness`, with optional
@@ -4145,6 +4202,16 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
 
 Use in one of two modes: a work-unit PR review during the loop, or the final
 whole-Sprint conformance pass. The evidence differs; independence does not.
+
+Read and accept the actionable request before beginning. During preparation,
+sign the exact current spec revision through the same authenticated surface:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
 
 ## Severity rubric
 

--- a/.super-coder/migrations/0151_seed_sprint_v2_skills.sql
+++ b/.super-coder/migrations/0151_seed_sprint_v2_skills.sql
@@ -20,9 +20,11 @@ been chosen. Close-out supplies meaning; the compiler supplies facts.
 
 Before conformance, re-read work units, dependencies, registered PRs, checks,
 merge observations, task membership, pending actionable messages, and active
-native runs. Every planned unit must be completed/cancelled with an explicit
-disposition, and code units must have their real PR outcome. Do not infer task
-completion from PR state alone.
+native runs. Normally every planned unit is completed/cancelled with an
+explicit disposition, and code units have their real PR outcome. Close-out is
+advisory: the packet surfaces gaps but never prevents the owning Planner or FnB
+from making and reporting a completion judgment. Do not infer code completion
+from PR state alone.
 
 Boot an independent Reviewer into `sprint_rev` conformance mode with the bound
 spec revision hashes, integrated main SHA, and ratified judgment list. Do not
@@ -39,6 +41,16 @@ evidence rather than a silently reopened editing lane.
 
 Verify report id, follow-up ids, author identity, and idempotent replay before
 synthesis.
+
+FnB records one terminal disposition per follow-up. `accepted` acknowledges
+ship-as-is; `resolved` and `dismissed` require a resolution file.
+
+```text
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition accepted
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition resolved --resolution-file <path>
+```
 
 ## Compile bounded evidence
 
@@ -99,14 +111,16 @@ nothing.
 
 ## Terminal handoff
 
-Commit the final or abort report before the lifecycle transition. Complete only
-after conformance evidence and synthesis are durable; abort only under Planner
-or FnB authority. Terminal state stops Sprint services and removes live pills
-while retaining conversations, messages, events, PR evidence, reports, and
-follow-ups.
+Pass the final synthesis to `complete`; the surface commits the append-only
+`final` report before attempting the lifecycle transition. Omitting the report
+is permitted under advisory close-out, but the evidence packet records the gap.
+Abort only under Planner or FnB authority. Terminal state stops Sprint services
+and removes live pills while retaining conversations, messages, events, PR
+evidence, reports, and follow-ups.
 
 ```text
-sc sprint complete --sprint <id> --reason <summary> --outcome <outcome>
+sc sprint complete --sprint <id> --reason <summary> --outcome <outcome> \
+  --report-file <path> --key <stable-key>
 sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
 ```
 
@@ -132,6 +146,12 @@ Use for an actionable work-unit assignment in an armed Sprint. Marking that
 Sprint message read is acceptance and starts work immediately. If you cannot
 accept, decline with a concrete reason; never leave it unread and waking.
 
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
 ## Orient and bound the lane
 
 Read the assignment, expected output, bound spec revision, dependencies,
@@ -154,6 +174,15 @@ Verification must exercise the unit''s independent stage gate and realistic
 failure paths. A local exploratory number is not merge evidence. Record real CI
 failures, anomalous infrastructure failures, retries, review friction, and
 known departures for the final report.
+
+An explicitly planned report-only or no-code lane completes with its durable
+result instead of a PR. Code lanes cannot use this path; they complete only
+after merge authorization and observation.
+
+```text
+sc sprint complete-unit --sprint <id> --work-unit <id> \
+  --result-file <path>
+```
 
 Register the PR through the authoritative Sprint surface and retain ownership
 until it is green. The watcher supplies red/green facts; do not write PR state
@@ -237,6 +266,11 @@ participant routes, active conversations, registered PRs, unresolved
 expectations, and recent anomalies. Viewing a participant conversation is
 observation, not activity; never manufacture progress from browser presence.
 
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+```
+
 Release every dependency-ready lane through the production surface:
 
 ```text
@@ -270,6 +304,17 @@ sc sprint monitor --sprint <id>
 
 Do not poll this command on a schedule. It evaluates only due accepted
 expectations and its nudge/escalation identities are durable.
+
+Revise only a still-planned lane; name its complete new projection so the
+before/after event is reviewable. Cancel only an unreleased lane, with the
+reason retained as its terminal result:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  --developer-shell <id> --reviewer-shell <id> --wave <n> \
+  [--depends-on <work-unit-id>] [--output-kind code|report-only|no-code]
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reason>
+```
 
 ## Escalation judgment
 
@@ -353,6 +398,17 @@ Read the feature, selected spec bodies, task ledgers, QAQC records, shell roster
 model routes, quota state, repository access, and worktree availability. Record
 the exact revision hash you inspected; a title or document id is not a revision.
 
+The Review shell records its verdict against the current exact body through the
+authenticated Sprint surface:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> --verdict pass \
+  [--findings-document <document-id>]
+```
+
+Use `fail` until every blocking finding is resolved. A body edit changes the
+revision hash and therefore needs a fresh signed record.
+
 Refuse arming when any of these is true:
 
 - a selected current revision lacks Review-shell QAQC approval;
@@ -392,7 +448,8 @@ sc sprint declare --feature <feature-id> \
 sc sprint plan-unit --sprint <id> \
   --developer-shell <id> --reviewer-shell <id> --title <title> \
   --expected-output-file <path> --task <task-id> \
-  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>]
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>] \
+  [--output-kind code|report-only|no-code]
 ```
 
 The participant file contains `shell_id`, `role`, and `harness`, with optional
@@ -440,6 +497,16 @@ VALUES (
 
 Use in one of two modes: a work-unit PR review during the loop, or the final
 whole-Sprint conformance pass. The evidence differs; independence does not.
+
+Read and accept the actionable request before beginning. During preparation,
+sign the exact current spec revision through the same authenticated surface:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
 
 ## Severity rubric
 

--- a/.super-coder/migrations/0152_sprint_surface_completion.sql
+++ b/.super-coder/migrations/0152_sprint_surface_completion.sql
@@ -1,0 +1,18 @@
+-- 0152 — durable non-code work-unit completion evidence.
+--
+-- Existing work units remain code lanes.  Planner-marked report-only/no-code
+-- lanes may finish through the shell-facing completion surface with their
+-- result retained on the authoritative work-unit row.
+
+BEGIN;
+
+ALTER TABLE sprint_work_units ADD COLUMN output_kind TEXT NOT NULL DEFAULT 'code'
+    CHECK (output_kind IN ('code','report_only','no_code'));
+
+ALTER TABLE sprint_work_units ADD COLUMN completion_result TEXT
+    CHECK (
+      completion_result IS NULL
+      OR length(trim(completion_result)) BETWEEN 1 AND 8000
+    );
+
+COMMIT;

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -478,7 +478,7 @@ def _render_get(surface: str, data: dict) -> int:
                 print("  ⤷ " + t["resolution_notes"])
         return 0
     if surface == "qaqc":
-        reviews = data.get("reviews", [])
+        reviews = data.get("approvals", [])
         if not reviews:
             print("mem: no QAQC reviews")
             return 0
@@ -488,9 +488,9 @@ def _render_get(surface: str, data: dict) -> int:
                 or f"shell #{review['reviewer_shell_id']}"
             )
             print(
-                f"#{review['review_id']} [{review['verdict']}] "
-                f"spec #{review['spec_doc_id']} · {reviewer} · "
-                f"{review['body_sha256']} · {review['completed_at']}"
+                f"#{review['approval_id']} [{review['verdict']}] "
+                f"spec #{review['document_id']} · {reviewer} · "
+                f"{review['revision_sha256']} · {review['reviewed_at']}"
             )
         return 0
     if surface == "messages":
@@ -533,7 +533,7 @@ def cmd_get(args) -> int:
     elif surface == "qaqc":
         if args.doc is None:
             die("get qaqc needs --doc <spec_document_id>")
-        path = f"/api/spec-qaqc-reviews?spec_doc_id={args.doc}"
+        path = f"/_sc/sprint/approvals/{args.doc}"
     data = _api("GET", path)
     if args.json:
         print(json.dumps(data, indent=2, default=str))
@@ -780,21 +780,23 @@ def cmd_oriented(args) -> int:
 def cmd_doc(args) -> int:
     if args.doc_cmd == "qaqc":
         payload = {
-            "spec_doc_id": args.document_id,
-            "verdict": args.verdict,
+            "document_id": args.document_id,
+            "verdict": (
+                "pass" if args.verdict == "approved" else "fail"
+            ),
         }
         if args.findings_doc is not None:
-            payload["findings_doc_id"] = args.findings_doc
+            payload["findings_document_id"] = args.findings_doc
         review = _api(
             "POST",
-            "/api/spec-qaqc-reviews",
+            "/_sc/sprint/qaqc",
             payload,
             idempotent=True,
             idem_key=f"qaqc|{args.document_id}|{uuid.uuid4()}",
         )
         return _finish_api(
-            f"mem: QAQC review #{review['review_id']} → {review['verdict']} "
-            f"for spec #{args.document_id} at {review['body_sha256']}"
+            f"mem: QAQC approval #{review['approval_id']} → {review['verdict']} "
+            f"for spec #{args.document_id} at {review['revision_sha256']}"
         )
     if args.doc_cmd == "freeze":
         r = _api("PATCH", f"/_sc/mem/docs/{args.document_id}/freeze",

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -58,6 +58,20 @@ def cmd_declare(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_record_qaqc(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/qaqc",
+        {
+            "document_id": args.document,
+            "verdict": args.verdict,
+            "findings_document_id": args.findings_document,
+        },
+        idempotent=True,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
 def cmd_plan_unit(args: argparse.Namespace) -> int:
     result = _post(
         "/_sc/sprint/plan-unit",
@@ -70,6 +84,82 @@ def cmd_plan_unit(args: argparse.Namespace) -> int:
             "task_ids": _integer_list(args.task),
             "planned_wave": args.wave,
             "dependency_ids": _integer_list(args.depends_on),
+            "output_kind": args.output_kind.replace("-", "_"),
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_replan_unit(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/replan-unit",
+        {
+            "sprint_id": args.sprint,
+            "work_unit_id": args.work_unit,
+            "assigned_shell_id": args.developer_shell,
+            "reviewer_shell_id": args.reviewer_shell,
+            "planned_wave": args.wave,
+            "dependency_ids": _integer_list(args.depends_on),
+            "output_kind": (
+                args.output_kind.replace("-", "_") if args.output_kind else None
+            ),
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_inbox(args: argparse.Namespace) -> int:
+    result = mem._api("GET", f"/_sc/sprint/{args.sprint}/inbox")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_accept(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/inbox-read",
+        {"sprint_id": args.sprint, "message_id": args.message},
+        idempotent=True,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_decline(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/inbox-decline",
+        {
+            "sprint_id": args.sprint,
+            "message_id": args.message,
+            "reason": args.reason,
+        },
+        idempotent=True,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_complete_unit(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/complete-unit",
+        {
+            "sprint_id": args.sprint,
+            "work_unit_id": args.work_unit,
+            "result": _text(args.result_file, "completion result"),
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_cancel_unit(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/cancel-unit",
+        {
+            "sprint_id": args.sprint,
+            "work_unit_id": args.work_unit,
+            "reason": args.reason,
         },
     )
     print(json.dumps(result, indent=2, sort_keys=True))
@@ -115,12 +205,18 @@ def cmd_resume(args: argparse.Namespace) -> int:
 
 
 def cmd_complete(args: argparse.Namespace) -> int:
+    if bool(args.report_file) != bool(args.key):
+        raise SystemExit("sprint: --report-file and --key must be provided together")
     result = _post(
         "/_sc/sprint/complete",
         {
             "sprint_id": args.sprint,
             "reason": args.reason,
             "terminal_outcome": args.outcome,
+            "final_report": (
+                _text(args.report_file, "final report") if args.report_file else None
+            ),
+            "idempotency_key": args.key,
         },
     )
     print(json.dumps(result, indent=2, sort_keys=True))
@@ -215,6 +311,25 @@ def cmd_record_conformance(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_disposition_followup(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/followup-disposition",
+        {
+            "sprint_id": args.sprint,
+            "followup_id": args.followup,
+            "disposition": args.disposition,
+            "resolution": (
+                _text(args.resolution_file, "resolution")
+                if args.resolution_file
+                else None
+            ),
+        },
+        idempotent=True,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
 def cmd_compile_report(args: argparse.Namespace) -> int:
     result = mem._api("GET", f"/_sc/sprint/{args.sprint}/report?limit={args.limit}")
     print(json.dumps(result["evidence_packet"], indent=2, sort_keys=True))
@@ -230,6 +345,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
+
+    qaqc = sub.add_parser(
+        "record-qaqc", help="Review shell signs the current exact spec revision"
+    )
+    qaqc.add_argument("--document", type=int, required=True)
+    qaqc.add_argument("--verdict", choices=("pass", "fail"), required=True)
+    qaqc.add_argument("--findings-document", type=int)
+    qaqc.set_defaults(fn=cmd_record_qaqc)
 
     declare = sub.add_parser(
         "declare", help="Planner creates one editable prepared Sprint envelope"
@@ -256,11 +379,65 @@ def build_parser() -> argparse.ArgumentParser:
     plan.add_argument("--task", type=int, action="append", required=True)
     plan.add_argument("--wave", type=int, default=0)
     plan.add_argument("--depends-on", type=int, action="append")
+    plan.add_argument(
+        "--output-kind",
+        choices=("code", "report-only", "no-code"),
+        default="code",
+    )
     plan.set_defaults(fn=cmd_plan_unit)
+
+    replan = sub.add_parser(
+        "replan-unit", help="Planner revises one still-planned editing lane"
+    )
+    replan.add_argument("--sprint", type=int, required=True)
+    replan.add_argument("--work-unit", type=int, required=True)
+    replan.add_argument("--developer-shell", type=int, required=True)
+    replan.add_argument("--reviewer-shell", type=int, required=True)
+    replan.add_argument("--wave", type=int, default=0)
+    replan.add_argument("--depends-on", type=int, action="append")
+    replan.add_argument(
+        "--output-kind", choices=("code", "report-only", "no-code")
+    )
+    replan.set_defaults(fn=cmd_replan_unit)
 
     arm = sub.add_parser("arm", help="Planner atomically arms an eligible plan")
     arm.add_argument("--sprint", type=int, required=True)
     arm.set_defaults(fn=cmd_arm)
+
+    inbox = sub.add_parser("inbox", help="Read unread messages addressed to this shell")
+    inbox.add_argument("--sprint", type=int, required=True)
+    inbox.set_defaults(fn=cmd_inbox)
+
+    accept = sub.add_parser(
+        "accept", help="Mark one Sprint message read and accept actionable work"
+    )
+    accept.add_argument("--sprint", type=int, required=True)
+    accept.add_argument("--message", type=int, required=True)
+    accept.set_defaults(fn=cmd_accept)
+
+    decline = sub.add_parser(
+        "decline", help="Decline one actionable Sprint message with a reason"
+    )
+    decline.add_argument("--sprint", type=int, required=True)
+    decline.add_argument("--message", type=int, required=True)
+    decline.add_argument("--reason", required=True)
+    decline.set_defaults(fn=cmd_decline)
+
+    complete_unit = sub.add_parser(
+        "complete-unit", help="Developer completes an explicit report-only/no-code lane"
+    )
+    complete_unit.add_argument("--sprint", type=int, required=True)
+    complete_unit.add_argument("--work-unit", type=int, required=True)
+    complete_unit.add_argument("--result-file", required=True)
+    complete_unit.set_defaults(fn=cmd_complete_unit)
+
+    cancel_unit = sub.add_parser(
+        "cancel-unit", help="Planner cancels one unreleased planned lane"
+    )
+    cancel_unit.add_argument("--sprint", type=int, required=True)
+    cancel_unit.add_argument("--work-unit", type=int, required=True)
+    cancel_unit.add_argument("--reason", required=True)
+    cancel_unit.set_defaults(fn=cmd_cancel_unit)
 
     register = sub.add_parser(
         "register-pr", help="Developer registers one PR to its owning work unit"
@@ -285,6 +462,8 @@ def build_parser() -> argparse.ArgumentParser:
     complete.add_argument("--sprint", type=int, required=True)
     complete.add_argument("--reason", required=True)
     complete.add_argument("--outcome", required=True)
+    complete.add_argument("--report-file")
+    complete.add_argument("--key", help="stable final-report retry identity")
     complete.set_defaults(fn=cmd_complete)
 
     abort = sub.add_parser(
@@ -337,6 +516,19 @@ def build_parser() -> argparse.ArgumentParser:
     conformance.add_argument("--findings-file", required=True)
     conformance.add_argument("--key", required=True, help="stable retry identity")
     conformance.set_defaults(fn=cmd_record_conformance)
+
+    followup = sub.add_parser(
+        "disposition-followup", help="FnB records a terminal follow-up disposition"
+    )
+    followup.add_argument("--sprint", type=int, required=True)
+    followup.add_argument("--followup", type=int, required=True)
+    followup.add_argument(
+        "--disposition",
+        choices=("accepted", "resolved", "dismissed"),
+        required=True,
+    )
+    followup.add_argument("--resolution-file")
+    followup.set_defaults(fn=cmd_disposition_followup)
 
     report = sub.add_parser(
         "compile-report", help="Planner prints the bounded evidence packet"

--- a/.super-coder/scripts/sprint_close.py
+++ b/.super-coder/scripts/sprint_close.py
@@ -25,6 +25,12 @@ class ConformanceReceipt:
     created: bool
 
 
+@dataclass(frozen=True)
+class FinalReportReceipt:
+    report_id: int
+    created: bool
+
+
 class SprintCloseStore:
     """Record close-out findings and compile deterministic evidence packets."""
 
@@ -106,6 +112,130 @@ class SprintCloseStore:
             )
         return ConformanceReceipt(report_id, tuple(followup_ids), True)
 
+    def record_final_report(
+        self,
+        sprint_id: int,
+        caller_shell_id: int,
+        *,
+        body: str,
+        idempotency_key: str,
+    ) -> FinalReportReceipt:
+        """Commit the optional final synthesis before lifecycle completion."""
+        body = self._required(body, "final report body")
+        idempotency_key = self._required(
+            idempotency_key, "idempotency key", maximum=220
+        )
+        with db_driver.write_transaction(self.con, "sprint.close.final_report"):
+            sprint = self._require_close_authority(sprint_id, caller_shell_id)
+            existing = self.con.execute(
+                "SELECT report_id,body,idempotency_key FROM sprint_reports "
+                "WHERE sprint_id=? AND report_kind='final' ORDER BY report_id LIMIT 1",
+                (sprint_id,),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    existing["body"] != body
+                    or existing["idempotency_key"] != idempotency_key
+                ):
+                    raise SprintInvariantError(
+                        "Sprint already has a different final report"
+                    )
+                return FinalReportReceipt(int(existing["report_id"]), False)
+            if sprint["lifecycle"] != "armed":
+                raise SprintInvariantError(
+                    f"final report requires an armed Sprint, not {sprint['lifecycle']}"
+                )
+            report_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_reports "
+                    "(sprint_id,report_kind,author_shell_id,body,idempotency_key) "
+                    "VALUES (?,'final',?,?,?)",
+                    (sprint_id, caller_shell_id, body, idempotency_key),
+                ).lastrowid
+            )
+            actor_kind = "fnb" if sprint["caller_flavor"] == "admin" else "planner"
+            self._event(
+                sprint_id,
+                "final_report.recorded",
+                caller_shell_id,
+                {"report_id": report_id},
+                actor_kind=actor_kind,
+            )
+        return FinalReportReceipt(report_id, True)
+
+    def disposition_followup(
+        self,
+        sprint_id: int,
+        followup_id: int,
+        caller_shell_id: int,
+        *,
+        disposition: str,
+        resolution: str | None = None,
+    ) -> bool:
+        """Record the FnB's terminal disposition of one conformance follow-up."""
+        if disposition not in {"accepted", "resolved", "dismissed"}:
+            raise ValueError(
+                "follow-up disposition must be accepted, resolved, or dismissed"
+            )
+        normalized_resolution = (resolution or "").strip()
+        if disposition == "accepted" and normalized_resolution:
+            raise ValueError("accepted follow-ups do not take a resolution")
+        if disposition in {"resolved", "dismissed"} and not normalized_resolution:
+            raise ValueError(f"{disposition} follow-ups require a resolution")
+        if len(normalized_resolution) > 8000:
+            raise ValueError("follow-up resolution exceeds 8000 characters")
+        with db_driver.write_transaction(self.con, "sprint.followup.disposition"):
+            caller = self.con.execute(
+                "SELECT flavor FROM shells WHERE shell_id=? "
+                "AND COALESCE(is_deleted,0)=0",
+                (caller_shell_id,),
+            ).fetchone()
+            if caller is None or caller["flavor"] != "admin":
+                raise SprintAuthorityError("only FnB may disposition Sprint follow-ups")
+            followup = self.con.execute(
+                "SELECT sprint_id,disposition,resolution FROM sprint_followups "
+                "WHERE sprint_id=? AND followup_id=?",
+                (sprint_id, followup_id),
+            ).fetchone()
+            if followup is None:
+                raise KeyError(
+                    f"unknown Sprint follow-up {followup_id} for Sprint {sprint_id}"
+                )
+            if followup["disposition"] != "pending":
+                existing_resolution = (followup["resolution"] or "").strip()
+                if (
+                    followup["disposition"] == disposition
+                    and existing_resolution == normalized_resolution
+                ):
+                    return False
+                raise SprintInvariantError(
+                    "Sprint follow-up already has a terminal disposition"
+                )
+            if disposition == "accepted":
+                self.con.execute(
+                    "UPDATE sprint_followups SET disposition='accepted' "
+                    "WHERE followup_id=?",
+                    (followup_id,),
+                )
+            else:
+                self.con.execute(
+                    "UPDATE sprint_followups SET disposition=?,resolution=?,"
+                    "resolved_at=datetime('now') WHERE followup_id=?",
+                    (disposition, normalized_resolution, followup_id),
+                )
+            self._event(
+                int(followup["sprint_id"]),
+                "followup.dispositioned",
+                caller_shell_id,
+                {
+                    "followup_id": followup_id,
+                    "disposition": disposition,
+                    "resolution": normalized_resolution or None,
+                },
+                actor_kind="fnb",
+            )
+        return True
+
     def compile_evidence_packet(
         self,
         sprint_id: int,
@@ -168,7 +298,7 @@ class SprintCloseStore:
         pending_followups = self._rows(
             "SELECT followup_id,severity,title,spec_document_id,work_unit_id,"
             "disposition,created_at FROM sprint_followups WHERE sprint_id=? "
-            "AND disposition IN ('pending','accepted') ORDER BY followup_id",
+            "AND disposition='pending' ORDER BY followup_id",
             (sprint_id,),
         )
         conformance_reports = self._rows(
@@ -183,6 +313,13 @@ class SprintCloseStore:
             "spec_document_id,work_unit_id,disposition,resolution,created_at,"
             "resolved_at FROM sprint_followups WHERE sprint_id=? "
             "ORDER BY followup_id",
+            (sprint_id,),
+        )
+        final_reports = self._rows(
+            "SELECT r.report_id,r.author_shell_id,s.shortname,r.body,r.created_at "
+            "FROM sprint_reports r LEFT JOIN shells s "
+            "ON s.shell_id=r.author_shell_id WHERE r.sprint_id=? "
+            "AND r.report_kind='final' ORDER BY r.report_id",
             (sprint_id,),
         )
         spec_events = [
@@ -221,6 +358,9 @@ class SprintCloseStore:
             "conformance": {
                 "reports": self._bounded(conformance_reports, section_limit),
                 "followups": self._bounded(conformance_followups, section_limit),
+                "final_reports": self._bounded(final_reports, section_limit),
+                "missing_conformance": not conformance_reports,
+                "missing_final_report": not final_reports,
             },
             "unresolved_work": {
                 "work_units": self._bounded(unresolved_units, section_limit),
@@ -255,8 +395,9 @@ class SprintCloseStore:
     def _planned_vs_actual(self, sprint_id: int) -> list[dict[str, Any]]:
         units = self._rows(
             "SELECT work_unit_id,assigned_shell_id,reviewer_shell_id,title,"
-            "expected_output,planned_wave,disposition,created_at,updated_at,"
-            "completed_at FROM sprint_work_units WHERE sprint_id=? "
+            "expected_output,output_kind,completion_result,planned_wave,"
+            "disposition,created_at,updated_at,completed_at "
+            "FROM sprint_work_units WHERE sprint_id=? "
             "ORDER BY planned_wave,work_unit_id",
             (sprint_id,),
         )
@@ -573,14 +714,17 @@ class SprintCloseStore:
         event_type: str,
         shell_id: int,
         payload: dict[str, Any],
+        *,
+        actor_kind: str = "participant",
     ) -> None:
         self.con.execute(
             "INSERT INTO sprint_events "
             "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
-            "VALUES (?,?,'participant',?,?)",
+            "VALUES (?,?,?,?,?)",
             (
                 sprint_id,
                 event_type,
+                actor_kind,
                 shell_id,
                 json.dumps(payload, separators=(",", ":"), sort_keys=True),
             ),

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -29,6 +29,7 @@ SPRINT_TRANSITIONS = {
 EDITING_UNIT_DISPOSITIONS = frozenset(
     {"active", "in_review", "fixing", "merge_ready"}
 )
+WORK_UNIT_OUTPUT_KINDS = frozenset({"code", "report_only", "no_code"})
 
 
 class SprintLifecycleError(ValueError):
@@ -85,12 +86,115 @@ class AbortReceipt:
     notification_conversation_ids: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class SpecApprovalReceipt:
+    approval_id: int
+    revision_sha256: str
+    verdict: str
+    created: bool
+
+
 def transition_allowed(current: str, target: str) -> bool:
     return (
         current in SPRINT_TRANSITIONS
         and target in SPRINT_TRANSITIONS
         and (target == current or target in SPRINT_TRANSITIONS[current])
     )
+
+
+class SprintSpecApprovalStore:
+    """Append exact-revision QAQC approvals signed by Review shells."""
+
+    def __init__(self, con: sqlite3.Connection) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+
+    def record(
+        self,
+        document_id: int,
+        reviewer_shell_id: int,
+        *,
+        verdict: str,
+        findings_document_id: int | None = None,
+    ) -> SpecApprovalReceipt:
+        if verdict not in {"pass", "fail"}:
+            raise ValueError("QAQC verdict must be pass or fail")
+        with db_driver.write_transaction(self.con, "sprint.spec_approval.record"):
+            reviewer = self.con.execute(
+                "SELECT flavor FROM shells WHERE shell_id=? "
+                "AND COALESCE(is_deleted,0)=0",
+                (reviewer_shell_id,),
+            ).fetchone()
+            if reviewer is None or reviewer["flavor"] != "reviewer":
+                raise SprintAuthorityError(
+                    "only an active Review shell may record Sprint QAQC"
+                )
+            document = self.con.execute(
+                "SELECT feature_id,kind,body FROM documents WHERE document_id=?",
+                (document_id,),
+            ).fetchone()
+            if document is None:
+                raise KeyError(f"unknown document: {document_id}")
+            if document["kind"] != "spec" or document["body"] is None:
+                raise SprintInvariantError("Sprint QAQC requires a spec document body")
+            if findings_document_id is not None:
+                findings = self.con.execute(
+                    "SELECT feature_id FROM documents WHERE document_id=?",
+                    (findings_document_id,),
+                ).fetchone()
+                if findings is None:
+                    raise KeyError(f"unknown findings document: {findings_document_id}")
+                if findings["feature_id"] != document["feature_id"]:
+                    raise SprintInvariantError(
+                        "QAQC findings must belong to the reviewed spec feature"
+                    )
+            revision = hashlib.sha256(document["body"].encode()).hexdigest()
+            existing = self.con.execute(
+                "SELECT approval_id,verdict,findings_document_id "
+                "FROM sprint_spec_approvals WHERE document_id=? "
+                "AND revision_sha256=? AND reviewer_shell_id=?",
+                (document_id, revision, reviewer_shell_id),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    existing["verdict"] != verdict
+                    or existing["findings_document_id"] != findings_document_id
+                ):
+                    raise SprintInvariantError(
+                        "QAQC approval already exists with different evidence"
+                    )
+                return SpecApprovalReceipt(
+                    int(existing["approval_id"]), revision, verdict, False
+                )
+            approval_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_spec_approvals "
+                    "(document_id,revision_sha256,reviewer_shell_id,verdict,"
+                    "findings_document_id) VALUES (?,?,?,?,?)",
+                    (
+                        document_id,
+                        revision,
+                        reviewer_shell_id,
+                        verdict,
+                        findings_document_id,
+                    ),
+                ).lastrowid
+            )
+        return SpecApprovalReceipt(approval_id, revision, verdict, True)
+
+    def for_document(self, document_id: int) -> list[dict]:
+        return [
+            dict(row)
+            for row in self.con.execute(
+                "SELECT a.approval_id,a.document_id,a.revision_sha256,"
+                "a.reviewer_shell_id,s.shortname AS reviewer_shortname,"
+                "a.verdict,a.findings_document_id,a.reviewed_at "
+                "FROM sprint_spec_approvals a JOIN shells s "
+                "ON s.shell_id=a.reviewer_shell_id WHERE a.document_id=? "
+                "ORDER BY a.approval_id",
+                (document_id,),
+            )
+        ]
 
 
 class SprintLifecycleStore:
@@ -1108,10 +1212,13 @@ class SprintLifecycleStore:
             "SELECT COUNT(*) FROM sprint_specs ss "
             "JOIN sprint_spec_approvals a ON a.approval_id=ss.approval_id "
             "JOIN documents d ON d.document_id=ss.document_id "
+            "JOIN shells reviewer ON reviewer.shell_id=a.reviewer_shell_id "
             "WHERE ss.sprint_id=? AND "
             "(a.verdict<>'pass' OR a.document_id<>ss.document_id "
             "OR a.revision_sha256<>ss.bound_revision_sha256 "
-            "OR d.kind<>'spec' OR d.feature_id<>?)",
+            "OR d.kind<>'spec' OR d.feature_id<>? "
+            "OR reviewer.flavor<>'reviewer' "
+            "OR COALESCE(reviewer.is_deleted,0)<>0)",
             (sprint_id, sprint["feature_id"]),
         ).fetchone()[0]
         bound_specs = self.con.execute(
@@ -1254,6 +1361,7 @@ class SprintWorkUnitStore:
         task_ids: Iterable[int],
         planned_wave: int = 0,
         dependency_ids: Iterable[int] = (),
+        output_kind: str = "code",
     ) -> int:
         """Create one planned editing lane from existing governing-spec tasks."""
         title = title.strip()
@@ -1268,6 +1376,8 @@ class SprintWorkUnitStore:
             raise SprintInvariantError("work units require at least one spec task")
         if planned_wave < 0:
             raise ValueError("planned wave must be non-negative")
+        if output_kind not in WORK_UNIT_OUTPUT_KINDS:
+            raise ValueError("work-unit output kind must be code, report_only, or no_code")
 
         with db_driver.write_transaction(self.con, "sprint.work_unit.create"):
             lifecycle, _ = self._require_planner(sprint_id, planner_shell_id)
@@ -1280,7 +1390,7 @@ class SprintWorkUnitStore:
                 self.con.execute(
                     "INSERT INTO sprint_work_units "
                     "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
-                    "expected_output,planned_wave) VALUES (?,?,?,?,?,?)",
+                    "expected_output,planned_wave,output_kind) VALUES (?,?,?,?,?,?,?)",
                     (
                         sprint_id,
                         assigned_shell_id,
@@ -1288,6 +1398,7 @@ class SprintWorkUnitStore:
                         title,
                         expected_output,
                         planned_wave,
+                        output_kind,
                     ),
                 ).lastrowid
             )
@@ -1306,6 +1417,7 @@ class SprintWorkUnitStore:
                     "assigned_shell_id": assigned_shell_id,
                     "reviewer_shell_id": reviewer_shell_id,
                     "planned_wave": planned_wave,
+                    "output_kind": output_kind,
                     "task_ids": list(tasks),
                     "dependency_ids": list(dependencies),
                 },
@@ -1322,6 +1434,7 @@ class SprintWorkUnitStore:
         reviewer_shell_id: int,
         planned_wave: int,
         dependency_ids: Iterable[int],
+        output_kind: str | None = None,
     ) -> bool:
         """Replace the editable plan projection and append its before/after fact."""
         if planned_wave < 0:
@@ -1339,23 +1452,32 @@ class SprintWorkUnitStore:
                 )
             self._require_participant(sprint_id, assigned_shell_id, "developer")
             self._require_participant(sprint_id, reviewer_shell_id, "reviewer")
+            if output_kind is None:
+                output_kind = str(unit["output_kind"])
+            if output_kind not in WORK_UNIT_OUTPUT_KINDS:
+                raise ValueError(
+                    "work-unit output kind must be code, report_only, or no_code"
+                )
             before = self._plan_projection(unit)
             after = {
                 "assigned_shell_id": assigned_shell_id,
                 "reviewer_shell_id": reviewer_shell_id,
                 "planned_wave": planned_wave,
+                "output_kind": output_kind,
                 "dependency_ids": sorted(dependencies),
             }
             if before == after:
                 return False
             self.con.execute(
                 "UPDATE sprint_work_units SET assigned_shell_id=?,"
-                "reviewer_shell_id=?,planned_wave=?,updated_at=datetime('now') "
+                "reviewer_shell_id=?,planned_wave=?,output_kind=?,"
+                "updated_at=datetime('now') "
                 "WHERE work_unit_id=?",
                 (
                     assigned_shell_id,
                     reviewer_shell_id,
                     planned_wave,
+                    output_kind,
                     work_unit_id,
                 ),
             )
@@ -1399,29 +1521,49 @@ class SprintWorkUnitStore:
         sprint_id: int,
         work_unit_id: int,
         shell_id: int,
+        *,
+        result: str,
     ) -> list[int]:
-        """Record Developer completion and release newly unblocked work."""
+        """Record a non-code Developer result and release newly unblocked work."""
+        result = result.strip()
+        if not result:
+            raise ValueError("work-unit completion result is required")
+        if len(result) > 8000:
+            raise ValueError("work-unit completion result exceeds 8000 characters")
         with db_driver.write_transaction(self.con, "sprint.work_unit.complete"):
             unit = self._unit(sprint_id, work_unit_id)
             if int(unit["assigned_shell_id"]) != shell_id:
                 raise SprintAuthorityError("only the assigned Developer owns completion")
             if unit["disposition"] == "completed":
+                if unit["completion_result"] != result:
+                    raise SprintInvariantError(
+                        "work unit was already completed with a different result"
+                    )
                 return []
-            if unit["disposition"] not in EDITING_UNIT_DISPOSITIONS:
+            if unit["output_kind"] not in {"report_only", "no_code"}:
+                raise SprintInvariantError(
+                    "code work units complete only through the merge judgment chain"
+                )
+            if unit["disposition"] != "active":
                 raise SprintInvariantError(
                     f"cannot complete work unit from {unit['disposition']}"
                 )
             self.con.execute(
                 "UPDATE sprint_work_units SET disposition='completed',"
-                "completed_at=datetime('now'),updated_at=datetime('now') "
+                "completion_result=?,completed_at=datetime('now'),"
+                "updated_at=datetime('now') "
                 "WHERE work_unit_id=?",
-                (work_unit_id,),
+                (result, work_unit_id),
             )
             self._event(
                 sprint_id,
                 "work_unit.completed",
                 shell_id,
-                {"work_unit_id": work_unit_id},
+                {
+                    "work_unit_id": work_unit_id,
+                    "output_kind": str(unit["output_kind"]),
+                    "result": result,
+                },
                 actor_kind="participant",
             )
             sprint = self.con.execute(
@@ -1440,6 +1582,45 @@ class SprintWorkUnitStore:
                 sprint_id,
                 planner_participant_id=planner,
             )
+
+    def cancel(
+        self,
+        sprint_id: int,
+        work_unit_id: int,
+        planner_shell_id: int,
+        *,
+        reason: str,
+    ) -> bool:
+        """Cancel one unreleased plan without rewriting completed history."""
+        reason = reason.strip()
+        if not reason:
+            raise ValueError("work-unit cancellation reason is required")
+        if len(reason) > 8000:
+            raise ValueError("work-unit cancellation reason exceeds 8000 characters")
+        with db_driver.write_transaction(self.con, "sprint.work_unit.cancel"):
+            self._require_planner(sprint_id, planner_shell_id)
+            unit = self._unit(sprint_id, work_unit_id)
+            if unit["disposition"] == "cancelled":
+                if unit["completion_result"] != reason:
+                    raise SprintInvariantError(
+                        "work unit was already cancelled with a different reason"
+                    )
+                return False
+            if unit["disposition"] != "planned":
+                raise SprintInvariantError("only planned work units may be cancelled")
+            self.con.execute(
+                "UPDATE sprint_work_units SET disposition='cancelled',"
+                "completion_result=?,completed_at=datetime('now'),"
+                "updated_at=datetime('now') WHERE work_unit_id=?",
+                (reason, work_unit_id),
+            )
+            self._event(
+                sprint_id,
+                "work_unit.cancelled",
+                planner_shell_id,
+                {"work_unit_id": work_unit_id, "reason": reason},
+            )
+        return True
 
     def complete_from_merge_in_transaction(
         self,
@@ -1782,6 +1963,7 @@ class SprintWorkUnitStore:
             "assigned_shell_id": int(unit["assigned_shell_id"]),
             "reviewer_shell_id": int(unit["reviewer_shell_id"]),
             "planned_wave": int(unit["planned_wave"]),
+            "output_kind": str(unit["output_kind"]),
             "dependency_ids": dependencies,
         }
 

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -149,10 +149,16 @@ class SprintMessageStore:
             (sprint_id, shell_id),
         ).fetchall()
 
-    def mark_read(self, message_id: int, shell_id: int) -> str | None:
+    def mark_read(
+        self,
+        message_id: int,
+        shell_id: int,
+        *,
+        sprint_id: int | None = None,
+    ) -> str | None:
         """Read one message; actionable reads atomically accept it."""
         with db_driver.write_transaction(self.con, "sprint.message.read"):
-            message = self._recipient_message(message_id, shell_id)
+            message = self._recipient_message(message_id, shell_id, sprint_id)
             accepted_now = False
             if message["actionable"]:
                 if message["disposition"] == "declined":
@@ -211,13 +217,20 @@ class SprintMessageStore:
             self._cancel_resolved_wakes(message_id)
             return disposition
 
-    def decline(self, message_id: int, shell_id: int, reason: str) -> int:
+    def decline(
+        self,
+        message_id: int,
+        shell_id: int,
+        reason: str,
+        *,
+        sprint_id: int | None = None,
+    ) -> int:
         """Resolve an actionable message and actively route the result to Planner."""
         reason = reason.strip()
         if not reason:
             raise ValueError("decline requires a reason")
         with db_driver.write_transaction(self.con, "sprint.message.decline"):
-            message = self._recipient_message(message_id, shell_id)
+            message = self._recipient_message(message_id, shell_id, sprint_id)
             if not message["actionable"]:
                 raise SprintInvariantError("informational messages cannot be declined")
             if message["disposition"] == "accepted":
@@ -396,13 +409,24 @@ class SprintMessageStore:
         )
         return wake_id
 
-    def _recipient_message(self, message_id: int, shell_id: int) -> sqlite3.Row:
+    def _recipient_message(
+        self,
+        message_id: int,
+        shell_id: int,
+        sprint_id: int | None,
+    ) -> sqlite3.Row:
+        scope = " AND m.sprint_id=?" if sprint_id is not None else ""
+        params = (
+            (message_id, shell_id, sprint_id)
+            if sprint_id is not None
+            else (message_id, shell_id)
+        )
         row = self.con.execute(
             "SELECT m.* FROM sprint_messages m "
             "JOIN sprint_participants p "
             "ON p.sprint_id=m.sprint_id AND p.participant_id=m.to_participant_id "
-            "WHERE m.message_id=? AND p.shell_id=?",
-            (message_id, shell_id),
+            "WHERE m.message_id=? AND p.shell_id=?" + scope,
+            params,
         ).fetchone()
         if row is None:
             raise KeyError(f"Sprint message {message_id} is not addressed to shell")

--- a/sc
+++ b/sc
@@ -1543,7 +1543,7 @@ super-coder — forkable shell substrate
                              source-pure one: it verifies the CALLER's engine sources and local artifacts, and names the checkout it read.
   ./sc mem <cmd> [args]    a shell's own memory, over the engine API (get/state/seed/lns/decision/flag/roadmap/doc/narrative);
                              already wired to this launched shell, identity resolved by the engine — no DB path, no direct-DB fallback. `./sc mem which` to orient
-  ./sc sprint <cmd>        authenticated Sprints v2 actions: request-review · record-review · authorize-merge · dispatch · monitor · record-conformance · compile-report
+  ./sc sprint <cmd>        authenticated Sprints v2 actions (run without a command for the full verb list)
                              caller identity is resolved by the engine; report and review bodies use files, and mutating retries carry stable keys where required
   ./sc token               print the browser sign-in operator token (an operator capability: the Admin runtime
                              credential from the owner-only artifact .super-coder/run/mem/<shortname>.json, mode 0600)

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -6,6 +6,7 @@
     ".super-coder/migrations/0149_sprint_liveness_monitor.sql",
     ".super-coder/migrations/0150_sprint_close_reports.sql",
     ".super-coder/migrations/0151_seed_sprint_v2_skills.sql",
+    ".super-coder/migrations/0152_sprint_surface_completion.sql",
     ".super-coder/assets/skills/sprint_prep/SKILL.md",
     ".super-coder/assets/skills/sprint_pln/SKILL.md",
     ".super-coder/assets/skills/sprint_dev/SKILL.md",
@@ -475,7 +476,7 @@
       ],
       "sc": [
         "sprint)       exec \"$PY\" \"$S/sprint_cli.py\" \"$@\" ;;",
-        "./sc sprint <cmd>        authenticated Sprints v2 actions: request-review · record-review · authorize-merge · dispatch · monitor · record-conformance · compile-report"
+        "./sc sprint <cmd>        authenticated Sprints v2 actions (run without a command for the full verb list)"
       ]
     },
     "forbidden_pattern": "(?:\\bsprints?\\b|\\bconductor\\b|SC_SPRINT_|pr_event|watched_prs|watch-daemon|interface_(?:generations|sessions|writer_leases|input_state|idempotency_keys|recovery_observations)|planner_(?:wake_batches|wake_items|action_receipts|alerts))",

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -38,6 +38,7 @@ import server  # noqa: E402
 
 TOKEN = "test-token-deadbeef"
 PEER_TOKEN = "peer-token-cafebabe"   # second shell — cross-shell read coverage
+REVIEW_TOKEN = "review-token-012345"
 
 
 class MemMessageHelpContractTest(unittest.TestCase):
@@ -85,6 +86,13 @@ def build_engine_db(path: Path) -> None:
         "INSERT INTO shells (shell_id, display_name, shortname, mandate, system_prompt, "
         "user_id, is_shared, has_identity, bootstrapped, api_key) "
         "VALUES (2, 'Peer', 'peer', 'test', 'sp', 1, 0, 1, 0, ?)", (PEER_TOKEN,))
+    con.execute(
+        "INSERT INTO shells (shell_id, display_name, shortname, flavor, mandate, "
+        "system_prompt, user_id, is_shared, has_identity, bootstrapped, api_key) "
+        "VALUES (3, 'Reviewer', 'rev1', 'reviewer', 'test', 'sp', "
+        "1, 0, 1, 0, ?)",
+        (REVIEW_TOKEN,),
+    )
     con.execute(
         "INSERT INTO shell_memory_archives (archive_id, shell_id, session_id, date) "
         "VALUES (1, 1, '0001', '2026-01-01')")
@@ -488,6 +496,42 @@ class ApiMemTest(unittest.TestCase):
         tid = self.q("SELECT task_id FROM spec_tasks WHERE title='task C'")[0]
         self.run_mem("task", "done", str(tid))
         self.assertEqual(self.q("SELECT status FROM spec_tasks WHERE task_id=?", tid)[0], "done")
+
+    def test_legacy_mem_qaqc_command_uses_the_sprint_approval_surface(self):
+        self.run_mem("roadmap", "add", "feat QAQC")
+        fid = self.q("SELECT feature_id FROM roadmap WHERE title='feat QAQC'")[0]
+        body = self.tmp / "qaqc.md"
+        body.write_text("# exact QAQC body\n")
+        self.run_mem(
+            "doc",
+            "add",
+            "spec QAQC",
+            "--body-file",
+            str(body),
+            "--feature",
+            str(fid),
+        )
+        did = self.q("SELECT document_id FROM documents WHERE title='spec QAQC'")[0]
+        original_token = mem.SC_API_TOKEN
+        mem.SC_API_TOKEN = REVIEW_TOKEN
+        try:
+            self.assertEqual(
+                0,
+                self.run_mem(
+                    "doc", "qaqc", str(did), "--verdict", "approved"
+                ),
+            )
+        finally:
+            mem.SC_API_TOKEN = original_token
+
+        approval = self.q(
+            "SELECT reviewer_shell_id,verdict,revision_sha256 "
+            "FROM sprint_spec_approvals WHERE document_id=?",
+            did,
+        )
+        self.assertEqual((3, "pass"), tuple(approval[:2]))
+        self.assertEqual(64, len(approval["revision_sha256"]))
+        self.assertEqual(0, self.run_mem("get", "qaqc", "--doc", str(did)))
 
     # ── doc writes serialize headlessly (subfloor#434) ───────────────────────
     def test_doc_write_serializes(self):

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -270,6 +270,7 @@ class SprintCliApiTest(unittest.TestCase):
                     (1, "Developer", "DEV1", "dev", "prompt", TOKENS["developer"]),
                     (2, "Reviewer", "REV1", "reviewer", "prompt", TOKENS["reviewer"]),
                     (3, "Planner", "PLN1", "planner", "prompt", TOKENS["planner"]),
+                    (4, "Developer 2", "DEV2", "dev", "prompt", "dev2-token"),
                     (5, "FnB", "FNB", "admin", "prompt", TOKENS["admin"]),
                 ),
             )
@@ -386,6 +387,307 @@ class SprintCliApiTest(unittest.TestCase):
                     "ORDER BY event_id LIMIT 2",
                     (sprint_id,),
                 ).fetchall(),
+            )
+        finally:
+            con.close()
+
+    def test_remediation_surfaces_are_authenticated_and_durable(self):
+        self.use_isolated_db()
+        con = sqlite3.connect(self.db)
+        try:
+            feature_id = int(
+                con.execute(
+                    "INSERT INTO roadmap (title,roadmap_status) "
+                    "VALUES ('Surface remediation','in_progress')"
+                ).lastrowid
+            )
+            document_id = int(
+                con.execute(
+                    "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                    "VALUES (?,'spec',1,'Surface spec','REV9 body')",
+                    (feature_id,),
+                ).lastrowid
+            )
+            task_ids = [
+                int(
+                    con.execute(
+                        "INSERT INTO spec_tasks "
+                        "(feature_id,document_id,seq,title) VALUES (?,?,?,?)",
+                        (feature_id, document_id, seq, title),
+                    ).lastrowid
+                )
+                for seq, title in enumerate(("Report", "Optional lane"))
+            ]
+            con.commit()
+        finally:
+            con.close()
+
+        approval = self.run_cli(
+            TOKENS["reviewer"],
+            "record-qaqc",
+            "--document",
+            str(document_id),
+            "--verdict",
+            "pass",
+        )
+        self.assertTrue(approval["created"])
+        with self.assertRaisesRegex(SystemExit, "HTTP 403.*Review shell"):
+            self.run_cli(
+                TOKENS["developer"],
+                "record-qaqc",
+                "--document",
+                str(document_id),
+                "--verdict",
+                "pass",
+            )
+
+        participants = self.write(
+            json.dumps(
+                [
+                    {"shell_id": 3, "role": "planner", "harness": "codex"},
+                    {"shell_id": 1, "role": "developer", "harness": "codex"},
+                    {"shell_id": 4, "role": "developer", "harness": "codex"},
+                    {"shell_id": 2, "role": "reviewer", "harness": "kimi"},
+                ]
+            )
+        )
+        con = sqlite3.connect(self.db)
+        try:
+            bad_approval_id = int(
+                con.execute(
+                    "INSERT INTO sprint_spec_approvals "
+                    "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+                    "VALUES (?,?,1,'pass')",
+                    (document_id, hashlib.sha256(b"REV9 body").hexdigest()),
+                ).lastrowid
+            )
+            con.commit()
+        finally:
+            con.close()
+        with self.assertRaisesRegex(
+            SystemExit, "HTTP 409.*current passing approvals"
+        ):
+            self.run_cli(
+                TOKENS["planner"],
+                "declare",
+                "--feature",
+                str(feature_id),
+                "--spec-approval",
+                str(bad_approval_id),
+                "--participants-file",
+                participants,
+                "--merge-grant",
+            )
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(0, con.execute("SELECT COUNT(*) FROM sprints").fetchone()[0])
+        finally:
+            con.close()
+        sprint_id = self.run_cli(
+            TOKENS["planner"],
+            "declare",
+            "--feature",
+            str(feature_id),
+            "--spec-approval",
+            str(approval["approval_id"]),
+            "--participants-file",
+            participants,
+            "--merge-grant",
+        )["sprint_id"]
+        report_unit = self.run_cli(
+            TOKENS["planner"],
+            "plan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--developer-shell",
+            "1",
+            "--reviewer-shell",
+            "2",
+            "--title",
+            "Report lane",
+            "--expected-output-file",
+            self.write("Durable report"),
+            "--task",
+            str(task_ids[0]),
+            "--output-kind",
+            "report-only",
+        )["work_unit_id"]
+        optional_unit = self.run_cli(
+            TOKENS["planner"],
+            "plan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--developer-shell",
+            "4",
+            "--reviewer-shell",
+            "2",
+            "--title",
+            "Optional lane",
+            "--expected-output-file",
+            self.write("Optional result"),
+            "--task",
+            str(task_ids[1]),
+        )["work_unit_id"]
+        replanned = self.run_cli(
+            TOKENS["planner"],
+            "replan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--work-unit",
+            str(optional_unit),
+            "--developer-shell",
+            "4",
+            "--reviewer-shell",
+            "2",
+            "--wave",
+            "7",
+            "--output-kind",
+            "no-code",
+        )
+        self.assertTrue(replanned["changed"])
+        self.run_cli(TOKENS["planner"], "arm", "--sprint", str(sprint_id))
+
+        inbox = self.run_cli(
+            TOKENS["developer"], "inbox", "--sprint", str(sprint_id)
+        )
+        self.assertEqual(1, len(inbox["messages"]))
+        report_message = inbox["messages"][0]["message_id"]
+        accepted = self.run_cli(
+            TOKENS["developer"],
+            "accept",
+            "--sprint",
+            str(sprint_id),
+            "--message",
+            str(report_message),
+        )
+        self.assertEqual("accepted", accepted["disposition"])
+        declined_inbox = self.run_cli(
+            "dev2-token", "inbox", "--sprint", str(sprint_id)
+        )
+        declined_message = declined_inbox["messages"][0]["message_id"]
+        decline = self.run_cli(
+            "dev2-token",
+            "decline",
+            "--sprint",
+            str(sprint_id),
+            "--message",
+            str(declined_message),
+            "--reason",
+            "capacity moved",
+        )
+        self.assertIsInstance(decline["result_message_id"], int)
+        cancelled = self.run_cli(
+            TOKENS["planner"],
+            "cancel-unit",
+            "--sprint",
+            str(sprint_id),
+            "--work-unit",
+            str(optional_unit),
+            "--reason",
+            "Declined lane removed from scope",
+        )
+        self.assertTrue(cancelled["changed"])
+        completed_unit = self.run_cli(
+            TOKENS["developer"],
+            "complete-unit",
+            "--sprint",
+            str(sprint_id),
+            "--work-unit",
+            str(report_unit),
+            "--result-file",
+            self.write("Report document #77"),
+        )
+        self.assertEqual([], completed_unit["wake_ids"])
+
+        conformance = self.run_cli(
+            TOKENS["reviewer"],
+            "record-conformance",
+            "--sprint",
+            str(sprint_id),
+            "--body-file",
+            self.write("Conformance complete"),
+            "--findings-file",
+            self.write(
+                json.dumps(
+                    [{"severity": "Low", "title": "Note", "body": "Track it"}]
+                )
+            ),
+            "--key",
+            "surface-conformance",
+        )
+        followup_id = conformance["followup_ids"][0]
+        with self.assertRaisesRegex(SystemExit, "HTTP 403.*only FnB"):
+            self.run_cli(
+                TOKENS["planner"],
+                "disposition-followup",
+                "--sprint",
+                str(sprint_id),
+                "--followup",
+                str(followup_id),
+                "--disposition",
+                "accepted",
+            )
+        disposition = self.run_cli(
+            TOKENS["admin"],
+            "disposition-followup",
+            "--sprint",
+            str(sprint_id),
+            "--followup",
+            str(followup_id),
+            "--disposition",
+            "accepted",
+        )
+        self.assertTrue(disposition["changed"])
+
+        completed = self.run_cli(
+            TOKENS["planner"],
+            "complete",
+            "--sprint",
+            str(sprint_id),
+            "--reason",
+            "close",
+            "--outcome",
+            "accepted",
+            "--report-file",
+            self.write("Final Sprint report"),
+            "--key",
+            "surface-final-report",
+        )
+        self.assertTrue(completed["changed"])
+        self.assertIsInstance(completed["report_id"], int)
+
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                [
+                    (report_unit, "report_only", "completed", "Report document #77"),
+                    (
+                        optional_unit,
+                        "no_code",
+                        "cancelled",
+                        "Declined lane removed from scope",
+                    ),
+                ],
+                con.execute(
+                    "SELECT work_unit_id,output_kind,disposition,completion_result "
+                    "FROM sprint_work_units WHERE sprint_id=? ORDER BY work_unit_id",
+                    (sprint_id,),
+                ).fetchall(),
+            )
+            self.assertEqual(
+                [("final", "Final Sprint report")],
+                con.execute(
+                    "SELECT report_kind,body FROM sprint_reports WHERE sprint_id=? "
+                    "AND report_kind='final'",
+                    (sprint_id,),
+                ).fetchall(),
+            )
+            self.assertEqual(
+                "accepted",
+                con.execute(
+                    "SELECT disposition FROM sprint_followups WHERE followup_id=?",
+                    (followup_id,),
+                ).fetchone()[0],
             )
         finally:
             con.close()

--- a/tests/test_sprint_close.py
+++ b/tests/test_sprint_close.py
@@ -13,6 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 MIGRATIONS = ENGINE / "migrations"
 MIGRATION = MIGRATIONS / "0150_sprint_close_reports.sql"
+SURFACE_MIGRATION = MIGRATIONS / "0152_sprint_surface_completion.sql"
 
 sys.path[:0] = [str(ENGINE / "scripts"), str(ROOT / "tests")]
 import sprint_close  # noqa: E402
@@ -94,6 +95,73 @@ class SprintCloseMigrationTest(unittest.TestCase):
                 ).fetchone()
             )
             self.assertEqual([], con.execute("PRAGMA foreign_key_check").fetchall())
+
+    def test_surface_migration_preserves_code_units_and_accepts_non_code_result(self):
+        with closing(sqlite3.connect(":memory:")) as con:
+            apply_schema(con, through="0151_seed_sprint_v2_skills.sql")
+            con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+            con.executemany(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,system_prompt,user_id) "
+                "VALUES (?,?,?,?,1)",
+                (
+                    (1, "Developer", "DEV1", "prompt"),
+                    (2, "Reviewer", "REV1", "prompt"),
+                    (3, "Planner", "PLN1", "prompt"),
+                ),
+            )
+            feature_id = int(
+                con.execute("INSERT INTO roadmap (title) VALUES ('Feature')").lastrowid
+            )
+            sprint_id = int(
+                con.execute(
+                    "INSERT INTO sprints "
+                    "(feature_id,originating_planner_shell_id) VALUES (?,3)",
+                    (feature_id,),
+                ).lastrowid
+            )
+            unit_id = int(
+                con.execute(
+                    "INSERT INTO sprint_work_units "
+                    "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                    "expected_output) VALUES (?,1,2,'Existing','Code PR')",
+                    (sprint_id,),
+                ).lastrowid
+            )
+
+            con.executescript(SURFACE_MIGRATION.read_text())
+
+            self.assertEqual(
+                ("code", None),
+                tuple(
+                    con.execute(
+                        "SELECT output_kind,completion_result "
+                        "FROM sprint_work_units WHERE work_unit_id=?",
+                        (unit_id,),
+                    ).fetchone()
+                ),
+            )
+            con.execute(
+                "UPDATE sprint_work_units SET output_kind='report_only',"
+                "completion_result='Report #77' WHERE work_unit_id=?",
+                (unit_id,),
+            )
+            self.assertEqual(
+                ("report_only", "Report #77"),
+                tuple(
+                    con.execute(
+                        "SELECT output_kind,completion_result "
+                        "FROM sprint_work_units WHERE work_unit_id=?",
+                        (unit_id,),
+                    ).fetchone()
+                ),
+            )
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute(
+                    "UPDATE sprint_work_units SET output_kind='spreadsheet' "
+                    "WHERE work_unit_id=?",
+                    (unit_id,),
+                )
 
 
 class ConformanceFollowupTest(SprintCloseCase):
@@ -269,6 +337,153 @@ class ConformanceFollowupTest(SprintCloseCase):
                 (self.sprint_id,),
             ).fetchone()[0],
         )
+
+    def test_final_report_is_idempotent_and_replays_after_completion(self):
+        first = self.close.record_final_report(
+            self.sprint_id,
+            3,
+            body="Delivered scope, conformance, judgments, and follow-ups.",
+            idempotency_key="final-synthesis",
+        )
+        self.assertTrue(first.created)
+        sprint_domain.SprintLifecycleStore(self.con).transition(
+            self.sprint_id,
+            "completed",
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="close",
+            terminal_outcome="accepted",
+        )
+        replay = self.close.record_final_report(
+            self.sprint_id,
+            3,
+            body="Delivered scope, conformance, judgments, and follow-ups.",
+            idempotency_key="final-synthesis",
+        )
+        self.assertFalse(replay.created)
+        self.assertEqual(first.report_id, replay.report_id)
+        self.assertEqual(
+            (
+                "final",
+                3,
+                "Delivered scope, conformance, judgments, and follow-ups.",
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT report_kind,author_shell_id,body FROM sprint_reports "
+                    "WHERE report_id=?",
+                    (first.report_id,),
+                ).fetchone()
+            ),
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "different final report"
+        ):
+            self.close.record_final_report(
+                self.sprint_id,
+                3,
+                body="Conflicting report",
+                idempotency_key="final-synthesis",
+            )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "different final report"
+        ):
+            self.close.record_final_report(
+                self.sprint_id,
+                3,
+                body="Delivered scope, conformance, judgments, and follow-ups.",
+                idempotency_key="second-final-key",
+            )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_reports WHERE sprint_id=? "
+                "AND report_kind='final'",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+
+    def test_only_fnb_dispositions_followup_and_only_pending_is_unresolved(self):
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (5,'FnB','FNB','admin','prompt',1)"
+        )
+        self.con.commit()
+        receipt = self.close.record_conformance(
+            self.sprint_id,
+            2,
+            body="Two follow-ups",
+            findings=[
+                self.finding(title="Accepted"),
+                self.finding(title="Resolved"),
+            ],
+            idempotency_key="disposition-pass",
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintAuthorityError, "only FnB"
+        ):
+            self.close.disposition_followup(
+                self.sprint_id,
+                receipt.followup_ids[0],
+                3,
+                disposition="accepted",
+            )
+        self.assertEqual(
+            "pending",
+            self.con.execute(
+                "SELECT disposition FROM sprint_followups WHERE followup_id=?",
+                (receipt.followup_ids[0],),
+            ).fetchone()[0],
+        )
+
+        self.assertTrue(
+            self.close.disposition_followup(
+                self.sprint_id,
+                receipt.followup_ids[0],
+                5,
+                disposition="accepted",
+            )
+        )
+        self.assertTrue(
+            self.close.disposition_followup(
+                self.sprint_id,
+                receipt.followup_ids[1],
+                5,
+                disposition="resolved",
+                resolution="Fixed by PR #900",
+            )
+        )
+        self.assertFalse(
+            self.close.disposition_followup(
+                self.sprint_id,
+                receipt.followup_ids[1],
+                5,
+                disposition="resolved",
+                resolution="Fixed by PR #900",
+            )
+        )
+        self.assertEqual(
+            [
+                ("accepted", None, None),
+                ("resolved", "Fixed by PR #900", 1),
+            ],
+            [
+                (
+                    row["disposition"],
+                    row["resolution"],
+                    int(row["resolved_at"] is not None) if row["resolved_at"] else None,
+                )
+                for row in self.con.execute(
+                    "SELECT disposition,resolution,resolved_at "
+                    "FROM sprint_followups WHERE source_report_id=? "
+                    "ORDER BY followup_id",
+                    (receipt.report_id,),
+                )
+            ],
+        )
+        packet = self.close.compile_evidence_packet(self.sprint_id, 3)
+        self.assertEqual(0, packet["unresolved_work"]["followups"]["total"])
+        self.assertEqual([], packet["unresolved_work"]["followups"]["items"])
 
 
 class EvidenceCompilerTest(SprintCloseCase):

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -130,8 +130,9 @@ class SprintLivenessCase(unittest.TestCase):
         self.unit_id = int(
             self.con.execute(
                 "INSERT INTO sprint_work_units "
-                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,expected_output) "
-                "VALUES (?,1,2,'Unit','Ship it')",
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output,output_kind) "
+                "VALUES (?,1,2,'Unit','Ship it','no_code')",
                 (self.sprint_id,),
             ).lastrowid
         )
@@ -652,7 +653,10 @@ class DeliveryAndActivationTest(SprintLivenessCase):
 
     def test_terminal_work_unit_resolves_assignment_expectation(self) -> None:
         sprint_domain.SprintWorkUnitStore(self.con).complete(
-            self.sprint_id, self.unit_id, 1
+            self.sprint_id,
+            self.unit_id,
+            1,
+            result="Liveness fixture completed without code",
         )
         expectation = self.expectation()
         self.assertIsNotNone(expectation["resolved_at"])

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -81,9 +81,16 @@ class SprintSkillTest(unittest.TestCase):
 
     def test_skills_use_only_the_shipped_shell_command_surface(self):
         expected = {
+            "record-qaqc",
             "declare",
             "plan-unit",
+            "replan-unit",
             "arm",
+            "inbox",
+            "accept",
+            "decline",
+            "complete-unit",
+            "cancel-unit",
             "register-pr",
             "pause",
             "resume",
@@ -95,6 +102,7 @@ class SprintSkillTest(unittest.TestCase):
             "dispatch",
             "monitor",
             "record-conformance",
+            "disposition-followup",
             "compile-report",
         }
         combined = "\n".join(

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -170,6 +170,114 @@ class MigrationAndShapeTest(SprintDomainCase):
         )
 
 
+class SpecApprovalTest(SprintDomainCase):
+    def test_review_shell_records_exact_revision_and_retry_is_idempotent(self) -> None:
+        feature_id = int(
+            self.con.execute(
+                "INSERT INTO roadmap (title) VALUES ('QAQC feature')"
+            ).lastrowid
+        )
+        document_id = int(
+            self.con.execute(
+                "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                "VALUES (?,'spec',1,'QAQC spec','exact body')",
+                (feature_id,),
+            ).lastrowid
+        )
+        findings_id = int(
+            self.con.execute(
+                "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                "VALUES (?,'doc',1,'Findings','none')",
+                (feature_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+        approvals = sprint_domain.SprintSpecApprovalStore(self.con)
+
+        first = approvals.record(
+            document_id,
+            2,
+            verdict="pass",
+            findings_document_id=findings_id,
+        )
+        replay = approvals.record(
+            document_id,
+            2,
+            verdict="pass",
+            findings_document_id=findings_id,
+        )
+
+        self.assertTrue(first.created)
+        self.assertFalse(replay.created)
+        self.assertEqual(first.approval_id, replay.approval_id)
+        self.assertEqual(hashlib.sha256(b"exact body").hexdigest(), first.revision_sha256)
+        self.assertEqual(
+            (
+                document_id,
+                2,
+                "pass",
+                findings_id,
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT document_id,reviewer_shell_id,verdict,"
+                    "findings_document_id FROM sprint_spec_approvals "
+                    "WHERE approval_id=?",
+                    (first.approval_id,),
+                ).fetchone()
+            ),
+        )
+        listed = approvals.for_document(document_id)
+        self.assertEqual(1, len(listed))
+        self.assertEqual("REV1", listed[0]["reviewer_shortname"])
+
+    def test_non_reviewer_cannot_record_or_arm_hand_seeded_approval(self) -> None:
+        feature_id = int(
+            self.con.execute(
+                "INSERT INTO roadmap (title) VALUES ('Bad signer feature')"
+            ).lastrowid
+        )
+        document_id = int(
+            self.con.execute(
+                "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                "VALUES (?,'spec',1,'Bad signer','body')",
+                (feature_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+        approvals = sprint_domain.SprintSpecApprovalStore(self.con)
+        with self.assertRaisesRegex(
+            sprint_domain.SprintAuthorityError, "Review shell"
+        ):
+            approvals.record(document_id, 1, verdict="pass")
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_spec_approvals WHERE document_id=?",
+                (document_id,),
+            ).fetchone()[0],
+        )
+
+        sprint_id, _ = self.create_sprint()
+        self.con.execute(
+            "UPDATE sprint_spec_approvals SET reviewer_shell_id=1 "
+            "WHERE approval_id=(SELECT approval_id FROM sprint_specs "
+            "WHERE sprint_id=?)",
+            (sprint_id,),
+        )
+        self.con.commit()
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "passing spec approval"
+        ):
+            self.store.arm(sprint_id, 3)
+        self.assertEqual(
+            "prepared",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()[0],
+        )
+
+
 class LifecycleTest(SprintDomainCase):
     def test_sprint_insert_must_start_prepared(self) -> None:
         sprint_id, _ = self.create_sprint()

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -124,6 +124,7 @@ class SprintWorkDispatchCase(unittest.TestCase):
         wave: int = 0,
         dependencies: tuple[int, ...] = (),
         title: str | None = None,
+        output_kind: str = "code",
     ) -> int:
         task_id = self.task_ids[self.next_task]
         self.next_task += 1
@@ -137,6 +138,7 @@ class SprintWorkDispatchCase(unittest.TestCase):
             task_ids=(task_id,),
             planned_wave=wave,
             dependency_ids=dependencies,
+            output_kind=output_kind,
         )
 
     def assignment_message(self, unit_id: int) -> int:
@@ -204,7 +206,9 @@ class DispatchGateTest(SprintWorkDispatchCase):
         )
 
     def test_dependencies_block_and_each_developer_gets_one_editing_lane(self) -> None:
-        first = self.create_unit(developer=1, wave=0, title="First")
+        first = self.create_unit(
+            developer=1, wave=0, title="First", output_kind="no_code"
+        )
         same_shell = self.create_unit(developer=1, wave=1, title="Second")
         blocked = self.create_unit(
             developer=4,
@@ -224,7 +228,9 @@ class DispatchGateTest(SprintWorkDispatchCase):
         )
         self.assertEqual("active", self.dispositions()[0][1])
 
-        released = self.units.complete(self.sprint_id, first, 1)
+        released = self.units.complete(
+            self.sprint_id, first, 1, result="Durable non-code result"
+        )
 
         self.assertEqual(2, len(released))
         self.assertEqual(
@@ -243,6 +249,86 @@ class DispatchGateTest(SprintWorkDispatchCase):
                 )
             ],
         )
+        self.assertEqual(
+            ("no_code", "Durable non-code result"),
+            tuple(
+                self.con.execute(
+                    "SELECT output_kind,completion_result FROM sprint_work_units "
+                    "WHERE work_unit_id=?",
+                    (first,),
+                ).fetchone()
+            ),
+        )
+
+    def test_only_explicit_non_code_lane_completes_with_exact_result(self) -> None:
+        code = self.create_unit(developer=1, title="Code")
+        report = self.create_unit(
+            developer=4, title="Report", output_kind="report_only"
+        )
+        self.lifecycle.arm(self.sprint_id, 3)
+        self.messages.mark_read(self.assignment_message(code), 1)
+        self.messages.mark_read(self.assignment_message(report), 4)
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "merge judgment chain"
+        ):
+            self.units.complete(self.sprint_id, code, 1, result="Not allowed")
+        self.assertEqual("active", self.dispositions()[0][1])
+        self.assertIsNone(
+            self.con.execute(
+                "SELECT completion_result FROM sprint_work_units "
+                "WHERE work_unit_id=?",
+                (code,),
+            ).fetchone()[0]
+        )
+
+        self.assertEqual(
+            [],
+            self.units.complete(
+                self.sprint_id, report, 4, result="Published conformance report #77"
+            ),
+        )
+        row = self.con.execute(
+            "SELECT disposition,completion_result FROM sprint_work_units "
+            "WHERE work_unit_id=?",
+            (report,),
+        ).fetchone()
+        self.assertEqual(("completed", "Published conformance report #77"), tuple(row))
+        event = self.con.execute(
+            "SELECT payload FROM sprint_events WHERE event_type='work_unit.completed' "
+            "AND actor_shell_id=4"
+        ).fetchone()
+        self.assertEqual(
+            "Published conformance report #77", json.loads(event[0])["result"]
+        )
+
+    def test_planner_cancels_only_unreleased_lane_with_reason(self) -> None:
+        cancelled = self.create_unit(developer=1, title="Cancelled")
+        self.assertTrue(
+            self.units.cancel(
+                self.sprint_id, cancelled, 3, reason="Superseded by unit 99"
+            )
+        )
+        self.assertEqual(
+            ("cancelled", "Superseded by unit 99"),
+            tuple(
+                self.con.execute(
+                    "SELECT disposition,completion_result FROM sprint_work_units "
+                    "WHERE work_unit_id=?",
+                    (cancelled,),
+                ).fetchone()
+            ),
+        )
+        self.assertFalse(
+            self.units.cancel(
+                self.sprint_id, cancelled, 3, reason="Superseded by unit 99"
+            )
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintAuthorityError, "originating Planner"
+        ):
+            other = self.create_unit(developer=4, title="Still planned")
+            self.units.cancel(self.sprint_id, other, 1, reason="Not mine")
 
     def test_declined_assignment_returns_to_pool_with_a_new_durable_identity(self) -> None:
         unit = self.create_unit(developer=1)
@@ -279,7 +365,9 @@ class DispatchGateTest(SprintWorkDispatchCase):
         self.assertEqual([(unit, "ready")], self.dispositions())
 
     def test_replanning_is_acyclic_and_preserves_before_after_history(self) -> None:
-        upstream = self.create_unit(developer=1, title="Upstream")
+        upstream = self.create_unit(
+            developer=1, title="Upstream", output_kind="no_code"
+        )
         target = self.create_unit(
             developer=4,
             dependencies=(upstream,),
@@ -328,8 +416,9 @@ class DispatchGateTest(SprintWorkDispatchCase):
             {
                 "assigned_shell_id": 4,
                 "reviewer_shell_id": 2,
-                "planned_wave": 1,
-                "dependency_ids": [upstream],
+            "planned_wave": 1,
+            "output_kind": "code",
+            "dependency_ids": [upstream],
             },
             payload["before"],
         )
@@ -337,15 +426,18 @@ class DispatchGateTest(SprintWorkDispatchCase):
             {
                 "assigned_shell_id": 4,
                 "reviewer_shell_id": 5,
-                "planned_wave": 7,
-                "dependency_ids": [],
+            "planned_wave": 7,
+            "output_kind": "code",
+            "dependency_ids": [],
             },
             payload["after"],
         )
 
         self.lifecycle.arm(self.sprint_id, 3)
         self.messages.mark_read(self.assignment_message(upstream), 1)
-        self.units.complete(self.sprint_id, upstream, 1)
+        self.units.complete(
+            self.sprint_id, upstream, 1, result="Upstream planning result"
+        )
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError, "only planned"
         ):


### PR DESCRIPTION
## Outcome

Completes Sprint 51 unit 11 / spec task #198 by exposing the store-deep v2 capabilities through authenticated API and CLI surfaces:

- Review-signed exact-revision QAQC recording, plus repaired `sc mem doc qaqc` compatibility
- Sprint inbox/read-equals-acceptance/decline commands
- Planner replan and cancellation, and explicit report-only/no-code completion with durable results
- append-only final report submission through advisory `sc sprint complete`
- FnB-only terminal conformance-follow-up disposition
- five role skills updated to name the real commands, with baseline + 0151 seed copies synchronized

The additive 0152 migration defaults existing work units to `code`; only units explicitly planned as `report_only`/`no_code` can use direct Developer completion. Code units retain the REV9 merge-judgment chain.

## Verification

- full suite: 1395 passed, 1 skipped, 774 subtests
- post-rebase focused gate: 105 passed, 39 subtests
- `git diff --check` and Python compilation green
- `./sc map` green
- `./sc render-check` / `./sc verify` blocked by pre-existing local dogfood snapshot drift: #876 (SC-034); clean `origin/main` render path passes

## Sprint handoff

Reviewer: REV2. No watch registration and no dev merge per sprint doc #51.