### PR TITLE
feat(ui): normalize modal and flag actions

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -194,25 +194,52 @@ function glassDropdown({ items, value, onChange }) {
 }
 
 // Modal base (dos-arch dialog): overlay click or Esc closes; header carries
-// the title + an optional readout; footer nodes sit space-between. Returns
-// the close function.
-function openModal({ title, headExtra, bodyNode, footNodes, width = 650, height = 700 }) {
+// the title + an optional readout; footer content uses explicit physical
+// start/end slots. Returns the close function.
+let modalSequence = 0;
+function openModal({
+  title, headExtra, bodyNode, footerStart, footerEnd, width = 650, height = 700,
+}) {
+  const priorFocus = document.activeElement;
   const overlay = el("div", { className: "modal-overlay" });
-  const close = () => overlay.remove();
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    overlay.remove();
+    if (priorFocus?.isConnected && typeof priorFocus.focus === "function") priorFocus.focus();
+  };
+  overlay.closeModal = close;
   overlay.onmousedown = (e) => { if (e.target === overlay) close(); };
   const dlg = el("div", { className: "modal" });
+  const titleId = `modal-title-${++modalSequence}`;
+  dlg.setAttribute("role", "dialog");
+  dlg.setAttribute("aria-modal", "true");
+  dlg.setAttribute("aria-labelledby", titleId);
   dlg.style.width = width + "px";
   dlg.style.height = height + "px";
-  const head = el("div", { className: "modal-head" }, el("div", { className: "modal-title" }, title));
+  const head = el("div", { className: "modal-head" },
+    el("div", { className: "modal-title", id: titleId }, title));
   if (headExtra) head.append(headExtra);
   dlg.append(head, el("div", { className: "modal-body" }, bodyNode));
-  if (footNodes?.length) dlg.append(el("div", { className: "modal-foot" }, ...footNodes));
+  if (footerStart || footerEnd) {
+    const foot = el("div", { className: "modal-foot" });
+    if (footerStart) foot.append(el("div", { className: "modal-foot-start" }, footerStart));
+    if (footerEnd) foot.append(el("div", { className: "modal-foot-end" }, footerEnd));
+    dlg.append(foot);
+  }
   overlay.append(dlg);
   document.body.append(overlay);
   return close;
 }
 
