### PR TITLE
test: add segmented response contract traces

### DIFF
--- a/tests/segmented_response_traces.py
+++ b/tests/segmented_response_traces.py
@@ -1,0 +1,155 @@
+"""Executable event traces for segmented assistant response contracts."""
+
+HISTORICAL_SEGMENT_TRACES = (
+    {
+        "name": "plain_prose",
+        "events": (
+            ("assistant.delta", {"text": "plain "}),
+            ("assistant.delta", {"text": "prose"}),
+        ),
+        "expected": (
+            ("assistant", 0, 3, 4, "plain prose"),
+        ),
+    },
+    {
+        "name": "prose_tool_prose",
+        "events": (
+            ("assistant.delta", {"text": "plan"}),
+            ("tool.started", {"name": "write"}),
+            ("tool.completed", {"name": "write"}),
+            ("assistant.delta", {"text": "result "}),
+            ("assistant.delta", {"text": "done"}),
+        ),
+        "expected": (
+            ("assistant", 0, 3, 3, "plan"),
+            ("assistant", 5, 6, 7, "result done"),
+        ),
+    },
+    {
+        "name": "multiple_tools",
+        "events": (
+            ("assistant.delta", {"text": "before"}),
+            ("tool.started", {"name": "read"}),
+            ("tool.completed", {"name": "read"}),
+            ("tool.started", {"name": "write"}),
+            ("tool.completed", {"name": "write"}),
+            ("assistant.delta", {"text": "after"}),
+        ),
+        "expected": (
+            ("assistant", 0, 3, 3, "before"),
+            ("assistant", 7, 8, 8, "after"),
+        ),
+    },
+    {
+        "name": "tool_before_prose",
+        "events": (
+            ("tool.started", {"name": "read"}),
+            ("tool.completed", {"name": "read"}),
+            ("assistant.delta", {"text": "first visible text"}),
+        ),
+        "expected": (
+            ("assistant", 4, 5, 5, "first visible text"),
+        ),
+    },
+    {
+        "name": "permission_and_input_pauses",
+        "events": (
+            ("assistant.delta", {"text": "explain"}),
+            ("permission.requested", {"detail": "approve write"}),
+            ("assistant.delta", {"text": "approved"}),
+            ("input.requested", {"detail": "choose target"}),
+            ("assistant.delta", {"text": "continued"}),
+        ),
+        "expected": (
+            ("assistant", 0, 3, 3, "explain"),
+            ("activity", 4, 4, 4, "permission.requested"),
+            ("assistant", 4, 5, 5, "approved"),
+            ("activity", 6, 6, 6, "input.requested"),
+            ("assistant", 6, 7, 7, "continued"),
+        ),
+    },
+)
+
+
+PENDING_BOUNDARY_TRACE = (
+    ("assistant.delta", {"text": "before tool"}),
+    ("tool.started", {"name": "write"}),
+    ("tool.completed", {"name": "write"}),
+)
+
+
+LIVE_SEGMENT_EVENTS = (
+    {
+        "sequence": 6,
+        "event_type": "tool.started",
+        "message_id": 1,
+        "run_id": 77,
+        "created_at": "2026-07-30 20:01:00",
+        "payload": {"name": "write"},
+    },
+    {
+        "sequence": 7,
+        "event_type": "tool.completed",
+        "message_id": 1,
+        "run_id": 77,
+        "created_at": "2026-07-30 20:01:01",
+        "payload": {"name": "write"},
+    },
+    {
+        "sequence": 8,
+        "event_type": "assistant.delta",
+        "message_id": 1,
+        "run_id": 77,
+        "created_at": "2026-07-30 20:01:02",
+        "payload": {"text": "after tool"},
+    },
+)
+
+
+def version_two_snapshot() -> dict:
+    """Return a fresh snapshot paused after an initial assistant segment."""
+    return {
+        "conversation_id": "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "projection_version": 2,
+        "through_sequence": 5,
+        "assistant_cursor": {
+            "run_id": 77,
+            "segment_anchor_sequence": 0,
+        },
+        "controls": {
+            "conversation_version": 4,
+            "conversation_state": "running",
+            "queued_count": 0,
+            "active_run_id": 77,
+            "close_requested_at": None,
+        },
+        "items": [
+            {
+                "item_id": "message:1",
+                "kind": "user",
+                "order_sequence": 1,
+                "message_id": 1,
+                "run_id": None,
+                "created_at": "2026-07-30 20:00:00",
+                "text": "use a tool",
+                "state": "running",
+                "completed_at": None,
+                "text_truncated": False,
+            },
+            {
+                "item_id": "run:77:assistant:0",
+                "kind": "assistant",
+                "order_sequence": 3,
+                "message_id": 1,
+                "run_id": 77,
+                "created_at": "2026-07-30 20:00:02",
+                "text": "before tool",
+                "outcome": None,
+                "segment_anchor_sequence": 0,
+                "first_sequence": 3,
+                "last_sequence": 3,
+                "text_truncated": False,
+            },
+        ],
+        "truncation": None,
+    }

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -12,8 +12,11 @@ from contextlib import closing
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ROOT / "tests"))
 sys.path.insert(0, str(ENGINE / "api"))
 sys.path.insert(0, str(ENGINE / "scripts"))
 
