### PR TITLE
fix: harden Sprint recovery semantics

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2320,6 +2320,7 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, {
                     "changed": receipt.changed,
                     "dispatched_wake_ids": list(receipt.dispatched_wake_ids),
+                    "requeued_wake_ids": list(receipt.requeued_wake_ids),
                     "projected_work_unit_ids": list(
                         receipt.projected_work_unit_ids
                     ),

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -72,6 +72,7 @@ class PauseReceipt:
 class ResumeReceipt:
     changed: bool
     dispatched_wake_ids: tuple[int, ...]
+    requeued_wake_ids: tuple[int, ...]
     projected_work_unit_ids: tuple[int, ...]
     resolved_review_message_ids: tuple[int, ...]
     spec_drift_document_ids: tuple[int, ...]
@@ -280,6 +281,8 @@ class SprintLifecycleStore:
                 reason=reason or terminal_outcome or "aborted",
                 terminal_outcome=terminal_outcome,
             ).changed
+        cleanup_run_ids: tuple[int, ...] = ()
+        cleanup_conversations: tuple[str, ...] = ()
         with db_driver.write_transaction(self.con, "sprint.transition"):
             sprint = self._sprint(sprint_id)
             current = str(sprint["lifecycle"])
@@ -301,12 +304,24 @@ class SprintLifecycleStore:
                 target=target,
                 outcome=terminal_outcome,
             )
+            if target == "completed":
+                cleanup_run_ids, cleanup_conversations = (
+                    sprint_participant_chats.close_for_terminal_lifecycle(
+                        self.con,
+                        sprint_id,
+                        lifecycle=target,
+                    )
+                )
             self._event(
                 sprint_id,
                 f"lifecycle.{target}",
                 actor,
                 {"from": current, "reason": reason},
             )
+        self._signal_terminal_conversation_cleanup(
+            cleanup_run_ids,
+            cleanup_conversations,
+        )
         return True
 
     def pause(
@@ -355,7 +370,7 @@ class SprintLifecycleStore:
             sprint = self._sprint(sprint_id)
             current = str(sprint["lifecycle"])
             if current == "armed":
-                return ResumeReceipt(False, (), (), (), (), anomalies)
+                return ResumeReceipt(False, (), (), (), (), (), anomalies)
             if current == "prepared":
                 raise SprintInvariantError(
                     "prepared Sprints must use arm() so plan release is atomic"
@@ -374,6 +389,7 @@ class SprintLifecycleStore:
             )
             if reconcile_in_transaction is not None:
                 reconcile_in_transaction(self.con)
+            requeued = self._requeue_failed_wakes_in_transaction(sprint_id)
             projected, resolved = self._reconcile_registered_prs_in_transaction(
                 sprint_id
             )
@@ -384,6 +400,7 @@ class SprintLifecycleStore:
             evidence = self._reconciliation_evidence(
                 sprint_id,
                 trigger="resume",
+                requeued_wake_ids=requeued,
                 projected_work_unit_ids=projected,
                 resolved_review_message_ids=resolved,
                 spec_drift=drift,
@@ -395,11 +412,12 @@ class SprintLifecycleStore:
                 actor,
                 evidence,
             )
-            if drift or all_anomalies:
+            if drift or all_anomalies or requeued:
                 _, notice_conversations = self._queue_planner_notice(
                     sprint_id,
                     body=(
                         f"Sprint {sprint_id} resumed with reconciliation evidence: "
+                        f"{len(requeued)} failed wake(s) re-queued, "
                         f"{len(drift)} spec drift item(s), "
                         f"{len(all_anomalies)} anomaly item(s)."
                     ),
@@ -429,6 +447,7 @@ class SprintLifecycleStore:
         return ResumeReceipt(
             True,
             dispatched,
+            requeued,
             tuple(projected),
             tuple(resolved),
             tuple(sorted(drift)),
@@ -497,11 +516,28 @@ class SprintLifecycleStore:
                     "interrupt_run_ids": list(run_ids),
                 },
             )
+            cleanup_run_ids, cleanup_conversations = (
+                sprint_participant_chats.close_for_terminal_lifecycle(
+                    self.con,
+                    sprint_id,
+                    lifecycle="aborted",
+                )
+            )
+            if set(cleanup_run_ids) != set(run_ids):
+                raise SprintInvariantError(
+                    "terminal conversation cleanup found an untracked active run"
+                )
             receipt = AbortReceipt(
                 True,
                 report_id,
                 run_ids,
-                tuple(sorted(set(run_conversations) | set(notice_conversations))),
+                tuple(
+                    sorted(
+                        set(run_conversations)
+                        | set(notice_conversations)
+                        | set(cleanup_conversations)
+                    )
+                ),
             )
         self._signal_interrupts_and_notifications(receipt)
         return receipt
@@ -834,13 +870,24 @@ class SprintLifecycleStore:
                     )
                 ) if unit_ids else ()
                 if incomplete:
