### PR TITLE
feat: reconcile managed skill projections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,11 @@
 
 # Per-shell skill renders — rebuilt at boot for whichever shell launches
 # (harness-consumed caches, like the boot artifact). `.claude/skills` is the
-# stable mirror; `.agents/skills` is Codex-native. Only render output is ignored;
-# a fork's other .claude/.agents configuration stays tracked.
+# stable mirror; `.agents/skills` is Codex-native and `.opencode/skills` is
+# OpenCode-native. Only render output is ignored; other harness config stays tracked.
 /.claude/skills/
 /.agents/skills/
+/.opencode/skills/
 
 # Engine-managed harness config, re-emitted each launch (the branch-guard hook
 # per harness). Kept separate from the fork's own tracked config: claude's

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -74,6 +74,7 @@ import sprint_recovery  # noqa: E402  (Sprints v2 pause/resume reconciliation)
 import sprint_review_loop  # noqa: E402  (Sprints v2 Dev/Review command surface)
 import sprint_runtime  # noqa: E402  (armed-only Sprint dispatch + wake delivery)
 import sprint_board  # noqa: E402  (read-only Sprints v2 FnB board projections)
+import skill_projection  # noqa: E402  (exact bounded grant mirrors)
 sys.path.insert(0, str(ENGINE / "api"))
 import conversation_routes  # noqa: E402  (Feature #24 browser conversations)
 import review_routes  # noqa: E402  (Feature #26 browser Diff review)
@@ -3965,12 +3966,35 @@ class Handler(BaseHTTPRequestHandler):
                 ok, err = set_flavor_grant(
                     con, parts[2], int(parts[4]),
                     bool(self._body().get("granted")))
+                if ok:
+                    try:
+                        skill_projection.reconcile_flavors(con, [parts[2]])
+                    except skill_projection.ProjectionError as exc:
+                        error = skill_projection.partial_failure_message(
+                            f"flavor {parts[2]} skill toggle", exc
+                        )
+                        return self._send(500, {
+                            "ok": False, "committed": True, "error": error,
+                        })
                 return self._send(200 if ok else 404,
                                   {"ok": ok, "error": err})
             if len(parts) == 5 and parts[1] == "shells" and parts[3] == "skills":
+                shell_id = int(parts[2])
                 ok, err = set_grant(
-                    con, int(parts[2]), int(parts[4]),
+                    con, shell_id, int(parts[4]),
                     bool(self._body().get("granted")))
+                if ok:
+                    try:
+                        skill_projection.reconcile_assignment_targets(
+                            con, [shell_id]
+                        )
+                    except skill_projection.ProjectionError as exc:
+                        error = skill_projection.partial_failure_message(
+                            f"shell {shell_id} skill toggle", exc
+                        )
+                        return self._send(500, {
+                            "ok": False, "committed": True, "error": error,
+                        })
                 status = 200 if ok else (
                     409 if err and "edit the flavor pack" in err else 404)
                 return self._send(status, {"ok": ok, "error": err})

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -35,6 +35,7 @@ ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
 sys.path.insert(0, str(ENGINE / "scripts"))
 import artifact_policy  # noqa: E402
+import skill_projection  # noqa: E402
 
 # The do-not-edit banner (spec §Content & Render). No timestamp — render must be
 # deterministic so unchanged DB → unchanged file → clean diff.
