### PR TITLE
fix(conversations): harden broker buffering and recovery

### DIFF
--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -181,12 +181,23 @@ class ReconcileResult:
     outcome: str
     proven: bool
     detail: str
+    interrupt_evidence: str | None = None
 
     def __post_init__(self) -> None:
         if self.outcome not in RECONCILE_OUTCOMES:
             raise ValueError(f"unknown reconciliation outcome: {self.outcome}")
         if self.outcome == "unknown" and self.proven:
             raise ValueError("an unknown adapter outcome cannot be proven")
+        if self.outcome == "cancelled":
+            if self.interrupt_evidence not in INTERRUPT_EVIDENCE:
+                raise ValueError(
+                    "cancelled reconciliation requires structured native or "
+                    "operator evidence"
+                )
+        elif self.interrupt_evidence is not None:
+            raise ValueError(
+                "interrupt evidence is valid only for cancelled reconciliation"
+            )
 
 
 class ConversationAdapter(abc.ABC):

--- a/.super-coder/scripts/conversation_adapters/claude.py
+++ b/.super-coder/scripts/conversation_adapters/claude.py
@@ -338,6 +338,10 @@ class ClaudeAdapter(ConversationAdapter):
                 if event.type in TERMINAL_EVENTS:
                     terminal = True
                     turn.metadata["terminal"] = event.type
+                    if event.interrupt_evidence:
+                        turn.metadata["interrupt_evidence"] = (
+                            event.interrupt_evidence
+                        )
                 yield event
         returncode = process.wait()
         turn.metadata["returncode"] = returncode
@@ -440,10 +444,16 @@ class ClaudeAdapter(ConversationAdapter):
     ) -> ReconcileResult:
         terminal = turn.metadata.get("terminal")
         if terminal in TERMINAL_EVENTS:
+            outcome = terminal_outcome(terminal)
             return ReconcileResult(
-                terminal_outcome(terminal),
+                outcome,
                 True,
                 f"terminal {terminal} was observed on Claude stdout",
+                (
+                    turn.metadata.get("interrupt_evidence")
+                    if outcome == "cancelled"
+                    else None
+                ),
             )
         process = turn.opaque
         if process is not None and process.poll() is None:
@@ -455,10 +465,12 @@ class ClaudeAdapter(ConversationAdapter):
         inspection = self.inspect(turn.session_ref, context)
         transcript_terminal = inspection.metadata.get("terminal")
         if transcript_terminal in TERMINAL_EVENTS:
+            outcome = terminal_outcome(str(transcript_terminal))
             return ReconcileResult(
-                terminal_outcome(str(transcript_terminal)),
+                outcome,
                 True,
                 "Claude transcript contains a terminal result",
+                "native" if outcome == "cancelled" else None,
             )
         return ReconcileResult(
             "unknown",

--- a/.super-coder/scripts/conversation_adapters/codex.py
+++ b/.super-coder/scripts/conversation_adapters/codex.py
@@ -545,6 +545,10 @@ class CodexAdapter(ConversationAdapter):
                     ensure_exact_session(turn.session_ref, session)
                 if event.type in TERMINAL_EVENTS:
                     turn.metadata["terminal"] = event.type
+                    if event.interrupt_evidence:
+                        turn.metadata["interrupt_evidence"] = (
+                            event.interrupt_evidence
+                        )
                 yield event
                 if event.type in TERMINAL_EVENTS:
                     return
@@ -605,10 +609,16 @@ class CodexAdapter(ConversationAdapter):
     ) -> ReconcileResult:
         terminal = turn.metadata.get("terminal")
         if terminal in TERMINAL_EVENTS:
+            outcome = terminal_outcome(terminal)
             return ReconcileResult(
-                terminal_outcome(terminal),
+                outcome,
                 True,
                 f"terminal {terminal} was observed from app-server",
+                (
+                    turn.metadata.get("interrupt_evidence")
+                    if outcome == "cancelled"
+                    else None
+                ),
             )
         inspection = self.inspect(turn.session_ref, context)
         if not inspection.exists:
@@ -641,6 +651,7 @@ class CodexAdapter(ConversationAdapter):
                         outcome,
                         True,
                         f"Codex thread/read reports {status}",