+                    merge_ready = tuple(
+                        int(item[0])
+                        for item in self.con.execute(
+                            "SELECT work_unit_id FROM sprint_work_units "
+                            "WHERE work_unit_id IN ("
+                            + ",".join("?" for _ in unit_ids)
+                            + ") AND disposition='merge_ready' "
+                            "ORDER BY work_unit_id",
+                            unit_ids,
+                        )
+                    )
                     units.complete_from_merge_in_transaction(
                         sprint_id,
                         unit_ids,
                         transition_key=str(row["transition_key"]),
                         dispatch=False,
                     )
-                    projected.extend(incomplete)
+                    projected.extend(merge_ready)
             elif row["normalized_state"] == "closed":
                 for unit_id in unit_ids:
                     resolved.extend(
@@ -850,6 +897,58 @@ class SprintLifecycleStore:
                         )
                     )
         return tuple(sorted(set(projected))), tuple(sorted(set(resolved)))
+
+    def _requeue_failed_wakes_in_transaction(self, sprint_id: int) -> tuple[int, ...]:
+        if not self.con.in_transaction:
+            raise RuntimeError("wake reconciliation requires an active transaction")
+        rows = self.con.execute(
+            "SELECT DISTINCT w.wake_id,w.participant_id FROM sprint_wake_outbox w "
+            "JOIN sprint_wake_messages wm ON wm.sprint_id=w.sprint_id "
+            "AND wm.wake_id=w.wake_id JOIN sprint_messages m "
+            "ON m.sprint_id=wm.sprint_id AND m.message_id=wm.message_id "
+            "WHERE w.sprint_id=? AND w.state='failed' AND m.read_at IS NULL "
+            "ORDER BY w.wake_id",
+            (sprint_id,),
+        ).fetchall()
+        replacements: list[int] = []
+        for row in rows:
+            old_wake_id = int(row["wake_id"])
+            participant_id = int(row["participant_id"])
+            pending = self.con.execute(
+                "SELECT wake_id FROM sprint_wake_outbox WHERE sprint_id=? "
+                "AND participant_id=? AND state='pending'",
+                (sprint_id, participant_id),
+            ).fetchone()
+            if pending is None:
+                new_wake_id = int(
+                    self.con.execute(
+                        "INSERT INTO sprint_wake_outbox "
+                        "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
+                        (
+                            sprint_id,
+                            participant_id,
+                            f"sprint-resume:{sprint_id}:failed-wake:{old_wake_id}",
+                        ),
+                    ).lastrowid
+                )
+            else:
+                new_wake_id = int(pending["wake_id"])
+            self.con.execute(
+                "UPDATE sprint_wake_messages SET wake_id=? "
+                "WHERE sprint_id=? AND wake_id=?",
+                (new_wake_id, sprint_id, old_wake_id),
+            )
+            self._event(
+                sprint_id,
+                "wake.requeued",
+                LifecycleActor("system"),
+                {
+                    "failed_wake_id": old_wake_id,
+                    "replacement_wake_id": new_wake_id,
+                },
+            )
+            replacements.append(new_wake_id)
+        return tuple(sorted(set(replacements)))
 
     def _resolve_review_expectations_in_transaction(
         self, work_unit_id: int, resolution: str
@@ -917,6 +1016,7 @@ class SprintLifecycleStore:
         sprint_id: int,
         *,
         trigger: str,
+        requeued_wake_ids: Iterable[int],
         projected_work_unit_ids: Iterable[int],
         resolved_review_message_ids: Iterable[int],
         spec_drift: dict[int, dict[str, str]],
@@ -957,6 +1057,7 @@ class SprintLifecycleStore:
                     (sprint_id,),
                 )
             ],
