### PR TITLE
feat: reconcile tombstoned skills

### DIFF
--- a/.super-coder/assets/skill_tombstones.json
+++ b/.super-coder/assets/skill_tombstones.json
@@ -1,0 +1,15 @@
+[
+  "dev_sprint",
+  "plan_sprint",
+  "rev_sprint",
+  "sprint",
+  "sprint_cond",
+  "sprint_onboarding",
+  "sprint_orchestration",
+  "sprint_orchestration_close",
+  "sprint_orchestration_recover",
+  "sprint_review",
+  "engine_surgery",
+  "test_authoring_pg",
+  "test_authoring_sqlite"
+]

--- a/.super-coder/scripts/engine_manifest.py
+++ b/.super-coder/scripts/engine_manifest.py
@@ -69,6 +69,7 @@ ENGINE_PATHS = [
     ".super-coder/adapters",
     ".super-coder/api",
     ".super-coder/ui",
+    ".super-coder/assets/skill_tombstones.json",
     ".super-coder/assets/skills",
     ".super-coder/hooks",
     ".super-coder/shadow",

--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -36,8 +36,10 @@ Usage:
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import artifact_policy
@@ -47,6 +49,142 @@ SKILLS_DIR = ENGINE / "assets" / "skills"
 OUT = ENGINE / "migrations" / "0001_seed_skills.sql"
 DB_PATH = ENGINE / "shell_db.db"
 RETIRED_FILE = artifact_policy.retired_skills_path()
+TOMBSTONES_FILE = ENGINE / "assets" / "skill_tombstones.json"
+SKILL_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+# These three legacy names remain in the generated seed until the catalogue
+# source-removal change lands. Until then, only their seed-owned assets may
+# overlap the registry; intersecting this tolerance with seeded_skill_names()
+# makes the exception disappear on that regeneration.
+LEGACY_SEED_TOMBSTONE_TOLERANCE = frozenset({
+    "engine_surgery",
+    "test_authoring_pg",
+    "test_authoring_sqlite",
+})
+
+
+@dataclass(frozen=True)
+class TombstoneReconciliation:
+    """The authority removed by one tombstone reconciliation pass."""
+
+    changed_names: tuple[str, ...]
+    grant_count: int
+
+
+def tombstoned_skill_names() -> list[str]:
+    """Load the permanent upstream skill-name reservations.
+
+    The registry is authored source, not best-effort configuration. Refuse a
+    malformed registry before any catalogue write can partially apply.
+    """
+    try:
+        names = json.loads(TOMBSTONES_FILE.read_text())
+    except FileNotFoundError as e:
+        raise ValueError(f"skill tombstone registry missing: {TOMBSTONES_FILE}") from e
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"skill tombstone registry {TOMBSTONES_FILE} is not valid JSON: {e}"
+        ) from e
+    if not isinstance(names, list):
+        raise TypeError(
+            f"skill tombstone registry {TOMBSTONES_FILE} must be a JSON array"
+        )
+    if not names:
+        raise ValueError(f"skill tombstone registry {TOMBSTONES_FILE} is empty")
+
+    seen: set[str] = set()
+    validated: list[str] = []
+    for index, name in enumerate(names):
+        if not isinstance(name, str):
+            raise TypeError(
+                f"skill tombstone registry entry {index} must be a string"
+            )
+        if not SKILL_NAME_RE.fullmatch(name):
+            raise ValueError(
+                f"skill tombstone registry entry {index} has malformed name {name!r}"
+            )
+        if name in seen:
+            raise ValueError(
+                f"skill tombstone registry contains duplicate name {name!r}"
+            )
+        seen.add(name)
+        validated.append(name)
+    return validated
+
+
+def validate_upstream_skill_namespace(active_names: list[str]) -> list[str]:
+    """Prove that active upstream names and permanent tombstones are disjoint."""
+    tombstones = tombstoned_skill_names()
+    overlap = sorted(set(active_names) & set(tombstones))
+    if overlap:
+        raise ValueError(
+            "active and tombstoned upstream skill names overlap: "
+            + ", ".join(overlap)
+        )
+    return tombstones
+
+
+def _validate_skill_specs_claimable(specs: list[dict]) -> None:
+    """Reject a fork-local asset that claims a reserved upstream name.
+
+    Three legacy skills remain in the active seed until the catalogue-removal
+    unit regenerates it. Those seed-owned rows are the only temporary overlap;
+    a name absent from the seed is a new fork-local claim and is refused now.
+    """
+    tombstones = set(tombstoned_skill_names())
+    tolerated = (
+        LEGACY_SEED_TOMBSTONE_TOLERANCE
+        & tombstones
+        & set(seeded_skill_names())
+    )
+    claimed = sorted(
+        spec["name"] for spec in specs
+        if spec["name"] in tombstones and spec["name"] not in tolerated
+    )
+    if claimed:
+        raise ValueError(
+            "skill asset claims tombstoned upstream name(s): " + ", ".join(claimed)
+        )
+
+
+def reconcile_tombstoned_skills(con) -> TombstoneReconciliation:
+    """Hard-delete tombstoned skills and both kinds of child grant.
+
+    A savepoint makes the operation atomic both as a standalone lifecycle step
+    and inside a caller-owned transaction. Releasing an outermost savepoint
+    commits; nested callers keep ownership of their surrounding transaction.
+    """
+    tombstones = tombstoned_skill_names()
+    placeholders = ",".join("?" for _ in tombstones)
+    rows = con.execute(
+        f"SELECT skill_id, name FROM skills WHERE name IN ({placeholders}) "
+        "ORDER BY name",
+        tombstones,
+    ).fetchall()
+    if not rows:
+        return TombstoneReconciliation((), 0)
+
+    skill_ids = [row[0] for row in rows]
+    id_placeholders = ",".join("?" for _ in skill_ids)
+    con.execute("SAVEPOINT reconcile_skill_tombstones")
+    try:
+        grant_count = con.execute(
+            f"DELETE FROM shell_skills WHERE skill_id IN ({id_placeholders})",
+            skill_ids,
+        ).rowcount
+        grant_count += con.execute(
+            f"DELETE FROM flavor_skills WHERE skill_id IN ({id_placeholders})",
+            skill_ids,
+        ).rowcount
+        con.execute(
+            f"DELETE FROM skills WHERE skill_id IN ({id_placeholders})",
+            skill_ids,
+        )
+    except Exception:
+        con.execute("ROLLBACK TO reconcile_skill_tombstones")
+        con.execute("RELEASE reconcile_skill_tombstones")
+        raise
+    con.execute("RELEASE reconcile_skill_tombstones")
+    return TombstoneReconciliation(tuple(row[1] for row in rows), grant_count)
 
 
 def sql_str(v) -> str:
