### PR TITLE
feat: transcript projection version 2

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -77,7 +77,7 @@ TRANSCRIPT_MAX_TURNS = 200
 TRANSCRIPT_MAX_SOURCE_EVENTS = 20_000
 TRANSCRIPT_MAX_SOURCE_BYTES = 8 * 1024 * 1024
 TRANSCRIPT_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
-TRANSCRIPT_PROJECTION_VERSION = 1
+TRANSCRIPT_PROJECTION_VERSION = 2
 TRANSCRIPT_MAX_WARNINGS = 20
 TRANSCRIPT_MAX_ACTIVITY_LABEL_BYTES = 1024
 
@@ -1529,15 +1529,25 @@ def _transcript_projection(
             "SELECT r.run_id,r.trigger_message_id,r.state,"
             "r.started_at,r.ended_at,r.error_code,r.error_detail,"
             "r.harness_session_before,r.harness_session_after,r.runner_ref,"
-            "(SELECT COUNT(*) FROM conversation_events delta_count "
-            " WHERE delta_count.run_id=r.run_id "
-            " AND delta_count.event_type='assistant.delta' "
-            " AND delta_count.sequence<=?) AS assistant_delta_count "
+            "(SELECT COUNT(*) FROM conversation_events evidence_count "
+            " WHERE evidence_count.run_id=r.run_id "
+            " AND evidence_count.event_type IN "
+            " ('assistant.delta','tool.started','tool.completed',"
+            "'permission.requested','input.requested') "
+            " AND evidence_count.sequence<=?) AS segmentation_evidence_count,"
+            "(SELECT COALESCE(MAX(boundary.sequence),0) "
+            " FROM conversation_events boundary "
+            " WHERE boundary.run_id=r.run_id "
+            " AND boundary.event_type IN "
+            " ('tool.started','tool.completed','permission.requested',"
+            "'input.requested') "
+            " AND boundary.sequence<=?) AS latest_boundary_sequence "
             "FROM conversation_runs r WHERE r.conversation_id=? AND ("
             + run_where
             + (" OR r.run_id=?" if active_run_id is not None else "")
             + ") ORDER BY r.run_id",
             (
+                through_sequence,
                 through_sequence,
                 conversation_id,
                 *message_ids,
@@ -1557,7 +1567,13 @@ def _transcript_projection(
             " ORDER BY sequence ROWS BETWEEN UNBOUNDED PRECEDING "
             " AND 1 PRECEDING"
             ") AS older_count,"
-            "LAG(sequence) OVER (ORDER BY sequence) AS prior_sequence "
+            "LAG(sequence) OVER (ORDER BY sequence) AS prior_sequence,"
+            "MAX(CASE WHEN run_id IS NOT NULL AND event_type IN "
+            " ('tool.started','tool.completed','permission.requested',"
+            "'input.requested') THEN sequence ELSE 0 END) OVER ("
+            " PARTITION BY run_id ORDER BY sequence "
+            " ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"
+            ") AS segment_anchor_sequence "
             " FROM conversation_events "
             " WHERE conversation_id=? AND sequence<=?"
             ") SELECT * FROM ranked "
@@ -1631,6 +1647,7 @@ def _transcript_projection(
                 "message_id": row["message_id"],
                 "run_id": row["run_id"],
                 "created_at": row["created_at"],
+                "segment_anchor_sequence": int(row["segment_anchor_sequence"]),
             })
 
         accepted_sequence = {
@@ -1639,8 +1656,15 @@ def _transcript_projection(
             if event["event_type"] == "message.accepted"
             and event["message_id"] is not None
         }
-        deltas_by_run: dict[int, list[dict]] = {}
+        segments_by_run: dict[int, dict[int, list[dict]]] = {}
+        evidence_count_by_run: dict[int, int] = {}
         activities = []
+        boundary_types = {
+            "tool.started",
+            "tool.completed",
+            "permission.requested",
+            "input.requested",
+        }
         activity_types = {
             "permission.requested",
             "input.requested",
@@ -1649,13 +1673,27 @@ def _transcript_projection(
             "run.unknown",
         }
         for event in events:
-            if event["event_type"] == "assistant.delta" and event["run_id"] is not None:
-                deltas_by_run.setdefault(int(event["run_id"]), []).append(event)
+            run_id = event["run_id"]
+            if run_id is not None and (
+                event["event_type"] == "assistant.delta"
+                or event["event_type"] in boundary_types
+            ):
+                evidence_count_by_run[int(run_id)] = (
+                    evidence_count_by_run.get(int(run_id), 0) + 1
+                )
+            if event["event_type"] == "assistant.delta" and run_id is not None:
+                anchor = event["segment_anchor_sequence"]
+                segments_by_run.setdefault(int(run_id), {}).setdefault(
+                    anchor,
+                    [],
+                ).append(event)
             elif event["event_type"] in activity_types:
                 activities.append(event)
 
         run_by_message: dict[int, list] = {}
+        run_by_id = {}
         for row in run_rows:
+            run_by_id[int(row["run_id"])] = row
             run_by_message.setdefault(
                 int(row["trigger_message_id"]),
                 [],
@@ -1668,8 +1706,8 @@ def _transcript_projection(
             order_sequence = accepted_sequence.get(message_id)
             message_runs = run_by_message.get(message_id, [])
             loaded_complete = all(
-                len(deltas_by_run.get(int(run["run_id"]), []))
-                == int(run["assistant_delta_count"])
+                evidence_count_by_run.get(int(run["run_id"]), 0)
+                == int(run["segmentation_evidence_count"])
                 for run in message_runs
             )
             non_terminal = any(
@@ -1693,22 +1731,27 @@ def _transcript_projection(
             })
             for run in message_runs:
                 run_id = int(run["run_id"])
-                deltas = deltas_by_run.get(run_id, [])
-                if not deltas:
-                    continue
-                items.append({
-                    "item_id": f"run:{run_id}:assistant",
-                    "kind": "assistant",
-                    "order_sequence": deltas[0]["sequence"],
-                    "message_id": message_id,
-                    "run_id": run_id,
-                    "created_at": deltas[0]["created_at"],
-                    "text": "".join(delta["payload"]["text"] for delta in deltas),
-                    "outcome": run["state"],
-                    "first_sequence": deltas[0]["sequence"],
-                    "last_sequence": deltas[-1]["sequence"],
-                    "text_truncated": False,
-                })
+                segments = segments_by_run.get(run_id, {})
+                for anchor, deltas in sorted(
+                    segments.items(),
+                    key=lambda entry: entry[1][0]["sequence"],
+                ):
+                    items.append({
+                        "item_id": f"run:{run_id}:assistant:{anchor}",
+                        "kind": "assistant",
+                        "order_sequence": deltas[0]["sequence"],
+                        "message_id": message_id,
+                        "run_id": run_id,
+                        "created_at": deltas[0]["created_at"],
+                        "text": "".join(
+                            delta["payload"]["text"] for delta in deltas
+                        ),
+                        "outcome": run["state"],
+                        "segment_anchor_sequence": anchor,
+                        "first_sequence": deltas[0]["sequence"],
+                        "last_sequence": deltas[-1]["sequence"],
+                        "text_truncated": False,
+                    })
 
         for event in activities:
             message_id = (
@@ -1799,6 +1842,14 @@ def _transcript_projection(
                 else None
             ),
         }
+        if active_run_id is not None and int(active_run_id) in run_by_id:
+            active_run = run_by_id[int(active_run_id)]
+            projection["assistant_cursor"] = {
+                "run_id": int(active_run_id),
+                "segment_anchor_sequence": int(
+                    active_run["latest_boundary_sequence"]
+                ),
+            }
         if warnings:
             projection["warnings"] = warnings
         _bound_transcript_response(

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -12,8 +12,6 @@ from contextlib import closing
 from pathlib import Path
 from unittest import mock
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 sys.path.insert(0, str(ROOT / "tests"))
@@ -1628,7 +1626,7 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
         self.assertEqual(status, 200, transcript)
         self.assertEqual(headers["Cache-Control"], "no-store")
         self.assertEqual(transcript["conversation_id"], conversation_id)
-        self.assertEqual(transcript["projection_version"], 1)
+        self.assertEqual(transcript["projection_version"], 2)
         self.assertEqual(transcript["through_sequence"], through_sequence)
         self.assertEqual(transcript["truncation"], None)
         self.assertEqual(
@@ -1644,7 +1642,7 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
             [
                 (f"message:{message_ids[0]}", "user", message_ids[0], None),
                 (
-                    f"run:{transcript['items'][1]['run_id']}:assistant",
+                    f"run:{transcript['items'][1]['run_id']}:assistant:0",
                     "assistant",
                     message_ids[0],
                     transcript["items"][1]["run_id"],
@@ -1665,51 +1663,21 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
                 source_rows,
             )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Sprint 63 unit 2 removes this projection-v2 marker",
-    )
-    @unittest.expectedFailure
     def test_segmented_plain_prose_keeps_one_stable_anchor_zero_item(self) -> None:
         self.assert_historical_segment_trace("plain_prose")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Sprint 63 unit 2 removes this projection-v2 marker",
-    )
-    @unittest.expectedFailure
     def test_segmented_prose_tool_prose_has_exact_items_ids_and_order(self) -> None:
         self.assert_historical_segment_trace("prose_tool_prose")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Sprint 63 unit 2 removes this projection-v2 marker",
-    )
-    @unittest.expectedFailure
     def test_segmented_multiple_tools_use_only_the_latest_boundary(self) -> None:
         self.assert_historical_segment_trace("multiple_tools")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Sprint 63 unit 2 removes this projection-v2 marker",
-    )
-    @unittest.expectedFailure
     def test_segmented_tool_before_prose_creates_no_empty_bubble(self) -> None:
         self.assert_historical_segment_trace("tool_before_prose")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Sprint 63 unit 2 removes this projection-v2 marker",
-    )
-    @unittest.expectedFailure
     def test_segmented_actionable_pauses_remain_between_assistant_items(self) -> None:
         self.assert_historical_segment_trace("permission_and_input_pauses")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Sprint 63 unit 2 removes this projection-v2 marker",
-    )
-    @unittest.expectedFailure
     def test_segmented_pending_boundary_snapshot_carries_active_cursor(self) -> None:
         with closing(self.connect()) as con:
             conversation_id = self.seed_conversation(
@@ -1736,11 +1704,6 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
             "segment_anchor_sequence": 5,
         })
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Sprint 63 unit 2 removes this projection-v2 marker",
-    )
-    @unittest.expectedFailure
     def test_segmented_fresh_run_cursor_does_not_leak_prior_run_boundary(self) -> None:
         with closing(self.connect()) as con:
             conversation_id = self.seed_conversation(
@@ -1775,11 +1738,6 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
             "segment_anchor_sequence": 0,
         })
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Sprint 63 unit 2 removes this projection-v2 marker",
-    )
-    @unittest.expectedFailure
     def test_segmented_cursor_uses_full_prefix_when_boundary_is_source_capped(
         self,
     ) -> None:
@@ -1814,6 +1772,52 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
             "run_id": run_id,
             "segment_anchor_sequence": 5,
         })
+
+    def test_segmented_terminal_suffix_omits_incomplete_boundary_evidence(
+        self,
+    ) -> None:
+        trace = next(
+            item
+            for item in HISTORICAL_SEGMENT_TRACES
+            if item["name"] == "prose_tool_prose"
+        )
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=714,
+                state="closed",
+            )
+            self.seed_segmented_trace(
+                con,
+                conversation_id=conversation_id,
+                events=trace["events"],
+            )
+            source_rows = con.execute(
+                "SELECT COUNT(*) FROM conversation_events "
+                "WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0]
+            con.commit()
+            transcript = conversation_routes._transcript_projection(
+                con,
+                conversation_id,
+                owner_user_id=1,
+                limits=conversation_routes.TranscriptLimits(
+                    max_turns=200,
+                    max_source_events=3,
+                    max_source_bytes=1_000_000,
+                    max_response_bytes=1_000_000,
+                ),
+            )
+            retained_source_rows = con.execute(
+                "SELECT COUNT(*) FROM conversation_events "
+                "WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0]
+
+        self.assertEqual(transcript["items"], [])
+        self.assertEqual(transcript["truncation"]["reason"], "source_event_limit")
+        self.assertEqual(retained_source_rows, source_rows)
 
     def test_transcript_caps_are_injected_explicit_and_never_mutate_sources(
         self,

--- a/tests/test_conversation_release_gate.py
+++ b/tests/test_conversation_release_gate.py
@@ -13,8 +13,6 @@ from collections.abc import Iterator
 from pathlib import Path
 from unittest import mock
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 sys.path.insert(0, str(ENGINE / "api"))
@@ -494,11 +492,6 @@ class CrossHarnessReleaseGateTest(unittest.TestCase):
     def test_codex_release_journey_and_crash_windows(self) -> None:
         self.assert_release_journey("codex")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="unit 2 removes this projection marker",
-    )
-    @unittest.expectedFailure
     def test_same_adapter_conversations_keep_segment_ids_run_scoped(self) -> None:
         state = NativeHarnessState("codex")
         state.segmented_trace = True
@@ -544,7 +537,7 @@ class CrossHarnessReleaseGateTest(unittest.TestCase):
                 [(item["item_id"], item["text"]) for item in assistant],
                 [
                     (f"run:{run_id}:assistant:0", "codex before tool"),
-                    (f"run:{run_id}:assistant:6", "codex after tool"),
+                    (f"run:{run_id}:assistant:7", "codex after tool"),
                 ],
             )
 


### PR DESCRIPTION
## Summary

- advance transcript projection to v2 and fold assistant deltas into durable sequence-anchored segments inside the existing event read
- derive the active run cursor from the full pre-cap prefix and count assistant/boundary evidence so truncated terminal runs fail closed
- preserve the single SQLite snapshot, fixed five reads, caps, redaction, warnings, and source immutability
- remove exactly the unit-2 staged markers, including the same-adapter concurrency probe

## R2 fixture correction (explicit reviewer callout)

The reviewed unit-1 concurrency fixture expected the post-tool segment at `:6` (`tool.started`). R1 says every boundary replaces the pending anchor, and the durable trace is `tool.started:6` then `tool.completed:7` before the delta. PLN2 ratified the corrected `:7` expectation as Sprint 63 ruling R2. REV3: please review this named unit-1 artifact edit rather than treating it as incidental test churn.

## Verification

- focused projection/concurrency gate: 12 passed
- complete API + release-gate files: 54 passed, 13 subtests passed
- `./sc test`: passed (durable job 32, 1m18s)
- `./sc render-check`: passed
- changed-path Ruff checks: passed; unrelated main debt tracked in #890
- `git diff --check`: passed

## Notes

One concurrency run returned before both rows terminalized; its immediate isolated rerun and the subsequent focused/full suites passed. Per sprint ruling this is recorded as an anomalous fixture timing race, not a product fix.