+            "requeued_wake_ids": list(requeued_wake_ids),
             "work_units": [
                 dict(row)
                 for row in self.con.execute(
@@ -1138,6 +1239,18 @@ class SprintLifecycleStore:
             conversation_events.notify(conversation_id)
         if tuple(conversation_ids):
             self.notify_commit()
+
+    def _signal_terminal_conversation_cleanup(
+        self,
+        run_ids: Iterable[int],
+        conversation_ids: Iterable[str],
+    ) -> None:
+        self._signal_notifications(conversation_ids)
+        for run_id in run_ids:
+            try:
+                self.interrupt_run(run_id)
+            except Exception:  # noqa: BLE001 - durable intent is already committed
+                self.notify_commit()
 
     @staticmethod
     def _required_text(value: str, label: str, limit: int) -> str:
@@ -1660,19 +1773,34 @@ class SprintWorkUnitStore:
         for unit in units:
             if unit["disposition"] == "completed":
                 continue
-            changed = True
             if unit["disposition"] != "merge_ready":
-                self._event(
+                existing_bypass = self.con.execute(
+                    "SELECT 1 FROM sprint_events WHERE sprint_id=? "
+                    "AND event_type='merge.grant_bypassed' "
+                    "AND json_extract(payload,'$.transition_key')=? "
+                    "AND json_extract(payload,'$.work_unit_id')=?",
+                    (sprint_id, transition_key, int(unit["work_unit_id"])),
+                ).fetchone()
+                if existing_bypass is None:
+                    self._event(
+                        sprint_id,
+                        "merge.grant_bypassed",
+                        None,
+                        {
+                            "before": unit["disposition"],
+                            "transition_key": transition_key,
+                            "work_unit_id": int(unit["work_unit_id"]),
+                        },
+                        actor_kind="system",
+                    )
+                self._queue_planner_merge_bypass(
                     sprint_id,
-                    "merge.grant_bypassed",
-                    None,
-                    {
-                        "before": unit["disposition"],
-                        "transition_key": transition_key,
-                        "work_unit_id": int(unit["work_unit_id"]),
-                    },
-                    actor_kind="system",
+                    work_unit_id=int(unit["work_unit_id"]),
+                    transition_key=transition_key,
+                    before=str(unit["disposition"]),
                 )
+                continue
+            changed = True
             self.con.execute(
                 "UPDATE sprint_work_units SET disposition='completed',"
                 "completed_at=datetime('now'),updated_at=datetime('now') "
@@ -1701,6 +1829,70 @@ class SprintWorkUnitStore:
             sprint_id,
             planner_participant_id=planner,
         )
+
+    def _queue_planner_merge_bypass(
+        self,
+        sprint_id: int,
+        *,
+        work_unit_id: int,
+        transition_key: str,
+        before: str,
+    ) -> int:
+        planner = self.con.execute(
+            "SELECT participant_id FROM sprint_participants "
+            "WHERE sprint_id=? AND role='planner'",
+            (sprint_id,),
+        ).fetchone()
+        if planner is None:
+            raise SprintInvariantError("Sprint has no Planner participant")
+        planner_id = int(planner["participant_id"])
+        key = f"merge-grant-bypassed:{transition_key}:unit:{work_unit_id}"
+        existing = self.con.execute(
+            "SELECT message_id FROM sprint_messages WHERE idempotency_key=?",
+            (key,),
+        ).fetchone()
+        if existing is not None:
+            return int(existing["message_id"])
+        message_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_messages "
+                "(sprint_id,to_participant_id,work_unit_id,message_kind,body,"
+                "actionable,idempotency_key) VALUES (?,?,?,'notification',?,0,?)",
+                (
+                    sprint_id,
+                    planner_id,
+                    work_unit_id,
+                    (
+                        f"Merged PR bypassed the Sprint merge grant for work unit "
+                        f"{work_unit_id} from {before}; the unit remains incomplete "
+                        "and requires Planner disposition."
+                    ),
+                    key,
+                ),
+            ).lastrowid
+        )
+        pending = self.con.execute(
+            "SELECT wake_id FROM sprint_wake_outbox WHERE sprint_id=? "
+            "AND participant_id=? AND state='pending'",
+            (sprint_id, planner_id),
+        ).fetchone()
+        wake_id = (
+            int(pending["wake_id"])
+            if pending is not None
+            else int(
+                self.con.execute(
+                    "INSERT INTO sprint_wake_outbox "
+                    "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
+                    (sprint_id, planner_id, f"wake:{key}"),
+                ).lastrowid
+            )
+        )
+        self.con.execute(
+            "INSERT INTO sprint_wake_messages "
+            "(sprint_id,wake_id,message_id) VALUES (?,?,?)",
+            (sprint_id, wake_id, message_id),
+        )
+        return message_id
 
     def _dispatch_ready_locked(
         self,

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -14,6 +14,7 @@ import json
 import uuid
 from typing import Any
 
+import conversation_broker
 import run as run_mod
 
 _PURPOSES = {"work", "fix", "merge", "fallback"}
@@ -89,6 +90,152 @@ def _append_created_event(
             ),
         ),
     )