@@ -236,6 +374,7 @@ def sync_engine_skills(con, specs: list[dict] | None = None) -> list[str]:
     transaction boundary intent; we commit our own writes."""
     if specs is None:
         specs = _engine_specs()
+    _validate_skill_specs_claimable(specs)
     stale = stale_engine_skills(con, specs)
     by_name = {s["name"]: s for s in specs}
     for name in stale:                       # stale ⊆ spec names, so always hits

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -218,6 +218,10 @@ def cmd_add(con, argv: list[str]) -> int:
         sys.exit(f"sc skill add: '{name}' is an ENGINE skill — the seed owns that "
                  "name and upserts it on every update. Pick a different one "
                  f"(e.g. {author}_{name}).")
+    if name in set(seed_skills.tombstoned_skill_names()):
+        sys.exit(f"sc skill add: '{name}' is a retired ENGINE skill — its name "
+                 "is permanently reserved by the upstream tombstone registry. "
+                 "Pick a different namespaced name.")
     # Guard 2 — namespace by shortname. A future upstream release claiming a
     # bare name would clobber this shell's content on the next sync; a
     # shortname prefix is a name upstream will never mint.

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -1,5 +1,6 @@
 {
   "allowed_reference_files": [
+    ".super-coder/assets/skill_tombstones.json",
     ".super-coder/migrations/0146_sprint_v2_domain.sql",
     ".super-coder/migrations/0147_sprint_participant_conversations.sql",
     ".super-coder/migrations/0148_sprint_message_delivery.sql",
@@ -46,6 +47,7 @@
     "tests/test_sprint_live_proof.py",
     "tests/test_sprint_board_api.py",
     "tests/test_sprint_board_ui.py",
+    "tests/test_skill_tombstones.py",
     "tests/fixtures/sprint_v2_acceptance.json",
     "tests/fixtures/sprint_handoff_hardening_acceptance.json",
     "tests/test_callable_floor.py",

--- a/tests/test_skill_tombstones.py
+++ b/tests/test_skill_tombstones.py
@@ -1,0 +1,277 @@
+"""Regression tests for the upstream skill tombstone ownership boundary."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+seed_skills = importlib.import_module("seed_skills")
+skill_mod = importlib.import_module("skill")
+
+
+TOMBSTONES = [
+    "dev_sprint",
+    "plan_sprint",
+    "rev_sprint",
+    "sprint",
+    "sprint_cond",
+    "sprint_onboarding",
+    "sprint_orchestration",
+    "sprint_orchestration_close",
+    "sprint_orchestration_recover",
+    "sprint_review",
+    "engine_surgery",
+    "test_authoring_pg",
+    "test_authoring_sqlite",
+]
+
+DDL = """
+PRAGMA foreign_keys=ON;
+CREATE TABLE skills (
+    skill_id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    category TEXT,
+    content TEXT,
+    command TEXT,
+    common INTEGER NOT NULL DEFAULT 1,
+    is_deleted INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE shell_skills (
+    shell_skill_id INTEGER PRIMARY KEY,
+    shell_id INTEGER NOT NULL,
+    skill_id INTEGER NOT NULL REFERENCES skills(skill_id),
+    UNIQUE(shell_id, skill_id)
+);
+CREATE TABLE flavor_skills (
+    flavor TEXT NOT NULL,
+    skill_id INTEGER NOT NULL REFERENCES skills(skill_id),
+    UNIQUE(flavor, skill_id)
+);
+"""
+
+
+class RegistryTest(unittest.TestCase):
+    def setUp(self):
+        self.saved = seed_skills.TOMBSTONES_FILE
+        self.tmp = tempfile.TemporaryDirectory()
+        self.registry = Path(self.tmp.name) / "skill_tombstones.json"
+
+    def tearDown(self):
+        seed_skills.TOMBSTONES_FILE = self.saved
+        self.tmp.cleanup()
+
+    def write_registry(self, value) -> None:
+        self.registry.write_text(json.dumps(value))
+        seed_skills.TOMBSTONES_FILE = self.registry
+
+    def test_tracked_registry_has_the_exact_reserved_namespace(self):
+        self.assertEqual(seed_skills.tombstoned_skill_names(), TOMBSTONES)
+
+    def test_registry_rejects_non_array_non_string_blank_malformed_and_duplicate(self):
+        bad_values = [
+            [],
+            {"sprint": True},
+            ["sprint", 7],
+            ["sprint", ""],
+            ["sprint", "Bad-Name"],
+            ["sprint", "sprint"],
+        ]
+        for value in bad_values:
+            with self.subTest(value=value):
+                self.write_registry(value)
+                with self.assertRaises((TypeError, ValueError)):
+                    seed_skills.tombstoned_skill_names()
+
+    def test_namespace_validation_rejects_active_overlap(self):
+        self.write_registry(["retired_name"])
+        with self.assertRaisesRegex(ValueError, "retired_name"):
+            seed_skills.validate_upstream_skill_namespace(
+                ["active_name", "retired_name"]
+            )
+        self.assertEqual(
+            seed_skills.validate_upstream_skill_namespace(["active_name"]),
+            ["retired_name"],
+        )
+
+
+class ReconciliationTest(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite3.connect(":memory:")
+        self.con.executescript(DDL)
+        for index, name in enumerate(TOMBSTONES, start=1):
+            self.con.execute(
+                "INSERT INTO skills (skill_id,name,description,content,common) "
+                "VALUES (?,?,?,?,?)",
+                (index, name, f"retired {index}", f"body {index}", index % 2),
+            )
+            self.con.execute(
+                "INSERT INTO shell_skills (shell_id,skill_id) VALUES (?,?)",
+                (100 + index, index),
+            )
+            self.con.execute(
+                "INSERT INTO flavor_skills (flavor,skill_id) VALUES (?,?)",
+                (f"flavor-{index}", index),
+            )
+        self.local_id = len(TOMBSTONES) + 1
+        self.local_row = (
+            self.local_id,
+            "fork_specialized_testing",
+            "local description",
+            "local category",
+            "local body byte-for-byte",
+            "local command",
+            0,
+            1,
+        )
+        self.con.execute(
+            "INSERT INTO skills (skill_id,name,description,category,content,command,"
+            "common,is_deleted) VALUES (?,?,?,?,?,?,?,?)",
+            self.local_row,
+        )
+        self.con.execute(
+            "INSERT INTO shell_skills (shell_id,skill_id) VALUES (999,?)",
+            (self.local_id,),
+        )
+        self.con.execute(
+            "INSERT INTO flavor_skills (flavor,skill_id) VALUES ('local',?)",
+            (self.local_id,),
+        )
+        self.con.commit()
+
+    def tearDown(self):
+        self.con.close()
+
+    def test_dirty_database_converges_twice_and_preserves_local_state_exactly(self):
+        first = seed_skills.reconcile_tombstoned_skills(self.con)
+        self.assertEqual(first.changed_names, tuple(sorted(TOMBSTONES)))
+        self.assertEqual(first.grant_count, 26)
+        self.assertEqual(
+            self.con.execute("SELECT * FROM skills").fetchall(), [self.local_row]
+        )
+        self.assertEqual(
+            self.con.execute("SELECT shell_id,skill_id FROM shell_skills").fetchall(),
+            [(999, self.local_id)],
+        )
+        self.assertEqual(
+            self.con.execute("SELECT flavor,skill_id FROM flavor_skills").fetchall(),
+            [("local", self.local_id)],
+        )
+
+        second = seed_skills.reconcile_tombstoned_skills(self.con)
+        self.assertEqual(second.changed_names, ())
+        self.assertEqual(second.grant_count, 0)
+        self.assertEqual(
+            self.con.execute("SELECT * FROM skills").fetchall(), [self.local_row]
+        )
+
+    def test_failure_rolls_back_grant_deletes(self):
+        self.con.execute(
+            "CREATE TRIGGER refuse_skill_delete BEFORE DELETE ON skills "
+            "BEGIN SELECT RAISE(ABORT, 'refuse'); END"
+        )
+        with self.assertRaisesRegex(sqlite3.IntegrityError, "refuse"):
+            seed_skills.reconcile_tombstoned_skills(self.con)
+        self.assertEqual(
+            self.con.execute("SELECT COUNT(*) FROM skills").fetchone()[0], 14
+        )
+        self.assertEqual(
+            self.con.execute("SELECT COUNT(*) FROM shell_skills").fetchone()[0], 14
+        )
+        self.assertEqual(
+            self.con.execute("SELECT COUNT(*) FROM flavor_skills").fetchone()[0], 14
+        )
+
+
+class ReservedAssetTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.saved = (seed_skills.TOMBSTONES_FILE, seed_skills.OUT)
+        tombstones = root / "skill_tombstones.json"
+        tombstones.write_text('["retired_name"]\n')
+        seed = root / "0001_seed_skills.sql"
+        seed.write_text(
+            "INSERT INTO skills (name) VALUES ('active_name') "
+            "ON CONFLICT(name) DO NOTHING;\n"
+        )
+        seed_skills.TOMBSTONES_FILE = tombstones
+        seed_skills.OUT = seed
+        self.con = sqlite3.connect(":memory:")
+        self.con.execute(
+            "CREATE TABLE skills (skill_id INTEGER PRIMARY KEY, name TEXT UNIQUE, "
+            "description TEXT, category TEXT, content TEXT, command TEXT, "
+            "common INTEGER DEFAULT 1, is_deleted INTEGER DEFAULT 0)"
+        )
+        self.con.execute(
+            "CREATE TABLE shells (shell_id INTEGER PRIMARY KEY, shortname TEXT, "
+            "display_name TEXT, flavor TEXT, api_key TEXT, is_deleted INTEGER DEFAULT 0)"
+        )
+        self.con.execute("INSERT INTO shells (shell_id,shortname) VALUES (1,'DEV1')")
+
+    def tearDown(self):
+        seed_skills.TOMBSTONES_FILE, seed_skills.OUT = self.saved
+        self.con.close()
+        self.tmp.cleanup()
+
+    def test_explicit_seed_refuses_new_fork_asset_claim_before_writing(self):
+        spec = {
+            "name": "retired_name",
+            "description": "must not land",
+            "category": None,
+            "command": None,
+            "common": 0,
+            "content": "must not land",
+        }
+        with self.assertRaisesRegex(ValueError, "retired_name"):
+            seed_skills.sync_engine_skills(self.con, specs=[spec])
+        self.assertEqual(self.con.execute("SELECT * FROM skills").fetchall(), [])
+
+    def test_legacy_tolerance_dies_when_regenerated_seed_drops_overlap(self):
+        seed_skills.TOMBSTONES_FILE.write_text('["engine_surgery"]\n')
+        seed_skills.OUT.write_text(
+            "INSERT INTO skills (name) VALUES ('engine_surgery') "
+            "ON CONFLICT(name) DO NOTHING;\n"
+        )
+        spec = {
+            "name": "engine_surgery",
+            "description": "legacy upstream asset",
+            "category": None,
+            "command": None,
+            "common": 0,
+            "content": "legacy upstream body",
+        }
+        self.assertEqual(
+            seed_skills.sync_engine_skills(self.con, specs=[spec]), ["engine_surgery"]
+        )
+        self.con.execute("DELETE FROM skills WHERE name='engine_surgery'")
+        self.con.commit()
+
+        seed_skills.OUT.write_text(
+            "INSERT INTO skills (name) VALUES ('active_name') "
+            "ON CONFLICT(name) DO NOTHING;\n"
+        )
+        with self.assertRaisesRegex(ValueError, "engine_surgery"):
+            seed_skills.sync_engine_skills(self.con, specs=[spec])
+        self.assertEqual(self.con.execute("SELECT * FROM skills").fetchall(), [])
+
+    def test_db_creation_path_refuses_reserved_name_before_writing(self):
+        body = seed_skills.TOMBSTONES_FILE.parent / "candidate.md"
+        body.write_text("candidate body\n")
+        with self.assertRaisesRegex(SystemExit, "permanently reserved"):
+            skill_mod.cmd_add(
+                self.con,
+                ["retired_name", "--file", str(body), "--for", "DEV1"],
+            )
+        self.assertEqual(self.con.execute("SELECT * FROM skills").fetchall(), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add the validated 13-name upstream skill tombstone registry
- add atomic grant-first DB reconciliation with changed-name/grant reporting
- reserve tombstoned names across explicit asset seeding and the existing DB creation path
- scope the ratified legacy overlap tolerance to the three names still present in generated 0001; seed regeneration automatically restores strict rejection

## Verification
- 1521 passed, 1 skipped via ./sc test
- 43 focused tests plus 6 subtests
- ./sc render-check
- ruff on new/changed tombstone surfaces
- git diff --check

## Judgement
PLN1 ratified staged enforcement because three tombstones remain active until Sprint 70 unit 4. The tolerance is the exact three-name allowlist intersected with registry and generated-seed membership; a direct negative test proves it dies when 0001 drops the overlap.

## Known gate deviation
./sc verify safely refuses linked worktrees and would target the shared live checkout. Existing issue #769 records the workflow conflict; no live state was touched.