@@ -21,6 +24,10 @@ import conversation_broker
 import conversation_events
 import conversation_routes
 import sprint_participant_chats
+from segmented_response_traces import (
+    HISTORICAL_SEGMENT_TRACES,
+    PENDING_BOUNDARY_TRACE,
+)
 
 
 def apply_schema(con: sqlite3.Connection) -> None:
@@ -281,6 +288,145 @@ class ConversationApiCase(unittest.TestCase):
                 (conversation_id, sequence, message_id, run_id),
             )
         return message_ids, sequence
+
+    def seed_segmented_trace(
+        self,
+        con: sqlite3.Connection,
+        *,
+        conversation_id: str,
+        events: tuple[tuple[str, dict], ...],
+        active: bool = False,
+        body: str = "trace prompt",
+        start_sequence: int = 0,
+    ) -> tuple[int, int, int]:
+        message = con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash,state,completed_at) "
+            "VALUES (?,'user','operator','prompt',?,?,?, ?,?)",
+            (
+                conversation_id,
+                body,
+                f"trace-{start_sequence}-{body}",
+                f"hash-{start_sequence}-{body}",
+                "running" if active else "completed",
+                None if active else "2026-07-30 12:01:00",
+            ),
+        )
+        message_id = int(message.lastrowid)
+        run = con.execute(
+            "INSERT INTO conversation_runs "
+            "(conversation_id,shell_id,trigger_message_id,lease_owner,"
+            "lease_expires_at,state,started_at,ended_at) "
+            "VALUES (?,1,?,'fixture','2026-07-30 13:00:00',?,"
+            "'2026-07-30 12:00:00',?)",
+            (
+                conversation_id,
+                message_id,
+                "running" if active else "succeeded",
+                None if active else "2026-07-30 12:01:00",
+            ),
+        )
+        run_id = int(run.lastrowid)
+        sequence = start_sequence + 1
+        con.execute(
+            "INSERT INTO conversation_events "
+            "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+            "VALUES (?,?,'message.accepted',?,?,NULL)",
+            (conversation_id, sequence, json.dumps({"text": body}), message_id),
+        )
+        sequence += 1
+        con.execute(
+            "INSERT INTO conversation_events "
+            "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+            "VALUES (?,?,'run.started','{}',?,?)",
+            (conversation_id, sequence, message_id, run_id),
+        )
+        for event_type, payload in events:
+            sequence += 1
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,?,?,?,?)",
+                (
+                    conversation_id,
+                    sequence,
+                    event_type,
+                    json.dumps(payload),
+                    message_id,
+                    run_id,
+                ),
+            )
+        if active:
+            con.execute(
+                "UPDATE conversations SET state='running' WHERE conversation_id=?",
+                (conversation_id,),
+            )
+        else:
+            sequence += 1
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,'run.completed','{}',?,?)",
+                (conversation_id, sequence, message_id, run_id),
+            )
+        return message_id, run_id, sequence
+
+    def assert_historical_segment_trace(self, name: str) -> None:
+        trace = next(
+            item for item in HISTORICAL_SEGMENT_TRACES if item["name"] == name
+        )
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=710,
+                state="closed",
+            )
+            _message_id, run_id, _through = self.seed_segmented_trace(
+                con,
+                conversation_id=conversation_id,
+                events=trace["events"],
+            )
+            con.commit()
+
+        status, _, transcript = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/transcript",
+        )
+        self.assertEqual(status, 200, transcript)
+        actual = []
+        for item in transcript["items"]:
+            if item["kind"] == "user":
+                continue
+            if item["kind"] == "assistant":
+                actual.append((
+                    item["item_id"],
+                    item["kind"],
+                    item.get("segment_anchor_sequence"),
+                    item["first_sequence"],
+                    item["last_sequence"],
+                    item["text"],
+                ))
+            else:
+                actual.append((
+                    item["item_id"],
+                    item["kind"],
+                    None,
+                    item["sequence"],
+                    item["sequence"],
+                    item["activity_type"],
+                ))
+        expected = []
+        for kind, anchor, first, last, value in trace["expected"]:
+            item_id = (
+                f"run:{run_id}:assistant:{anchor}"
+                if kind == "assistant"
+                else f"event:{anchor}"
+            )
+            expected.append((item_id, kind, anchor if kind == "assistant" else None,
+                             first, last, value))
+        self.assertEqual(actual, expected)
+        self.assertEqual(transcript["projection_version"], 2)
 
     def test_creation_observation_is_post_commit_and_cannot_fail_create(self):
         def observer(db_path, conversation_id):