+
+
+def _append_event(
+    con,
+    conversation_id: str,
+    event_type: str,
+    payload: dict[str, Any],
+    *,
+    run_id: int | None = None,
+) -> None:
+    sequence = int(
+        con.execute(
+            "SELECT COALESCE(MAX(sequence),0)+1 FROM conversation_events "
+            "WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()[0]
+    )
+    con.execute(
+        "INSERT INTO conversation_events "
+        "(conversation_id,sequence,event_type,payload,run_id) VALUES (?,?,?,?,?)",
+        (
+            conversation_id,
+            sequence,
+            event_type,
+            _canonical_json(payload),
+            run_id,
+        ),
+    )
+
+
+def _cancel_queued_turns(con, conversation_id: str) -> int:
+    message_ids = [
+        int(row[0])
+        for row in con.execute(
+            "SELECT DISTINCT message_id FROM conversation_outbox "
+            "WHERE conversation_id=? AND state IN ('pending','claimed')",
+            (conversation_id,),
+        )
+    ]
+    if not message_ids:
+        return 0
+    marks = ",".join("?" for _ in message_ids)
+    cancelled = con.execute(
+        "UPDATE conversation_messages SET state='cancelled',"
+        "completed_at=datetime('now') "
+        f"WHERE message_id IN ({marks}) "
+        "AND state IN ('accepted','queued','running')",
+        message_ids,
+    ).rowcount
+    con.execute(
+        "UPDATE conversation_outbox SET state='cancelled',claim_owner=NULL,"
+        "claimed_at=NULL,lease_expires_at=NULL "
+        f"WHERE message_id IN ({marks}) AND state IN ('pending','claimed')",
+        message_ids,
+    )
+    return int(cancelled)
+
+
+def close_for_terminal_lifecycle(
+    con,
+    sprint_id: int,
+    *,
+    lifecycle: str,
+) -> tuple[tuple[int, ...], tuple[str, ...]]:
+    """Close linked conversations or persist close intent for live runs."""
+    if not con.in_transaction:
+        raise RuntimeError("Sprint conversation cleanup requires a transaction")
+    if lifecycle not in {"completed", "aborted"}:
+        raise ValueError("Sprint conversation cleanup requires a terminal lifecycle")
+    rows = con.execute(
+        "SELECT DISTINCT c.conversation_id,c.state "
+        "FROM sprint_participant_conversations pc "
+        "JOIN sprint_participants p "
+        "ON p.participant_id=pc.sprint_participant_id "
+        "JOIN conversations c ON c.conversation_id=pc.conversation_id "
+        "WHERE p.sprint_id=? ORDER BY c.conversation_id",
+        (sprint_id,),
+    ).fetchall()
+    run_ids: list[int] = []
+    conversation_ids: list[str] = []
+    now = str(con.execute("SELECT datetime('now')").fetchone()[0])
+    for row in rows:
+        conversation_id = str(row["conversation_id"])
+        if row["state"] == "closed":
+            continue
+        conversation_ids.append(conversation_id)
+        cancelled = _cancel_queued_turns(con, conversation_id)
+        active = con.execute(
+            "SELECT run_id FROM conversation_runs WHERE conversation_id=? "
+            "AND state IN ('leased','starting','running') "
+            "ORDER BY run_id DESC LIMIT 1",
+            (conversation_id,),
+        ).fetchone()
+        if active is not None:
+            run_id = int(active["run_id"])
+            run_ids.append(run_id)
+            close_requested = con.execute(
+                "SELECT 1 FROM conversation_events WHERE conversation_id=? "
+                "AND event_type='conversation.close.requested' LIMIT 1",
+                (conversation_id,),
+            ).fetchone()
+            if close_requested is None:
+                _append_event(
+                    con,
+                    conversation_id,
+                    "conversation.close.requested",
+                    {
+                        "cancelled_queued_turns": cancelled,
+                        "reason": f"sprint.lifecycle.{lifecycle}",
+                        "sprint_id": sprint_id,
+                    },
+                    run_id=run_id,
+                )
+            conversation_broker.BrokerStore.request_interrupt_in_transaction(
+                con,
+                run_id,
+                requested_at=now,
+            )
+            continue
+        if row["state"] == "queued":
+            con.execute(
+                "UPDATE conversations SET state='idle' WHERE conversation_id=?",
+                (conversation_id,),
+            )
+        elif row["state"] == "running":
+            con.execute(
+                "UPDATE conversations SET state='error' WHERE conversation_id=?",
+                (conversation_id,),
+            )
+        con.execute(
+            "UPDATE conversations SET state='closed',closed_at=?,"
+            "last_activity_at=?,version=version+1 WHERE conversation_id=?",
+            (now, now, conversation_id),
+        )
+        _append_event(
+            con,
+            conversation_id,
+            "conversation.closed",
+            {
+                "cancelled_queued_turns": cancelled,
+                "reason": f"sprint.lifecycle.{lifecycle}",
+                "sprint_id": sprint_id,
+                "state": "closed",
+            },
+        )
+    return tuple(run_ids), tuple(conversation_ids)
 
 
 def create_and_select(

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -495,6 +495,17 @@ class SprintPRWatcher:
                     "registered_pr.closed_without_merge",
                 )
             )
+        elif (
+            state == "merged"
+            and work_unit_id is not None
+            and unit_rows[0]["disposition"] != "merge_ready"
+        ):
+            resolved_review_message_ids = (
+                self.liveness.resolve_review_requests_for_work_unit_in_transaction(
+                    work_unit_id,
+                    "registered_pr.merged_grant_bypassed",
+                )
+            )
         recipients: dict[int, bool] = {
             int(registered["owner_participant_id"]): state in {"red", "green"}
         }
@@ -527,6 +538,7 @@ class SprintPRWatcher:
         )
         if (
             head_changed
+            and state not in {"merged", "closed"}
             and len(unit_rows) == 1
             and unit_rows[0]["disposition"] == "merge_ready"
         ):

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -397,17 +397,21 @@ class SprintPRWatcher:
         if current is None or current["lifecycle"] != "armed":
             return None
         latest = self.con.execute(
-            "SELECT transition_key,normalized_state "
+            "SELECT transition_key,normalized_state,observed_head_sha "
             "FROM sprint_pr_transitions WHERE registered_pr_id=? "
             "ORDER BY transition_id DESC LIMIT 1",
             (registered_pr_id,),
         ).fetchone()