+                        "native" if outcome == "cancelled" else None,
                     )
         return ReconcileResult(
             "unknown",

--- a/.super-coder/scripts/conversation_adapters/kimi.py
+++ b/.super-coder/scripts/conversation_adapters/kimi.py
@@ -940,6 +940,7 @@ class KimiAdapter(ConversationAdapter):
                 "native" if cancelled else "operator",
             )
             turn.metadata["terminal"] = event.type
+            turn.metadata["interrupt_evidence"] = event.interrupt_evidence
             yield event
             return
         if native_completed.is_set() or returncode == 0:
@@ -1057,10 +1058,16 @@ class KimiAdapter(ConversationAdapter):
     ) -> ReconcileResult:
         terminal = turn.metadata.get("terminal")
         if terminal in TERMINAL_EVENTS:
+            outcome = terminal_outcome(str(terminal))
             return ReconcileResult(
-                terminal_outcome(str(terminal)),
+                outcome,
                 True,
                 f"terminal {terminal} was observed on Kimi stdout",
+                (
+                    turn.metadata.get("interrupt_evidence")
+                    if outcome == "cancelled"
+                    else None
+                ),
             )
         if turn.metadata.get("identity_mismatch"):
             return ReconcileResult(
@@ -1089,6 +1096,7 @@ class KimiAdapter(ConversationAdapter):
                 "cancelled",
                 True,
                 "Kimi exact run slice contains turn.cancel",
+                "native",
             )
         if self._completion_proven(records):
             return ReconcileResult(

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -674,6 +674,7 @@ class OpenCodeAdapter(ConversationAdapter):
             if turn.metadata.get("interrupt_requested"):
                 turn.metadata["dispatch_pending"] = False
                 turn.metadata["terminal"] = "run.interrupted"
+                turn.metadata["interrupt_evidence"] = "operator"
                 interrupted_before_dispatch = True
             else:
                 turn.metadata["dispatch_pending"] = False
@@ -718,6 +719,10 @@ class OpenCodeAdapter(ConversationAdapter):
                     observed_activity = True
                 if event.type in TERMINAL_EVENTS:
                     turn.metadata["terminal"] = event.type
+                    if event.interrupt_evidence:
+                        turn.metadata["interrupt_evidence"] = (
+                            event.interrupt_evidence
+                        )
                 yield event
                 if event.type in TERMINAL_EVENTS:
                     return
@@ -782,10 +787,16 @@ class OpenCodeAdapter(ConversationAdapter):
     ) -> ReconcileResult:
         terminal = turn.metadata.get("terminal")
         if terminal in TERMINAL_EVENTS:
+            outcome = terminal_outcome(terminal)
             return ReconcileResult(
-                terminal_outcome(terminal),
+                outcome,
                 True,
                 f"terminal {terminal} was observed on the native stream",
+                (
+                    turn.metadata.get("interrupt_evidence")
+                    if outcome == "cancelled"
+                    else None
+                ),
             )
         inspection = self.inspect(turn.session_ref, context)
         if not inspection.exists:

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import socket
 import threading
 import time
@@ -50,6 +51,8 @@ DEFAULT_MAX_WORKERS = 8
 DEFAULT_EVENT_BATCH_SIZE = 64
 DEFAULT_EVENT_BACKLOG_SIZE = 1024
 DEFAULT_EVENT_FLUSH_SECONDS = 0.1
+DEFAULT_BUSY_RETRY_ATTEMPTS = 6
+_STREAM_END = object()
 
 
 class BrokerError(RuntimeError):
@@ -923,6 +926,7 @@ class ConversationBroker(threading.Thread):
         event_batch_size: int = DEFAULT_EVENT_BATCH_SIZE,
         event_backlog_size: int = DEFAULT_EVENT_BACKLOG_SIZE,
         event_flush_seconds: float = DEFAULT_EVENT_FLUSH_SECONDS,
+        busy_retry_attempts: int = DEFAULT_BUSY_RETRY_ATTEMPTS,
     ) -> None:
         super().__init__(name="conversation-broker", daemon=True)
         self.store = store or BrokerStore(db_path)