@@ -1518,6 +1664,156 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
                 ).fetchone()[0],
                 source_rows,
             )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Sprint 63 unit 2 removes this projection-v2 marker",
+    )
+    @unittest.expectedFailure
+    def test_segmented_plain_prose_keeps_one_stable_anchor_zero_item(self) -> None:
+        self.assert_historical_segment_trace("plain_prose")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Sprint 63 unit 2 removes this projection-v2 marker",
+    )
+    @unittest.expectedFailure
+    def test_segmented_prose_tool_prose_has_exact_items_ids_and_order(self) -> None:
+        self.assert_historical_segment_trace("prose_tool_prose")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Sprint 63 unit 2 removes this projection-v2 marker",
+    )
+    @unittest.expectedFailure
+    def test_segmented_multiple_tools_use_only_the_latest_boundary(self) -> None:
+        self.assert_historical_segment_trace("multiple_tools")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Sprint 63 unit 2 removes this projection-v2 marker",
+    )
+    @unittest.expectedFailure
+    def test_segmented_tool_before_prose_creates_no_empty_bubble(self) -> None:
+        self.assert_historical_segment_trace("tool_before_prose")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Sprint 63 unit 2 removes this projection-v2 marker",
+    )
+    @unittest.expectedFailure
+    def test_segmented_actionable_pauses_remain_between_assistant_items(self) -> None:
+        self.assert_historical_segment_trace("permission_and_input_pauses")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Sprint 63 unit 2 removes this projection-v2 marker",
+    )
+    @unittest.expectedFailure
+    def test_segmented_pending_boundary_snapshot_carries_active_cursor(self) -> None:
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=711,
+                state="running",
+            )
+            _message_id, run_id, through = self.seed_segmented_trace(
+                con,
+                conversation_id=conversation_id,
+                events=PENDING_BOUNDARY_TRACE,
+                active=True,
+            )
+            con.commit()
+
+        status, _, transcript = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/transcript",
+        )
+        self.assertEqual(status, 200, transcript)
+        self.assertEqual(transcript["through_sequence"], through)
+        self.assertEqual(transcript["assistant_cursor"], {
+            "run_id": run_id,
+            "segment_anchor_sequence": 5,
+        })
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Sprint 63 unit 2 removes this projection-v2 marker",
+    )
+    @unittest.expectedFailure
+    def test_segmented_fresh_run_cursor_does_not_leak_prior_run_boundary(self) -> None:
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=712,
+                state="running",
+            )
+            _message_id, _old_run_id, through = self.seed_segmented_trace(
+                con,
+                conversation_id=conversation_id,
+                events=PENDING_BOUNDARY_TRACE,
+                body="earlier tool turn",
+            )
+            _message_id, active_run_id, through = self.seed_segmented_trace(
+                con,
+                conversation_id=conversation_id,
+                events=(("assistant.delta", {"text": "fresh prose"}),),
+                active=True,
+                body="fresh boundary-free turn",
+                start_sequence=through,
+            )
+            con.commit()
+
+        status, _, transcript = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/transcript",
+        )
+        self.assertEqual(status, 200, transcript)
+        self.assertEqual(transcript["through_sequence"], through)
+        self.assertEqual(transcript["assistant_cursor"], {
+            "run_id": active_run_id,
+            "segment_anchor_sequence": 0,
+        })
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Sprint 63 unit 2 removes this projection-v2 marker",
+    )
+    @unittest.expectedFailure
+    def test_segmented_cursor_uses_full_prefix_when_boundary_is_source_capped(
+        self,
+    ) -> None:
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=713,
+                state="running",
+            )
+            events = (*PENDING_BOUNDARY_TRACE, ("usage.updated", {"tokens": 3}))
+            _message_id, run_id, through = self.seed_segmented_trace(
+                con,
+                conversation_id=conversation_id,
+                events=events,
+                active=True,
+            )
+            con.commit()
+            transcript = conversation_routes._transcript_projection(
+                con,
+                conversation_id,
+                owner_user_id=1,
+                limits=conversation_routes.TranscriptLimits(
+                    max_turns=200,
+                    max_source_events=1,
+                    max_source_bytes=1_000_000,
+                    max_response_bytes=1_000_000,
+                ),
+            )
+
+        self.assertEqual(transcript["through_sequence"], through)
+        self.assertEqual(transcript["assistant_cursor"], {
+            "run_id": run_id,
+            "segment_anchor_sequence": 5,
+        })
 
     def test_transcript_caps_are_injected_explicit_and_never_mutate_sources(
         self,

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -8,7 +8,9 @@ end-to-end DOM/runtime gate over the actual static UI and mocked read API.
 from __future__ import annotations
 
 import json
+import sys
 import threading
+from contextlib import closing
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -16,10 +18,12 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tests"))
 pytest.importorskip("playwright.sync_api")
 from playwright.sync_api import sync_playwright
+from segmented_response_traces import LIVE_SEGMENT_EVENTS, version_two_snapshot
 
-ROOT = Path(__file__).resolve().parents[1]
 UI = ROOT / ".super-coder" / "ui"
 CONVERSATION_ID = "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 TARGET_ID = "gt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -1136,9 +1140,25 @@ def test_chat_performance_uses_bounded_requests_and_keyed_frames(static_ui):
               transcriptReplacements: 0,
               assistantReplacements: 0,
             });
