### PR TITLE
fix(codex): render native repo skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,12 @@
 /AGENTS.md
 /opencode.json
 
-# Per-shell skill render — .claude/skills/<name>/SKILL.md, rebuilt at boot for
-# whichever shell launches (harness-consumed cache, like the boot artifact).
-# Only the render output is ignored; a fork's own .claude/settings stays tracked.
+# Per-shell skill renders — rebuilt at boot for whichever shell launches
+# (harness-consumed caches, like the boot artifact). `.claude/skills` is the
+# stable mirror; `.agents/skills` is Codex-native. Only render output is ignored;
+# a fork's other .claude/.agents configuration stays tracked.
 /.claude/skills/
+/.agents/skills/
 
 # Engine-managed harness config, re-emitted each launch (the branch-guard hook
 # per harness). Kept separate from the fork's own tracked config: claude's

--- a/.super-coder/adapters/codex/README.md
+++ b/.super-coder/adapters/codex/README.md
@@ -1,8 +1,10 @@
 # adapters/codex — OpenAI Codex CLI
 
 Codex reads the boot artifact (`AGENTS.md`) and project `AGENTS.md` conventions
-natively — already emitted by the render chain — so the adapter only carries the
-launch command plus how it takes a model and a sandbox flag.
+natively. The render chain also emits each shell's exact grants to Codex's
+native `.agents/skills/<name>/SKILL.md` tree while retaining the cross-harness
+`.claude/skills/<name>/SKILL.md` mirror. The adapter carries those skill targets,
+the launch command, and how Codex takes a model and sandbox flag.
 
 **Why it exists:** the *subscription* path for OpenAI models. Signing into Codex
 with a ChatGPT plan bills against that plan (flat, capped) instead of per-token
@@ -18,6 +20,7 @@ billing. opencode stays as the universal metered catch-all.
 | `launch` | argv exec'd to start the harness (`codex --dangerously-bypass-hook-trust`) |
 | `boot_artifact` | the context file this harness reads (`AGENTS.md`, informational) |
 | `emit` | files copied to the repo root at launch (`.codex/hooks.json` — the branch-guard hook) |
+| `skill_dirs` | exact shell grants rendered to `.claude/skills` and Codex-native `.agents/skills` |
 | `env` | extra env merged into the launch environment |
 | `model` | `{ "flag": "--model" }` — run.py appends `--model <id>` for the flavor's codex model |
 | `headless.effort` | maps requested effort to `-c model_reasoning_effort="<level>"` |

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -3,6 +3,7 @@
   "launch": ["codex", "--dangerously-bypass-hook-trust"],
   "boot_artifact": "AGENTS.md",
   "emit": [".codex/hooks.json"],
+  "skill_dirs": [".claude/skills", ".agents/skills"],
   "env": {},
   "model": { "flag": "--model" },
   "headless": {

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -10,16 +10,14 @@ reverse):
     suffix flags provenance and avoids colliding with a host repo's own `/docs`.
     DB → flat is one-way; the files are never read back.
 
-  • Harness skills — `.claude/skills/<name>/SKILL.md` for the booting shell's
-    granted skills. A NON-load-bearing convenience cache for harnesses that
-    auto-discover this path natively (Claude Code / OpenCode / Crush). It is NOT
-    the source of truth and NOT the cross-harness load path: codex reads its own
-    `$CODEX_HOME/skills`, kimi its `.kimi-code/skills` / `.agents/skills`, and
-    vibe (Mistral) has no skill dir at all. The
-    canonical, harness-agnostic load path is the DB — the boot doc's `## SKILLS`
-    block renders each grant's exact `SELECT content FROM skills …` query
-    (see compose.render_skills). Like the boot artifact (CLAUDE.md/AGENTS.md)
-    this dir is GITIGNORED and rebuilt at launch — a per-shell cache.
+  • Harness skills — granted skills rendered as Agent Skills `SKILL.md` files
+    for the booting shell. `.claude/skills` is the stable cross-harness mirror;
+    adapters may request an additional native tree such as Codex's
+    `.agents/skills` or OpenCode's `.opencode/skills`. These are generated caches,
+    not sources of truth. The boot doc's `## SKILLS` block points at the stable
+    mirror so every harness can load the same procedure with a file read, never
+    an ad-hoc DB query. Like the boot artifact (CLAUDE.md/AGENTS.md), managed
+    skill trees are rebuilt at launch for the selected shell.
 
 Render is incremental: an artifact whose composed content already matches what
 is on disk is skipped (no write, no mtime churn), so re-rendering an unchanged
@@ -260,7 +258,8 @@ def render_skill_md(con: sqlite3.Connection, shell_id: int,
     """Render the booting shell's granted skills to
     `<skills_dir>/<name>/SKILL.md` (Agent Skills format: name + description
     frontmatter, content body). The default is `.claude/skills`; adapters may
-    request an additional native directory such as `.opencode/skills`.
+    request an additional native directory such as `.agents/skills` or
+    `.opencode/skills`.
 
     Harness-consumed and gitignored, like the boot artifact — rebuilt every
     launch for whichever shell boots. Stale skill folders (a grant since

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -140,6 +140,7 @@ GENERATED_INSTALL_PATHS = (
     Path(".claude/settings.local.json"),
     Path(".codex/hooks.json"),
     Path(".claude/skills"),
+    Path(".agents/skills"),
     Path("roadmap_sc.md"),
     Path("docs_sc"),
     Path("specs_sc"),
@@ -543,6 +544,7 @@ _GITIGNORE_BLOCK = f"""
 /AGENTS.md
 /opencode.json
 /.claude/skills/
+/.agents/skills/
 # Engine-managed harness config re-emitted each launch (per-harness branch-guard
 # hook); kept apart from a fork's own tracked config (claude settings.json /
 # codex config.toml).

--- a/tests/test_artifact_policy.py
+++ b/tests/test_artifact_policy.py
@@ -143,7 +143,7 @@ class SourceCleanlinessTest(unittest.TestCase):
                 ".sc-state/content.sql", ".sc-state/map.config.json",
                 ".sc-state/map_content.sql", "roadmap_sc.md",
                 "docs_sc", "specs_sc", "skills_sc", "AGENTS.md", "CLAUDE.md",
-                ".claude/skills",
+                ".claude/skills", ".agents/skills",
             ],
             capture_output=True,
             text=True,