-        if latest is not None and latest["normalized_state"] == state:
+        if (
+            latest is not None
+            and latest["normalized_state"] == state
+            and latest["observed_head_sha"] == pull_request.head_sha
+        ):
             self._backoff.pop(registered_pr_id, None)
             return None
         parent_key = latest["transition_key"] if latest is not None else "root"
         transition_key = hashlib.sha256(
-            f"{registered_pr_id}:{parent_key}:{state}".encode()
+            f"{registered_pr_id}:{parent_key}:{state}:{pull_request.head_sha}".encode()
         ).hexdigest()
         transition_id = int(
             self.con.execute(
@@ -428,6 +432,11 @@ class SprintPRWatcher:
             transition_key,
             state,
             pull_request,
+            previous_head_sha=(
+                str(latest["observed_head_sha"])
+                if latest is not None and latest["observed_head_sha"] is not None
+                else None
+            ),
         )
         if state == "merged":
             self.review_loop.observe_merge_in_transaction(
@@ -464,11 +473,12 @@ class SprintPRWatcher:
         transition_key: str,
         state: str,
         pull_request: PullRequest,
+        previous_head_sha: str | None,
     ) -> tuple[int, ...]:
         sprint_id = int(registered["sprint_id"])
         registered_pr_id = int(registered["registered_pr_id"])
         unit_rows = self.con.execute(
-            "SELECT l.work_unit_id,u.reviewer_shell_id "
+            "SELECT l.work_unit_id,u.reviewer_shell_id,u.disposition "
             "FROM sprint_pr_work_units l JOIN sprint_work_units u "
             "ON u.sprint_id=l.sprint_id AND u.work_unit_id=l.work_unit_id "
             "WHERE l.registered_pr_id=? ORDER BY l.work_unit_id",
@@ -511,6 +521,89 @@ class SprintPRWatcher:
             reviewer_id = int(reviewer["participant_id"])
             recipients.setdefault(reviewer_id, False)
 
+        head_changed = (
+            previous_head_sha is not None
+            and previous_head_sha != pull_request.head_sha
+        )
+        if (
+            head_changed
+            and len(unit_rows) == 1
+            and unit_rows[0]["disposition"] == "merge_ready"
+        ):
+            reviewer = self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=? AND role='reviewer'",
+                (sprint_id, int(unit_rows[0]["reviewer_shell_id"])),
+            ).fetchone()
+            if reviewer is None:
+                raise SprintInvariantError(
+                    "registered PR work unit has no Reviewer participant"
+                )
+            reviewer_id = int(reviewer["participant_id"])
+            work_unit_id = int(unit_rows[0]["work_unit_id"])
+            invalidated_message_id = self._invalidate_stale_approval(
+                sprint_id,
+                work_unit_id,
+            )
+            self.con.execute(
+                "UPDATE sprint_work_units SET disposition='in_review',"
+                "updated_at=datetime('now') WHERE work_unit_id=? "
+                "AND disposition='merge_ready'",
+                (work_unit_id,),
+            )
+            self.con.execute(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,payload) "
+                "VALUES (?,'review.approval_invalidated','system',?)",
+                (
+                    sprint_id,
+                    json.dumps(
+                        {
+                            "head_sha": pull_request.head_sha,
+                            "invalidated_message_id": invalidated_message_id,
+                            "previous_head_sha": previous_head_sha,
+                            "registered_pr_id": registered_pr_id,
+                            "transition_key": transition_key,
+                            "work_unit_id": work_unit_id,
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+            review_request = self.messages.send_in_transaction(
+                sprint_id,
+                to_participant_id=reviewer_id,
+                work_unit_id=work_unit_id,
+                message_kind="review_request",
+                body=(
+                    f"PR #{registered['pr_number']} moved from {previous_head_sha} "
+                    f"to {pull_request.head_sha} after approval. Perform a delta "
+                    "review against the new head."
+                ),
+                actionable=True,
+                active=True,
+                idempotency_key=f"pr-head-change:{transition_key}:delta-review",
+            )
+            self.con.execute(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,payload) "
+                "VALUES (?,'review.requested','system',?)",
+                (
+                    sprint_id,
+                    json.dumps(
+                        {
+                            "head_sha": pull_request.head_sha,
+                            "message_id": review_request.message_id,
+                            "previous_head_sha": previous_head_sha,
+                            "registered_pr_id": registered_pr_id,
+                            "source": "watcher.head_changed",
+                            "work_unit_id": work_unit_id,
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+
         head = pull_request.head_sha or "unknown head"
         body = (
             f"GitHub observed {registered['repository']} PR "
@@ -529,6 +622,52 @@ class SprintPRWatcher:
                 ),
             )
         return resolved_review_message_ids
+
+    def _invalidate_stale_approval(
+        self,
+        sprint_id: int,
+        work_unit_id: int,
+    ) -> int | None:
+        approval = self.con.execute(
+            "SELECT payload FROM sprint_events WHERE sprint_id=? "
+            "AND event_type='review.approved' "
+            "AND json_extract(payload,'$.work_unit_id')=? "
+            "ORDER BY event_id DESC LIMIT 1",
+            (sprint_id, work_unit_id),
+        ).fetchone()
+        if approval is None:
+            return None
+        message_id = json.loads(approval["payload"]).get("message_id")
+        if not isinstance(message_id, int):
+            return None
+        self.con.execute(
+            "UPDATE sprint_messages SET read_at=COALESCE(read_at,datetime('now')) "
+            "WHERE sprint_id=? AND message_id=?",
+            (sprint_id, message_id),
+        )
+        wake_ids = [
+            int(row[0])
+            for row in self.con.execute(
+                "SELECT wake_id FROM sprint_wake_messages "
+                "WHERE sprint_id=? AND message_id=?",
+                (sprint_id, message_id),
+            )
+        ]
+        for wake_id in wake_ids:
+            unread = self.con.execute(
+                "SELECT 1 FROM sprint_wake_messages wm JOIN sprint_messages m "
+                "ON m.sprint_id=wm.sprint_id AND m.message_id=wm.message_id "
+                "WHERE wm.sprint_id=? AND wm.wake_id=? AND m.read_at IS NULL LIMIT 1",
+                (sprint_id, wake_id),
+            ).fetchone()
+            if unread is None:
+                self.con.execute(
+                    "UPDATE sprint_wake_outbox SET state='cancelled',"
+                    "claim_owner=NULL,claimed_at=NULL,lease_expires_at=NULL "
+                    "WHERE sprint_id=? AND wake_id=? AND state='pending'",
+                    (sprint_id, wake_id),
+                )
+        return message_id
 
     def _poll_failed(
         self,

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -10,6 +10,8 @@ SCRIPTS = ROOT / ".super-coder" / "scripts"
 sys.path[:0] = [str(SCRIPTS), str(ROOT / "tests")]
 
 import sprint_domain
+import sprint_message_delivery
+import sprint_participant_chats
 import sprint_recovery
 from github_pull_requests import GitHubReadError
 from test_sprint_pr_watcher import SprintPRWatcherCase, pull_request
@@ -208,6 +210,54 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         )
         self.assertEqual([run_id], [row["run_id"] for row in report["deterministic"]["active_turns"]])
 
+        receipt = self.coordinator().resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="retry the stranded assignment",
+        )
+        self.assertEqual(1, len(receipt.requeued_wake_ids))
+        replacement = receipt.requeued_wake_ids[0]
+        self.assertNotEqual(wake_id, replacement)
+        self.assertEqual(
+            [(wake_id, "failed", 3), (replacement, "pending", 0)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT wake_id,state,attempt_count FROM sprint_wake_outbox "
+                    "WHERE wake_id IN (?,?) ORDER BY wake_id",
+                    (wake_id, replacement),
+                )
+            ],
+        )
+        self.assertEqual(
+            [(replacement,)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT wake_id FROM sprint_wake_messages WHERE sprint_id=?",
+                    (self.sprint_id,),
+                )
+                if row[0] == replacement
+            ],
+        )
+        evidence = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='lifecycle.reconciled' ORDER BY event_id DESC LIMIT 1",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual([replacement], evidence["requeued_wake_ids"])
+        self.assertIn(
+            replacement,
+            [wake["wake_id"] for wake in evidence["pending_wakes"]],
+        )
+        lease = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).claim_next("requeued-wake")
+        self.assertEqual(replacement, lease.wake_id)
+        self.assertEqual(1, lease.attempt_number)
+
     def test_resume_projects_observed_merge_before_releasing_downstream(self):
         registered = self.register()
         self.con.execute(
@@ -243,7 +293,12 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             (registered.registered_pr_id, "b" * 40),
         )
         self.con.commit()
-        self.reader.current = pull_request(state="MERGED", checks="SUCCESS", checks_failed=False)
+        self.reader.current = pull_request(
+            state="MERGED",
+            checks="SUCCESS",
+            checks_failed=False,
+            head_sha="b" * 40,
+        )
 
         receipt = coordinator.resume(
             self.sprint_id,
@@ -485,6 +540,73 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
                 "SELECT COUNT(*) FROM sprint_work_units WHERE work_unit_id=?",
                 (unit_id,),
             ).fetchone()[0],
+        )
+
+    def test_terminal_lifecycle_closes_every_sprint_conversation(self):
+        terminal_sprints = []
+        for target in ("completed", "aborted"):
+            sprint_id, _ = self.create_sprint()
+            self.store.arm(sprint_id, 3)
+            conversation_ids = [
+                str(row[0])
+                for row in self.con.execute(
+                    "SELECT pc.conversation_id "
+                    "FROM sprint_participant_conversations pc "
+                    "JOIN sprint_participants p "
+                    "ON p.participant_id=pc.sprint_participant_id "
+                    "WHERE p.sprint_id=? ORDER BY pc.conversation_id",
+                    (sprint_id,),
+                )
+            ]
+            self.assertEqual(3, len(conversation_ids))
+
+            self.store.transition(
+                sprint_id,
+                target,
+                sprint_domain.LifecycleActor("planner", 3),
+                reason=f"finish as {target}",
+                terminal_outcome=f"terminal {target}",
+            )
+
+            marks = ",".join("?" for _ in conversation_ids)
+            self.assertEqual(
+                [("closed", 1)] * 3,
+                [
+                    tuple(row)
+                    for row in self.con.execute(
+                        "SELECT state,closed_at IS NOT NULL FROM conversations "
+                        f"WHERE conversation_id IN ({marks}) ORDER BY conversation_id",
+                        conversation_ids,
+                    )
+                ],
+            )
+            self.assertEqual(
+                3,
+                self.con.execute(
+                    "SELECT COUNT(*) FROM conversation_events "
+                    f"WHERE conversation_id IN ({marks}) "
+                    "AND event_type='conversation.closed'",
+                    conversation_ids,
+                ).fetchone()[0],
+            )
+            terminal_sprints.append(sprint_id)
+
+        self.assertEqual(
+            [{"shell_id": 1, "sprint": None}, {"shell_id": 2, "sprint": None}],
+            sprint_participant_chats.attach_live_participations(
+                self.con,
+                [{"shell_id": 1}, {"shell_id": 2}],
+            ),
+        )
+        self.assertEqual(
+            ["completed", "aborted"],
+            [
+                self.con.execute(
+                    "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                    (sprint_id,),
+                ).fetchone()[0]
+                for sprint_id in terminal_sprints
+            ],
         )
 
     def test_restart_recovers_prepared_armed_and_paused_without_state_drift(self):

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -555,6 +555,74 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             ).head_sha,
         )
 