+            window.__fakeEventSources[0].emit("tool.started", {
+              sequence: 7001,
+              event_type: "tool.started",
+              message_id: 1,
+              run_id: 77,
+              created_at: "2026-07-30 20:01:00",
+              payload: { name: "write" },
+            });
+            window.__fakeEventSources[0].emit("tool.completed", {
+              sequence: 7002,
+              event_type: "tool.completed",
+              message_id: 1,
+              run_id: 77,
+              created_at: "2026-07-30 20:01:01",
+              payload: { name: "write" },
+            });
             for (let offset = 1; offset <= 500; offset += 1) {
               window.__fakeEventSources[0].emit("assistant.delta", {
-                sequence: 7000 + offset,
+                sequence: 7002 + offset,
                 event_type: "assistant.delta",
                 message_id: 1,
                 run_id: 77,
@@ -1167,4 +1187,169 @@ def test_chat_performance_uses_bounded_requests_and_keyed_frames(static_ui):
         )
         browser.close()
 
+    assert not browser_errors
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="projection v2 live segment reducer lands in Sprint 63 unit 3",
+)
+def test_segmented_live_trace_refresh_replay_and_node_identity(static_ui):
+    requests: list[str] = []
+    browser_errors: list[str] = []
+    selected = {**conversation(), "title": "Segmented trace"}
+    snapshot = version_two_snapshot()
+
+    def fulfill(route, payload, *, status=200):
+        route.fulfill(
+            status=status,
+            content_type="application/json",
+            body=json.dumps(payload),
+        )
+
+    def route_api(route):
+        parsed = urlparse(route.request.url)
+        requests.append(parsed.path)
+        if parsed.path == "/api/health":
+            return fulfill(route, {"repo": "subfloor"})
+        if parsed.path == "/api/shells":
+            return fulfill(route, {
+                "shells": [{
+                    "shell_id": 1,
+                    "display_name": "CC",
+                    "shortname": "cc",
+                    "flavor": "dev",
+                }]
+            })
+        if parsed.path == "/api/conversations":
+            return fulfill(route, {"items": [selected], "next_cursor": None})
+        if parsed.path == f"/api/conversations/{CONVERSATION_ID}":
+            return fulfill(route, selected)
+        if parsed.path == f"/api/conversations/{CONVERSATION_ID}/transcript":
+            return fulfill(route, snapshot)
+        return fulfill(
+            route,
+            {"error": {"code": "UNMOCKED", "message": parsed.path}},
+            status=404,
+        )
+
+    with (
+        sync_playwright() as playwright,
+        closing(playwright.chromium.launch(headless=True)) as browser,
+    ):
+        page = browser.new_page(viewport={"width": 1280, "height": 800})
+        page.add_init_script(
+            """
+            window.__chatPerf = {
+              rafOutstanding: 0,
+              maxRafOutstanding: 0,
+              transcriptReplacements: 0,
+              assistantReplacements: 0,
+            };
+            const nativeFrame = window.requestAnimationFrame.bind(window);
+            window.requestAnimationFrame = (callback) => {
+              window.__chatPerf.rafOutstanding += 1;
+              window.__chatPerf.maxRafOutstanding = Math.max(
+                window.__chatPerf.maxRafOutstanding,
+                window.__chatPerf.rafOutstanding);
+              return nativeFrame((timestamp) => {
+                window.__chatPerf.rafOutstanding -= 1;
+                callback(timestamp);
+              });
+            };
+            const nativeReplace = Element.prototype.replaceChildren;
+            Element.prototype.replaceChildren = function(...children) {
+              if (this.classList?.contains("chat-transcript"))
+                window.__chatPerf.transcriptReplacements += 1;
+              if (this.classList?.contains("chat-assistant-body"))
+                window.__chatPerf.assistantReplacements += 1;
+              return nativeReplace.apply(this, children);
+            };
+            window.__fakeEventSources = [];
+            class FakeEventSource {
+              constructor(url) {
+                this.url = url;
+                this.listeners = {};
+                window.__fakeEventSources.push(this);
+                queueMicrotask(() => this.onopen && this.onopen());
+              }
+              addEventListener(type, callback) {
+                (this.listeners[type] ||= []).push(callback);
+              }
+              emit(type, payload) {
+                for (const callback of this.listeners[type] || [])
+                  callback({ data: JSON.stringify(payload) });
+              }
+              close() {}
+            }
+            window.EventSource = FakeEventSource;
+            """
+        )
+        page.route("**/api/**", route_api)
+        page.on(
+            "pageerror",
+            lambda error: browser_errors.append(f"pageerror: {error}"),
+        )
+        page.goto(
+            f"{static_ui}/#interface/cc/{CONVERSATION_ID}",
+            wait_until="networkidle",
+        )
+        page.locator(".chat-transcript").wait_for()
+        assert page.locator(".chat-bubble.chat-assistant").all_text_contents() == [
+            "before tool"
+        ]
+
+        for event in LIVE_SEGMENT_EVENTS[:2]:
+            page.evaluate(
+                "([type, payload]) => "
+                "window.__fakeEventSources[0].emit(type, payload)",
+                [event["event_type"], event],
+            )
+        snapshot["through_sequence"] = 7
+        snapshot["assistant_cursor"] = {
+            "run_id": 77,
+            "segment_anchor_sequence": 7,
+        }
+        page.reload(wait_until="networkidle")
+        page.locator(".chat-transcript").wait_for()
+        page.evaluate(
+            """
+            window.__firstSegmentNode =
+              document.querySelector('.chat-bubble.chat-assistant');
+            Object.assign(window.__chatPerf, {
+              rafOutstanding: 0,
+              maxRafOutstanding: 0,
+              transcriptReplacements: 0,
+              assistantReplacements: 0,
+            });
+            """
+        )
+
+        replayed_boundary = LIVE_SEGMENT_EVENTS[1]
+        delta = LIVE_SEGMENT_EVENTS[2]
+        for event in (replayed_boundary, delta):
+            page.evaluate(
+                "([type, payload]) => "
+                "window.__fakeEventSources[0].emit(type, payload)",
+                [event["event_type"], event],
+            )
+        page.get_by_text("after tool", exact=True).wait_for()
+
+        assert page.locator(".chat-bubble.chat-assistant").all_text_contents() == [
+            "before tool",
+            "after tool",
+        ]
+        assert page.locator(".chat-bubble.chat-activity").count() == 0
+        assert page.evaluate(
+            "window.__firstSegmentNode === "
+            "document.querySelector('.chat-bubble.chat-assistant')"
+        )
+        counts = page.evaluate("window.__chatPerf")
+        assert counts["maxRafOutstanding"] <= 1
+        assert counts["transcriptReplacements"] == 0
+        assert counts["assistantReplacements"] <= 1
+
+    assert requests.count(
+        f"/api/conversations/{CONVERSATION_ID}/transcript"
+    ) == 2
     assert not browser_errors

--- a/tests/test_conversation_release_gate.py
+++ b/tests/test_conversation_release_gate.py
@@ -496,7 +496,7 @@ class CrossHarnessReleaseGateTest(unittest.TestCase):
 
     @pytest.mark.xfail(
         strict=True,
-        reason="Sprint 63 unit 4 removes this cross-harness gate marker",
+        reason="unit 4 removes this cross-harness gate marker",
     )
     @unittest.expectedFailure
     def test_same_adapter_conversations_keep_segment_ids_run_scoped(self) -> None:

--- a/tests/test_conversation_release_gate.py
+++ b/tests/test_conversation_release_gate.py
@@ -496,7 +496,7 @@ class CrossHarnessReleaseGateTest(unittest.TestCase):
 
     @pytest.mark.xfail(
         strict=True,
-        reason="unit 4 removes this cross-harness gate marker",
+        reason="unit 2 removes this projection marker",
     )
     @unittest.expectedFailure
     def test_same_adapter_conversations_keep_segment_ids_run_scoped(self) -> None:

--- a/tests/test_conversation_release_gate.py
+++ b/tests/test_conversation_release_gate.py
@@ -13,6 +13,8 @@ from collections.abc import Iterator
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 sys.path.insert(0, str(ENGINE / "api"))
@@ -53,6 +55,11 @@ class NativeHarnessState:
         self.resumed: list[str] = []
         self.reconciled: list[tuple[str, str]] = []
         self.run_serial = 0
+        self.segmented_trace = False
+        self.stream_barrier: threading.Barrier | None = None
+        self.stream_lock = threading.Lock()
+        self.active_streams = 0
+        self.max_active_streams = 0
 
     def next_run(self, prefix: str) -> str:
         self.run_serial += 1
@@ -103,16 +110,40 @@ class ReleaseGateAdapter:
         )
 
     def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
