### PR TITLE
feat: render keyed live assistant segments

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3517,19 +3517,47 @@ async function chatRenderNew(host, shell, defaults, catalog) {
 }
 
 function chatCreateTranscriptState(snapshot) {
-  if (snapshot.projection_version !== 1)
+  if (snapshot.projection_version !== 2)
     throw new Error("Unsupported transcript projection.");
   const items = new Map();
   for (const item of snapshot.items || []) {
     if (!item.item_id || items.has(item.item_id))
       throw new Error("Transcript contains a keyed identity conflict.");
+    if (item.kind === "assistant") {
+      const anchor = Number(item.segment_anchor_sequence);
+      if (item.run_id == null || !Number.isInteger(anchor) || anchor < 0
+          || item.item_id !== `run:${item.run_id}:assistant:${anchor}`)
+        throw new Error("Transcript contains an invalid assistant segment.");
+    }
     items.set(item.item_id, { ...item });
+  }
+  const activeRunId = snapshot.controls?.active_run_id;
+  const cursor = snapshot.assistant_cursor || null;
+  if ((activeRunId == null) !== (cursor == null)
+      || cursor && (cursor.run_id !== activeRunId
+        || !Number.isInteger(Number(cursor.segment_anchor_sequence))
+        || Number(cursor.segment_anchor_sequence) < 0
+        || Number(cursor.segment_anchor_sequence)
+          > Number(snapshot.through_sequence || 0)))
+    throw new Error("Transcript contains an invalid assistant cursor.");
+  if (cursor && [...items.values()].some((item) =>
+    item.kind === "assistant" && item.run_id === activeRunId
+      && Number(item.segment_anchor_sequence)
+        > Number(cursor.segment_anchor_sequence)))
+    throw new Error("Transcript assistant cursor moved backward.");
+  const assistantAnchors = new Map();
+  if (cursor) {
+    assistantAnchors.set(
+      cursor.run_id,
+      Number(cursor.segment_anchor_sequence),
+    );
   }
   return {
     projectionVersion: snapshot.projection_version,
     throughSequence: Number(snapshot.through_sequence || 0),
     lastSequence: Number(snapshot.through_sequence || 0),
     items,
+    assistantAnchors,
     order: [...items.keys()].sort((left, right) => {
       const a = items.get(left);
       const b = items.get(right);
@@ -4104,6 +4132,22 @@ async function chatRenderOpen(host, initialConversation, initialSnapshot) {
     const userItem = event.message_id == null
       ? null
       : transcriptState.items.get(`message:${event.message_id}`);
+    const boundary = [
+      "tool.started",
+      "tool.completed",
+      "permission.requested",
+      "input.requested",
+    ].includes(type);
+
+    if (boundary && event.run_id != null) {
+      const previousAnchor = transcriptState.assistantAnchors.get(event.run_id)
+        || 0;
+      if (sequence <= previousAnchor) {
+        reconcileTranscript();
+        return;
+      }
+      transcriptState.assistantAnchors.set(event.run_id, sequence);
+    }
 
     if (type === "message.accepted") {
       if (!userItem) {
@@ -4125,9 +4169,16 @@ async function chatRenderOpen(host, initialConversation, initialSnapshot) {
         return;
       }
       const runId = event.run_id;
-      const itemId = `run:${runId}:assistant`;
+      if (runId == null || runId !== conversation.active_run_id) {
+        reconcileTranscript();
+        return;
+      }
+      const anchor = transcriptState.assistantAnchors.get(runId) || 0;
+      const itemId = `run:${runId}:assistant:${anchor}`;
       let assistant = transcriptState.items.get(itemId);
-      if (assistant && assistant.message_id !== event.message_id) {
+      if (assistant && (assistant.message_id !== event.message_id
+          || assistant.run_id !== runId
+          || Number(assistant.segment_anchor_sequence) !== anchor)) {
         reconcileTranscript();
         return;
       }
@@ -4141,6 +4192,7 @@ async function chatRenderOpen(host, initialConversation, initialSnapshot) {
           created_at: event.created_at,
           text: "",
           outcome: null,
+          segment_anchor_sequence: anchor,
           first_sequence: sequence,
           last_sequence: sequence,
           text_truncated: false,
@@ -4191,6 +4243,8 @@ async function chatRenderOpen(host, initialConversation, initialSnapshot) {
     if (type === "run.started") {
       conversation.state = "running";
       conversation.active_run_id = event.run_id;
+      if (event.run_id != null)
+        transcriptState.assistantAnchors.set(event.run_id, 0);
     }
     if (type === "conversation.updated" || type === "conversation.renamed")
       Object.assign(conversation, event.payload || {});
@@ -4207,6 +4261,8 @@ async function chatRenderOpen(host, initialConversation, initialSnapshot) {
       .includes(type)) {
       stopRequest = null;
       conversation.active_run_id = null;
+      if (event.run_id != null)
+        transcriptState.assistantAnchors.delete(event.run_id);
     }
 
     if (type === "assistant.delta") {

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -310,8 +310,12 @@ def test_diff_workspace_preserves_live_chat_and_uses_get_only(
     ]
     transcript_page = {
         "conversation_id": CONVERSATION_ID,
-        "projection_version": 1,
+        "projection_version": 2,
         "through_sequence": 22,
+        "assistant_cursor": {
+            "run_id": 77,
+            "segment_anchor_sequence": 0,
+        },
         "controls": {
             "conversation_version": 4,
             "conversation_state": "running",
@@ -335,7 +339,7 @@ def test_diff_workspace_preserves_live_chat_and_uses_get_only(
             for item in messages
         ] + [
             {
-                "item_id": "run:77:assistant",
+                "item_id": "run:77:assistant:0",
                 "kind": "assistant",
                 "order_sequence": 22,
                 "message_id": 1,
@@ -343,6 +347,7 @@ def test_diff_workspace_preserves_live_chat_and_uses_get_only(
                 "created_at": "2026-07-30 20:00:02",
                 "text": "initial",
                 "outcome": None,
+                "segment_anchor_sequence": 0,
                 "first_sequence": 22,
                 "last_sequence": 22,
                 "text_truncated": False,
@@ -853,6 +858,7 @@ export { mode };"""
         current["state"] = "closed"
         transcript_page["controls"]["conversation_state"] = "closed"
         transcript_page["controls"]["active_run_id"] = None
+        transcript_page.pop("assistant_cursor")
         page.reload(wait_until="networkidle")
         page.locator(".review-workspace").wait_for()
         assert page.get_by_role("button", name="Close").is_disabled()
@@ -893,8 +899,12 @@ def test_chat_performance_uses_bounded_requests_and_keyed_frames(static_ui):
     stars = [summary(100 + number, starred=True) for number in range(3)]
     transcript = {
         "conversation_id": CONVERSATION_ID,
-        "projection_version": 1,
+        "projection_version": 2,
         "through_sequence": 7000,
+        "assistant_cursor": {
+            "run_id": 77,
+            "segment_anchor_sequence": 0,
+        },
         "controls": {
             "conversation_version": 4,
             "conversation_state": "running",
@@ -916,7 +926,7 @@ def test_chat_performance_uses_bounded_requests_and_keyed_frames(static_ui):
                 "text_truncated": False,
             },
             {
-                "item_id": "run:77:assistant",
+                "item_id": "run:77:assistant:0",
                 "kind": "assistant",
                 "order_sequence": 2,
                 "message_id": 1,
@@ -924,6 +934,7 @@ def test_chat_performance_uses_bounded_requests_and_keyed_frames(static_ui):
                 "created_at": "2026-07-30 20:00:02",
                 "text": "initial",
                 "outcome": None,
+                "segment_anchor_sequence": 0,
                 "first_sequence": 2,
                 "last_sequence": 7000,
                 "text_truncated": False,
@@ -1175,7 +1186,10 @@ def test_chat_performance_uses_bounded_requests_and_keyed_frames(static_ui):
         assert hidden_counts["assistantReplacements"] == 0
 
         page.get_by_role("tab", name="Chat").click()
-        page.get_by_text("initial" + ("x" * 500), exact=True).wait_for()
+        page.get_by_text("x" * 500, exact=True).wait_for()
+        assert page.locator(".chat-assistant-body").evaluate_all(
+            "nodes => nodes.map((node) => node.textContent.trim())"
+        ) == ["initial", "x" * 500]
         catch_up = page.evaluate("window.__chatPerf")
         assert catch_up["maxRafOutstanding"] <= 1
         assert catch_up["markdownParses"] <= 1
@@ -1190,10 +1204,6 @@ def test_chat_performance_uses_bounded_requests_and_keyed_frames(static_ui):
     assert not browser_errors
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="projection v2 live segment reducer lands in Sprint 63 unit 3",
-)
 def test_segmented_live_trace_refresh_replay_and_node_identity(static_ui):
     requests: list[str] = []
     browser_errors: list[str] = []
@@ -1295,7 +1305,9 @@ def test_segmented_live_trace_refresh_replay_and_node_identity(static_ui):
             wait_until="networkidle",
         )
         page.locator(".chat-transcript").wait_for()
-        assert page.locator(".chat-bubble.chat-assistant").all_text_contents() == [
+        assert page.locator(".chat-assistant-body").evaluate_all(
+            "nodes => nodes.map((node) => node.textContent.trim())"
+        ) == [
             "before tool"
         ]
 
@@ -1325,24 +1337,48 @@ def test_segmented_live_trace_refresh_replay_and_node_identity(static_ui):
             """
         )
 
-        replayed_boundary = LIVE_SEGMENT_EVENTS[1]
         delta = LIVE_SEGMENT_EVENTS[2]
-        for event in (replayed_boundary, delta):
+        page.evaluate(
+            "([type, payload]) => "
+            "window.__fakeEventSources[0].emit(type, payload)",
+            [delta["event_type"], delta],
+        )
+        page.get_by_text("after tool", exact=True).wait_for()
+        page.evaluate(
+            """
+            window.__secondSegmentNode =
+              document.querySelectorAll('.chat-bubble.chat-assistant')[1];
+            """
+        )
+
+        replayed_boundary = LIVE_SEGMENT_EVENTS[0]
+        continued_delta = {
+            **delta,
+            "sequence": 9,
+            "payload": {"text": " continued"},
+        }
+        for event in (replayed_boundary, continued_delta):
             page.evaluate(
                 "([type, payload]) => "
                 "window.__fakeEventSources[0].emit(type, payload)",
                 [event["event_type"], event],
             )
-        page.get_by_text("after tool", exact=True).wait_for()
+        page.get_by_text("after tool continued", exact=True).wait_for()
 
-        assert page.locator(".chat-bubble.chat-assistant").all_text_contents() == [
+        assert page.locator(".chat-assistant-body").evaluate_all(
+            "nodes => nodes.map((node) => node.textContent.trim())"
+        ) == [
             "before tool",
-            "after tool",
+            "after tool continued",
         ]
         assert page.locator(".chat-bubble.chat-activity").count() == 0
         assert page.evaluate(
             "window.__firstSegmentNode === "
             "document.querySelector('.chat-bubble.chat-assistant')"
+        )
+        assert page.evaluate(
+            "window.__secondSegmentNode === "
+            "document.querySelectorAll('.chat-bubble.chat-assistant')[1]"
         )
         counts = page.evaluate("window.__chatPerf")
         assert counts["maxRafOutstanding"] <= 1

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -125,7 +125,7 @@ def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():
     keyed = interface[interface.index("function chatCreateTranscriptState"):
                       interface.index("async function renderInterface")]
 
-    assert "snapshot.projection_version !== 1" in keyed
+    assert "snapshot.projection_version !== 2" in keyed
     assert "items.has(item.item_id)" in keyed
     assert "nodes: new Map()" in keyed
     assert "dirty: new Set(items.keys())" in keyed
@@ -139,7 +139,7 @@ def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():
     assert "transcriptState.hiddenDirty = true" in keyed
     assert "sequence !== transcriptState.lastSequence + 1" in keyed
     assert "if (reconcilePromise" in keyed
-    assert "`run:${runId}:assistant`" in keyed
+    assert "`run:${runId}:assistant:${anchor}`" in keyed
     assert "assistant.text += event.payload?.text || \"\"" in keyed
     assert "transcriptState.throughSequence" in keyed
     assert "/events?after=${afterSequence}" in interface
@@ -150,10 +150,6 @@ def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():
     ]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="projection v2 keyed assistant segments land in Sprint 63 unit 3",
-)
 def test_segmented_transcript_source_contract_is_versioned_and_run_scoped():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
@@ -189,10 +185,12 @@ def test_connection_status_is_attached_to_transcript_without_visible_copy():
 def test_transcript_hides_routine_tools_but_keeps_actionable_activity():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
-    activity = interface[
-        interface.index("const activityLabel = (event) =>"):
-        interface.index("chatOpenStream(", interface.index(
-          "const activityLabel = (event) =>"))
+    reducer = interface[interface.index("const reduceEvent = (event) =>"):
+                        interface.index("chatOpenStream(", interface.index(
+                            "const reduceEvent = (event) =>"))]
+    activity = reducer[
+        reducer.index('} else if ([\n      "permission.requested"'):
+        reducer.index("transcriptState.lastSequence = sequence")
     ]
     assert '"tool.started"' not in activity
     assert '"tool.completed"' not in activity


### PR DESCRIPTION
## Summary

- hydrate projection v2 assistant cursors and reduce tool/wait boundaries into run-scoped stable segment keys
- preserve completed DOM nodes while only reparsing the dirty assistant segment, including hidden-Chat catch-up and bounded frames
- remove exactly the Sprint 63 unit-3 strict xfails and prove actual outer-node identity in Playwright
- strengthen reconnect replay so a stale boundary would create a duplicate bubble or replace the active node under a naive reducer
- update the performance fixture/assertion from the v1 concatenated bubble to the v2 two-bubble shape

This closes Sprint 63 ruling R3's temporary projection-v2/UI-v1 safe-failure window.

## Verification

- `node --check .super-coder/ui/app.js`
- Ruff on the modified Python tests
- focused UI + Playwright + release gate: 33 passed before rebase; rebased run 33 passed with one known unit-2 terminalization timing race, immediate isolated rerun passed
- segmented API projection/reconnect selection: 10 passed
- full pytest before final rebase: 1,461 passed and 785 subtests passed
- `./sc render-check` and `git diff --check`

`./sc verify` remains unavailable from the required linked worktree; reproduced on existing issue #769 without touching the occupied shared live checkout.