### PR TITLE
fix: stabilize Sprint conversation idempotency

### DIFF
--- a/.super-coder/migrations/0155_sprint_conversation_generations.sql
+++ b/.super-coder/migrations/0155_sprint_conversation_generations.sql
@@ -1,0 +1,44 @@
+-- Give every Sprint incarnation a durable identity for generic-conversation
+-- idempotency.  Runtime Sprint rows are intentionally not snapshot content,
+-- while their closed browser conversations may be preserved.  Numeric
+-- sprint/participant ids can therefore be reused after rebuild and must not
+-- be the global conversation-creation identity.
+BEGIN;
+
+ALTER TABLE sprints
+ADD COLUMN conversation_generation TEXT NOT NULL DEFAULT ''
+    CHECK (
+      conversation_generation='' OR (
+        length(conversation_generation)=32
+        AND conversation_generation NOT GLOB '*[^0-9a-f]*'
+      )
+    );
+
+UPDATE sprints
+SET conversation_generation=lower(hex(randomblob(16)))
+WHERE conversation_generation='';
+
+CREATE UNIQUE INDEX idx_sprints_conversation_generation
+    ON sprints(conversation_generation)
+    WHERE conversation_generation<>'';
+
+-- ALTER TABLE cannot add a non-constant random default.  Populate the
+-- generation inside the inserting statement's transaction instead.
+CREATE TRIGGER trg_sprints_conversation_generation_fill
+AFTER INSERT ON sprints
+WHEN NEW.conversation_generation=''
+BEGIN
+  UPDATE sprints
+  SET conversation_generation=lower(hex(randomblob(16)))
+  WHERE sprint_id=NEW.sprint_id;
+END;
+
+CREATE TRIGGER trg_sprints_conversation_generation_immutable
+BEFORE UPDATE OF conversation_generation ON sprints
+WHEN OLD.conversation_generation<>''
+  AND NEW.conversation_generation<>OLD.conversation_generation
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint conversation generation is immutable');
+END;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_liveness.py
+++ b/.super-coder/scripts/sprint_liveness.py
@@ -507,15 +507,15 @@ class PlannerEscalationRouter:
         incident_source = primary.key or primary.provider or "unknown"
         incident = hashlib.sha256(incident_source.encode()).hexdigest()[:16]
         fallback_key = f"sprint:{sprint_id}:liveness:planner-fallback:{incident}"
