### PR TITLE
fix: round Diff toggle outer chamfers

### DIFF
--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -466,19 +466,18 @@ body.interface-view main {
 .review-freshness .warning { color: var(--warn); }
 .review-refresh.act { margin: 0; padding: .34rem .7rem; font-size: .7rem; }
 .review-group-switch {
-  --review-tab-cut: 10px;
-  --review-tab-radius: 6px;
-  --review-tab-radius-diagonal: 4.2px;
-  margin: 0; flex: none; border-radius: 4px 4px 0 4px;
-}
-.review-group-switch,
-.review-group-switch button:first-child.active {
+  /* 8px fillet -> 8px 45deg segment -> 8px fillet on each bottom corner. */
+  --review-tab-cut: 16.97px;
+  --review-tab-radius: 8px;
+  --review-tab-radius-diagonal: 5.66px;
+  margin: 0; flex: none; border-radius: 0;
   clip-path: polygon(
     0 0,
     100% 0,
     100% calc(100% - var(--review-tab-cut)),
     calc(100% - var(--review-tab-cut)) 100%,
-    0 100%
+    var(--review-tab-cut) 100%,
+    0 calc(100% - var(--review-tab-cut))
   );
   clip-path: shape(
     from 0 0,
@@ -491,27 +490,22 @@ body.interface-view main {
       calc(100% - var(--review-tab-radius-diagonal)),
     curve to calc(100% - var(--review-tab-cut) - var(--review-tab-radius)) 100%
       with calc(100% - var(--review-tab-cut)) 100%,
-    line to 0 100%,
+    line to calc(var(--review-tab-cut) + var(--review-tab-radius)) 100%,
+    curve to calc(var(--review-tab-cut) - var(--review-tab-radius-diagonal))
+      calc(100% - var(--review-tab-radius-diagonal))
+      with var(--review-tab-cut) 100%,
+    line to var(--review-tab-radius-diagonal)
+      calc(100% - var(--review-tab-cut) + var(--review-tab-radius-diagonal)),
+    curve to 0 calc(100% - var(--review-tab-cut) - var(--review-tab-radius))
+      with 0 calc(100% - var(--review-tab-cut)),
     close
   );
 }
 .review-group-switch button {
+  display: flex; align-items: center; justify-content: center;
   position: relative; z-index: 0;
 }
 .review-group-switch button.active { z-index: 1; }
-.review-group-switch button + button { border-left: 0; }
-.review-group-switch button:first-child.active + button {
-  z-index: 0;
-}
-.review-group-switch button:first-child.active + button::before {
-  content: ""; position: absolute; inset: 0 auto auto 0;
-  height: calc(100% - var(--review-tab-cut) - var(--review-tab-radius));
-  border-left: 1px solid var(--line); pointer-events: none;
-}
-.review-group-switch button:first-child:not(.active)::after {
-  content: ""; position: absolute; inset: 0 0 auto auto; height: 100%;
-  border-right: 1px solid var(--line); pointer-events: none;
-}
 .review-change-switch { margin: 0; flex: none; }
 .review-scope-switch button { padding-inline: 1rem; }
 .review-body {

--- a/tests/test_conversation_diff_browser.py
+++ b/tests/test_conversation_diff_browser.py
@@ -687,11 +687,12 @@ export { mode };"""
             "tabsBottomRightRadius: getComputedStyle(nodes[4]).borderBottomRightRadius, "
             "tabsBottomLeftRadius: getComputedStyle(nodes[4]).borderBottomLeftRadius, "
             "activeClip: getComputedStyle(nodes[5]).clipPath, "
+            "activeAlign: getComputedStyle(nodes[5]).alignItems, "
+            "activeJustify: getComputedStyle(nodes[5]).justifyContent, "
             "activeHeight: active.height, "
             "activeLayer: getComputedStyle(nodes[5]).zIndex, "
             "inactiveLayer: getComputedStyle(nodes[6]).zIndex, "
-            "dividerBorder: getComputedStyle(nodes[6], '::before').borderLeftWidth, "
-            "dividerHeight: parseFloat(getComputedStyle(nodes[6], '::before').height), "
+            "inactiveHeight: nodes[6].getBoundingClientRect().height, "
             "buttonBorder: getComputedStyle(nodes[6]).borderLeftWidth}; }"
         )
         assert patch_header["tabsLeft"] - patch_header["titleRight"] >= 12
@@ -702,18 +703,17 @@ export { mode };"""
         assert abs(summary_alignment["tabsCenter"] - patch_header["tabsCenter"]) <= 1
         assert abs(patch_header["headerTop"] - patch_header["tabsTop"]) <= 1
         assert patch_header["tabsClip"].startswith("shape(")
-        assert patch_header["activeClip"].startswith("shape(")
-        assert patch_header["tabsTopLeftRadius"] == "4px"
-        assert patch_header["tabsTopRightRadius"] == "4px"
+        assert patch_header["activeClip"] == "none"
+        assert patch_header["tabsTopLeftRadius"] == "0px"
+        assert patch_header["tabsTopRightRadius"] == "0px"
         assert patch_header["tabsBottomRightRadius"] == "0px"
-        assert patch_header["tabsBottomLeftRadius"] == "4px"
+        assert patch_header["tabsBottomLeftRadius"] == "0px"
+        assert patch_header["activeAlign"] == "center"
+        assert patch_header["activeJustify"] == "center"
         assert patch_header["activeLayer"] == "1"
         assert patch_header["inactiveLayer"] == "0"
-        assert patch_header["dividerBorder"] == "1px"
-        assert patch_header["buttonBorder"] == "0px"
-        assert abs(
-            patch_header["activeHeight"] - patch_header["dividerHeight"] - 16
-        ) <= 1
+        assert patch_header["buttonBorder"] == "1px"
+        assert abs(patch_header["activeHeight"] - patch_header["inactiveHeight"]) <= 1
         initial_observations = sum(
             method == "POST" and path.endswith("/review-observations")
             for method, path, _query in requests
@@ -822,13 +822,15 @@ export { mode };"""
             "nodes => ({inactiveLayer: getComputedStyle(nodes[0]).zIndex, "
             "activeLayer: getComputedStyle(nodes[1]).zIndex, "
             "dividerBorder: getComputedStyle(nodes[0], '::after').borderRightWidth, "
-            "activeBorder: getComputedStyle(nodes[1]).borderLeftWidth})"
+            "activeBorder: getComputedStyle(nodes[1]).borderLeftWidth, "
+            "activeClip: getComputedStyle(nodes[1]).clipPath})"
         )
         assert shell_layers == {
             "inactiveLayer": "0",
             "activeLayer": "1",
-            "dividerBorder": "1px",
-            "activeBorder": "0px",
+            "dividerBorder": "0px",
+            "activeBorder": "1px",
+            "activeClip": "none",
         }
         page.get_by_role("button", name="CLAUDE.md").click()
         page.locator(".review-shell-file").wait_for()

--- a/tests/test_conversation_diff_ui.py
+++ b/tests/test_conversation_diff_ui.py
@@ -196,14 +196,17 @@ def test_diff_layout_is_full_width_bounded_and_responsive():
     assert "grid-template-rows: auto minmax(0, 1fr)" in STYLE
     assert "grid-column: 1 / -1; grid-row: 1" in STYLE
     assert "align-self: start; margin-top: -.4rem" in STYLE
-    assert "--review-tab-cut: 10px" in STYLE
-    assert "--review-tab-radius: 6px" in STYLE
-    assert "border-radius: 4px 4px 0 4px" in STYLE
+    assert "--review-tab-cut: 16.97px" in STYLE
+    assert "--review-tab-radius: 8px" in STYLE
+    assert "--review-tab-radius-diagonal: 5.66px" in STYLE
+    assert "margin: 0; flex: none; border-radius: 0" in STYLE
     assert STYLE.count("clip-path: shape(") == 1
+    assert "line to calc(var(--review-tab-cut) + var(--review-tab-radius)) 100%" in STYLE
+    assert "curve to 0 calc(100% - var(--review-tab-cut) - var(--review-tab-radius))" in STYLE
+    assert "display: flex; align-items: center; justify-content: center" in STYLE
     assert ".review-group-switch button.active { z-index: 1; }" in STYLE
-    assert ".review-group-switch button:first-child.active + button::before" in STYLE
-    assert ".review-group-switch button:first-child:not(.active)::after" in STYLE
-    assert "height: calc(100% - var(--review-tab-cut) - var(--review-tab-radius))" in STYLE
+    assert ".review-group-switch button:first-child.active" not in STYLE
+    assert ".review-group-switch button:first-child:not(.active)" not in STYLE
     assert "flex: 1 1 auto" in STYLE
     assert "text-overflow: ellipsis" in STYLE
     source = current_workspace_source()


### PR DESCRIPTION
## Summary
- shape both outside bottom corners of the Changes / Shell files toggle with 8px fillets around an 8px 45-degree segment
- keep the top corners square and the center divider straight
- vertically center both tab labels
- replace the asymmetric inner-edge contracts with browser coverage for the approved geometry

## Verification
- ./sc test tests/test_conversation_diff_ui.py tests/test_conversation_diff_browser.py -q
- 12 passed
- inspected the generated desktop browser screenshot

## Trade-off
The existing clip-path shape path carries the exact curved geometry in current browsers; the polygon fallback preserves the symmetric 45-degree silhouette without curved fillets.