-        yield NormalizedEvent(
-            "session.started",
-            {"session_ref": turn.session_ref},
-        )
-        yield NormalizedEvent("run.started", {"status": "running"})
-        yield NormalizedEvent(
-            "assistant.delta",
-            {"text": f"{self.harness} completed the turn"},
-        )
-        yield NormalizedEvent("run.completed", {"status": "succeeded"})
+        with self.state.stream_lock:
+            self.state.active_streams += 1
+            self.state.max_active_streams = max(
+                self.state.max_active_streams,
+                self.state.active_streams,
+            )
+        try:
+            if self.state.stream_barrier is not None:
+                self.state.stream_barrier.wait(timeout=3)
+            yield NormalizedEvent(
+                "session.started",
+                {"session_ref": turn.session_ref},
+            )
+            yield NormalizedEvent("run.started", {"status": "running"})
+            if self.state.segmented_trace:
+                yield NormalizedEvent(
+                    "assistant.delta",
+                    {"text": f"{self.harness} before tool"},
+                )
+                yield NormalizedEvent("tool.started", {"name": "write"})
+                yield NormalizedEvent("tool.completed", {"name": "write"})
+                yield NormalizedEvent(
+                    "assistant.delta",
+                    {"text": f"{self.harness} after tool"},
+                )
+            else:
+                yield NormalizedEvent(
+                    "assistant.delta",
+                    {"text": f"{self.harness} completed the turn"},
+                )
+            yield NormalizedEvent("run.completed", {"status": "succeeded"})
+        finally:
+            with self.state.stream_lock:
+                self.state.active_streams -= 1
 
     def interrupt(self, turn: NativeTurn) -> InterruptResult:
         self.interrupted.set()