-        existing = self.con.execute(
-            "SELECT c.conversation_id,c.harness "
-            "FROM sprint_participant_conversations link "
-            "JOIN conversations c ON c.conversation_id=link.conversation_id "
-            "WHERE link.sprint_participant_id=? AND link.purpose='fallback' "
-            "AND c.creation_idempotency_key=?",
-            (participant_id, fallback_key),
-        ).fetchone()
-        if existing is not None:
+        existing_id = sprint_participant_chats.linked_conversation_for_key(
+            self.con, participant_id, "fallback", fallback_key
+        )
+        if existing_id is not None:
+            existing = self.con.execute(
+                "SELECT conversation_id,harness FROM conversations "
+                "WHERE conversation_id=?",
+                (existing_id,),
+            ).fetchone()
             self.con.execute(
                 "UPDATE sprint_participants SET current_conversation_id=? "
                 "WHERE participant_id=?",

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -74,14 +74,77 @@ def _participant(con, participant_id: int):
     row = con.execute(
         "SELECT p.participant_id,p.sprint_id,p.shell_id,"
         "p.persistent_conversation_id,p.current_conversation_id,"
-        "s.shortname,s.flavor FROM sprint_participants p "
-        "JOIN shells s ON s.shell_id=p.shell_id "
+        "s.conversation_generation,sh.shortname,sh.flavor "
+        "FROM sprint_participants p "
+        "JOIN sprints s ON s.sprint_id=p.sprint_id "
+        "JOIN shells sh ON sh.shell_id=p.shell_id "
         "WHERE p.participant_id=?",
         (participant_id,),
     ).fetchone()
     if row is None:
         raise SprintConversationError("Sprint participant does not exist")
     return row
+
+
+def _scoped_idempotency_key(participant, purpose: str, operation_key: str) -> str:
+    generation = _nonblank(
+        participant["conversation_generation"],
+        "Sprint conversation generation",
+        maximum=32,
+    )
+    digest = hashlib.sha256(operation_key.encode()).hexdigest()
+    return (
+        f"sprint-generation:{generation}:participant:"
+        f"{participant['participant_id']}:{purpose}:{digest}"
+    )
+
+
+def _reroute_operation_key(operation_key: str, index: int) -> str:
+    if index == 0:
+        return operation_key
+    digest = hashlib.sha256(operation_key.encode()).hexdigest()
+    return f"reroute:{index}:{digest}"
+
+
+def conversation_idempotency_key(
+    con,
+    participant_id: int,
+    purpose: str,
+    operation_key: str,
+) -> str:
+    """Return the generation-stable global key for one participant operation."""
+    if purpose not in _PURPOSES:
+        raise SprintConversationError(f"unsupported conversation purpose: {purpose}")
+    operation_key = _nonblank(
+        operation_key, "idempotency_key", maximum=255
+    )
+    return _scoped_idempotency_key(
+        _participant(con, participant_id), purpose, operation_key
+    )
+
+
+def linked_conversation_for_key(
+    con,
+    participant_id: int,
+    purpose: str,
+    operation_key: str,
+) -> str | None:
+    """Find a new scoped key or one legacy raw key linked to this participant."""
+    operation_key = _nonblank(
+        operation_key, "idempotency_key", maximum=255
+    )
+    scoped_key = conversation_idempotency_key(
+        con, participant_id, purpose, operation_key
+    )
+    row = con.execute(
+        "SELECT c.conversation_id FROM sprint_participant_conversations link "
+        "JOIN conversations c ON c.conversation_id=link.conversation_id "
+        "WHERE link.sprint_participant_id=? AND link.purpose=? "
+        "AND c.creation_idempotency_key IN (?,?) "
+        "ORDER BY c.creation_idempotency_key=? DESC LIMIT 1",
+        (participant_id, purpose, scoped_key, operation_key, scoped_key),
+    ).fetchone()
+    return None if row is None else str(row["conversation_id"])
 
 
 def _linked_to_participant(con, participant_id: int, conversation_id: str) -> bool:
@@ -306,8 +369,11 @@ def create_and_select(
     harness = _nonblank(harness, "harness", maximum=64)
     worktree = _nonblank(worktree, "worktree", maximum=4096)
     title = _nonblank(title, "title", maximum=200)
-    idempotency_key = _nonblank(idempotency_key, "idempotency_key", maximum=255)
+    operation_key = _nonblank(idempotency_key, "idempotency_key", maximum=255)
     participant = _participant(con, participant_id)
+    idempotency_key = _scoped_idempotency_key(
+        participant, purpose, operation_key
+    )
 
     if parent_conversation_id and not _linked_to_participant(
         con, participant_id, parent_conversation_id
@@ -327,7 +393,10 @@ def create_and_select(
                 "WHERE conversation_id=?",
                 (existing_work["conversation_id"],),
             ).fetchone()
-            if existing["creation_idempotency_key"] != idempotency_key:
+            if existing["creation_idempotency_key"] not in {
+                idempotency_key,
+                operation_key,
+            }:
                 raise SprintConversationError(
                     "the participant already has a persistent work conversation"
                 )
@@ -353,6 +422,16 @@ def create_and_select(
         "WHERE owner_user_id=? AND creation_idempotency_key=?",
         (owner_user_id, idempotency_key),
     ).fetchone()
+    if existing is None:
+        legacy = con.execute(
+            "SELECT conversation_id,creation_request_hash FROM conversations "
+            "WHERE owner_user_id=? AND creation_idempotency_key=?",
+            (owner_user_id, operation_key),
+        ).fetchone()
+        if legacy is not None and _linked_to_participant(
+            con, participant_id, legacy["conversation_id"]
+        ):
+            existing = legacy
     if existing is not None:
         if existing["creation_request_hash"] != request_hash:
             raise SprintConversationError(
@@ -485,13 +564,33 @@ def ensure_wake_conversation(
             parent_id = str(candidate)
             break
     purpose = "fallback" if parent_id is not None else "work"
-    prior_routes = con.execute(
-        "SELECT conversation_id,state,creation_idempotency_key "
-        "FROM conversations WHERE owner_user_id=? "
-        "AND (creation_idempotency_key=? "
-        "OR creation_idempotency_key LIKE ?) ORDER BY rowid",
-        (row["user_id"], idempotency_key, f"{idempotency_key}:reroute:%"),
+    linked_routes = con.execute(
+        "SELECT c.conversation_id,c.state,c.creation_idempotency_key "
+        "FROM sprint_participant_conversations link "
+        "JOIN conversations c ON c.conversation_id=link.conversation_id "
+        "WHERE link.sprint_participant_id=? AND link.purpose=? "
+        "AND c.owner_user_id=? ORDER BY c.rowid",
+        (participant_id, purpose, row["user_id"]),
     ).fetchall()
+    routes_by_key = {
+        str(route["creation_idempotency_key"]): route for route in linked_routes
+    }
+    prior_routes = []
+    route_indices = []
+    for index in range(len(linked_routes) + 2):
+        operation_key = _reroute_operation_key(idempotency_key, index)
+        scoped_key = conversation_idempotency_key(
+            con, participant_id, purpose, operation_key
+        )
+        legacy_key = (
+            idempotency_key
+            if index == 0
+            else f"{idempotency_key}:reroute:{index}"
+        )
+        prior = routes_by_key.get(scoped_key) or routes_by_key.get(legacy_key)
+        if prior is not None:
+            prior_routes.append(prior)
+            route_indices.append(index)
     for prior in reversed(prior_routes):
         if (
             prior["state"] in _USABLE_WAKE_STATES
@@ -503,10 +602,9 @@ def ensure_wake_conversation(
                 (prior["conversation_id"], participant_id),
             )
             return WakeConversationRoute(str(prior["conversation_id"]), False)
-    route_key = (
-        idempotency_key
-        if not prior_routes
-        else f"{idempotency_key}:reroute:{len(prior_routes)}"
+    route_key = _reroute_operation_key(
+        idempotency_key,
+        0 if not route_indices else max(route_indices) + 1,
     )
     worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
     conversation_id = create_and_select(

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -167,7 +167,11 @@ class SprintReviewLoopStore:
                 raise SprintInvariantError("active review outcome has no wake")
             conversation_key = f"{idempotency_key}:conversation"
             if not receipt.created:
-                conversation_id = self._conversation_for_key(conversation_key)
+                conversation_id = self._conversation_for_key(
+                    int(lane["developer_participant_id"]),
+                    purpose,
+                    conversation_key,
+                )
                 outcome = self._outcome_receipt(
                     lane, conversation_id, receipt, disposition
                 )
@@ -420,15 +424,15 @@ class SprintReviewLoopStore:
         ).fetchone()
         return json.loads(row["payload"]).get("head_sha") if row is not None else None
 
-    def _conversation_for_key(self, key: str) -> str:
-        row = self.con.execute(
-            "SELECT conversation_id FROM conversations "
-            "WHERE creation_idempotency_key=?",
-            (key,),
-        ).fetchone()
-        if row is None:
+    def _conversation_for_key(
+        self, participant_id: int, purpose: str, key: str
+    ) -> str:
+        conversation_id = sprint_participant_chats.linked_conversation_for_key(
+            self.con, participant_id, purpose, key
+        )
+        if conversation_id is None:
             raise SprintInvariantError("review outcome replay lost its conversation")
-        return str(row["conversation_id"])
+        return conversation_id
 
     @staticmethod
     def _require_live_green(identity: sqlite3.Row, live: PullRequest) -> None:

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -10,6 +10,7 @@
     ".super-coder/migrations/0152_sprint_surface_completion.sql",
     ".super-coder/migrations/0153_harden_sprint_handoff_skills.sql",
     ".super-coder/migrations/0154_remove_tombstoned_skills.sql",
+    ".super-coder/migrations/0155_sprint_conversation_generations.sql",
     ".super-coder/assets/skills/sprint_prep/SKILL.md",
     ".super-coder/assets/skills/sprint_pln/SKILL.md",
     ".super-coder/assets/skills/sprint_dev/SKILL.md",

--- a/tests/test_sprint_participant_chats.py
+++ b/tests/test_sprint_participant_chats.py
@@ -40,6 +40,7 @@ def substrate():
           sprint_id INTEGER PRIMARY KEY,
           feature_id INTEGER NOT NULL REFERENCES roadmap(feature_id),
           originating_planner_shell_id INTEGER NOT NULL REFERENCES shells(shell_id),
+          conversation_generation TEXT NOT NULL,
           lifecycle TEXT NOT NULL,
           paused_at TEXT
         );
@@ -112,8 +113,9 @@ def substrate():
         INSERT INTO shells VALUES
           (10,'DEV1','dev',1),(20,'REV1','reviewer',1),(30,'PLN1','planner',1);
         INSERT INTO sprints
-          (sprint_id,feature_id,originating_planner_shell_id,lifecycle)
-          VALUES (7,31,30,'armed');
+          (sprint_id,feature_id,originating_planner_shell_id,
+           conversation_generation,lifecycle)
+          VALUES (7,31,30,'0123456789abcdef0123456789abcdef','armed');
         INSERT INTO sprint_specs VALUES (7,46,'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
         INSERT INTO sprint_participants
           (participant_id,sprint_id,shell_id,role,harness,model,effort,disposition)
@@ -220,6 +222,101 @@ def test_replay_is_idempotent_and_conflicting_reuse_changes_nothing() -> None:
             == work
         )
         assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 1
+
+
+def test_every_purpose_ignores_orphan_legacy_keys_and_replays_scoped_key() -> None:
+    operations = {
+        "work": "s7:p101:work",
+        "fix": "review:55:fix:conversation",
+        "merge": "review:56:merge:conversation",
+        "fallback": "s7:p101:fallback:quota-1",
+    }
+    with substrate() as con:
+        con.executemany(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,owner_user_id,harness,worktree,state,title,"
+            "creation_idempotency_key,creation_request_hash,conversation_scope) "
+            "VALUES (?,?,1,'codex','/historical','closed','Orphan',?,"
+            "'historical-request','sprint')",
+            (
+                (f"cv_orphan_{purpose}", 10, key)
+                for purpose, key in operations.items()
+            ),
+        )
+        work = create(con, 101, "work", operations["work"])
+        created = {"work": work}
+        for purpose in ("fix", "merge", "fallback"):
+            changes = {"parent_conversation_id": work}
+            if purpose == "fallback":
+                changes["context_packet"] = {"reason": "route exhausted"}
+            created[purpose] = create(
+                con, 101, purpose, operations[purpose], **changes
+            )
+            assert (
+                create(con, 101, purpose, operations[purpose], **changes)
+                == created[purpose]
+            )
+
+        assert len(set(created.values())) == 4
+        keys = {
+            row["purpose"]: row["creation_idempotency_key"]
+            for row in con.execute(
+                "SELECT link.purpose,c.creation_idempotency_key "
+                "FROM sprint_participant_conversations link "
+                "JOIN conversations c ON c.conversation_id=link.conversation_id"
+            )
+        }
+        for purpose, operation_key in operations.items():
+            assert keys[purpose] == sprint_participant_chats.conversation_idempotency_key(
+                con, 101, purpose, operation_key
+            )
+            assert keys[purpose] != operation_key
+            assert len(keys[purpose]) <= 255
+        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 8
+
+
+def test_wake_reroutes_use_bounded_scoped_keys_and_replay_latest_route() -> None:
+    with substrate() as con:
+        work = create(con, 101, "work", "s7:p101:work")
+        con.execute(
+            "UPDATE conversations SET state='closed' WHERE conversation_id=?",
+            (work,),
+        )
+        maximum_key = "k" * 255
+        first = sprint_participant_chats.ensure_wake_conversation(
+            con, 101, idempotency_key=maximum_key
+        )
+        assert first.created
+        con.execute(
+            "UPDATE conversations SET state='closed' WHERE conversation_id=?",
+            (first.conversation_id,),
+        )
+        second = sprint_participant_chats.ensure_wake_conversation(
+            con, 101, idempotency_key=maximum_key
+        )
+        assert second.created
+        assert second.conversation_id != first.conversation_id
+
+        replay = sprint_participant_chats.ensure_wake_conversation(
+            con, 101, idempotency_key=maximum_key
+        )
+        assert replay == sprint_participant_chats.WakeConversationRoute(
+            second.conversation_id, False
+        )
+        keys = [
+            row[0]
+            for row in con.execute(
+                "SELECT c.creation_idempotency_key "
+                "FROM sprint_participant_conversations link "
+                "JOIN conversations c ON c.conversation_id=link.conversation_id "
+                "WHERE link.sprint_participant_id=101 AND link.purpose='fallback' "
+                "ORDER BY link.participant_conversation_id"
+            )
+        ]
+        assert len(keys) == 2
+        assert len(set(keys)) == 2
+        assert all(key.startswith("sprint-generation:") for key in keys)
+        assert all(len(key) <= 255 for key in keys)
 
 
 def test_caller_transaction_rolls_back_every_row_when_pointer_selection_fails() -> None:

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -17,6 +17,7 @@ ENGINE = ROOT / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
 MIGRATIONS = ENGINE / "migrations"
 FOUNDATION = MIGRATIONS / "0146_sprint_v2_domain.sql"
+GENERATION_MIGRATION = MIGRATIONS / "0155_sprint_conversation_generations.sql"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver  # noqa: E402
@@ -112,6 +113,131 @@ class SprintDomainCase(unittest.TestCase):
 
 
 class MigrationAndShapeTest(SprintDomainCase):
+    def test_conversation_generation_backfills_prepared_plan_without_drift(self) -> None:
+        with closing(sqlite3.connect(":memory:")) as con:
+            con.row_factory = sqlite3.Row
+            apply_schema(con, through="0154_remove_tombstoned_skills.sql")
+            con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+            con.executemany(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (?,?,?,?,?,1)",
+                (
+                    (1, "Developer", "DEV1", "dev", "prompt"),
+                    (2, "Reviewer", "REV1", "reviewer", "prompt"),
+                    (3, "Planner", "PLN1", "planner", "prompt"),
+                ),
+            )
+            feature_id = con.execute(
+                "INSERT INTO roadmap (title,roadmap_status) "
+                "VALUES ('Prepared feature','in_progress')"
+            ).lastrowid
+            body = "exact prepared governing revision"
+            document_id = con.execute(
+                "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                "VALUES (?,'spec',1,'Prepared spec',?)",
+                (feature_id, body),
+            ).lastrowid
+            revision = hashlib.sha256(body.encode()).hexdigest()
+            approval_id = con.execute(
+                "INSERT INTO sprint_spec_approvals "
+                "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+                "VALUES (?,?,2,'pass')",
+                (document_id, revision),
+            ).lastrowid
+            sprint_id = con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+            con.execute(
+                "INSERT INTO sprint_specs "
+                "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+                "VALUES (?,?,?,?)",
+                (sprint_id, document_id, revision, approval_id),
+            )
+            con.executemany(
+                "INSERT INTO sprint_participants "
+                "(sprint_id,shell_id,role,harness,model,effort) "
+                "VALUES (?,?,?,?,?,?)",
+                (
+                    (sprint_id, 3, "planner", "codex", "planner-model", "high"),
+                    (sprint_id, 1, "developer", "kimi", "dev-model", "high"),
+                    (sprint_id, 2, "reviewer", "claude", "review-model", "high"),
+                ),
+            )
+            con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,expected_output) "
+                "VALUES (?,1,2,'Tiny unit','One small verified change')",
+                (sprint_id,),
+            )
+            before = {
+                "sprint": tuple(
+                    con.execute(
+                        "SELECT sprint_id,feature_id,originating_planner_shell_id,"
+                        "lifecycle,merge_grant_enabled FROM sprints"
+                    ).fetchone()
+                ),
+                "spec": tuple(con.execute("SELECT * FROM sprint_specs").fetchone()),
+                "participants": [
+                    tuple(row)
+                    for row in con.execute(
+                        "SELECT participant_id,sprint_id,shell_id,role,harness,"
+                        "model,effort,persistent_conversation_id,current_conversation_id "
+                        "FROM sprint_participants ORDER BY participant_id"
+                    )
+                ],
+                "unit": tuple(
+                    con.execute(
+                        "SELECT work_unit_id,sprint_id,assigned_shell_id,"
+                        "reviewer_shell_id,title,expected_output,disposition "
+                        "FROM sprint_work_units"
+                    ).fetchone()
+                ),
+            }
+
+            con.executescript(GENERATION_MIGRATION.read_text())
+
+            generation = con.execute(
+                "SELECT conversation_generation FROM sprints WHERE sprint_id=?",
+                (sprint_id,),
+            ).fetchone()[0]
+            self.assertRegex(generation, r"^[0-9a-f]{32}$")
+            after = {
+                "sprint": tuple(
+                    con.execute(
+                        "SELECT sprint_id,feature_id,originating_planner_shell_id,"
+                        "lifecycle,merge_grant_enabled FROM sprints"
+                    ).fetchone()
+                ),
+                "spec": tuple(con.execute("SELECT * FROM sprint_specs").fetchone()),
+                "participants": [
+                    tuple(row)
+                    for row in con.execute(
+                        "SELECT participant_id,sprint_id,shell_id,role,harness,"
+                        "model,effort,persistent_conversation_id,current_conversation_id "
+                        "FROM sprint_participants ORDER BY participant_id"
+                    )
+                ],
+                "unit": tuple(
+                    con.execute(
+                        "SELECT work_unit_id,sprint_id,assigned_shell_id,"
+                        "reviewer_shell_id,title,expected_output,disposition "
+                        "FROM sprint_work_units"
+                    ).fetchone()
+                ),
+            }
+            self.assertEqual(before, after)
+            with self.assertRaisesRegex(
+                sqlite3.IntegrityError, "conversation generation is immutable"
+            ):
+                con.execute(
+                    "UPDATE sprints SET conversation_generation=? WHERE sprint_id=?",
+                    ("f" * 32, sprint_id),
+                )
+
     def test_upgrade_from_zero_sprint_baseline_creates_v2_domain(self) -> None:
         with closing(sqlite3.connect(":memory:")) as con:
             apply_schema(con, through="0145_reseed_generic_guidance.sql")
@@ -424,6 +550,68 @@ class LifecycleTest(SprintDomainCase):
                     (sprint_id,),
                 )
             ],
+        )
+
+    def test_arm_ignores_orphan_conversation_keys_from_reused_numeric_ids(self) -> None:
+        historical = (
+            ("cv_old_planner", 3, "sprint:1:participant:1:work"),
+            ("cv_old_developer", 1, "sprint:1:participant:2:work"),
+            ("cv_old_reviewer", 2, "sprint:1:participant:3:work"),
+        )
+        self.con.executemany(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,owner_user_id,harness,worktree,state,"
+            "closed_at,title,creation_idempotency_key,creation_request_hash,"
+            "conversation_scope) "
+            "VALUES (?,?,1,'codex','/historical','closed',datetime('now'),"
+            "'Closed historical Sprint',?,'historical-request','sprint')",
+            historical,
+        )
+        self.con.commit()
+
+        sprint_id, _ = self.create_sprint()
+        participants = self.con.execute(
+            "SELECT participant_id FROM sprint_participants "
+            "WHERE sprint_id=? ORDER BY participant_id",
+            (sprint_id,),
+        ).fetchall()
+        self.assertEqual(1, sprint_id)
+        self.assertEqual([1, 2, 3], [row[0] for row in participants])
+
+        wake_ids = self.store.arm(sprint_id, 3)
+
+        self.assertEqual(1, len(wake_ids))
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()[0],
+        )
+        linked = self.con.execute(
+            "SELECT c.conversation_id,c.creation_idempotency_key "
+            "FROM sprint_participant_conversations link "
+            "JOIN conversations c ON c.conversation_id=link.conversation_id "
+            "ORDER BY link.sprint_participant_id"
+        ).fetchall()
+        self.assertEqual(3, len(linked))
+        self.assertTrue(
+            all(
+                row["conversation_id"] not in {item[0] for item in historical}
+                and row["creation_idempotency_key"].startswith(
+                    "sprint-generation:"
+                )
+                and len(row["creation_idempotency_key"]) <= 255
+                for row in linked
+            )
+        )
+        first_ids = [row["conversation_id"] for row in linked]
+        replay_ids = sprint_domain.sprint_participant_chats.provision_at_arming(
+            self.con, sprint_id
+        )
+        self.assertEqual(first_ids, replay_ids)
+        self.assertEqual(
+            6,
+            self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0],
         )
 
     def test_armed_sprint_merge_grant_is_immutable(self) -> None:


### PR DESCRIPTION
Closes #914.\n\nAdds an immutable random conversation generation to each Sprint and centrally scopes every participant conversation key (work, fix, merge, fallback, and wake reroute) by generation, participant, purpose, and a bounded operation-key digest. Existing linked legacy keys remain replayable, while orphan or differently linked history cannot capture a new Sprint after numeric ID reuse.\n\nRegression coverage reproduces the dos-app rebuild shape with closed historical conversations, absent Sprint rows, reused numeric IDs, successful atomic arm, and same-Sprint replay. It also verifies prepared-plan migration backfill without spec/participant/unit drift, all conversation purposes, bounded maximum-length reroutes, review replay, and liveness fallback.\n\nChecks: 294 Sprint/API tests + 140 subtests passed; 44 migration/schema/removal tests + 192 subtests passed; focused ruff and compileall passed; sc map, sc render-check, and git diff --check passed. sc verify cannot run from the required linked worktree (#769).