-// Unified edit modal — 650×700, Save bottom-LEFT / Cancel bottom-RIGHT,
+// Action dialogs name intent instead of physical position. Dismissal is always
+// first/left and the primary or destructive action is always last/right.
+function openActionModal({ dismissNode, actionNode, ...modal }) {
+  return openModal({ ...modal, footerStart: dismissNode, footerEnd: actionNode });
+}
+
+// Unified edit modal — 650×700, Cancel bottom-left / Save bottom-right,
 // live ~tokens / chars readout in the header.
 function openEditModal({ title, value, onSave }) {
   const counter = el("div", { className: "modal-count" });
@@ -221,7 +248,9 @@ function openEditModal({ title, value, onSave }) {
   ta.oninput = upd; upd();
   const save = el("button", { className: "act primary", type: "button", textContent: "Save" });
   const cancel = el("button", { className: "act", type: "button", textContent: "Cancel" });
-  const close = openModal({ title, headExtra: counter, bodyNode: ta, footNodes: [save, cancel] });
+  const close = openActionModal({
+    title, headExtra: counter, bodyNode: ta, dismissNode: cancel, actionNode: save,
+  });
   save.onclick = async () => {
     save.disabled = true; save.textContent = "Saving…";
     try { await onSave(ta.value); close(); }
@@ -251,7 +280,7 @@ async function openSkillContentModal(skill) {
     const closeBtn = el("button", { className: "act", type: "button", textContent: "Close" });
     const close = openModal({
       title: skill.name, headExtra: counter, bodyNode: body,
-      footNodes: [rawBtn, closeBtn],
+      footerStart: rawBtn, footerEnd: closeBtn,
       width: 800, height: 650,
     });
     closeBtn.onclick = close;
@@ -273,8 +302,8 @@ function openNewShellModal(templates, root) {
   const form = el("div", { className: "modal-form" },
     el("span", { className: "k" }, "shell type"), fl,
     el("span", { className: "k" }, "name"), nm);
-  const close = openModal({ title: "New shell", bodyNode: form,
-    footNodes: [cancel, create], width: 600, height: 300 });
+  const close = openActionModal({ title: "New shell", bodyNode: form,
+    dismissNode: cancel, actionNode: create, width: 600, height: 300 });
   create.onclick = async () => {
     if (!nm.value.trim()) return toast("name required");
     create.disabled = true; create.textContent = "Creating…";
@@ -1229,14 +1258,14 @@ function featureForm(f, candidates = [], projects = []) {
 
 // Click-to-open edit modal — the same editor as the Board card's inline expand,
 // reachable from any card (small Flow cards, shipped cards, and the Board card's
-// ⤢ button). Save bottom-left / Cancel bottom-right; reloads the roadmap on save.
+// ⤢ button). Cancel bottom-left / Save bottom-right; reloads the roadmap on save.
 function openFeatureModal(f, candidates = [], projects = []) {
   const { node, save } = featureForm(f, candidates, projects);
   const saveBtn = el("button", { className: "act primary", type: "button", textContent: "Save" });
   const cancel = el("button", { className: "act", type: "button", textContent: "Cancel" });
-  const close = openModal({
+  const close = openActionModal({
     title: (f.title || "(untitled)") + "  #" + f.feature_id,
-    bodyNode: node, footNodes: [saveBtn, cancel],
+    bodyNode: node, dismissNode: cancel, actionNode: saveBtn,
     width: 680, height: 720,
   });
   saveBtn.onclick = async () => {
@@ -1372,32 +1401,59 @@ async function renderDocs(root) {
 let flagFilter = "open";   // open | resolved | all — persists across re-renders
 let flagQuery = "";        // flags search; persists across re-renders
 
-// New-flag form in a 600×400 modal — Create bottom-left, Cancel bottom-right.
-function openNewFlagModal(features) {
-  const name = el("input", { type: "text", placeholder: "display name (e.g. SC-001)" });
-  const desc = el("textarea", { rows: 4, placeholder: "[Area] description | Blocker for: …" });
+// Shared create/edit flag form — roomy description, dismissal left, action right.
+function openFlagModal(features, flag = null) {
+  const editing = Boolean(flag);
+  const name = el("input", {
+    type: "text", placeholder: "display name (e.g. SC-001)", value: flag?.display_name || "",
+  });
+  const desc = el("textarea", {
+    rows: 8, placeholder: "[Area] description | Blocker for: …", value: flag?.description || "",
+  });
   const feat = el("select", {});
-  feat.append(el("option", { value: "", textContent: "— no feature —" }));
-  for (const f of features) feat.append(el("option", { value: f.feature_id, textContent: `#${f.feature_id} ${f.title}` }));
+  feat.append(el("option", {
+    value: "", selected: flag?.feature_id == null, textContent: "— no feature —",
+  }));
+  for (const f of features) feat.append(el("option", {
+    value: f.feature_id,
+    selected: String(f.feature_id) === String(flag?.feature_id),
+    textContent: `#${f.feature_id} ${f.title}`,
+  }));
   const prio = el("select", {});
-  for (const p of ["High", "Medium", "Low"]) prio.append(el("option", { value: p, selected: p === "Medium", textContent: p }));
-  const create = el("button", { className: "act primary", type: "button", textContent: "Create" });
+  for (const p of ["High", "Medium", "Low"]) prio.append(el("option", {
+    value: p, selected: p === (flag?.priority || "Medium"), textContent: p,
+  }));
+  const actionLabel = editing ? "Save" : "Create";
+  const action = el("button", {
+    className: "act primary", type: "button", textContent: actionLabel,
+  });
   const cancel = el("button", { className: "act", type: "button", textContent: "Cancel" });
   const form = el("div", { className: "modal-form" },
     el("span", { className: "k" }, "name"), name,
     el("span", { className: "k" }, "description"), desc,
     el("span", { className: "k" }, "feature"), feat,
     el("span", { className: "k" }, "priority"), prio);
-  const close = openModal({ title: "New flag", bodyNode: form,
-    footNodes: [create, cancel], width: 600, height: 400 });
-  create.onclick = async () => {
+  const close = openActionModal({
+    title: editing ? `Edit flag #${flag.flag_id}` : "New flag",
+    bodyNode: form, dismissNode: cancel, actionNode: action,
+    width: 600, height: 520,
+  });
+  action.onclick = async () => {
     if (!desc.value) return toast("description required");
-    create.disabled = true; create.textContent = "Creating…";
+    action.disabled = true; action.textContent = editing ? "Saving…" : "Creating…";
+    const payload = {
+      display_name: name.value || null,
+      description: desc.value,
+      feature_id: feat.value || null,
+      priority: prio.value,
+    };
     try {
-      await api("/flags", "POST", { display_name: name.value || null, description: desc.value,
-        feature_id: feat.value || null, priority: prio.value });
-      close(); setStatus("flag created"); load("flags");
-    } catch (e) { toast("error: " + e.message); create.disabled = false; create.textContent = "Create"; }
+      await api(editing ? "/flags/" + flag.flag_id : "/flags", editing ? "PATCH" : "POST", payload);
+      close(); setStatus(editing ? "flag saved" : "flag created"); load("flags");
+    } catch (e) {
+      toast("error: " + e.message);
+      action.disabled = false; action.textContent = actionLabel;
+    }
   };
   cancel.onclick = close;
   desc.focus();
@@ -1420,7 +1476,7 @@ async function renderFlags(root) {
     bar.append(chip);
   }
   const newBtn = el("button", { className: "act newflag", type: "button", textContent: "＋ New flag" });
-  newBtn.onclick = () => openNewFlagModal(features);
+  newBtn.onclick = () => openFlagModal(features);
   root.append(el("div", { className: "flagbar" }, bar, newBtn));
 
   // results repaint in place: filter by the toggle, then narrow by the query
@@ -1447,14 +1503,14 @@ async function renderFlags(root) {
     for (const [title, list] of unlinkedLast(Object.entries(byFeat))) {
       const c = el("div", { className: "card" });
       c.append(el("h2", {}, title));
-      for (const f of list) c.append(flagRow(f));
+      for (const f of list) c.append(flagRow(f, features));
       results.append(c);
     }
   }
   draw();
 }
 
-function flagRow(f) {
+function flagRow(f, features) {
   // Expandable: collapsed row shows the priority badge + title + #id;
   // expanding reveals the full description, linked items as cards, and the
   // resolution note (resolved) or the resolve action (open).
@@ -1483,18 +1539,26 @@ function flagRow(f) {
     body.append(lc);
   }
 
+  const actions = el("div", { className: "flag-actions" });
   if (f.resolved) {
     body.append(el("div", { className: "tag" }, `resolved ${f.resolved_date || ""} — ${f.resolution_notes || ""}`));
   } else {
-    const btn = el("button", { className: "act", textContent: "resolve" });
+    const btn = el("button", { className: "act", type: "button", textContent: "resolve" });
     btn.onclick = async () => {
       const notes = prompt("Resolution notes:");
       if (notes === null) return;
       try { await api("/flags/" + f.flag_id, "PATCH", { resolved: 1, resolution_notes: notes }); setStatus("flag resolved"); load("flags"); }
       catch (e) { toast("error: " + e.message); }
     };
-    body.append(btn);
+    actions.append(btn);
   }
+  const edit = el("button", { className: "act flag-edit", type: "button", textContent: "edit" });
+  edit.onclick = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    openFlagModal(features, f);
+  };
+  actions.append(edit);
+  body.append(actions);
   row.append(body);
   return row;
 }
@@ -1627,10 +1691,10 @@ async function openWinVmModal() {
 
   const save = el("button", { className: "act primary", textContent: "save" });
   const cancel = el("button", { className: "act", textContent: "close" });
-  const close = openModal({
+  const close = openActionModal({
     title: "Windows Test VM", width: 680, height: 760,
     bodyNode: el("div", {}, form, el("div", { className: "modal-form-foot" }, runAll), note, results),
-    footNodes: [save, cancel],
+    dismissNode: cancel, actionNode: save,
   });
   save.onclick = async () => {
     save.disabled = true; setStatus("saving VM config…");
@@ -4993,10 +5057,11 @@ function openSprintActionModal(sprint, target, label) {
     target === "aborted" ? el("div", { className: "sprint-abort-note" },
       "Abort stops active work but retains the complete Sprint history and the Planner's durable abort-report request.") : "",
     el("label", { className: "k" }, "Reason"), reason);
-  const close = openModal({
+  const close = openActionModal({
     title: `${label} · Sprint ${sprint.sprint_id}`,
     bodyNode: body,
-    footNodes: [confirmButton, cancel],
+    dismissNode: cancel,
+    actionNode: confirmButton,
     width: 560,
     height: 360,
   });
@@ -5090,7 +5155,8 @@ function openSprintUnitModal(unit, snapshot) {
   const close = openModal({
     title: `U${unit.work_unit_id} · ${unit.title}`,
     bodyNode: body,
-    footNodes: [el("span", { className: "muted" }, `Sprint ${snapshot.sprint.sprint_id}`), closeButton],
+    footerStart: el("span", { className: "muted" }, `Sprint ${snapshot.sprint.sprint_id}`),
+    footerEnd: closeButton,
     width: 840,
     height: 760,
   });
@@ -5436,7 +5502,8 @@ document.addEventListener("mousedown", (e) => {
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
     const overlays = document.querySelectorAll(".modal-overlay");
-    overlays[overlays.length - 1]?.remove();
+    const overlay = overlays[overlays.length - 1];
+    if (overlay?.closeModal) overlay.closeModal();
   }
 });
 $("#snapshot").onclick = async () => {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -874,6 +874,8 @@ details.feature.shipped-bar { border-left-color: var(--lock); }
 .flag-body { padding: 0 .4rem .7rem 1.8rem; }
 .flag-desc { white-space: pre-wrap; font-size: .85rem; line-height: 1.55; margin-bottom: .6rem; }
 .flag-links { display: flex; flex-wrap: wrap; gap: .4rem; margin-bottom: .6rem; }
+.flag-actions { display: flex; align-items: center; gap: .6rem; margin-top: .7rem; }
+.flag-actions .flag-edit { margin-left: auto; }
 .link-card {
   display: inline-flex; flex-direction: column; gap: .1rem;
   background: var(--panel2); border: 1px solid var(--line); border-radius: 6px;
@@ -1123,7 +1125,9 @@ button.gmenu-name:hover { color: #fff; }
 /* feature editor in a modal: scroll the form, don't stretch a lone textarea */
 .modal-body > .feature-body { flex: 1; min-height: 0; overflow: auto; padding: .2rem .2rem 0; }
 .modal-body > .feature-body textarea { flex: none; resize: vertical; font: inherit; width: 100%; }
-.modal-foot { display: flex; justify-content: space-between; padding: .6rem 1.2rem 1rem; }
+.modal-foot { display: flex; align-items: center; padding: .6rem 1.2rem 1rem; }
+.modal-foot-start, .modal-foot-end { display: flex; align-items: center; gap: .6rem; }
+.modal-foot-end { margin-left: auto; }
 .modal-foot .act { margin-top: 0; }
 
 /* ── Markdown surfaces (vendored marked + DOMPurify; dos-arch ramp on flat

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -540,7 +540,7 @@
         "el(\"span\", {}, `Sprint ${sprint.sprint_id}`),",
         "else if (activeTab === \"sprints\") load(\"sprints\");",
         "feature: board.sprint.feature,",
-        "footNodes: [el(\"span\", { className: \"muted\" }, `Sprint ${snapshot.sprint.sprint_id}`), closeButton],",
+        "footerStart: el(\"span\", { className: \"muted\" }, `Sprint ${snapshot.sprint.sprint_id}`),",
         "for (const [kind, label] of [[\"events\", \"Sprint events\"], [\"summaries\", \"Sprint summaries\"]]) {",
         "for (const path of svg.querySelectorAll(\".sprint-wire\")) {",
         "function openSprintActionModal(sprint, target, label) {",

--- a/tests/test_flags_ui.py
+++ b/tests/test_flags_ui.py
@@ -1,0 +1,198 @@
+"""Flags create/edit modal and expanded-card action contracts."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
+STYLE = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
+FLAG_FORM = APP[
+    APP.index("function openFlagModal"):
+    APP.index("async function renderFlags")
+]
+FLAG_ROW = APP[
+    APP.index("function flagRow"):
+    APP.index("// ── Scripts")
+]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is required"
+)
+
+
+def run_js(script: str) -> dict:
+    proc = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+ELEMENT_HARNESS = r"""
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag; this.nodeType = 1; this.children = []; this.className = "";
+    this.value = ""; this.selected = false; this.disabled = false; this._text = "";
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  focus() { this.focused = true; }
+  set textContent(value) { this._text = String(value ?? ""); this.children = []; }
+  get textContent() {
+    return this._text + this.children.map((node) =>
+      typeof node === "string" ? node : (node.textContent || "")).join("");
+  }
+}
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({nodeType: 3, textContent: String(text ?? "")}),
+};
+const el = (tag, props = {}, ...kids) => {
+  const node = Object.assign(new FakeElement(tag), props);
+  for (const kid of kids) node.append(kid?.nodeType ? kid : document.createTextNode(kid ?? ""));
+  return node;
+};
+"""
+
+
+def test_create_and_edit_share_one_roomy_form_and_send_exact_mutations():
+    script = ELEMENT_HARNESS + r"""
+let captured = null, closed = 0;
+const calls = [], statuses = [], loads = [], errors = [];
+function openActionModal(options) { captured = options; return () => { closed += 1; }; }
+async function api(...args) { calls.push(args); return {}; }
+function setStatus(value) { statuses.push(value); }
+function load(value) { loads.push(value); }
+function toast(value) { errors.push(value); }
+""" + FLAG_FORM + r"""
+(async () => {
+  const features = [{feature_id: 7, title: "Seven"}, {feature_id: 8, title: "Eight"}];
+  const flag = {flag_id: 41, display_name: "SC-041", description: "Original body",
+    feature_id: 7, priority: "Low", resolved: 1, resolution_notes: "done"};
+  openFlagModal(features, flag);
+  const edit = captured;
+  const editForm = edit.bodyNode;
+  const editName = editForm.children[1], editDesc = editForm.children[3];
+  const editFeature = editForm.children[5], editPriority = editForm.children[7];
+  const prefill = {
+    title: edit.title, action: edit.actionNode.textContent,
+    name: editName.value, description: editDesc.value, rows: editDesc.rows,
+    feature: editFeature.children.filter((option) => option.selected).map((option) => String(option.value)),
+    priority: editPriority.children.filter((option) => option.selected).map((option) => option.value),
+    width: edit.width, height: edit.height,
+  };
+  editName.value = "SC-041A"; editDesc.value = "Revised body";
+  editFeature.value = "8"; editPriority.value = "High";
+  await edit.actionNode.onclick();
+
+  openFlagModal(features);
+  const create = captured;
+  const createForm = create.bodyNode;
+  createForm.children[1].value = "SC-NEW";
+  createForm.children[3].value = "New body";
+  createForm.children[5].value = "";
+  createForm.children[7].value = "Medium";
+  const createAction = create.actionNode.textContent;
+  await create.actionNode.onclick();
+
+  console.log(JSON.stringify({
+    prefill,
+    editCall: calls[0], createCall: calls[1],
+    createTitle: create.title, createAction,
+    createRows: createForm.children[3].rows, createHeight: create.height,
+    dismissals: [edit.dismissNode.textContent, create.dismissNode.textContent],
+    closed, statuses, loads, errors,
+  }));
+})();
+"""
+    result = run_js(script)
+    assert result["prefill"] == {
+        "title": "Edit flag #41",
+        "action": "Save",
+        "name": "SC-041",
+        "description": "Original body",
+        "rows": 8,
+        "feature": ["7"],
+        "priority": ["Low"],
+        "width": 600,
+        "height": 520,
+    }
+    assert result["editCall"] == [
+        "/flags/41",
+        "PATCH",
+        {
+            "display_name": "SC-041A",
+            "description": "Revised body",
+            "feature_id": "8",
+            "priority": "High",
+        },
+    ]
+    assert result["createCall"] == [
+        "/flags",
+        "POST",
+        {
+            "display_name": "SC-NEW",
+            "description": "New body",
+            "feature_id": None,
+            "priority": "Medium",
+        },
+    ]
+    assert result["createTitle"] == "New flag"
+    assert result["createAction"] == "Create"
+    assert result["createRows"] == 8
+    assert result["createHeight"] == 520
+    assert result["dismissals"] == ["Cancel", "Cancel"]
+    assert result["closed"] == 2
+    assert result["statuses"] == ["flag saved", "flag created"]
+    assert result["loads"] == ["flags", "flags"]
+    assert result["errors"] == []
+
+
+def test_expanded_cards_keep_resolve_left_and_edit_anchored_right():
+    script = ELEMENT_HARNESS + r"""
+let opened = null, prevented = false, stopped = false;
+function openFlagModal(features, flag) { opened = {features, flag}; }
+function prompt() { return null; }
+async function api() {}
+function setStatus() {}
+function load() {}
+function toast() {}
+""" + FLAG_ROW + r"""
+const features = [{feature_id: 7, title: "Seven"}];
+const base = {flag_id: 4, display_name: "SC-4", priority: "Medium",
+  description: "Body", feature_id: 7, feature_title: "Seven"};
+const openRow = flagRow({...base, resolved: 0}, features);
+const resolvedRow = flagRow({...base, resolved: 1, resolved_date: "2026-08-01",
+  resolution_notes: "done"}, features);
+const openActions = openRow.children[1].children.at(-1);
+const resolvedActions = resolvedRow.children[1].children.at(-1);
+openActions.children[1].onclick({
+  preventDefault() { prevented = true; }, stopPropagation() { stopped = true; },
+});
+console.log(JSON.stringify({
+  openClass: openActions.className,
+  openLabels: openActions.children.map((node) => node.textContent),
+  resolvedLabels: resolvedActions.children.map((node) => node.textContent),
+  editClass: openActions.children[1].className,
+  openedFlag: opened.flag.flag_id,
+  featureCount: opened.features.length,
+  prevented, stopped,
+}));
+"""
+    result = run_js(script)
+    assert result == {
+        "openClass": "flag-actions",
+        "openLabels": ["resolve", "edit"],
+        "resolvedLabels": ["edit"],
+        "editClass": "act flag-edit",
+        "openedFlag": 4,
+        "featureCount": 1,
+        "prevented": True,
+        "stopped": True,
+    }
+    assert ".flag-actions .flag-edit { margin-left: auto; }" in STYLE

--- a/tests/test_modal_ui_contract.py
+++ b/tests/test_modal_ui_contract.py
@@ -1,0 +1,149 @@
+"""Shared modal frame behavior and caller contracts."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
+MODAL_BLOCK = APP[
+    APP.index("let modalSequence = 0"):
+    APP.index("// Unified edit modal")
+]
+ESCAPE_BLOCK = APP[
+    APP.index("// Esc dismisses the topmost modal."):
+    APP.index('$("#snapshot")')
+]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is required"
+)
+
+
+def run_js(script: str) -> dict:
+    proc = subprocess.run(
+        ["node", "-e", script], text=True, capture_output=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_action_frame_slots_accessibility_and_every_close_path_restore_focus():
+    harness = r"""
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag; this.nodeType = 1; this.children = []; this.className = "";
+    this.style = {}; this.attributes = {}; this.parentElement = null;
+    this.isConnected = false; this.focusCount = 0;
+  }
+  append(...nodes) {
+    for (const node of nodes) {
+      this.children.push(node);
+      if (node?.nodeType === 1) {
+        node.parentElement = this;
+        if (this.isConnected) connect(node, true);
+      }
+    }
+  }
+  remove() {
+    if (this.parentElement)
+      this.parentElement.children = this.parentElement.children.filter((x) => x !== this);
+    connect(this, false); this.parentElement = null;
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  focus() { this.focusCount += 1; document.activeElement = this; }
+}
+function connect(node, value) {
+  if (node?.nodeType !== 1) return;
+  node.isConnected = value;
+  for (const child of node.children) connect(child, value);
+}
+function all(node, predicate, out = []) {
+  if (node?.nodeType === 1 && predicate(node)) out.push(node);
+  for (const child of node?.children || []) all(child, predicate, out);
+  return out;
+}
+const body = new FakeElement("body"); body.isConnected = true;
+const listeners = {};
+globalThis.document = {
+  body, activeElement: null,
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({nodeType: 3, textContent: String(text ?? "")}),
+  addEventListener: (type, fn) => { listeners[type] = fn; },
+  querySelectorAll: (selector) => selector === ".modal-overlay"
+    ? all(body, (node) => node.className === "modal-overlay") : [],
+};
+const el = (tag, props = {}, ...kids) => {
+  const node = Object.assign(new FakeElement(tag), props);
+  for (const kid of kids) node.append(kid?.nodeType ? kid : document.createTextNode(kid ?? ""));
+  return node;
+};
+"""
+    script = harness + MODAL_BLOCK + ESCAPE_BLOCK + r"""
+const trigger1 = el("button", {id: "trigger-1"}); body.append(trigger1); trigger1.focus();
+const dismiss = el("button", {textContent: "Cancel"});
+const action = el("button", {textContent: "Save"});
+const close1 = openActionModal({title: "Edit", bodyNode: el("div"), dismissNode: dismiss,
+  actionNode: action, width: 400, height: 300});
+const overlay1 = document.querySelectorAll(".modal-overlay").at(-1);
+const dialog1 = overlay1.children[0];
+const footer1 = dialog1.children[2];
+const structure = {
+  role: dialog1.attributes.role,
+  modal: dialog1.attributes["aria-modal"],
+  labelledby: dialog1.attributes["aria-labelledby"],
+  titleId: dialog1.children[0].children[0].id,
+  startClass: footer1.children[0].className,
+  startNode: footer1.children[0].children[0].textContent,
+  endClass: footer1.children[1].className,
+  endNode: footer1.children[1].children[0].textContent,
+};
+close1();
+
+const trigger2 = el("button", {id: "trigger-2"}); body.append(trigger2); trigger2.focus();
+openModal({title: "Viewer", bodyNode: el("div"), footerEnd: el("button")});
+const overlay2 = document.querySelectorAll(".modal-overlay").at(-1);
+overlay2.onmousedown({target: overlay2});
+
+const trigger3 = el("button", {id: "trigger-3"}); body.append(trigger3); trigger3.focus();
+openModal({title: "Escape", bodyNode: el("div")});
+listeners.keydown({key: "Escape"});
+
+console.log(JSON.stringify({
+  structure,
+  directRestored: trigger1.focusCount === 2,
+  overlayRestored: trigger2.focusCount === 2,
+  escapeRestored: trigger3.focusCount === 2,
+  overlaysLeft: document.querySelectorAll(".modal-overlay").length,
+}));
+"""
+    result = run_js(script)
+    assert result == {
+        "structure": {
+            "role": "dialog",
+            "modal": "true",
+            "labelledby": "modal-title-1",
+            "titleId": "modal-title-1",
+            "startClass": "modal-foot-start",
+            "startNode": "Cancel",
+            "endClass": "modal-foot-end",
+            "endNode": "Save",
+        },
+        "directRestored": True,
+        "overlayRestored": True,
+        "escapeRestored": True,
+        "overlaysLeft": 0,
+    }
+
+
+def test_all_modal_callers_use_semantic_action_or_named_viewer_slots():
+    assert "footNodes" not in APP
+    assert APP.count("const close = openActionModal({") == 6
+    assert APP.count("footerStart:") == 3  # helper + two viewer callers
+    assert APP.count("footerEnd:") == 3
+    assert "if (overlay?.closeModal) overlay.closeModal();" in APP

--- a/tests/test_shells_ui_contract.py
+++ b/tests/test_shells_ui_contract.py
@@ -49,8 +49,9 @@ def test_new_shell_creator_offers_bespoke_without_a_flavor_template():
     assert "Bespoke — custom skill pack" in creator
     assert "flavor: fl.value || null" in creator
     assert '"shell type"' in creator
-    assert "footNodes: [cancel, create]" in creator
-    assert "footNodes: [create, cancel]" not in creator
+    assert "openActionModal" in creator
+    assert "dismissNode: cancel, actionNode: create" in creator
+    assert "footNodes" not in creator
 
 
 def test_skill_assignments_are_flavor_scoped_with_bespoke_exceptions():

--- a/tests/test_sprint_board_ui.py
+++ b/tests/test_sprint_board_ui.py
@@ -45,6 +45,23 @@ def test_global_header_leads_with_chats_sprints_shells_and_keeps_remaining_order
     assert INDEX.count('id="view-sprints"') == 1
 
 
+def test_sprint_modals_follow_action_and_viewer_footer_contracts():
+    action = SPRINT_BLOCK[
+        SPRINT_BLOCK.index("function openSprintActionModal"):
+        SPRINT_BLOCK.index("function sprintActionButtons")
+    ]
+    detail = SPRINT_BLOCK[
+        SPRINT_BLOCK.index("function openSprintUnitModal"):
+        SPRINT_BLOCK.index("function sprintWorkUnitCard")
+    ]
+    assert "openActionModal" in action
+    assert "dismissNode: cancel" in action
+    assert "actionNode: confirmButton" in action
+    assert "footerStart:" in detail
+    assert "footerEnd: closeButton" in detail
+    assert "footNodes" not in action + detail
+
+
 def test_priority_selection_is_armed_then_latest_paused_then_prepared_then_terminal():
     script = SPRINT_BLOCK + r"""
 const base = [


### PR DESCRIPTION
## Summary
- replace arbitrary modal footer arrays with named start/end slots and a semantic action-dialog wrapper
- normalize all eight current modal layouts, add dialog ARIA semantics, and restore focus on button/overlay/Escape close
- reuse one roomy 8-row, 600x520 Flag form for create/edit and add expanded-card Edit actions at bottom-right
- cover the modal frame, Flag POST/PATCH modes, Shells, Sprint callers, and the Sprint-removal source fixture

## Verification
- focused contract/API gate: 76 passed, 34 subtests passed
- full suite on current main: 1,444 passed, 785 subtests passed
- ./sc render-check
- node --check, Ruff, JSON validation, git diff --check

./sc verify cannot run from the required linked worktree; it refuses before mutation and is tracked in #769. All branch-local gates above are green.

Engine roadmap: feature #32, spec #62.