@@ -268,39 +269,10 @@ def render_skill_md(con: sqlite3.Connection, shell_id: int,
 
     work_dir overrides the write root (used for dev-shell worktrees).
     skills_dir is relative to that root."""
-    rows = con.execute(
-        "SELECT s.name, s.description, s.content FROM skills s "
-        "JOIN resolved_shell_skills ss ON ss.skill_id = s.skill_id "
-        "WHERE ss.shell_id=? AND s.is_deleted=0 ORDER BY s.name",
-        (shell_id,),
-    ).fetchall()
-    skills_root = (work_dir or REPO_ROOT) / (
-        skills_dir or Path(".claude/skills")
+    return skill_projection.reconcile_root(
+        con,
+        shell_id,
+        work_dir or REPO_ROOT,
+        skills_dir or Path(".claude/skills"),
+        create=True,
     )
-    written: list[Path] = []
-    skipped: list[Path] = []
-    current = {_skill_slug(r["name"]) for r in rows}
-
-    # Prune folders that no longer correspond to a current grant.
-    if skills_root.exists():
-        for child in skills_root.iterdir():
-            if child.is_dir() and child.name not in current:
-                for f in child.rglob("*"):
-                    if f.is_file():
-                        f.unlink()
-                child.rmdir()
-
-    for r in rows:
-        desc = (r["description"] or "").strip().replace("\n", " ")
-        body = "\n".join([
-            "---", f"name: {r['name']}", f"description: {desc}", "---", "",
-            (r["content"] or "").strip(), "",
-        ])
-        path = skills_root / _skill_slug(r["name"]) / "SKILL.md"
-        if path.exists() and path.read_text() == body:
-            skipped.append(path)
-            continue
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(body)
-        written.append(path)
-    return {"written": written, "skipped": skipped}

--- a/.super-coder/scripts/feature.py
+++ b/.super-coder/scripts/feature.py
@@ -48,6 +48,7 @@ PY = sys.executable
 sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver  # noqa: E402
 import artifact_policy  # noqa: E402
+import skill_projection  # noqa: E402
 
 # The registry. `block` is the instance.json key (None = procedure-only, no
 # infrastructure half); `block_auto` says whether enable may create it (only
@@ -216,6 +217,15 @@ def cmd_enable(name: str) -> int:
             note = f"  (no live {'/'.join(missing)} shell yet — create one and re-run)" if missing else ""
             print(f"  skill {skill} → {state}{note}")
         con.commit()
+        try:
+            skill_projection.reconcile_flavors(
+                con,
+                (flavor for flavors in f["grants"].values() for flavor in flavors),
+            )
+        except skill_projection.ProjectionError as exc:
+            sys.exit(skill_projection.partial_failure_message(
+                f"feature enable {name}", exc
+            ))
     finally:
         con.close()
 
@@ -257,6 +267,15 @@ def cmd_disable(name: str) -> int:
                 print(f"  skill {skill}: revoked {n} grant(s) "
                       f"(flavors: {', '.join(flavors)}; other shells untouched)")
             con.commit()
+            try:
+                skill_projection.reconcile_flavors(
+                    con,
+                    (flavor for flavors in f["grants"].values() for flavor in flavors),
+                )
+            except skill_projection.ProjectionError as exc:
+                sys.exit(skill_projection.partial_failure_message(
+                    f"feature disable {name}", exc
+                ))
         finally:
             con.close()
         if revoked:

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -142,6 +142,7 @@ GENERATED_INSTALL_PATHS = (
     Path(".codex/hooks.json"),
     Path(".claude/skills"),
     Path(".agents/skills"),
+    Path(".opencode/skills"),
     Path("roadmap_sc.md"),
     Path("docs_sc"),
     Path("specs_sc"),
@@ -546,6 +547,7 @@ _GITIGNORE_BLOCK = f"""
 /opencode.json
 /.claude/skills/
 /.agents/skills/
+/.opencode/skills/
 # Engine-managed harness config re-emitted each launch (per-harness branch-guard
 # hook); kept apart from a fork's own tracked config (claude settings.json /
 # codex config.toml).

--- a/.super-coder/scripts/render.py
+++ b/.super-coder/scripts/render.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 import artifact_policy  # noqa: E402
 import db_driver  # noqa: E402
 import flat  # noqa: E402
+import skill_projection  # noqa: E402
 from _serialize_guard import require_admin  # noqa: E402
 from seed_skills import sync_engine_skills  # noqa: E402
 
@@ -33,14 +34,15 @@ def _open():
     return db_driver.connect(DB_PATH)
 
 
-def _resolve_shell(con, shortname: str) -> int:
+def _resolve_shell(con, shortname: str):
     row = con.execute(
-        "SELECT shell_id FROM shells WHERE shortname=? AND COALESCE(is_deleted,0)=0",
+        "SELECT shell_id, shortname, flavor FROM shells "
+        "WHERE shortname=? AND COALESCE(is_deleted,0)=0",
         (shortname,),
     ).fetchone()
     if row is None:
         sys.exit(f"render: no shell '{shortname}'")
-    return row["shell_id"]
+    return row
 
 
 def _heal_fresh(con) -> None:
@@ -84,8 +86,22 @@ def main(argv: list[str]) -> int:
                 _heal_fresh(con)
                 artifact_policy.prepare_local_state()
                 _report("flat", flat.render_visibility(con))
-            shell_id = _resolve_shell(con, argv[1])
-            _report(f"skills[{argv[1]}]", flat.render_skill_md(con, shell_id))
+            shell = _resolve_shell(con, argv[1])
+            checkout = skill_projection.shell_checkout(
+                shell["shortname"], shell["flavor"]
+            )
+            if not checkout.is_dir():
+                sys.exit(
+                    f"render: shell checkout {checkout} does not exist — launch "
+                    f"{shell['shortname']} once before rendering its skills"
+                )
+            summary = skill_projection.reconcile_shell(
+                con,
+                shell["shell_id"],
+                checkout,
+                ensure_dirs=skill_projection.managed_skill_dirs(),
+            )
+            _report(f"skills[{argv[1]}]", summary)
         else:
             sys.exit(f"render: unknown mode '{mode}' (flat | skills <shell> | all <shell>)")
     finally:

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -60,6 +60,7 @@ import ports as ports_mod  # noqa: E402  — derive the per-fork API base URL
 import style  # noqa: E402  — launcher ANSI; degrades to plain text off-TTY
 import seed_skills  # noqa: E402  — boot-time self-heal of stale engine skills
 import shell_liveness  # noqa: E402  — headless boot's one-shell-one-session guard
+import skill_projection  # noqa: E402  — exact bounded harness skill mirrors
 
 sys.path.insert(0, str(ENGINE / "api"))
 import model_catalog  # noqa: E402  — HARNESS_PROVIDER: one source for harness → provider
@@ -173,24 +174,14 @@ def render_harness_skills(con: sqlite3.Connection, shell_id: int,
     selected harness. Adapters default to the Claude-compatible path and may
     add a native path where compatibility discovery is incomplete."""
     skill_dirs = adapter.get("skill_dirs") or [".claude/skills"]
-    written: list[Path] = []
-    skipped: list[Path] = []
-    for raw_dir in skill_dirs:
-        skills_dir = Path(raw_dir)
-        if skills_dir.is_absolute() or ".." in skills_dir.parts:
-            raise LaunchError(
-                f"adapter skill_dirs entry must stay inside the worktree: {raw_dir}"
-            )
-        summary = flat.render_skill_md(
-            con, shell_id, work_dir, skills_dir=skills_dir
+    try:
+        summary = skill_projection.reconcile_shell(
+            con, shell_id, work_dir, ensure_dirs=skill_dirs
         )
-        written.extend(summary["written"])
-        skipped.extend(summary["skipped"])
-    return {
-        "written": written,
-        "skipped": skipped,
-        "dirs": list(skill_dirs),
-    }
+    except skill_projection.ProjectionError as exc:
+        raise LaunchError(str(exc)) from exc
+    summary["dirs"] = list(skill_dirs)
+    return summary
 
 
 def resolve_opencode_plugins(work_dir: Path) -> None:
@@ -1532,7 +1523,8 @@ def main() -> None:
     print(f"→ wrote {work_dir / 'AGENTS.md'}")
     if headless and api_port and full["api_key"]:
         print(f"→ api: http://127.0.0.1:{api_port} (SC_API_TOKEN set)")
-    print(f"→ skills: {len(skills['written'])} written, "
+    print(f"→ skills: {len(skills['written'])} changed "
+          f"({len(skills['deleted'])} deleted), "
           f"{len(skills['skipped'])} unchanged → "
           f"{', '.join(skills['dirs'])}")
 

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -42,6 +42,7 @@ import db_driver  # noqa: E402
 import artifact_policy  # noqa: E402
 import mem  # noqa: E402
 import seed_skills  # noqa: E402 — seeded_skill_names is the engine/local line
+import skill_projection  # noqa: E402
 
 ENGINE = Path(__file__).resolve().parents[1]
 DB_PATH = ENGINE / "shell_db.db"
@@ -152,6 +153,20 @@ def persist_note() -> None:
     print(f"→ persist: ./sc snapshot   (serializes to {target}{suffix})")
 
 
+def _reconcile_targets(con, shell_ids: list[int], action: str) -> None:
+    try:
+        skill_projection.reconcile_assignment_targets(con, shell_ids)
+    except skill_projection.ProjectionError as exc:
+        sys.exit(skill_projection.partial_failure_message(action, exc))
+
+
+def _reconcile_all(con, action: str) -> None:
+    try:
+        skill_projection.reconcile_existing_checkouts(con)
+    except skill_projection.ProjectionError as exc:
+        sys.exit(skill_projection.partial_failure_message(action, exc))
+
+
 def print_catalogue(rows: list[dict]) -> int:
     engine = set(seed_skills.seeded_skill_names())
     retired = set(seed_skills.retired_skill_names())
@@ -186,24 +201,30 @@ def cmd_list_api() -> int:
 
 def cmd_grant(con, name: str, shell_refs: list[str]) -> int:
     skill_id = resolve_skill(con, name)
+    targets: list[int] = []
     for ref in shell_refs:
         shell_id, label = resolve_shell(con, ref)
+        targets.append(shell_id)
         changed, scope = set_target_grant(con, shell_id, label, skill_id, True)
         print(f"grant: {name} → {scope}"
               + ("" if changed else "  (already granted)"))
     con.commit()
+    _reconcile_targets(con, targets, f"grant {name}")
     persist_note()
     return 0
 
 
 def cmd_revoke(con, name: str, shell_refs: list[str]) -> int:
     skill_id = resolve_skill(con, name)
+    targets: list[int] = []
     for ref in shell_refs:
         shell_id, label = resolve_shell(con, ref)
+        targets.append(shell_id)
         changed, scope = set_target_grant(con, shell_id, label, skill_id, False)
         print(f"revoke: {name} ⇸ {scope}"
               + ("" if changed else "  (was not granted)"))
     con.commit()
+    _reconcile_targets(con, targets, f"revoke {name}")
     persist_note()
     return 0
 
@@ -235,6 +256,7 @@ def cmd_retire(con, name: str) -> int:
     if not already:
         _write_retire_list(names + [name])
     seed_skills.apply_retired(con)
+    _reconcile_all(con, f"retire {name}")
     dormant = grant_count(
         con, con.execute(
             "SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0])
@@ -254,6 +276,7 @@ def cmd_unretire(con, name: str) -> int:
                  f"({seed_skills.RETIRED_FILE}).")
     _write_retire_list([n for n in names if n != name])
     seed_skills.apply_retired(con)
+    _reconcile_all(con, f"unretire {name}")
     grants = grant_count(
         con, con.execute(
             "SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0])
@@ -275,6 +298,7 @@ def cmd_rm(con, name: str) -> int:
     n += con.execute("DELETE FROM shell_skills WHERE skill_id=?", (skill_id,)).rowcount
     con.execute("UPDATE skills SET is_deleted=1 WHERE skill_id=?", (skill_id,))
     con.commit()
+    _reconcile_all(con, f"rm {name}")
     print(f"rm: {name} soft-deleted, {n} grant(s) revoked.")
     asset = ENGINE / "assets" / "skills" / name
     if asset.exists():

--- a/.super-coder/scripts/skill_projection.py
+++ b/.super-coder/scripts/skill_projection.py
@@ -1,0 +1,358 @@
+"""Converge DB skill grants into bounded, engine-managed filesystem mirrors."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from collections.abc import Iterable
+from pathlib import Path
+
+import artifact_policy
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+ADAPTERS = ENGINE / "adapters"
+DEFAULT_SKILL_DIR = Path(".claude/skills")
+LEGACY_SKILLS_DIR = Path("skills_sc")
+RENDER_BANNER = "rendered_by: super-coder"
+
+
+class ProjectionError(RuntimeError):
+    """A managed projection cannot be reconciled without leaving its checkout."""
+
+
+def _validated_relative(raw: object) -> Path:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ProjectionError(
+            f"adapter skill_dirs entry must be a non-empty string: {raw!r}"
+        )
+    path = Path(raw)
+    if path.is_absolute() or ".." in path.parts or path == Path("."):
+        raise ProjectionError(
+            f"adapter skill_dirs entry must stay inside the checkout: {raw}"
+        )
+    return path
+
+
+def managed_skill_dirs(adapters: Path = ADAPTERS) -> tuple[Path, ...]:
+    """Return the validated union of every engine-managed harness skill root."""
+    roots = {DEFAULT_SKILL_DIR}
+    for config_path in sorted(adapters.glob("*/adapter.json")):
+        try:
+            config = json.loads(config_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ProjectionError(f"cannot read adapter {config_path}: {exc}") from exc
+        for raw in config.get("skill_dirs") or ():
+            roots.add(_validated_relative(raw))
+    return tuple(sorted(roots, key=lambda path: (path != DEFAULT_SKILL_DIR, str(path))))
+
+
+def _bounded_root(checkout: Path, relative: Path) -> Path:
+    relative = _validated_relative(str(relative))
+    checkout_root = checkout.resolve()
+    root = checkout / relative
+    if root.is_symlink():
+        raise ProjectionError(f"managed skill root is a symlink: {root}")
+    resolved = root.resolve(strict=False)
+    if not resolved.is_relative_to(checkout_root):
+        raise ProjectionError(f"managed skill root escapes checkout {checkout}: {root}")
+    if root.exists() and not root.is_dir():
+        raise ProjectionError(f"managed skill root is not a directory: {root}")
+    return root
+
+
+def _skill_rows(con, shell_id: int | None) -> list:
+    if shell_id is None:
+        return []
+    return con.execute(
+        "SELECT s.name, s.description, s.content FROM skills s "
+        "JOIN resolved_shell_skills ss ON ss.skill_id=s.skill_id "
+        "WHERE ss.shell_id=? AND s.is_deleted=0 ORDER BY s.name",
+        (shell_id,),
+    ).fetchall()
+
+
+def _skill_body(row) -> str:
+    description = (row["description"] or "").strip().replace("\n", " ")
+    return "\n".join(
+        [
+            "---",
+            f"name: {row['name']}",
+            f"description: {description}",
+            "---",
+            "",
+            (row["content"] or "").strip(),
+            "",
+        ]
+    )
+
+
+def _remove_tree(path: Path) -> None:
+    if path.is_symlink():
+        path.unlink()
+        return
+    shutil.rmtree(path)
+
+
+def reconcile_root(
+    con, shell_id: int | None, checkout: Path, relative: Path, *, create: bool
+) -> dict:
+    """Render one exact managed root without following filesystem symlinks."""
+    root = _bounded_root(checkout, relative)
+    if not root.exists() and not create:
+        return {"written": [], "skipped": [], "deleted": []}
+
+    rows = _skill_rows(con, shell_id)
+    if shell_id is None:
+        current = {
+            row[0].strip().lower().replace(" ", "-")
+            for row in con.execute(
+                "SELECT name FROM skills WHERE is_deleted=0 ORDER BY name"
+            )
+        }
+    else:
+        current = {row["name"].strip().lower().replace(" ", "-") for row in rows}
+    written: list[Path] = []
+    skipped: list[Path] = []
+    deleted: list[Path] = []
+
+    if root.exists():
+        for child in root.iterdir():
+            if child.name in current:
+                if child.is_symlink():
+                    raise ProjectionError(
+                        f"granted skill directory is a symlink: {child}"
+                    )
+                continue
+            if child.is_dir() or child.is_symlink():
+                _remove_tree(child)
+                written.append(child)
+                deleted.append(child)
+
+    for row in rows:
+        slug = row["name"].strip().lower().replace(" ", "-")
+        directory = root / slug
+        if directory.is_symlink():
+            raise ProjectionError(f"granted skill directory is a symlink: {directory}")
+        path = directory / "SKILL.md"
+        body = _skill_body(row)
+        if path.exists() and path.read_text() == body:
+            skipped.append(path)
+            continue
+        artifact_policy.atomic_write_text(path, body)
+        written.append(path)
+    return {"written": written, "skipped": skipped, "deleted": deleted}
+
+
+def reconcile_shell(
+    con, shell_id: int | None, checkout: Path, *, ensure_dirs: Iterable[Path | str] = ()
+) -> dict:
+    """Converge all existing managed roots, creating only explicitly used roots."""
+    managed = managed_skill_dirs()
+    ensured = {_validated_relative(str(path)) for path in ensure_dirs}
+    unknown = ensured - set(managed)
+    if unknown:
+        raise ProjectionError(
+            "requested skill root is not declared by an adapter: "
+            + ", ".join(str(path) for path in sorted(unknown, key=str))
+        )
+
+    written: list[Path] = []
+    skipped: list[Path] = []
+    deleted: list[Path] = []
+    visited: list[str] = []
+    for relative in managed:
+        candidate = checkout / relative
+        if (
+            relative not in ensured
+            and not candidate.exists()
+            and not candidate.is_symlink()
+        ):
+            continue
+        summary = reconcile_root(
+            con, shell_id, checkout, relative, create=relative in ensured
+        )
+        written.extend(summary["written"])
+        skipped.extend(summary["skipped"])
+        deleted.extend(summary["deleted"])
+        visited.append(str(relative))
+    return {
+        "written": written,
+        "skipped": skipped,
+        "deleted": deleted,
+        "dirs": visited,
+    }
+
+
+def shell_checkout(
+    shortname: str | None, flavor: str | None, repo_root: Path = REPO_ROOT
+) -> Path:
+    if shortname and flavor != "admin":
+        return repo_root / ".sc-worktrees" / shortname.lower()
+    return repo_root
+
+
+def reconcile_shell_ids(
+    con, shell_ids: Iterable[int], *, repo_root: Path = REPO_ROOT
+) -> dict:
+    ids = sorted({int(shell_id) for shell_id in shell_ids})
+    if not ids:
+        return {"written": [], "skipped": [], "deleted": [], "checkouts": []}
+    marks = ",".join("?" for _ in ids)
+    rows = con.execute(
+        f"SELECT shell_id, shortname, flavor FROM shells WHERE shell_id IN ({marks}) "
+        "AND COALESCE(is_deleted,0)=0 ORDER BY shell_id",
+        tuple(ids),
+    ).fetchall()
+    return _reconcile_shell_rows(con, rows, repo_root=repo_root)
+
+
+def reconcile_flavors(
+    con, flavors: Iterable[str], *, repo_root: Path = REPO_ROOT
+) -> dict:
+    names = sorted(set(flavors))
+    if not names:
+        return {"written": [], "skipped": [], "deleted": [], "checkouts": []}
+    marks = ",".join("?" for _ in names)
+    rows = con.execute(
+        f"SELECT shell_id, shortname, flavor FROM shells WHERE flavor IN ({marks}) "
+        "AND COALESCE(is_deleted,0)=0 ORDER BY shell_id",
+        tuple(names),
+    ).fetchall()
+    return _reconcile_shell_rows(con, rows, repo_root=repo_root)
+
+
+def reconcile_assignment_targets(
+    con, shell_ids: Iterable[int], *, repo_root: Path = REPO_ROOT
+) -> dict:
+    """Reconcile a Bespoke target or every live sibling in a target's flavor."""
+    ids = sorted({int(shell_id) for shell_id in shell_ids})
+    if not ids:
+        return {"written": [], "skipped": [], "deleted": [], "checkouts": []}
+    marks = ",".join("?" for _ in ids)
+    targets = con.execute(
+        f"SELECT shell_id, flavor FROM shells WHERE shell_id IN ({marks}) "
+        "AND COALESCE(is_deleted,0)=0",
+        tuple(ids),
+    ).fetchall()
+    bespoke = [row["shell_id"] for row in targets if row["flavor"] is None]
+    flavors = [row["flavor"] for row in targets if row["flavor"] is not None]
+    rows = []
+    if bespoke:
+        bespoke_marks = ",".join("?" for _ in bespoke)
+        rows.extend(
+            con.execute(
+                f"SELECT shell_id, shortname, flavor FROM shells "
+                f"WHERE shell_id IN ({bespoke_marks}) AND COALESCE(is_deleted,0)=0",
+                tuple(bespoke),
+            ).fetchall()
+        )
+    if flavors:
+        flavor_marks = ",".join("?" for _ in set(flavors))
+        rows.extend(
+            con.execute(
+                f"SELECT shell_id, shortname, flavor FROM shells "
+                f"WHERE flavor IN ({flavor_marks}) AND COALESCE(is_deleted,0)=0",
+                tuple(sorted(set(flavors))),
+            ).fetchall()
+        )
+    return _reconcile_shell_rows(con, rows, repo_root=repo_root)
+
+
+def _reconcile_shell_rows(con, rows, *, repo_root: Path) -> dict:
+    written: list[Path] = []
+    skipped: list[Path] = []
+    deleted: list[Path] = []
+    checkouts: list[Path] = []
+    seen: set[Path] = set()
+    for row in rows:
+        checkout = shell_checkout(row["shortname"], row["flavor"], repo_root)
+        if checkout in seen or not checkout.is_dir():
+            continue
+        seen.add(checkout)
+        summary = reconcile_shell(con, row["shell_id"], checkout)
+        written.extend(summary["written"])
+        skipped.extend(summary["skipped"])
+        deleted.extend(summary["deleted"])
+        checkouts.append(checkout)
+    return {
+        "written": written,
+        "skipped": skipped,
+        "deleted": deleted,
+        "checkouts": checkouts,
+    }
+
+
+def cleanup_legacy_skills_sc(checkout: Path) -> list[Path]:
+    """Remove only banner-owned legacy files; preserve mixed foreign content."""
+    root = checkout / LEGACY_SKILLS_DIR
+    if root.is_symlink():
+        raise ProjectionError(f"legacy skills_sc root is a symlink: {root}")
+    if not root.exists():
+        return []
+    if not root.is_dir():
+        raise ProjectionError(f"legacy skills_sc root is not a directory: {root}")
+    deleted: list[Path] = []
+    for child in root.iterdir():
+        if child.is_symlink() or not child.is_file():
+            continue
+        try:
+            managed = RENDER_BANNER in child.read_text()
+        except (OSError, UnicodeError):
+            managed = False
+        if managed:
+            child.unlink()
+            deleted.append(child)
+    if not any(root.iterdir()):
+        root.rmdir()
+        deleted.append(root)
+    return deleted
+
+
+def reconcile_existing_checkouts(con, *, repo_root: Path = REPO_ROOT) -> dict:
+    """Sweep root plus existing direct shell worktrees without creating either."""
+    shell_rows = con.execute(
+        "SELECT shell_id, shortname, flavor FROM shells "
+        "WHERE COALESCE(is_deleted,0)=0 ORDER BY shell_id"
+    ).fetchall()
+    by_checkout = {
+        shell_checkout(row["shortname"], row["flavor"], repo_root): row
+        for row in shell_rows
+    }
+    checkouts = [repo_root]
+    worktrees = repo_root / ".sc-worktrees"
+    if worktrees.is_dir() and not worktrees.is_symlink():
+        checkouts.extend(
+            path
+            for path in sorted(worktrees.iterdir())
+            if path.is_dir() and not path.is_symlink()
+        )
+
+    written: list[Path] = []
+    skipped: list[Path] = []
+    deleted: list[Path] = []
+    for checkout in checkouts:
+        row = by_checkout.get(checkout)
+        summary = reconcile_shell(
+            con, row["shell_id"] if row is not None else None, checkout
+        )
+        written.extend(summary["written"])
+        skipped.extend(summary["skipped"])
+        deleted.extend(summary["deleted"])
+        legacy = cleanup_legacy_skills_sc(checkout)
+        written.extend(legacy)
+        deleted.extend(legacy)
+    return {
+        "written": written,
+        "skipped": skipped,
+        "deleted": deleted,
+        "checkouts": checkouts,
+    }
+
+
+def partial_failure_message(action: str, exc: Exception) -> str:
+    return (
+        f"{action} committed in the DB, but skill projection failed: {exc}. "
+        "Fix the named path, then run `./sc update --no-fetch` (or "
+        "`./sc render skills <shortname>`) to retry exact cleanup."
+    )

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -78,6 +78,9 @@ import ports  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402
 import seed_skills  # noqa: E402
 import shell_factory  # noqa: E402
+import skill_projection  # noqa: E402
+sys.path.insert(0, str(ENGINE / "render"))
+import flat  # noqa: E402
 
 EJECTED_MARKER = STATE_DIR / "ejected"
 
@@ -981,6 +984,24 @@ def regrant() -> int:
         con.close()
 
 
+def reconcile_skill_projections() -> dict:
+    """Sweep existing checkouts and the active catalogue render after DB sync."""
+    con = db_driver.connect(DB_PATH)
+    try:
+        try:
+            summary = skill_projection.reconcile_existing_checkouts(con)
+        except skill_projection.ProjectionError as exc:
+            sys.exit(skill_projection.partial_failure_message(
+                "update catalogue reconciliation", exc
+            ))
+        catalogue = flat.render_visibility(con)
+    finally:
+        con.close()
+    summary["written"].extend(catalogue["written"])
+    summary["skipped"].extend(catalogue["skipped"])
+    return summary
+
+
 def expire_sandbox_harnesses() -> str | None:
     """Expire the harness CLIs baked into the sandbox image; return the epoch.
 
@@ -1108,6 +1129,17 @@ def main(argv: list[str]) -> int:
     sync_skills()
     print("→ re-grant catalogue skills to all shells")
     print(f"  {regrant()} grant change(s)")
+    print("→ reconcile managed skill projections")
+    projections = reconcile_skill_projections()
+    print(
+        f"  {len(projections['written'])} changed, "
+        f"{len(projections['skipped'])} unchanged across "
+        f"{len(projections['checkouts'])} existing checkout(s)"
+    )
+    print(
+        "  note: DB and disk are current; already-running harness sessions may "
+        "retain previously loaded skill text until reboot"
+    )
     print("→ wire map automation + map the repo")
     run_script("map_setup.py")
     print("→ snapshot the live state")

--- a/tests/test_artifact_policy.py
+++ b/tests/test_artifact_policy.py
@@ -143,7 +143,7 @@ class SourceCleanlinessTest(unittest.TestCase):
                 ".sc-state/content.sql", ".sc-state/map.config.json",
                 ".sc-state/map_content.sql", "roadmap_sc.md",
                 "docs_sc", "specs_sc", "skills_sc", "AGENTS.md", "CLAUDE.md",
-                ".claude/skills", ".agents/skills",
+                ".claude/skills", ".agents/skills", ".opencode/skills",
             ],
             capture_output=True,
             text=True,

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -149,6 +149,7 @@ class ProjectionTriggerTest(unittest.TestCase):
             mock.patch.object(feature.skill_projection, "reconcile_flavors",
                               side_effect=capture),
             mock.patch.object(feature, "_instance", return_value={"pg": {}}),
+            mock.patch.object(feature, "_write_instance"),
             mock.patch.object(feature, "_snapshot"),
         ):
             self.assertEqual(command("pg"), 0)

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -17,6 +17,7 @@ import sqlite3
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
@@ -131,6 +132,37 @@ class GrantRevokeTest(unittest.TestCase):
         rows = {r[0] for r in con.execute("SELECT flavor FROM flavor_skills")}
         self.assertEqual(rows, {"planner"}, "revoke must not touch packs outside "
                                            "the feature's flavors")
+
+
+class ProjectionTriggerTest(unittest.TestCase):
+    def _run(self, command) -> list[tuple[sqlite3.Connection, list[str]]]:
+        con = _mini_db()
+        calls: list[tuple[sqlite3.Connection, list[str]]] = []
+
+        def capture(target_con, flavors) -> dict:
+            calls.append((target_con, list(flavors)))
+            return {"written": [], "skipped": [], "deleted": [], "checkouts": []}
+
+        with (
+            mock.patch.object(feature, "DB_PATH", ROOT / "sc"),
+            mock.patch.object(feature.db_driver, "connect", return_value=con),
+            mock.patch.object(feature.skill_projection, "reconcile_flavors",
+                              side_effect=capture),
+            mock.patch.object(feature, "_instance", return_value={"pg": {}}),
+            mock.patch.object(feature, "_snapshot"),
+        ):
+            self.assertEqual(command("pg"), 0)
+        return calls
+
+    def test_enable_reconciles_every_granted_flavor(self):
+        calls = self._run(feature.cmd_enable)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][1], ["dev", "reviewer", "planner"])
+
+    def test_disable_reconciles_every_revoked_flavor(self):
+        calls = self._run(feature.cmd_disable)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][1], ["dev", "reviewer", "planner"])
 
 
 if __name__ == "__main__":

--- a/tests/test_flavor_skill_packs.py
+++ b/tests/test_flavor_skill_packs.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
@@ -17,9 +17,9 @@ MIGRATIONS = ENGINE / "migrations"
 ROOT_ONLY_MARKER = "<!-- sc-root-only:"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import run  # noqa: E402
 import shell_factory  # noqa: E402
 import snapshot  # noqa: E402
-import run  # noqa: E402
 
 sys.path.insert(0, str(ENGINE / "api"))
 import server  # noqa: E402
@@ -233,6 +233,48 @@ class GrantApiTest(unittest.TestCase):
         )
         self.assertIn("dev", row["granted_flavors"])
         self.assertEqual(row["granted_shells"], [self.custom1])
+
+    def test_flavor_toggle_reconciles_the_flavor(self) -> None:
+        con = mock.Mock()
+        with (
+            mock.patch.object(server, "db", return_value=con),
+            mock.patch.object(
+                server, "set_flavor_grant", return_value=(True, None)
+            ) as mutate,
+            mock.patch.object(
+                server.skill_projection, "reconcile_flavors"
+            ) as reconcile,
+        ):
+            status, _headers, body = server.dispatch_http(
+                "PUT",
+                f"/api/flavors/dev/skills/{self.kid}",
+                "Host: 127.0.0.1\r\nContent-Type: application/json\r\n"
+                "Content-Length: 17\r\n",
+                b'{"granted": true}',
+            )
+        self.assertEqual(status, 200, body)
+        mutate.assert_called_once_with(con, "dev", self.kid, True)
+        reconcile.assert_called_once_with(con, ["dev"])
+
+    def test_bespoke_toggle_reconciles_only_the_shell(self) -> None:
+        con = mock.Mock()
+        with (
+            mock.patch.object(server, "db", return_value=con),
+            mock.patch.object(server, "set_grant", return_value=(True, None)) as mutate,
+            mock.patch.object(
+                server.skill_projection, "reconcile_assignment_targets"
+            ) as reconcile,
+        ):
+            status, _headers, body = server.dispatch_http(
+                "PUT",
+                f"/api/shells/{self.custom1}/skills/{self.kid}",
+                "Host: 127.0.0.1\r\nContent-Type: application/json\r\n"
+                "Content-Length: 18\r\n",
+                b'{"granted": false}',
+            )
+        self.assertEqual(status, 200, body)
+        mutate.assert_called_once_with(con, self.custom1, self.kid, False)
+        reconcile.assert_called_once_with(con, [self.custom1])
 
 
 class ShellFactoryTest(unittest.TestCase):

--- a/tests/test_gitignore_sync.py
+++ b/tests/test_gitignore_sync.py
@@ -22,6 +22,7 @@ import install  # noqa: E402
 MAP_DB = "/.sc-state/map.db"
 DB_BACKUPS = "/.sc-state/db_backups/"
 CODEX_SKILLS = "/.agents/skills/"
+OPENCODE_SKILLS = "/.opencode/skills/"
 
 
 class EnsureGitignoreTest(unittest.TestCase):
@@ -71,6 +72,17 @@ class EnsureGitignoreTest(unittest.TestCase):
 
         self.assertTrue(install.ensure_gitignore(self.root))
         self.assertIn(CODEX_SKILLS, self.gi.read_text())
+        self.assertFalse(install.ensure_gitignore(self.root))
+
+    def test_tops_up_opencode_native_skill_render_on_existing_fork(self):
+        old = "\n".join(
+            ln for ln in install._GITIGNORE_BLOCK.splitlines()
+            if ln != OPENCODE_SKILLS
+        )
+        self.gi.write_text(old + "\n")
+
+        self.assertTrue(install.ensure_gitignore(self.root))
+        self.assertIn(OPENCODE_SKILLS, self.gi.read_text())
         self.assertFalse(install.ensure_gitignore(self.root))
 
     def test_no_marker_unrelated_content_appends_once(self):

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -48,6 +48,8 @@ class RemoveFixture(unittest.TestCase):
         (self.repo / "CLAUDE.md").write_text("generated\n")
         (self.repo / ".agents/skills/sample").mkdir(parents=True)
         (self.repo / ".agents/skills/sample/SKILL.md").write_text("generated\n")
+        (self.repo / ".opencode/skills/sample").mkdir(parents=True)
+        (self.repo / ".opencode/skills/sample/SKILL.md").write_text("generated\n")
         (self.repo / "docs_sc").mkdir()
         (self.repo / "docs_sc" / "generated.md").write_text("generated\n")
         (self.repo / "shared").mkdir()
@@ -148,6 +150,7 @@ class EndToEndRemoveTest(RemoveFixture):
         self.assertFalse((self.repo / "sc").exists())
         self.assertFalse((self.repo / "CLAUDE.md").exists())
         self.assertFalse((self.repo / ".agents/skills").exists())
+        self.assertFalse((self.repo / ".opencode/skills").exists())
         self.assertFalse((self.repo / "docs_sc").exists())
         self.assertFalse(
             (self.repo / ".github/workflows/subfloor-visual-qa.yml").exists()

--- a/tests/test_skill_projection.py
+++ b/tests/test_skill_projection.py
@@ -1,0 +1,257 @@
+"""Exact, bounded skill projection reconciliation regression coverage."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import seed_skills  # noqa: E402
+import skill_projection  # noqa: E402
+
+sys.path.insert(0, str(ROOT / "tests"))
+from skill_convergence_fixtures import (  # noqa: E402
+    LOCAL_SKILL_NAME,
+    TOMBSTONE_SKILLS,
+    build_dirty_skill_fork,
+)
+
+
+def build_db() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+    return con
+
+
+def add_shell(con: sqlite3.Connection, shortname: str, flavor: str | None) -> int:
+    return con.execute(
+        "INSERT INTO shells (display_name, shortname, system_prompt, flavor) "
+        "VALUES (?, ?, 'prompt', ?)",
+        (shortname, shortname.upper(), flavor),
+    ).lastrowid
+
+
+def grant(con: sqlite3.Connection, shell_id: int, skill: str) -> None:
+    skill_id = con.execute(
+        "SELECT skill_id FROM skills WHERE name=?", (skill,)
+    ).fetchone()[0]
+    con.execute(
+        "INSERT INTO shell_skills (shell_id, skill_id) VALUES (?, ?)",
+        (shell_id, skill_id),
+    )
+
+
+class SkillProjectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.con = build_db()
+
+    def tearDown(self) -> None:
+        self.con.close()
+
+    def test_managed_roots_match_adapter_inventory(self) -> None:
+        self.assertEqual(
+            skill_projection.managed_skill_dirs(),
+            (
+                Path(".claude/skills"),
+                Path(".agents/skills"),
+                Path(".opencode/skills"),
+            ),
+        )
+
+    def test_exact_render_prunes_stale_and_does_not_create_unused_native_root(
+        self,
+    ) -> None:
+        shell_id = add_shell(self.con, "custom", None)
+        grant(self.con, shell_id, "query_authoring_pg")
+        with tempfile.TemporaryDirectory() as tmp:
+            checkout = Path(tmp)
+            stale = checkout / ".opencode/skills/stale/nested/file.txt"
+            stale.parent.mkdir(parents=True)
+            stale.write_text("old")
+
+            summary = skill_projection.reconcile_shell(
+                self.con,
+                shell_id,
+                checkout,
+                ensure_dirs=(".claude/skills", ".opencode/skills"),
+            )
+
+            for relative in (".claude/skills", ".opencode/skills"):
+                rendered = checkout / relative / "query_authoring_pg/SKILL.md"
+                self.assertTrue(rendered.is_file())
+                self.assertIn("name: query_authoring_pg", rendered.read_text())
+            self.assertFalse((checkout / ".opencode/skills/stale").exists())
+            self.assertIn(checkout / ".opencode/skills/stale", summary["deleted"])
+            self.assertFalse(checkout.joinpath(".agents/skills").exists())
+
+    def test_revocation_deletes_exact_grant_from_every_existing_managed_root(
+        self,
+    ) -> None:
+        shell_id = add_shell(self.con, "custom", None)
+        grant(self.con, shell_id, "query_authoring_pg")
+        with tempfile.TemporaryDirectory() as tmp:
+            checkout = Path(tmp)
+            skill_projection.reconcile_shell(
+                self.con,
+                shell_id,
+                checkout,
+                ensure_dirs=(".claude/skills", ".agents/skills"),
+            )
+            self.con.execute("DELETE FROM shell_skills WHERE shell_id=?", (shell_id,))
+
+            summary = skill_projection.reconcile_shell(self.con, shell_id, checkout)
+
+            for relative in (".claude/skills", ".agents/skills"):
+                removed = checkout / relative / "query_authoring_pg"
+                self.assertFalse(removed.exists())
+                self.assertIn(removed, summary["deleted"])
+            self.assertFalse(checkout.joinpath(".opencode/skills").exists())
+
+    def test_symlink_root_is_refused_without_touching_target(self) -> None:
+        shell_id = add_shell(self.con, "custom", None)
+        grant(self.con, shell_id, "query_authoring_pg")
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as out:
+            checkout = Path(tmp)
+            target = Path(out)
+            sentinel = target / "sentinel.txt"
+            sentinel.write_text("foreign")
+            (checkout / ".claude").symlink_to(target, target_is_directory=True)
+
+            with self.assertRaisesRegex(
+                skill_projection.ProjectionError, "escapes checkout"
+            ):
+                skill_projection.reconcile_shell(
+                    self.con, shell_id, checkout, ensure_dirs=(".claude/skills",)
+                )
+
+            self.assertEqual(sentinel.read_text(), "foreign")
+            self.assertFalse((target / "skills").exists())
+
+    def test_stale_child_symlink_is_unlinked_without_following_target(self) -> None:
+        shell_id = add_shell(self.con, "custom", None)
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as out:
+            checkout = Path(tmp)
+            root = checkout / ".claude/skills"
+            root.mkdir(parents=True)
+            target = Path(out)
+            sentinel = target / "sentinel.txt"
+            sentinel.write_text("foreign")
+            link = root / "stale"
+            link.symlink_to(target, target_is_directory=True)
+
+            summary = skill_projection.reconcile_shell(self.con, shell_id, checkout)
+
+            self.assertFalse(link.exists())
+            self.assertFalse(link.is_symlink())
+            self.assertEqual(sentinel.read_text(), "foreign")
+            self.assertIn(link, summary["deleted"])
+
+    def test_sweep_cleans_existing_worktree_without_creating_dormant_one(self) -> None:
+        dev1 = add_shell(self.con, "dev1", "dev")
+        add_shell(self.con, "dev2", "dev")
+        skill_id = self.con.execute(
+            "SELECT skill_id FROM skills WHERE name='query_authoring_pg'"
+        ).fetchone()[0]
+        self.con.execute(
+            "INSERT INTO flavor_skills (flavor, skill_id) VALUES ('dev', ?)",
+            (skill_id,),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            root_live = repo / ".claude/skills/query_authoring_pg/SKILL.md"
+            root_live.parent.mkdir(parents=True)
+            root_live.write_text("preserve live unowned projection\n")
+            root_retired = repo / ".claude/skills/retired_upstream/SKILL.md"
+            root_retired.parent.mkdir()
+            root_retired.write_text("remove retired projection\n")
+            dev1_root = repo / ".sc-worktrees/dev1/.claude/skills"
+            dev1_root.mkdir(parents=True)
+            stale = dev1_root / "stale/SKILL.md"
+            stale.parent.mkdir()
+            stale.write_text("old")
+
+            summary = skill_projection.reconcile_existing_checkouts(
+                self.con, repo_root=repo
+            )
+
+            rendered = dev1_root / "query_authoring_pg/SKILL.md"
+            self.assertTrue(rendered.is_file())
+            self.assertFalse(stale.parent.exists())
+            self.assertEqual(
+                root_live.read_text(), "preserve live unowned projection\n"
+            )
+            self.assertFalse(root_retired.parent.exists())
+            self.assertFalse((repo / ".sc-worktrees/dev2").exists())
+            self.assertEqual(summary["checkouts"], [repo, repo / ".sc-worktrees/dev1"])
+            self.assertEqual(
+                self.con.execute(
+                    "SELECT COUNT(*) FROM resolved_shell_skills WHERE shell_id=? "
+                    "AND skill_id=?",
+                    (dev1, skill_id),
+                ).fetchone()[0],
+                1,
+            )
+
+    def test_legacy_cleanup_removes_only_banner_owned_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            checkout = Path(tmp)
+            legacy = checkout / "skills_sc"
+            legacy.mkdir()
+            managed = legacy / "retired.md"
+            managed.write_text("---\nrendered_by: super-coder\n---\nretired\n")
+            foreign = legacy / "notes.md"
+            foreign.write_text("operator notes\n")
+
+            deleted = skill_projection.cleanup_legacy_skills_sc(checkout)
+
+            self.assertIn(managed, deleted)
+            self.assertFalse(managed.exists())
+            self.assertEqual(foreign.read_text(), "operator notes\n")
+            self.assertTrue(legacy.is_dir())
+
+            foreign.unlink()
+            self.assertEqual(
+                skill_projection.cleanup_legacy_skills_sc(checkout), [legacy]
+            )
+            self.assertFalse(legacy.exists())
+
+    def test_dirty_fork_sweep_removes_retired_authority_and_preserves_local_controls(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = build_dirty_skill_fork(Path(tmp) / "downstream")
+            con = sqlite3.connect(fixture.database)
+            con.row_factory = sqlite3.Row
+            try:
+                reconciled = seed_skills.reconcile_tombstoned_skills(con)
+                summary = skill_projection.reconcile_existing_checkouts(
+                    con, repo_root=fixture.root
+                )
+            finally:
+                con.close()
+
+            self.assertEqual(set(reconciled.changed_names), set(TOMBSTONE_SKILLS))
+            self.assertEqual(reconciled.grant_count, len(TOMBSTONE_SKILLS) * 2)
+            self.assertEqual(summary["checkouts"], list(fixture.checkouts))
+            for skills_root in fixture.native_skill_roots:
+                self.assertTrue((skills_root / LOCAL_SKILL_NAME / "SKILL.md").is_file())
+                for retired in TOMBSTONE_SKILLS:
+                    self.assertFalse((skills_root / retired).exists())
+            for legacy_root, control in zip(
+                fixture.legacy_skill_roots, fixture.control_files, strict=True
+            ):
+                self.assertEqual(control.read_bytes(), fixture.expected_control_file)
+                self.assertEqual(list(legacy_root.iterdir()), [control])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_retire.py
+++ b/tests/test_skill_retire.py
@@ -51,8 +51,11 @@ def make_db() -> sqlite3.Connection:
         "CREATE TABLE flavor_skills (flavor TEXT, skill_id INTEGER, "
         "UNIQUE(flavor, skill_id))")
     con.execute(
-        "CREATE TABLE shells (shell_id INTEGER PRIMARY KEY, flavor TEXT)")
-    con.execute("INSERT INTO shells (shell_id, flavor) VALUES (1, NULL)")
+        "CREATE TABLE shells (shell_id INTEGER PRIMARY KEY, flavor TEXT, "
+        "shortname TEXT, display_name TEXT, is_deleted INTEGER DEFAULT 0)")
+    con.execute(
+        "INSERT INTO shells (shell_id, flavor, shortname, display_name) "
+        "VALUES (1, NULL, 'BSP1', 'Bespoke')")
     con.executescript(SEED_SQL)
     con.execute("INSERT INTO skills (name, description, content) "
                 "VALUES ('test_authoring_dosarch', 'fork skill', 'body')")
@@ -80,11 +83,20 @@ class RetireTest(unittest.TestCase):
             },
         )
         self.reconcile_existing = self.projection.start()
+        self.target_projection = mock.patch.object(
+            skill_cli.skill_projection,
+            "reconcile_assignment_targets",
+            return_value={
+                "written": [], "skipped": [], "deleted": [], "checkouts": []
+            },
+        )
+        self.reconcile_targets = self.target_projection.start()
         self.con = make_db()
 
     def tearDown(self):
         seed_skills.RETIRED_FILE, seed_skills.OUT = self._orig
         self.con.close()
+        self.target_projection.stop()
         self.projection.stop()
         self.tmp.cleanup()
 
@@ -191,9 +203,45 @@ class RetireTest(unittest.TestCase):
 
     def test_cmd_unretire_restores(self):
         skill_cli.cmd_retire(self.con, "test_authoring")
+        self.reconcile_existing.reset_mock()
         skill_cli.cmd_unretire(self.con, "test_authoring")
         self.assertEqual(json.loads(seed_skills.RETIRED_FILE.read_text()), [])
         self.assertEqual(self._deleted("test_authoring"), 0)
+        self.reconcile_existing.assert_called_once_with(self.con)
+
+    def test_cmd_grant_reconciles_the_target_shell(self):
+        skill_cli.cmd_grant(self.con, "review", ["BSP1"])
+        self.reconcile_targets.assert_called_once_with(self.con, [1])
+
+    def test_cmd_revoke_reconciles_the_target_shell(self):
+        skill_cli.cmd_grant(self.con, "review", ["BSP1"])
+        self.reconcile_targets.reset_mock()
+        skill_cli.cmd_revoke(self.con, "review", ["BSP1"])
+        self.reconcile_targets.assert_called_once_with(self.con, [1])
+
+    def test_cmd_rm_reconciles_every_existing_checkout(self):
+        skill_cli.cmd_rm(self.con, "test_authoring_dosarch")
+        self.reconcile_existing.assert_called_once_with(self.con)
+        self.assertEqual(self._deleted("test_authoring_dosarch"), 1)
+
+    def test_projection_failure_reports_committed_grant(self):
+        self.reconcile_targets.side_effect = (
+            skill_cli.skill_projection.ProjectionError("managed root is a symlink")
+        )
+        with self.assertRaisesRegex(
+            SystemExit,
+            "grant review committed in the DB, but skill projection failed: "
+            "managed root is a symlink",
+        ):
+            skill_cli.cmd_grant(self.con, "review", ["BSP1"])
+        self.assertEqual(
+            self.con.execute(
+                "SELECT COUNT(*) FROM shell_skills ss "
+                "JOIN skills s ON s.skill_id=ss.skill_id "
+                "WHERE ss.shell_id=1 AND s.name='review'"
+            ).fetchone()[0],
+            1,
+        )
 
     def test_cmd_unretire_unlisted_is_loud(self):
         with self.assertRaises(SystemExit):

--- a/tests/test_skill_retire.py
+++ b/tests/test_skill_retire.py
@@ -72,11 +72,20 @@ class RetireTest(unittest.TestCase):
         self._orig = (seed_skills.RETIRED_FILE, seed_skills.OUT)
         seed_skills.RETIRED_FILE = root / ".sc-state" / "skills_retired.json"
         seed_skills.OUT = seed
+        self.projection = mock.patch.object(
+            skill_cli.skill_projection,
+            "reconcile_existing_checkouts",
+            return_value={
+                "written": [], "skipped": [], "deleted": [], "checkouts": []
+            },
+        )
+        self.reconcile_existing = self.projection.start()
         self.con = make_db()
 
     def tearDown(self):
         seed_skills.RETIRED_FILE, seed_skills.OUT = self._orig
         self.con.close()
+        self.projection.stop()
         self.tmp.cleanup()
 
     def _retire_file(self, names) -> None:
@@ -170,6 +179,7 @@ class RetireTest(unittest.TestCase):
         self.assertEqual(json.loads(seed_skills.RETIRED_FILE.read_text()),
                          ["test_authoring"])
         self.assertEqual(self._deleted("test_authoring"), 1)
+        self.reconcile_existing.assert_called_once_with(self.con)
 
     def test_cmd_retire_refuses_local_skill(self):
         with self.assertRaises(SystemExit):

--- a/tests/test_style_spinner.py
+++ b/tests/test_style_spinner.py
@@ -278,7 +278,13 @@ class BootPhaseLabelTest(unittest.TestCase):
                 run.git_prune, "status_line", return_value=None))
             stack.enter_context(mock.patch.object(run, "compose_boot", return_value="boot"))
             stack.enter_context(mock.patch.object(
-                run.flat, "render_skill_md", return_value={"written": [], "skipped": []}))
+                run,
+                "render_harness_skills",
+                return_value={
+                    "written": [], "skipped": [], "deleted": [],
+                    "dirs": [".claude/skills"],
+                },
+            ))
             stack.enter_context(mock.patch.object(run, "atomic_write"))
             stack.enter_context(mock.patch.object(run, "load_adapter", return_value=adapter))
             stack.enter_context(mock.patch.object(run, "emit_adapter", return_value=[]))