@@ -155,11 +186,13 @@ class CrossHarnessReleaseGateTest(unittest.TestCase):
         con.execute(
             "INSERT INTO shells "
             "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
-            "VALUES (1,'Developer','dev','dev','prompt',1)"
+            "VALUES (1,'Developer','dev','dev','prompt',1),"
+            "(2,'Developer 2','dev2','dev','prompt',1)"
         )
         con.commit()
         con.close()
         (self.root / ".sc-worktrees" / "dev").mkdir(parents=True)
+        (self.root / ".sc-worktrees" / "dev2").mkdir(parents=True)
 
         self.active_broker: conversation_broker.ConversationBroker | None = None
         self.brokers: list[conversation_broker.ConversationBroker] = []
@@ -460,6 +493,60 @@ class CrossHarnessReleaseGateTest(unittest.TestCase):
 
     def test_codex_release_journey_and_crash_windows(self) -> None:
         self.assert_release_journey("codex")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Sprint 63 unit 4 removes this cross-harness gate marker",
+    )
+    @unittest.expectedFailure
+    def test_same_adapter_conversations_keep_segment_ids_run_scoped(self) -> None:
+        state = NativeHarnessState("codex")
+        state.segmented_trace = True
+        state.stream_barrier = threading.Barrier(2)
+        conversation_ids = []
+        for number in range(2):
+            status, _, created = self.request(
+                "POST",
+                "/api/conversations",
+                body={"shell_id": number + 1, "harness": "codex"},
+                key=f"segmented-create-{number}",
+            )
+            self.assertEqual(status, 201, created)
+            conversation_id = created["conversation_id"]
+            conversation_ids.append(conversation_id)
+            status, _, accepted = self.request(
+                "POST",
+                f"/api/conversations/{conversation_id}/messages",
+                body={"text": f"segmented response {number}"},
+                key=f"segmented-message-{number}",
+            )
+            self.assertEqual(status, 202, accepted)
+
+        first_broker = self.start_broker(state)
+        second_broker = self.start_broker(state)
+        rows = self.wait_for_run_count(2)
+        self.stop_broker(first_broker)
+        self.stop_broker(second_broker)
+        self.assertEqual(state.max_active_streams, 2)
+        self.assertEqual([row["state"] for row in rows], ["succeeded", "succeeded"])
+
+        for conversation_id, row in zip(conversation_ids, rows, strict=True):
+            status, _, transcript = self.request(
+                "GET",
+                f"/api/conversations/{conversation_id}/transcript",
+            )
+            self.assertEqual(status, 200, transcript)
+            run_id = int(row["run_id"])
+            assistant = [
+                item for item in transcript["items"] if item["kind"] == "assistant"
+            ]
+            self.assertEqual(
+                [(item["item_id"], item["text"]) for item in assistant],
+                [
+                    (f"run:{run_id}:assistant:0", "codex before tool"),
+                    (f"run:{run_id}:assistant:6", "codex after tool"),
+                ],
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
 INDEX = (ROOT / ".super-coder" / "ui" / "index.html").read_text()
@@ -129,6 +131,26 @@ def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():
       interface.index("const loadTranscript = async"):
       interface.index("await loadTranscript()")
     ]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="projection v2 keyed assistant segments land in Sprint 63 unit 3",
