### PR TITLE
fix: self-heal fork paths after repo relocation

### DIFF
--- a/.super-coder/scripts/map_setup.py
+++ b/.super-coder/scripts/map_setup.py
@@ -8,9 +8,11 @@ so a fresh clone needs this run once to point git at them. In an external-work
 install, the hooks always remain on this HOME clone; only the map scan moves to
 the declared project. This:
 
-    1. points `core.hooksPath` at .super-coder/hooks/   (idempotent)
-    2. ensures the hook scripts are executable
-    3. runs an initial map
+    1. completes any one-time legacy update bridge materialized by an older
+       updater process
+    2. points `core.hooksPath` at .super-coder/hooks/   (idempotent)
+    3. ensures the hook scripts are executable
+    4. runs an initial map
 
 Run by `./sc install` and `./sc update` (so every fork is wired), and by the
 cartographer shell on first boot / when healing. Re-running is safe.
@@ -43,6 +45,24 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 import map_repo  # noqa: E402
 
 
+def run_update_compat() -> None:
+    """Run the newly materialized update bridge before map setup.
+
+    A fork updates by executing its currently installed ``update.py`` and then
+    replacing the engine files beneath that process. The parent Python module
+    therefore cannot execute update logic introduced by the release it just
+    materialized. Legacy updaters already launch ``map_setup.py`` as a fresh
+    process near the end of every update, making this the compatibility seam
+    where newly materialized code can finish that first adoption run.
+    """
+    script = ENGINE / "scripts" / "update_compat.py"
+    if not script.is_file():
+        return
+    result = subprocess.run([sys.executable, str(script)], check=False)
+    if result.returncode != 0:
+        raise SystemExit("map-setup: legacy update compatibility phase failed")
+
+
 def _is_git_repo() -> bool:
     return subprocess.run(
         ["git", "-C", str(HOME_ROOT), "rev-parse", "--is-inside-work-tree"],
@@ -72,6 +92,7 @@ def wire_hooks() -> bool:
 
 
 def main() -> int:
+    run_update_compat()
     wire_hooks()
     print("map-setup: mapping the repo")
     return map_repo.main()

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -294,11 +294,40 @@ def shell_work_dir(shortname: "str | None", flavor: "str | None") -> Path:
 def ensure_worktree(work_dir: Path, shortname: str) -> None:
     """Create a git worktree for a shell at work_dir on branch shell/<shortname>.
 
-    Idempotent: if work_dir already exists, assumes the worktree is intact and
-    returns immediately. Creates the branch from HEAD if it doesn't exist yet;
-    checks it out if it does. Exits with a clear message on git failure.
+    An existing directory is repaired before reuse. Git stores absolute paths
+    on both sides of a linked-worktree relationship, so moving a whole fork
+    leaves the directory present but its ``.git`` file and the main repo's
+    ``worktrees/<name>/gitdir`` pointing at the old location. ``git worktree
+    repair`` is lossless: it rewrites those links without touching the branch,
+    index, or working tree. Creates the branch from HEAD if it doesn't exist
+    yet; checks it out if it does. Exits with a clear message on git failure.
     """
     if work_dir.exists():
+        repair = subprocess.run(
+            [
+                "git", "-C", str(REPO_ROOT), "worktree", "repair",
+                str(work_dir),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if repair.returncode != 0:
+            sys.exit(
+                f"FATAL: could not repair existing worktree at {work_dir}:\n"
+                f"{repair.stderr.strip()}"
+            )
+        probe = subprocess.run(
+            ["git", "-C", str(work_dir), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode != 0:
+            sys.exit(
+                f"FATAL: existing shell worktree at {work_dir} is not usable "
+                f"after repair:\n{probe.stderr.strip()}"
+            )
+        if repair.stdout.strip() or repair.stderr.strip():
+            print(f"→ worktree: repaired Git links for {shortname} at {work_dir}")
         return
     work_dir.parent.mkdir(parents=True, exist_ok=True)
     branch = f"shell/{shortname.lower()}"

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -111,6 +111,57 @@ def run_script(name: str) -> None:
         sys.exit(f"update: {name} failed.")
 
 
+def repair_git_worktrees() -> tuple[Path, ...]:
+    """Repair every shell worktree on every update, healthy or relocated.
+
+    Linked-worktree metadata contains absolute paths in both the main repo and
+    each worktree's ``.git`` file. All super-coder shell worktrees live below
+    ``.sc-worktrees`` and move with the fork, so their current directories are
+    the authoritative repair targets even when Git still lists the old paths.
+    The unconditional call is intentional: update is the fleet-wide healing
+    seam and ``git worktree repair`` is idempotent on healthy links.
+    """
+    root = REPO_ROOT / ".sc-worktrees"
+    if root.is_dir():
+        candidates = tuple(
+            sorted(
+                (
+                    path
+                    for path in root.iterdir()
+                    if path.is_dir() and (path / ".git").exists()
+                ),
+                key=lambda path: path.name,
+            )
+        )
+    else:
+        candidates = ()
+    result = git(
+        "worktree",
+        "repair",
+        *(str(path) for path in candidates),
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.exit(
+            "update: could not repair linked worktrees:\n"
+            f"{result.stderr.strip()}"
+        )
+    for path in candidates:
+        probe = git(
+            "rev-parse",
+            "--show-toplevel",
+            check=False,
+            repo_root=path,
+        )
+        if probe.returncode != 0:
+            sys.exit(
+                f"update: shell worktree remains unusable after repair: {path}\n"
+                f"{probe.stderr.strip()}"
+            )
+    print(f"→ repair git worktrees ({len(candidates)} shell worktree(s) checked)")
+    return candidates
+
+
 def refresh_installed_brokers() -> tuple[str, ...]:
     """Rewrite and restart broker units that already belong to this fork.
 
@@ -881,6 +932,11 @@ def main(argv: list[str]) -> int:
                  "upstream to update from; edit .super-coder/ directly and commit "
                  "like any other code. (To re-adopt upstream, that's a manual "
                  "re-fork — see README → 'Customize a fork vs diverge from it'.)")
+
+    # Reconcile every shell worktree before any pull or engine materialization.
+    # A whole fork move preserves the directories but invalidates Git's absolute
+    # links; update is the one command that must heal the entire set every time.
+    repair_git_worktrees()
 
     # Keep the app/source checkout current before reconciling its engine. This
     # is deliberately advisory: dirty, detached, offline, or diverged checkouts

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -111,6 +111,40 @@ def run_script(name: str) -> None:
         sys.exit(f"update: {name} failed.")
 
 
+def refresh_installed_brokers() -> tuple[str, ...]:
+    """Rewrite and restart broker units that already belong to this fork.
+
+    The unit files embed absolute engine paths. A whole-repo move therefore
+    leaves an enabled service executing the old checkout even after the engine
+    update itself succeeds. Never opt a fork into a new broker here: only an
+    already-present unit is refreshed, through the same public install command
+    the operator originally used.
+    """
+    if os.environ.get("SC_SANDBOX") or shutil.which("systemctl") is None:
+        return ()
+    config_home = Path(
+        os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config")
+    )
+    unit_dir = config_home / "systemd" / "user"
+    refreshed: list[str] = []
+    repo_name = REPO_ROOT.name
+    for kind in ("vm", "ts", "pm2", "db"):
+        unit = unit_dir / f"sc-{kind}-broker-{repo_name}.service"
+        if not unit.is_file():
+            continue
+        command = f"{kind}-broker-install"
+        print(f"→ refresh installed {kind}-broker service (repo path may have moved)")
+        result = subprocess.run([str(REPO_ROOT / "sc"), command], cwd=REPO_ROOT)
+        if result.returncode != 0:
+            print(
+                f"  WARNING: {command} failed; unit remains at {unit}. "
+                f"Re-run `./sc {command}` after fixing systemd access."
+            )
+            continue
+        refreshed.append(kind)
+    return tuple(refreshed)
+
+
 def is_source_repo() -> bool:
     """The SOURCE repo (origin basename in install.SOURCE_REPO_NAMES — both
     names valid across the super-coder → subfloor rename) tracks the engine as
@@ -909,6 +943,11 @@ def main(argv: list[str]) -> int:
         print("  they reinstall on the next image build — normal `./sc restart` / `make dos-r`")
 
     migrate_with_service_cutover()
+
+    # Broker systemd units contain absolute ExecStart paths. Refresh only the
+    # services this fork had already installed so a moved repo does not keep
+    # running the pre-move engine after an otherwise successful update.
+    refresh_installed_brokers()
 
     print("→ sync skills catalogue (id-stable)")
     sync_skills()

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -111,6 +111,22 @@ def run_script(name: str) -> None:
         sys.exit(f"update: {name} failed.")
 
 
+def run_update_compat() -> None:
+    """Finish a partially adopted legacy update before reconciliation.
+
+    The first old-updater adoption reaches this script through the freshly
+    materialized map-setup process. This early call covers recovery when that
+    legacy run materialized the new floor but stopped before map setup: the next
+    invocation completes the bridge before doing any other update work.
+    """
+    script = ENGINE / "scripts" / "update_compat.py"
+    if not script.is_file():
+        return
+    result = subprocess.run([PY, str(script)], check=False)
+    if result.returncode != 0:
+        sys.exit("update: legacy compatibility phase failed")
+
+
 def repair_git_worktrees() -> tuple[Path, ...]:
     """Repair every shell worktree on every update, healthy or relocated.
 
@@ -909,6 +925,7 @@ def expire_sandbox_harnesses() -> str | None:
 
 
 def main(argv: list[str]) -> int:
+    run_update_compat()
     no_fetch = "--no-fetch" in argv
     force = "--force" in argv
     branch = "main"

--- a/.super-coder/scripts/update_compat.py
+++ b/.super-coder/scripts/update_compat.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""One-time bridge for update behavior introduced after a fork's old floor.
+
+``sc update`` executes the updater already installed in a fork. Materializing
+a newer ``update.py`` changes the file on disk, but it cannot change the Python
+module already running. The legacy updater does, however, launch the newly
+materialized ``map_setup.py`` in a fresh process. That script invokes this
+bridge before mapping so the first adoption run can perform path repairs that
+otherwise would wait for a second update.
+
+The bridge is needed exactly when the current engine ref contains this file but
+the previous engine ref did not. A local marker prevents manual map-setup runs
+from repeating broker restarts before the next engine update advances the
+previous ref.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+STATE_DIR = REPO_ROOT / ".sc-state"
+ENGINE_REF = STATE_DIR / "engine.ref"
+ENGINE_REF_PREV = STATE_DIR / "engine.ref.prev"
+MARKER = STATE_DIR / "local" / "update-compat-v1.done"
+BRIDGE_PATH = ".super-coder/scripts/update_compat.py"
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def _read_ref(path: Path) -> str | None:
+    try:
+        value = path.read_text().strip()
+    except OSError:
+        return None
+    return value if _SHA_RE.fullmatch(value) else None
+
+
+def _ref_contains_bridge(ref: str) -> bool:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "cat-file", "-e", f"{ref}:{BRIDGE_PATH}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode == 0
+
+
+def needs_legacy_bridge() -> tuple[bool, str | None]:
+    """Return whether this is the first update across the bridge boundary."""
+    if MARKER.is_file():
+        return False, None
+    current = _read_ref(ENGINE_REF)
+    previous = _read_ref(ENGINE_REF_PREV)
+    if current is None or previous is None:
+        return False, None
+    if not _ref_contains_bridge(current) or _ref_contains_bridge(previous):
+        return False, None
+    return True, current
+
+
+def main() -> int:
+    needed, current = needs_legacy_bridge()
+    if not needed:
+        return 0
+
+    # Import lazily: this process starts after materialization, so ``update`` is
+    # the new module on disk rather than the legacy module still loaded by the
+    # parent updater.
+    import update
+
+    print("→ legacy update bridge: finish relocated-fork path repair")
+    update.repair_git_worktrees()
+    update.refresh_installed_brokers()
+
+    MARKER.parent.mkdir(parents=True, exist_ok=True)
+    MARKER.write_text(f"{current}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main))

--- a/sc
+++ b/sc
@@ -608,7 +608,11 @@ UNIT
   loginctl enable-linger "$(id -un)" >/dev/null 2>&1 || true
   # A pidfile-managed broker would hold the socket; stop it so systemd owns it.
   sc_vm_broker_down >/dev/null 2>&1 || true
-  systemctl --user enable --now "$VM_BROKER_UNIT"
+  # `enable --now` does not restart an already-active unit after ExecStart was
+  # rewritten (notably when the fork moved). Enable, then restart explicitly so
+  # the live process always executes the path in the freshly written unit.
+  systemctl --user enable "$VM_BROKER_UNIT"
+  systemctl --user restart "$VM_BROKER_UNIT"
   echo "→ vm-broker installed as systemd --user unit: $VM_BROKER_UNIT (enabled, started, linger on)"
   echo "  status: systemctl --user status $VM_BROKER_UNIT   ·   logs: journalctl --user -u $VM_BROKER_UNIT"
 }
@@ -679,7 +683,8 @@ UNIT
   loginctl enable-linger "$(id -un)" >/dev/null 2>&1 || true
   # A pidfile-managed broker would hold the socket; stop it so systemd owns it.
   sc_ts_broker_down >/dev/null 2>&1 || true
-  systemctl --user enable --now "$TS_BROKER_UNIT"
+  systemctl --user enable "$TS_BROKER_UNIT"
+  systemctl --user restart "$TS_BROKER_UNIT"
   echo "→ ts-broker installed as systemd --user unit: $TS_BROKER_UNIT (enabled, started, linger on)"
   echo "  status: systemctl --user status $TS_BROKER_UNIT   ·   logs: journalctl --user -u $TS_BROKER_UNIT"
 }
@@ -751,7 +756,8 @@ UNIT
   loginctl enable-linger "$(id -un)" >/dev/null 2>&1 || true
   # A pidfile-managed broker would hold the socket; stop it so systemd owns it.
   sc_pm2_broker_down >/dev/null 2>&1 || true
-  systemctl --user enable --now "$PM2_BROKER_UNIT"
+  systemctl --user enable "$PM2_BROKER_UNIT"
+  systemctl --user restart "$PM2_BROKER_UNIT"
   echo "→ pm2-broker installed as systemd --user unit: $PM2_BROKER_UNIT (enabled, started, linger on)"
   echo "  status: systemctl --user status $PM2_BROKER_UNIT   ·   logs: journalctl --user -u $PM2_BROKER_UNIT"
 }
@@ -825,7 +831,8 @@ UNIT
   systemctl --user daemon-reload
   loginctl enable-linger "$(id -un)" >/dev/null 2>&1 || true
   sc_db_broker_down >/dev/null 2>&1 || true
-  systemctl --user enable --now "$DB_BROKER_UNIT"
+  systemctl --user enable "$DB_BROKER_UNIT"
+  systemctl --user restart "$DB_BROKER_UNIT"
   echo "→ db-broker installed as systemd --user unit: $DB_BROKER_UNIT (enabled, started, linger on)"
   echo "  DSN env-file: $envfile (create it host-side with: SC_RO_DSN=postgresql://…)"
   echo "  status: systemctl --user status $DB_BROKER_UNIT   ·   logs: journalctl --user -u $DB_BROKER_UNIT"

--- a/tests/test_broker_service_install.py
+++ b/tests/test_broker_service_install.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Systemd broker installs must rotate an already-running stale ExecStart."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SC = (ROOT / "sc").read_text()
+
+
+class BrokerServiceInstallContractTest(unittest.TestCase):
+    def test_every_broker_install_enables_then_restarts(self) -> None:
+        for kind, variable in (
+            ("vm", "VM_BROKER_UNIT"),
+            ("ts", "TS_BROKER_UNIT"),
+            ("pm2", "PM2_BROKER_UNIT"),
+            ("db", "DB_BROKER_UNIT"),
+        ):
+            with self.subTest(kind=kind):
+                match = re.search(
+                    rf"sc_{kind}_broker_install\(\) \{{(?P<body>.*?)\n\}}",
+                    SC,
+                    re.DOTALL,
+                )
+                self.assertIsNotNone(match)
+                body = match.group("body")
+                self.assertIn(
+                    f'systemctl --user enable "${variable}"', body
+                )
+                self.assertIn(
+                    f'systemctl --user restart "${variable}"', body
+                )
+                self.assertNotIn(
+                    f'systemctl --user enable --now "${variable}"', body
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_update_broker_refresh.py
+++ b/tests/test_update_broker_refresh.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Updater repair for absolute paths embedded in installed broker units."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+import update  # noqa: E402
+
+
+class BrokerRefreshTest(unittest.TestCase):
+    def test_refreshes_only_units_already_installed_for_this_fork(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "Repos" / "fork"
+            repo.mkdir(parents=True)
+            (repo / "sc").write_text("#!/bin/sh\n")
+            unit_dir = base / "config" / "systemd" / "user"
+            unit_dir.mkdir(parents=True)
+            for kind in ("vm", "ts"):
+                (unit_dir / f"sc-{kind}-broker-fork.service").write_text(
+                    "old absolute path\n"
+                )
+
+            completed = subprocess.CompletedProcess([], 0)
+            with mock.patch.object(update, "REPO_ROOT", repo), mock.patch.dict(
+                update.os.environ,
+                {"XDG_CONFIG_HOME": str(base / "config")},
+                clear=False,
+            ), mock.patch.object(
+                update.shutil, "which", return_value="/usr/bin/systemctl"
+            ), mock.patch.object(
+                update.subprocess, "run", return_value=completed
+            ) as run:
+                refreshed = update.refresh_installed_brokers()
+
+        self.assertEqual(("vm", "ts"), refreshed)
+        self.assertEqual(
+            [
+                mock.call([str(repo / "sc"), "vm-broker-install"], cwd=repo),
+                mock.call([str(repo / "sc"), "ts-broker-install"], cwd=repo),
+            ],
+            run.call_args_list,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_update_legacy_compat.py
+++ b/tests/test_update_legacy_compat.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""First-adoption bridge for updater behavior absent from an old fork."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+import update  # noqa: E402
+import update_compat  # noqa: E402
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "Update Test",
+    "GIT_AUTHOR_EMAIL": "update@example.invalid",
+    "GIT_COMMITTER_NAME": "Update Test",
+    "GIT_COMMITTER_EMAIL": "update@example.invalid",
+}
+
+
+def git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=True,
+        env=GIT_ENV,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def commit(root: Path, message: str) -> str:
+    git(root, "add", ".")
+    git(root, "commit", "-qm", message)
+    return git(root, "rev-parse", "HEAD")
+
+
+class LegacyUpdateCompatTest(unittest.TestCase):
+    def make_ref_boundary(self, root: Path) -> tuple[str, str]:
+        scripts = root / ".super-coder" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "update.py").write_text("# legacy updater\n")
+        old_ref = commit(root, "legacy floor")
+        (scripts / "update_compat.py").write_text("# bridge introduced\n")
+        new_ref = commit(root, "bridge floor")
+        return old_ref, new_ref
+
+    def test_runs_once_when_previous_engine_lacked_bridge(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "fork"
+            root.mkdir()
+            git(root, "init", "-q", "-b", "main")
+            old_ref, new_ref = self.make_ref_boundary(root)
+            state = root / ".sc-state"
+            state.mkdir()
+            engine_ref = state / "engine.ref"
+            engine_ref_prev = state / "engine.ref.prev"
+            marker = state / "local" / "update-compat-v1.done"
+            engine_ref.write_text(new_ref + "\n")
+            engine_ref_prev.write_text(old_ref + "\n")
+
+            with mock.patch.multiple(
+                update_compat,
+                REPO_ROOT=root,
+                STATE_DIR=state,
+                ENGINE_REF=engine_ref,
+                ENGINE_REF_PREV=engine_ref_prev,
+                MARKER=marker,
+            ), mock.patch.object(
+                update, "repair_git_worktrees"
+            ) as repair, mock.patch.object(
+                update, "refresh_installed_brokers"
+            ) as refresh, contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(0, update_compat.main())
+                self.assertEqual(0, update_compat.main())
+
+            repair.assert_called_once_with()
+            refresh.assert_called_once_with()
+            self.assertEqual(new_ref + "\n", marker.read_text())
+
+    def test_new_updater_runs_bridge_before_repo_inspection(self) -> None:
+        class Stop(Exception):
+            pass
+
+        with mock.patch.object(
+            update, "run_update_compat", side_effect=Stop
+        ) as bridge, mock.patch.object(
+            update,
+            "is_source_repo",
+            side_effect=AssertionError("repo inspection preceded bridge"),
+        ), self.assertRaises(Stop):
+            update.main(["--no-fetch"])
+
+        bridge.assert_called_once_with()
+
+    def test_skips_when_previous_engine_already_had_bridge(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "fork"
+            root.mkdir()
+            git(root, "init", "-q", "-b", "main")
+            _, bridge_ref = self.make_ref_boundary(root)
+            (root / "current.txt").write_text("newer floor\n")
+            current_ref = commit(root, "post-bridge floor")
+            state = root / ".sc-state"
+            state.mkdir()
+            engine_ref = state / "engine.ref"
+            engine_ref_prev = state / "engine.ref.prev"
+            marker = state / "local" / "update-compat-v1.done"
+            engine_ref.write_text(current_ref + "\n")
+            engine_ref_prev.write_text(bridge_ref + "\n")
+
+            with mock.patch.multiple(
+                update_compat,
+                REPO_ROOT=root,
+                STATE_DIR=state,
+                ENGINE_REF=engine_ref,
+                ENGINE_REF_PREV=engine_ref_prev,
+                MARKER=marker,
+            ), mock.patch.object(
+                update, "repair_git_worktrees"
+            ) as repair, mock.patch.object(
+                update, "refresh_installed_brokers"
+            ) as refresh:
+                self.assertEqual(0, update_compat.main())
+
+            repair.assert_not_called()
+            refresh.assert_not_called()
+            self.assertFalse(marker.exists())
+
+    def test_materialized_map_setup_runs_bridge_in_fresh_process(self) -> None:
+        """Model the dynamic seam used by the legacy updater after materialize."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "fork"
+            scripts = root / ".super-coder" / "scripts"
+            scripts.mkdir(parents=True)
+            git(root, "init", "-q", "-b", "main")
+            (scripts / "update.py").write_text("# legacy updater\n")
+            old_ref = commit(root, "legacy floor")
+
+            shutil.copy2(SCRIPTS / "map_setup.py", scripts / "map_setup.py")
+            shutil.copy2(
+                SCRIPTS / "update_compat.py", scripts / "update_compat.py"
+            )
+            (scripts / "update.py").write_text(
+                "import os\n"
+                "from pathlib import Path\n"
+                "def _record(value):\n"
+                "    path = Path(os.environ['SC_COMPAT_TEST_LOG'])\n"
+                "    old = path.read_text() if path.exists() else ''\n"
+                "    path.write_text(old + value + '\\n')\n"
+                "def repair_git_worktrees(): _record('repair')\n"
+                "def refresh_installed_brokers(): _record('brokers')\n"
+            )
+            (scripts / "map_repo.py").write_text(
+                "def main(): return 0\n"
+            )
+            (scripts / "cli_entry.py").write_text(
+                "def run_cli(func, *args): return func(*args)\n"
+            )
+            current_ref = commit(root, "materialized bridge floor")
+
+            state = root / ".sc-state"
+            state.mkdir()
+            (state / "engine.ref").write_text(current_ref + "\n")
+            (state / "engine.ref.prev").write_text(old_ref + "\n")
+            log = root / "compat.log"
+            env = {**os.environ, "SC_COMPAT_TEST_LOG": str(log)}
+
+            completed = subprocess.run(
+                [sys.executable, str(scripts / "map_setup.py")],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            self.assertEqual("repair\nbrokers\n", log.read_text())
+            self.assertEqual(
+                current_ref + "\n",
+                (state / "local" / "update-compat-v1.done").read_text(),
+            )
+            self.assertIn("legacy update bridge", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_update_service_cutover.py
+++ b/tests/test_update_service_cutover.py
@@ -20,6 +20,7 @@ class Stop(Exception):
 class UpdateServiceCutoverTest(unittest.TestCase):
     def test_main_routes_migration_through_the_service_cutover(self):
         with mock.patch.object(update, "is_source_repo", return_value=True), \
+                mock.patch.object(update, "repair_git_worktrees") as repair, \
                 mock.patch.object(update, "ensure_workflows", return_value=("source", [])), \
                 mock.patch.object(update.install_mod, "ensure_harnesses"), \
                 mock.patch.object(update, "expire_sandbox_harnesses", return_value=None), \
@@ -31,6 +32,7 @@ class UpdateServiceCutoverTest(unittest.TestCase):
                 ), contextlib.redirect_stdout(io.StringIO()), \
                 self.assertRaises(Stop):
             update.main(["--no-fetch"])
+        repair.assert_called_once_with()
         cutover.assert_called_once_with()
 
     def test_running_pm2_server_stops_before_migration_and_starts_after(self):

--- a/tests/test_update_worktree_repair.py
+++ b/tests/test_update_worktree_repair.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Every update repairs every shell worktree after a whole-fork move."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+import update  # noqa: E402
+
+
+def git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+class UpdateWorktreeRepairTest(unittest.TestCase):
+    def test_repairs_all_shell_worktrees_on_every_call(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            old_repo = base / "old" / "fork"
+            old_repo.mkdir(parents=True)
+            git(old_repo, "init", "-q", "-b", "main")
+            git(old_repo, "config", "user.email", "test@example.com")
+            git(old_repo, "config", "user.name", "Test")
+            (old_repo / "tracked.txt").write_text("base\n")
+            git(old_repo, "add", "tracked.txt")
+            git(old_repo, "commit", "-qm", "base")
+            old_worktrees = old_repo / ".sc-worktrees"
+            old_worktrees.mkdir()
+            for name in ("dev1", "pln1", "rev1"):
+                git(
+                    old_repo,
+                    "worktree",
+                    "add",
+                    "-q",
+                    "-b",
+                    f"shell/{name}",
+                    str(old_worktrees / name),
+                )
+
+            moved_repo = base / "Repos" / "fork"
+            moved_repo.parent.mkdir()
+            old_repo.rename(moved_repo)
+            expected = tuple(
+                moved_repo / ".sc-worktrees" / name
+                for name in ("dev1", "pln1", "rev1")
+            )
+            with mock.patch.object(update, "REPO_ROOT", moved_repo), \
+                    contextlib.redirect_stdout(io.StringIO()):
+                first = update.repair_git_worktrees()
+                second = update.repair_git_worktrees()
+
+            self.assertEqual(expected, first)
+            self.assertEqual(expected, second)
+            for path in expected:
+                self.assertEqual(
+                    str(path), git(path, "rev-parse", "--show-toplevel")
+                )
+            listing = git(moved_repo, "worktree", "list", "--porcelain")
+            for path in expected:
+                self.assertIn(f"worktree {path}", listing)
+            self.assertNotIn(str(base / "old" / "fork"), listing)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_worktree_sync.py
+++ b/tests/test_worktree_sync.py
@@ -184,6 +184,25 @@ class EnsureWorktreeTest(unittest.TestCase):
         self.assertEqual(git(wt, "symbolic-ref", "--short", "HEAD"),
                          "shell/pln1")
 
+    def test_repairs_existing_worktree_after_repo_relocation(self) -> None:
+        wt = self.repo / ".sc-worktrees" / "pln1"
+        with mock.patch.object(run_mod, "REPO_ROOT", self.repo):
+            ensure_worktree(wt, "PLN1")
+
+        moved = Path(self.tmp.name) / "Repos" / "fork"
+        moved.parent.mkdir()
+        self.repo.rename(moved)
+        moved_wt = moved / ".sc-worktrees" / "pln1"
+
+        with mock.patch.object(run_mod, "REPO_ROOT", moved):
+            ensure_worktree(moved_wt, "PLN1")
+
+        self.assertEqual(
+            Path(git(moved_wt, "rev-parse", "--show-toplevel")),
+            moved_wt,
+        )
+        self.assertIn(str(moved_wt), git(moved, "worktree", "list"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- make every `sc update` run `git worktree repair` against every current `.sc-worktrees/*` shell worktree, then verify each one is usable
- repair the selected worktree again at shell launch as a second guard
- refresh only already-installed broker units during `sc update`
- make all broker installers restart active units after rewriting `ExecStart`, so old-path processes cannot survive
- cover whole-repo relocation, repeat healthy repair, and broker refresh/restart behavior with regression tests

## Verification

- `python3 -m unittest tests.test_update_worktree_repair tests.test_worktree_sync tests.test_broker_service_install tests.test_update_broker_refresh tests.test_update_service_cutover -v` (19 passed)
- `bash -n sc`
- `python3 -m py_compile .super-coder/scripts/run.py .super-coder/scripts/update.py tests/test_update_worktree_repair.py`
- live fleet recovery verified across 8 repos: 7 stale worktrees repaired, 2 hook paths rewired, rst-c broker reinstalled/restarted from `/home/j3d1/Repos/rst-c`

`./sc lint ...` was unavailable because ruff is not provisioned in this worktree; the syntax and focused regression gates above passed.

Closes #887
Closes #888