@@ -935,9 +939,18 @@ class ConversationBroker(threading.Thread):
         self.heartbeat_seconds = heartbeat_seconds
         self.recovery_seconds = recovery_seconds
         self.reconcile_attempts = reconcile_attempts
+        if event_batch_size <= 0:
+            raise ValueError("event_batch_size must be positive")
+        if event_backlog_size <= 0:
+            raise ValueError("event_backlog_size must be positive")
+        if event_flush_seconds <= 0:
+            raise ValueError("event_flush_seconds must be positive")
+        if busy_retry_attempts <= 0:
+            raise ValueError("busy_retry_attempts must be positive")
         self.event_batch_size = event_batch_size
         self.event_backlog_size = event_backlog_size
         self.event_flush_seconds = event_flush_seconds
+        self.busy_retry_attempts = busy_retry_attempts
         self._wake = threading.Event()
         self._stop_event = threading.Event()
         self._active: dict[int, _ActiveRun] = {}
@@ -1073,13 +1086,15 @@ class ConversationBroker(threading.Thread):
         wait: bool,
     ) -> tuple[bool, Any]:
         """Retry only exhausted SQLite writer acquisition, never native work."""
+        attempts = 0
         while not self._stop_event.is_set():
+            attempts += 1
             try:
                 return True, action()
             except Exception as exc:
                 if not db_driver.is_busy_error(exc):
                     raise
-                if not wait:
+                if not wait or attempts >= self.busy_retry_attempts:
                     return False, None
                 self._stop_event.wait(min(1.0, self.recovery_seconds))
         return False, None
@@ -1093,7 +1108,7 @@ class ConversationBroker(threading.Thread):
     ) -> bool:
         if not pending:
             return True