--- a/tests/test_verify_clean_clone.py
+++ b/tests/test_verify_clean_clone.py
@@ -35,6 +35,10 @@ class VerifyCleanCloneTest(unittest.TestCase):
                 ROOT / ".super-coder" / "scripts" / "run.py",
                 checkout / ".super-coder" / "scripts" / "run.py",
             )
+            shutil.copy2(
+                ROOT / ".super-coder" / "scripts" / "skill_projection.py",
+                checkout / ".super-coder" / "scripts" / "skill_projection.py",
+            )
             env = os.environ.copy()
             env.pop("SC_ARTIFACT_MODE", None)
             result = subprocess.run(


### PR DESCRIPTION
## Summary
- add one bounded projection reconciler for all adapter-declared skill roots
- converge boot, update, CLI, feature, explicit render, and GUI grant mutations after DB commit
- sweep existing dormant worktrees and banner-owned legacy skills_sc without following symlinks or deleting foreign controls
- align installer ignore/teardown inventories for .claude, .agents, and .opencode roots

## Verification
- full pytest: 1552 passed, 1 skipped, 824 subtests passed (durable job 38-f33-u6-full-r2)
- focused final: 76 passed
- dirty downstream fixture: all 13 retired projections removed; fork-local skill and controls preserved
- ./sc render-check
- scoped ruff E/F/I/UP/C4
- git diff --check

`./sc verify` was attempted and safely refused this linked worktree without touching the sibling-owned live checkout (known SC-019); its clean-clone behavior is covered by tests/test_verify_clean_clone.py and CI runs the canonical gate.

Trade-off: unknown legacy checkout roots preserve directories for any still-live catalogue skill because no shell identity can define an exact grant set there; known shell worktrees remain exact. This avoids deleting genuine fork-local projections while still removing retired upstream authority.

Sprint 70 · unit 6 · task #236.