+    def test_merged_head_move_completes_without_requesting_dead_delta_review(self):
+        self.approve()
+        self.reader.current = pull_request(
+            state="MERGED",
+            checks="SUCCESS",
+            checks_failed=False,
+            head_sha="b" * 40,
+        )
+
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(
+            "completed",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            (0, 0, 0),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_events "
+                    "WHERE event_type='review.approval_invalidated'),"
+                    "(SELECT COUNT(*) FROM sprint_messages "
+                    "WHERE idempotency_key LIKE 'pr-head-change:%:delta-review'),"
+                    "(SELECT COUNT(*) FROM sprint_events "
+                    "WHERE event_type='merge.grant_bypassed')"
+                ).fetchone()
+            ),
+        )
+
+    def test_closed_head_move_does_not_create_orphaned_delta_review(self):
+        self.approve()
+        self.reader.current = pull_request(
+            state="CLOSED",
+            checks=None,
+            checks_failed=False,
+            head_sha="b" * 40,
+        )
+
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(
+            "merge_ready",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            (0, 0, 0),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_events "
+                    "WHERE event_type='review.approval_invalidated'),"
+                    "(SELECT COUNT(*) FROM sprint_messages "
+                    "WHERE idempotency_key LIKE 'pr-head-change:%:delta-review'),"
+                    "(SELECT COUNT(*) FROM sprint_liveness_expectations e "
+                    "JOIN sprint_messages m USING (message_id) "
+                    "WHERE m.message_kind='review_request' "
+                    "AND e.resolved_at IS NULL)"
+                ).fetchone()
+            ),
+        )
+
     def test_grant_bypassed_merge_notifies_planner_without_completing_unit(self):
         self.reader.current = pull_request(
             state="MERGED", checks="SUCCESS", checks_failed=False
@@ -614,6 +682,40 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
                     "WHERE idempotency_key LIKE 'merge-grant-bypassed:%')"
                 ).fetchone()
             ),