+)
+def test_segmented_transcript_source_contract_is_versioned_and_run_scoped():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    keyed = interface[interface.index("function chatCreateTranscriptState"):
+                      interface.index("async function renderInterface")]
+
+    assert "snapshot.projection_version !== 2" in keyed
+    assert "assistant_cursor" in keyed
+    assert "segment_anchor_sequence" in keyed
+    assert "tool.started" in keyed
+    assert "tool.completed" in keyed
+    assert "permission.requested" in keyed
+    assert "input.requested" in keyed
+    assert ":assistant:${" in keyed
 
 
 def test_connection_status_is_attached_to_transcript_without_visible_copy():


### PR DESCRIPTION
## Summary

- add shared exact event traces for plain, tool-separated, multi-tool, tool-before-text, and actionable-wait assistant responses
- stage projection-v2 API and cursor contracts for Sprint 63 unit 2, including the amended fresh-run cursor-zero case and a source-capped boundary
- stage keyed live DOM, refresh/replay, hidden-Chat frame, and concurrent same-adapter conversation contracts for units 3 and 4

## Sprint judgment

R1: a fixtures-only PR must prove projection v1 red while remaining mergeable. The probes therefore use strict staged expected-failure markers. Every marker names its owning removal unit; an unexpected success is red and forces marker removal when that implementation lands.

## Verification

- `.venv/bin/pytest -q tests/test_conversation_api.py tests/test_conversation_ui.py tests/test_conversation_release_gate.py tests/test_conversation_diff_browser.py` — 71 passed, 11 xfailed, 13 subtests passed
- stdlib unittest over API and release-gate suites — 53 passed with 9 expected failures
- `pytest --runxfail` proves v1 failures on exact item count, stable IDs, ordering, missing active cursor, projection-version install, and same-adapter run scoping
- focused Ruff checks and `git diff --check` pass

The Playwright host seat lacked the documented baked Chromium revision; local verification used the Playwright-managed fallback browser and the environment defect is tracked as SC-034.