-        batch = list(pending)
+        batch = list(pending[: self.event_batch_size])
         persisted, _result = self._retry_busy(
             partial(self.store.append_events, run_id, batch),
             wait=wait,
@@ -1101,6 +1116,141 @@ class ConversationBroker(threading.Thread):
         if persisted:
             del pending[: len(batch)]
         return persisted
+
+    @staticmethod
+    def _produce_stream(
+        adapter: ConversationAdapter,
+        turn: NativeTurn,
+        items: queue.Queue[object],
+        stopped: threading.Event,
+    ) -> None:
+        """Drain one native stream into its bounded per-run queue."""
+        try:
+            for event in adapter.stream(turn):
+                while not stopped.is_set():
+                    try:
+                        items.put(event, timeout=0.1)
+                        break
+                    except queue.Full:
+                        continue
+                if stopped.is_set() or event.type in TERMINAL_EVENTS:
+                    break
+        except Exception as exc:
+            while not stopped.is_set():
+                try:
+                    items.put(exc, timeout=0.1)
+                    break
+                except queue.Full:
+                    continue
+        finally:
+            while not stopped.is_set():
+                try:
+                    items.put(_STREAM_END, timeout=0.1)
+                    break
+                except queue.Full:
+                    continue
+
+    def _consume_stream(
+        self,
+        active: _ActiveRun,
+        adapter: ConversationAdapter,
+        turn: NativeTurn,
+    ) -> bool:
+        """Persist one stream with real flush deadlines and bounded batches."""
+        items: queue.Queue[object] = queue.Queue(
+            maxsize=self.event_backlog_size
+        )
+        stopped = threading.Event()
+        threading.Thread(
+            target=self._produce_stream,
+            args=(adapter, turn, items, stopped),
+            name=f"conversation-stream-{active.run.run_id}",
+            daemon=True,
+        ).start()
+        pending: list[NormalizedEvent] = []
+        pending_since: float | None = None
+        retry_after = 0.0
+        try:
+            while not self._stop_event.is_set():
+                now = time.monotonic()
+                flush_at = None
+                if pending_since is not None:
+                    flush_at = max(
+                        pending_since + self.event_flush_seconds,
+                        retry_after,
+                    )
+                timeout = 0.1
+                if flush_at is not None:
+                    timeout = min(timeout, max(0.0, flush_at - now))
+                if (
+                    len(pending) >= self.event_batch_size
+                    and now >= retry_after
+                ):
+                    timeout = 0.0
+                try:
+                    item = items.get(timeout=timeout)
+                except queue.Empty:
+                    item = None
+
+                if isinstance(item, NormalizedEvent):
+                    if item.type in TERMINAL_EVENTS:
+                        while pending:
+                            if not self._flush_events(
+                                active.run.run_id,
+                                pending,
+                                wait=True,
+                            ):
+                                return False
+                        return self._finish_adapter_event(active, item)
+                    if not pending:
+                        pending_since = time.monotonic()
+                    pending.append(item)
+                elif item is _STREAM_END or isinstance(item, Exception):
+                    break
+
+                now = time.monotonic()
+                deadline_reached = (
+                    pending_since is not None
+                    and now >= pending_since + self.event_flush_seconds
+                )
+                meaningful_event = (
+                    isinstance(item, NormalizedEvent)
+                    and item.type != "assistant.delta"
+                )
+                batch_ready = len(pending) >= self.event_batch_size
+                force_backpressure = (
+                    len(pending) >= self.event_backlog_size
+                )
+                should_flush = (
+                    meaningful_event
+                    or batch_ready
+                    or deadline_reached
+                    or force_backpressure
+                )
+                if not should_flush:
+                    continue
+                if now < retry_after and not force_backpressure:
+                    continue
+                if self._flush_events(
+                    active.run.run_id,
+                    pending,
+                    wait=force_backpressure,
+                ):
+                    pending_since = time.monotonic() if pending else None
+                    retry_after = 0.0
+                else:
+                    retry_after = now + self.recovery_seconds
+
+            while pending:
+                if not self._flush_events(
+                    active.run.run_id,
+                    pending,
+                    wait=True,
+                ):
+                    return False
+            return False
+        finally:
+            stopped.set()
 
     def _finish_adapter_event(
         self,
@@ -1198,7 +1348,7 @@ class ConversationBroker(threading.Thread):
             except Exception as exc:
                 failures += 1
                 reconcile_detail = f"reconcile attempt {failures}: {exc}"
-                self._retry_busy(
+                persisted, _result = self._retry_busy(
                     partial(
                         self.store.note_reconcile_error,
                         active.run.run_id,
@@ -1207,6 +1357,8 @@ class ConversationBroker(threading.Thread):
                     ),
                     wait=True,
                 )
+                if not persisted:
+                    return
                 if failures >= self.reconcile_attempts:
                     self._finish_error(active.run.run_id, exc, proven=False)
                     return
@@ -1215,7 +1367,7 @@ class ConversationBroker(threading.Thread):
 
             if result.outcome == "running" and result.proven:
                 failures = 0
-                self._retry_busy(
+                persisted, _result = self._retry_busy(
                     partial(
                         self.store.renew_runs,
                         self.owner,
@@ -1223,6 +1375,8 @@ class ConversationBroker(threading.Thread):
                     ),
                     wait=True,
                 )
+                if not persisted:
+                    return
                 self._stop_event.wait(self.recovery_seconds)
                 continue
             outcome = result.outcome if result.proven else "unknown"
@@ -1230,6 +1384,11 @@ class ConversationBroker(threading.Thread):
                 "reconciled": True,
                 "proven": result.proven,
                 "detail": result.detail,
+                **(
+                    {"interrupt_evidence": result.interrupt_evidence}
+                    if result.interrupt_evidence
+                    else {}
+                ),
             }
             error_code = (
                 "HARNESS_OUTCOME_UNKNOWN" if outcome == "unknown" else None
@@ -1289,55 +1448,7 @@ class ConversationBroker(threading.Thread):
                 self.store.mark_native_started(run.run_id, self.owner, turn)
                 self._deliver_interrupt(active)
 
-                terminal = False
-                pending: list[NormalizedEvent] = []
-                last_flush = time.monotonic()
-                retry_after = 0.0
-                try:
-                    for event in adapter.stream(turn):
-                        if event.type in TERMINAL_EVENTS:
-                            if not self._flush_events(
-                                run.run_id,
-                                pending,
-                                wait=True,
-                            ):
-                                return
-                            terminal = self._finish_adapter_event(active, event)
-                            break
-                        pending.append(event)
-                        now = time.monotonic()
-                        should_flush = (
-                            event.type != "assistant.delta"
-                            or len(pending) >= self.event_batch_size
-                            or now - last_flush >= self.event_flush_seconds
-                        )
-                        force_backpressure = (
-                            len(pending) >= self.event_backlog_size
-                        )
-                        if not should_flush and not force_backpressure:
-                            continue
-                        if now < retry_after and not force_backpressure:
-                            continue
-                        if self._flush_events(
-                            run.run_id,
-                            pending,
-                            wait=force_backpressure,
-                        ):
-                            last_flush = time.monotonic()
-                            retry_after = 0.0
-                        else:
-                            retry_after = now + self.recovery_seconds
-                except Exception:
-                    # Exact identities are durable; inspect them rather than
-                    # replaying a message after a broken stream.
-                    pass
-                if terminal:
-                    return
-                if not self._flush_events(
-                    run.run_id,
-                    pending,
-                    wait=True,
-                ):
+                if self._consume_stream(active, adapter, turn):
                     return
                 self._reconcile_loop(active, context)
                 return

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -29,6 +29,7 @@ from conversation_adapters import (  # noqa: E402
     NativeTurn,
     NormalizedEvent,
     OpenCodeAdapter,
+    ReconcileResult,
     adapter_for,
 )
 
@@ -743,6 +744,18 @@ class ConversationAdapterTest(unittest.TestCase):
     def test_interrupted_events_require_structured_evidence(self) -> None:
         with self.assertRaisesRegex(ValueError, "structured native or operator"):
             NormalizedEvent("run.interrupted", {"status": "interrupted"})
+
+    def test_cancelled_reconciliation_requires_structured_evidence(self) -> None:
+        with self.assertRaisesRegex(ValueError, "structured native or operator"):
+            ReconcileResult("cancelled", True, "cancelled without provenance")
+
+        result = ReconcileResult(
+            "cancelled",
+            True,
+            "operator interrupt was durably recorded",
+            "operator",
+        )
+        self.assertEqual(result.interrupt_evidence, "operator")
 
     def test_identical_contract_start_stream_interrupt_resume_reconcile(
         self,

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -153,6 +153,23 @@ class BarrierAdapter(FakeAdapter):
         yield NormalizedEvent("run.completed", {"status": "completed"})
 
 
+class SparseDeltaAdapter(FakeAdapter):
+    """Pause after one delta so the broker must flush on its own deadline."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.delta_yielded = threading.Event()
+        self.release = threading.Event()
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        yield NormalizedEvent("session.started", {"session_ref": turn.session_ref})
+        yield NormalizedEvent("run.started", {"status": "running"})
+        yield NormalizedEvent("assistant.delta", {"text": "visible promptly"})
+        self.delta_yielded.set()
+        self.release.wait(2)
+        yield NormalizedEvent("run.completed", {"status": "completed"})
+
+
 class ReconcileSequenceAdapter(FakeAdapter):
     """End the stream uncertain, then prove running and terminal states."""
 
@@ -408,6 +425,7 @@ class ConversationBrokerCase(unittest.TestCase):
         *,
         heartbeat_seconds: int = 60,
         recovery_seconds: int = 60,
+        **kwargs,
     ) -> ConversationBroker:
         broker = ConversationBroker(
             self.db_path,
@@ -415,6 +433,7 @@ class ConversationBrokerCase(unittest.TestCase):
             owner=f"test-broker-{len(self.brokers) + 1}",
             heartbeat_seconds=heartbeat_seconds,
             recovery_seconds=recovery_seconds,
+            **kwargs,
         )
         self.brokers.append(broker)
         broker.start()
@@ -953,6 +972,113 @@ class ServiceContractTest(ConversationBrokerCase):
             ],
         )
         self.assertEqual(adapter.reconciled, 0)
+
+    def test_sparse_delta_flushes_without_waiting_for_the_next_native_event(
+        self,
+    ) -> None:
+        adapter = SparseDeltaAdapter()
+        self.addCleanup(adapter.release.set)
+        broker = self.start_broker(
+            lambda _harness: adapter,
+            event_flush_seconds=0.02,
+        )
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        broker.notify()
+        self.assertTrue(adapter.delta_yielded.wait(1))
+
+        deadline = time.monotonic() + 0.5
+        delta_rows = []
+        while time.monotonic() < deadline:
+            with self.connect() as con:
+                delta_rows = con.execute(
+                    "SELECT event_type,payload FROM conversation_events "
+                    "WHERE conversation_id=? AND event_type='assistant.delta'",
+                    (conversation_id,),
+                ).fetchall()
+            if delta_rows:
+                break
+            time.sleep(0.01)
+
+        self.assertEqual(len(delta_rows), 1)
+        self.assertEqual(
+            json.loads(delta_rows[0]["payload"])["text"],
+            "visible promptly",
+        )
+        adapter.release.set()
+
+    def test_event_flush_writes_at_most_the_configured_batch_size(self) -> None:
+        store = mock.Mock()
+        store.append_events.side_effect = lambda _run_id, events: list(
+            range(1, len(events) + 1)
+        )
+        broker = ConversationBroker(
+            self.db_path,
+            store=store,
+            event_batch_size=2,
+        )
+        pending = [
+            NormalizedEvent("assistant.delta", {"text": str(index)})
+            for index in range(5)
+        ]
+
+        self.assertTrue(broker._flush_events(7, pending, wait=False))
+
+        written = store.append_events.call_args.args[1]
+        self.assertEqual([event.payload["text"] for event in written], ["0", "1"])
+        self.assertEqual(
+            [event.payload["text"] for event in pending],
+            ["2", "3", "4"],
+        )
+
+    def test_busy_retry_stops_at_the_configured_attempt_budget(self) -> None:
+        broker = ConversationBroker(
+            self.db_path,
+            recovery_seconds=0.001,
+            busy_retry_attempts=3,
+        )
+        attempts = 0
+
+        def always_busy() -> None:
+            nonlocal attempts
+            attempts += 1
+            raise sqlite3.OperationalError("database is locked")
+
+        persisted, result = broker._retry_busy(always_busy, wait=True)
+
+        self.assertFalse(persisted)
+        self.assertIsNone(result)
+        self.assertEqual(attempts, 3)
+
+    def test_reconciled_cancellation_persists_native_evidence(self) -> None:
+        _conversation, _message, run_id = self.add_live_run(
+            state="running",
+            session_after="native-session",
+            runner_ref="native-run-cancelled",
+        )
+        adapter = FakeAdapter(
+            reconcile=ReconcileResult(
+                "cancelled",
+                True,
+                "native transcript proves cancellation",
+                "native",
+            )
+        )
+        broker = self.start_broker(lambda _harness: adapter)
+
+        self.wait_run_state(run_id, "cancelled")
+        self.assertTrue(broker.wait_idle())
+        with self.connect() as con:
+            terminal = con.execute(
+                "SELECT event_type,payload FROM conversation_events "
+                "WHERE run_id=? ORDER BY sequence DESC LIMIT 1",
+                (run_id,),
+            ).fetchone()
+
+        self.assertEqual(terminal["event_type"], "run.interrupted")
+        payload = json.loads(terminal["payload"])
+        self.assertEqual(payload["interrupt_evidence"], "native")
+        self.assertTrue(payload["reconciled"])
 
     def test_same_harness_runs_stream_concurrently_on_different_shells(
         self,


### PR DESCRIPTION
## Summary

- drain each native stream through a bounded per-run queue so sparse assistant deltas flush on a real deadline without a centralized writer
- cap every SQLite event transaction at the configured batch size and bound repeated busy acquisition before yielding to lease recovery
- carry structured native/operator interruption evidence through adapter reconciliation and durable cancelled terminals
- add regression coverage for sparse delta visibility, batch caps, persistent busy budgets, and recovered cancellation provenance

Follow-up hardening for #855.

## Verification

- full repository suite: 1442 collected, 1 skipped; green via `env -u SC_API_TOKEN ./sc test`
- full conversation suite: 186 passed, 162 subtests passed
- focused adapter/broker suite after final rebase: 56 passed, 4 subtests passed
- sparse flush + same-harness concurrency repeated 10x: 20 passed
- `./sc render-check`, Python compilation, change-scoped Ruff fatal/B023, and `git diff --check` passed
- `./sc verify` correctly refused the linked worktree and touched nothing; tracked in #769
- `./sc map` intentionally not run because repo-map ownership belongs to the cartographer; source-maintenance contradiction is already tracked in the live engine flag SC-019