--- a/tests/test_flavor_skill_packs.py
+++ b/tests/test_flavor_skill_packs.py
@@ -19,6 +19,7 @@ ROOT_ONLY_MARKER = "<!-- sc-root-only:"
 sys.path.insert(0, str(ENGINE / "scripts"))
 import shell_factory  # noqa: E402
 import snapshot  # noqa: E402
+import run  # noqa: E402
 
 sys.path.insert(0, str(ENGINE / "api"))
 import server  # noqa: E402
@@ -380,6 +381,44 @@ class RenderAndSnapshotTest(unittest.TestCase):
                 (Path(tmp) / ".opencode" / "skills"
                  / "engine_surgery" / "SKILL.md").exists()
             )
+
+    def test_codex_adapter_renders_and_prunes_native_skill_mirror(self) -> None:
+        self.con.execute(
+            "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+            (self.custom, self.kid),
+        )
+        adapter = json.loads(
+            (ENGINE / "adapters" / "codex" / "adapter.json").read_text()
+        )
+        self.assertEqual(
+            adapter["skill_dirs"],
+            [".claude/skills", ".agents/skills"],
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            summary = run.render_harness_skills(
+                self.con, self.custom, root, adapter
+            )
+            self.assertEqual(
+                summary["dirs"], [".claude/skills", ".agents/skills"]
+            )
+            for skill_root in (".claude", ".agents"):
+                rendered = (
+                    root / skill_root / "skills" / "engine_surgery" / "SKILL.md"
+                )
+                self.assertTrue(rendered.exists())
+                self.assertIn("name: engine_surgery", rendered.read_text())
+
+            self.con.execute(
+                "DELETE FROM shell_skills WHERE shell_id=? AND skill_id=?",
+                (self.custom, self.kid),
+            )
+            run.render_harness_skills(self.con, self.custom, root, adapter)
+            for skill_root in (".claude", ".agents"):
+                self.assertFalse(
+                    (root / skill_root / "skills" / "engine_surgery").exists()
+                )
 
     def test_snapshot_serializes_pack_grants_by_skill_name(self) -> None:
         self.con.execute(

--- a/tests/test_gitignore_sync.py
+++ b/tests/test_gitignore_sync.py
@@ -21,6 +21,7 @@ import install  # noqa: E402
 
 MAP_DB = "/.sc-state/map.db"
 DB_BACKUPS = "/.sc-state/db_backups/"
+CODEX_SKILLS = "/.agents/skills/"
 
 
 class EnsureGitignoreTest(unittest.TestCase):
@@ -59,6 +60,17 @@ class EnsureGitignoreTest(unittest.TestCase):
         # existing lines are not duplicated
         self.assertEqual(text.count("/.super-coder/"), 1)
         # and a second run is a no-op
+        self.assertFalse(install.ensure_gitignore(self.root))
+
+    def test_tops_up_codex_native_skill_render_on_existing_fork(self):
+        old = "\n".join(
+            ln for ln in install._GITIGNORE_BLOCK.splitlines()
+            if ln != CODEX_SKILLS
+        )
+        self.gi.write_text(old + "\n")
+
+        self.assertTrue(install.ensure_gitignore(self.root))
+        self.assertIn(CODEX_SKILLS, self.gi.read_text())
         self.assertFalse(install.ensure_gitignore(self.root))
 
     def test_no_marker_unrelated_content_appends_once(self):

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -46,6 +46,8 @@ class RemoveFixture(unittest.TestCase):
         (self.repo / "sc").write_text("#!/bin/sh\nexit 0\n")
         (self.repo / "README.md").write_text("# keep me\n")
         (self.repo / "CLAUDE.md").write_text("generated\n")
+        (self.repo / ".agents/skills/sample").mkdir(parents=True)
+        (self.repo / ".agents/skills/sample/SKILL.md").write_text("generated\n")
         (self.repo / "docs_sc").mkdir()
         (self.repo / "docs_sc" / "generated.md").write_text("generated\n")
         (self.repo / "shared").mkdir()
@@ -145,6 +147,7 @@ class EndToEndRemoveTest(RemoveFixture):
         self.assertFalse(self.engine.exists())
         self.assertFalse((self.repo / "sc").exists())
         self.assertFalse((self.repo / "CLAUDE.md").exists())
+        self.assertFalse((self.repo / ".agents/skills").exists())
         self.assertFalse((self.repo / "docs_sc").exists())
         self.assertFalse(
             (self.repo / ".github/workflows/subfloor-visual-qa.yml").exists()


### PR DESCRIPTION
## Summary
- render each Codex shell's exact grants to the native `.agents/skills` tree while retaining the stable `.claude/skills` mirror
- keep the generated Codex skill tree ignored, upgrade-safe, and removable
- correct stale cross-harness skill-loading guidance and add render/prune lifecycle coverage

## Verification
- `python3 -m unittest tests.test_flavor_skill_packs tests.test_gitignore_sync tests.test_artifact_policy tests.test_remove` (47 passed)
- `./sc map`
- `./sc render-check`
- `./sc verify`
- `git diff --check`