+        )
+
+    def test_grant_bypassed_merge_resolves_accepted_review_expectation(self):
+        handoff = self.request_review()
+        self.accept_review(handoff.message_id)
+        self.reader.current = pull_request(
+            state="MERGED", checks="SUCCESS", checks_failed=False
+        )
+
+        self.assertTrue(self.watcher.poll_once())
+
+        expectation = self.con.execute(
+            "SELECT resolved_at,resolution,next_evaluation_at "
+            "FROM sprint_liveness_expectations WHERE message_id=?",
+            (handoff.message_id,),
+        ).fetchone()
+        self.assertIsNotNone(expectation["resolved_at"])
+        self.assertEqual(
+            ("registered_pr.merged_grant_bypassed", None),
+            (expectation["resolution"], expectation["next_evaluation_at"]),
+        )
+        self.assertEqual(
+            "in_review",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='merge.grant_bypassed'"
+            ).fetchone()[0],
         )
 
     def test_observed_merge_completes_board_and_assigns_next_in_persistent_lane(self):

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -1,6 +1,7 @@
 """Stage 6 gates for the Sprints v2 Developer and Reviewer loop."""
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from unittest import mock
@@ -472,6 +473,147 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
                 "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
                 (approved.work_unit_id,),
             ).fetchone()[0],
