### PR TITLE
fix: gate transcript completeness per run

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -1701,22 +1701,24 @@ def _transcript_projection(
 
         items = []
         retained_messages = set()
+        retained_runs = set()
         for message in message_rows:
             message_id = int(message["message_id"])
             order_sequence = accepted_sequence.get(message_id)
             message_runs = run_by_message.get(message_id, [])
-            loaded_complete = all(
-                evidence_count_by_run.get(int(run["run_id"]), 0)
-                == int(run["segmentation_evidence_count"])
+            projected_runs = [
+                run
                 for run in message_runs
-            )
-            non_terminal = any(
-                run["state"] in ("leased", "starting", "running")
-                for run in message_runs
-            )
-            if order_sequence is None or (not loaded_complete and not non_terminal):
+                if (
+                    evidence_count_by_run.get(int(run["run_id"]), 0)
+                    == int(run["segmentation_evidence_count"])
+                    or run["state"] in ("leased", "starting", "running")
+                )
+            ]
+            if order_sequence is None or (message_runs and not projected_runs):
                 continue
             retained_messages.add(message_id)
+            retained_runs.update(int(run["run_id"]) for run in projected_runs)
             items.append({
                 "item_id": f"message:{message_id}",
                 "kind": "user",
@@ -1729,7 +1731,7 @@ def _transcript_projection(
                 "completed_at": message["completed_at"],
                 "text_truncated": False,
             })
-            for run in message_runs:
+            for run in projected_runs:
                 run_id = int(run["run_id"])
                 segments = segments_by_run.get(run_id, {})
                 for anchor, deltas in sorted(
@@ -1761,15 +1763,16 @@ def _transcript_projection(
             )
             if message_id is not None and message_id not in retained_messages:
                 continue
+            run_id = event["run_id"]
+            if run_id is not None and int(run_id) not in retained_runs:
+                continue
             items.append({
                 "item_id": f"event:{event['sequence']}",
                 "kind": "activity",
                 "order_sequence": event["sequence"],
                 "message_id": message_id,
                 "run_id": (
-                    int(event["run_id"])
-                    if event["run_id"] is not None
-                    else None
+                    int(run_id) if run_id is not None else None
                 ),
                 "created_at": event["created_at"],
                 "activity_type": event["event_type"],

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -1850,10 +1850,22 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
             con.execute(
                 "INSERT INTO conversation_events "
                 "(conversation_id,sequence,event_type,payload,message_id,run_id) "
-                "VALUES (?,?,'message.accepted',?,?,NULL)",
+                "VALUES (?,?,'run.failed',?,?,?)",
                 (
                     conversation_id,
                     sequence + 1,
+                    json.dumps({"error_code": "FIXTURE_TERMINAL_FAILURE"}),
+                    message_id,
+                    terminal_run_id,
+                ),
+            )
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,'message.accepted',?,?,NULL)",
+                (
+                    conversation_id,
+                    sequence + 2,
                     json.dumps({"text": "trace prompt", "attempt": 2}),
                     message_id,
                 ),
@@ -1862,7 +1874,7 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
                 "INSERT INTO conversation_events "
                 "(conversation_id,sequence,event_type,payload,message_id,run_id) "
                 "VALUES (?,?,'run.started','{}',?,?)",
-                (conversation_id, sequence + 2, message_id, active_run_id),
+                (conversation_id, sequence + 3, message_id, active_run_id),
             )
             con.execute(
                 "INSERT INTO conversation_events "
@@ -1870,7 +1882,7 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
                 "VALUES (?,?,'assistant.delta',?,?,?)",
                 (
                     conversation_id,
-                    sequence + 3,
+                    sequence + 4,
                     json.dumps({"text": "active suffix"}),
                     message_id,
                     active_run_id,

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -1819,6 +1819,104 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
         self.assertEqual(transcript["truncation"]["reason"], "source_event_limit")
         self.assertEqual(retained_source_rows, source_rows)
 
+    def test_segmented_terminal_suffix_is_omitted_with_active_sibling(
+        self,
+    ) -> None:
+        trace = next(
+            item
+            for item in HISTORICAL_SEGMENT_TRACES
+            if item["name"] == "prose_tool_prose"
+        )
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=715,
+                state="running",
+            )
+            message_id, terminal_run_id, sequence = self.seed_segmented_trace(
+                con,
+                conversation_id=conversation_id,
+                events=trace["events"],
+            )
+            active_run = con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,attempt,lease_owner,"
+                "lease_expires_at,state,started_at) "
+                "VALUES (?,1,?,2,'fixture','2026-07-30 13:00:00','running',"
+                "'2026-07-30 12:02:00')",
+                (conversation_id, message_id),
+            )
+            active_run_id = int(active_run.lastrowid)
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,'message.accepted',?,?,NULL)",
+                (
+                    conversation_id,
+                    sequence + 1,
+                    json.dumps({"text": "trace prompt", "attempt": 2}),
+                    message_id,
+                ),
+            )
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,'run.started','{}',?,?)",
+                (conversation_id, sequence + 2, message_id, active_run_id),
+            )
+            con.execute(
+                "INSERT INTO conversation_events "
+                "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+                "VALUES (?,?,'assistant.delta',?,?,?)",
+                (
+                    conversation_id,
+                    sequence + 3,
+                    json.dumps({"text": "active suffix"}),
+                    message_id,
+                    active_run_id,
+                ),
+            )
+            con.execute(
+                "UPDATE conversations SET state='running' WHERE conversation_id=?",
+                (conversation_id,),
+            )
+            con.commit()
+            transcript = conversation_routes._transcript_projection(
+                con,
+                conversation_id,
+                owner_user_id=1,
+                limits=conversation_routes.TranscriptLimits(
+                    max_turns=200,
+                    max_source_events=5,
+                    max_source_bytes=1_000_000,
+                    max_response_bytes=1_000_000,
+                ),
+            )
+
+        self.assertEqual(
+            [
+                (item["item_id"], item["kind"], item.get("text"))
+                for item in transcript["items"]
+            ],
+            [
+                (f"message:{message_id}", "user", "trace prompt"),
+                (
+                    f"run:{active_run_id}:assistant:0",
+                    "assistant",
+                    "active suffix",
+                ),
+            ],
+        )
+        self.assertFalse(any(
+            item.get("run_id") == terminal_run_id
+            for item in transcript["items"]
+        ))
+        self.assertEqual(transcript["truncation"]["reason"], "source_event_limit")
+        self.assertEqual(transcript["assistant_cursor"], {
+            "run_id": active_run_id,
+            "segment_anchor_sequence": 0,
+        })
+
     def test_transcript_caps_are_injected_explicit_and_never_mutate_sources(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- gate retained transcript runs independently so an incomplete terminal sibling cannot borrow an active sibling’s non-terminal allowance
- omit run-scoped activity for the same omitted run while retaining the message and active run suffix
- add the F1 multi-attempt, capped-terminal regression with exact surviving items and negative terminal-run coverage

R5 fixture note: a naive single-attempt suffix cap removes the original `message.accepted` before projection reaches the F1 completeness gate, so the regression retains a later attempt acceptance marker to isolate the per-run failure path.

## Verification

- focused F1 + adjacent truncation/cursor cases: 3 passed
- conversation API file: 51 passed, 13 subtests
- segmented conversation gate: 83 passed, 1 skipped, 13 subtests
- full `./sc test`: 1472 passed, 1 skipped
- `./sc render-check`
- targeted Ruff passes excluding pre-existing main-branch RET501/PLR1711 tracked in #900
- `git diff --check`

`./sc verify` safely refused the required linked worktree seat; existing workflow gap #769 was updated with this repro. No guard bypass was used.