+        )
+
+    def test_same_state_head_move_invalidates_approval_and_requests_delta_review(self):
+        approved = self.approve()
+        self.reader.current = pull_request(
+            checks="SUCCESS", checks_failed=False, head_sha="b" * 40
+        )
+
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(
+            [("green", "a" * 40), ("green", "b" * 40)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT normalized_state,observed_head_sha "
+                    "FROM sprint_pr_transitions ORDER BY transition_id"
+                )
+            ],
+        )
+        self.assertEqual(
+            "in_review",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+        delta = self.con.execute(
+            "SELECT message_id,to_participant_id,actionable,disposition,body "
+            "FROM sprint_messages WHERE idempotency_key LIKE "
+            "'pr-head-change:%:delta-review'"
+        ).fetchone()
+        self.assertEqual(
+            (self.reviewer_id, 1, "pending"),
+            (int(delta["to_participant_id"]), delta["actionable"], delta["disposition"]),
+        )
+        self.assertIn("Perform a delta review", delta["body"])
+        self.assertEqual(
+            [(self.reviewer_id, "pending")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT w.participant_id,w.state FROM sprint_wake_outbox w "
+                    "JOIN sprint_wake_messages wm USING (wake_id) "
+                    "WHERE wm.message_id=?",
+                    (delta["message_id"],),
+                )
+            ],
+        )
+        invalidated = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events "
+                "WHERE event_type='review.approval_invalidated'"
+            ).fetchone()[0]
+        )
+        self.assertEqual("a" * 40, invalidated["previous_head_sha"])
+        self.assertEqual("b" * 40, invalidated["head_sha"])
+        self.assertEqual(approved.message_id, invalidated["invalidated_message_id"])
+        self.assertIsNotNone(
+            self.con.execute(
+                "SELECT read_at FROM sprint_messages WHERE message_id=?",
+                (approved.message_id,),
+            ).fetchone()[0]
+        )
+
+        self.accept_review(int(delta["message_id"]))
+        outcome = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="approved",
+            body="Delta review is clean on the replacement head.",
+            idempotency_key="approved-after-head-move",
+        )
+        self.assertEqual("merge_ready", outcome.disposition)
+        self.assertEqual(
+            "b" * 40,
+            self.loop.authorize_merge(
+                self.sprint_id, self.registered_pr_id, 1
+            ).head_sha,
+        )
+
+    def test_grant_bypassed_merge_notifies_planner_without_completing_unit(self):
+        self.reader.current = pull_request(
+            state="MERGED", checks="SUCCESS", checks_failed=False
+        )
+
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(
+            "active",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+        bypass = self.con.execute(
+            "SELECT payload FROM sprint_events "
+            "WHERE event_type='merge.grant_bypassed'"
+        ).fetchone()
+        self.assertEqual("active", json.loads(bypass["payload"])["before"])
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='work_unit.completed'"
+            ).fetchone()[0],
+        )
+        notice = self.con.execute(
+            "SELECT m.to_participant_id,m.work_unit_id,m.body,w.state "
+            "FROM sprint_messages m JOIN sprint_wake_messages wm USING (message_id) "
+            "JOIN sprint_wake_outbox w USING (wake_id) "
+            "WHERE m.idempotency_key LIKE 'merge-grant-bypassed:%'"
+        ).fetchone()
+        self.assertEqual(
+            (self.planner_id, self.unit_id, "pending"),
+            (int(notice[0]), int(notice[1]), notice[3]),
+        )
+        self.assertIn("remains incomplete", notice["body"])
+
+        lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="inspect the bypass",
+        )
+        lifecycle.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+        self.assertEqual(
+            (1, 1),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_events "
+                    "WHERE event_type='merge.grant_bypassed'),"
+                    "(SELECT COUNT(*) FROM sprint_messages "
+                    "WHERE idempotency_key LIKE 'merge-grant-bypassed:%')"
+                ).fetchone()
+            ),
         )
 
     def test_observed_merge_completes_board_and_assigns_next_in_persistent_lane(self):


### PR DESCRIPTION
## Outcome

Implements Sprint 51 unit 12 / task #199 against spec #46 REV9:

- merged observation completes only `merge_ready` work; grant-bypassed merges retain the unit, record stable evidence, and actively wake the Planner
- PR observations dedupe on normalized state plus head; a moved approved head invalidates the old approval/wake, returns the unit to `in_review`, and creates a fresh actionable delta-review request
- resume replaces terminally failed wakes while retaining the failed wake + attempt history, and exposes replacement IDs in reconciliation evidence/API output
- completed/aborted lifecycle cleanup closes idle Sprint conversations and persists close+interrupt intent for active runs

No new module or migration; the Sprint v1 removal allowlist remains unchanged (R1).

## Verification

- `./sc test tests/test_sprint_*.py` — 139 passed
- `./sc test` — 1400 passed, 1 skipped (exact commit)
- `./sc render-check` — passed
- `git diff --check` — passed
- focused Ruff: no unit-introduced findings; repo-wide baseline remains red and is tracked in #878
- branch-local `./sc verify` is unavailable in linked worktrees; reproduced on existing #769

## Trade-off

Terminal conversation cleanup reuses the generic conversation state contract in the Sprint-owned module: idle/queued lanes close in the terminal transaction, while an active native run receives durable close and interrupt intent and closes when the broker terminalizes it. This preserves broker invariants without a parallel lifecycle table.