### PR TITLE
feat: make skill curation recommendations-only

### DIFF
--- a/.super-coder/assets/skills/curate/SKILL.md
+++ b/.super-coder/assets/skills/curate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: curate
-description: The periodic L&S sweep. Run when the STATUS L&S line says "curation due" — resolve contradictions, merge entries stating one rule, promote a recurring process to a skill, move environment facts out, then stamp `sc mem curated`. Yours alone; never delegate it.
+description: The periodic L&S sweep. Run when the STATUS L&S line says "curation due" — resolve contradictions, merge entries stating one rule, recommend recurring processes upstream, move environment facts out, then stamp `sc mem curated`. Yours alone; never delegate it.
 category: substrate
 common: true
 ---
@@ -11,7 +11,7 @@ Write-time triage (`--supersedes` / `--new`) catches contradiction and
 restatement pairwise, at the moment of writing. It **cannot** catch the
 emergent cluster: five entries can each be a valid distinct rule and only in
 aggregate be five instances of one principle. That is this pass's job, along
-with promotion, category drift, and size drift.
+with recommendation, category drift, and size drift.
 
 **Yours alone.** Law 3 and Law 7 reserve curation to the shell. Never hand this
 to a subagent, never let another shell run it for you, never accept a proposed
@@ -56,28 +56,52 @@ The incidents behind the entries are already in the narrative. They do not need
 a second home, and the merged rule must not try to carry them: an entry is the
 rule, ≤500 chars, hard-enforced.
 
-## Pass 3 — Promote
+## Pass 3 — Recommend
 
 A cluster of three or more that keeps **recurring across sessions** is a
-*process*, not a lesson. Author it as a skill and keep one L&S rule pointing at
-it:
+candidate reusable process. Curation never creates or promotes a skill
+directly. Deduplicate against all upstream issues first:
 
-```
-sc skill add <you>_<topic> --file <path.md> --desc "<one line>"
+```bash
+gh issue list --repo jedbjorn/subfloor --state all --search "skills: recommend <topic>"
 ```
 
-Local skills are DB-only and namespaced by your shortname — the command
-enforces both. This is the pressure valve that makes a hard budget survivable:
-knowledge relocates to a lazy surface instead of being deleted.
+An existing recommendation gets the new evidence in a comment. Otherwise open
+one issue titled `skills: recommend <topic>` containing:
+
+- the trigger that makes the procedure useful;
+- the repeated incidents that exposed the need;
+- the proposed ownership boundary;
+- the expected users;
+- why existing skills do not cover it; and
+- a compact candidate procedure.
+
+```bash
+gh issue comment <number> --repo jedbjorn/subfloor --body "<new evidence>"
+gh issue create --repo jedbjorn/subfloor \
+  --title "skills: recommend <topic>" \
+  --body "<trigger, incidents, ownership, users, coverage gap, procedure>"
+```
+
+Keep one compressed L&S entry carrying the knowledge until a reviewed upstream
+skill ships **and is granted**. Filing or updating an issue is not grounds to
+retire it. If issue search or creation is unavailable, surface the failure to
+the FnB, keep the L&S, and create no local skill or asset.
+
+Deliberate fork-specific skill authoring is separate from curation and remains
+administrator-owned. The admin follows `local_skill_management`: authored
+asset → explicit seed → grant → snapshot → render.
 
 ## Pass 4 — Category
 
 An entry that is an **environment fact** (a routing quirk, a term to avoid, a
-path) is not an operating principle. It belongs in a skill, not in L&S. Retire
-it and put the fact where it is looked up.
+path) is not an operating principle. Move it into an existing authoritative
+skill when one owns that fact. Otherwise keep one compressed entry and include
+the missing ownership in a recommendation; do not invent a local skill during
+curation.
 
 ```
-sc mem retire <entry_id>
+sc mem retire <entry_id>  # only after the authoritative replacement is live
 ```
 
 ## Stamp
@@ -93,7 +117,8 @@ you would learn to ignore it. The stamp says "I looked," not "I cut."
 ## Stance
 
 Curate the set toward ~12–14 entries, not toward the cap. Cap 20 is a ceiling
-never to reach — if you ever hit it, this sweep is not running.
+never to reach — if you ever hit it, this sweep is not running. Recommendation
+issues do not bypass the cap by deleting knowledge before its replacement ships.
 
 The trigger firing often does not mean the threshold is wrong; it means entries
 are being written faster than they are reconciled. Fix that at write time, with

--- a/.super-coder/assets/skills/issue_reporting/SKILL.md
+++ b/.super-coder/assets/skills/issue_reporting/SKILL.md
@@ -92,10 +92,29 @@ No `gh` / no network from your seat -> save the identical body as a fork flag:
 `sc mem flag open "[Engine] <symptom> | Blocker for: <x>" --name UP-###`, then
 message the **admin** shell to relay it upstream (see `messaging`).
 
+## Authorized curation recommendation
+
+The `curate` skill has one FnB-authorized exception to the normal enhancement
+gate below. When a recurring L&S cluster may warrant a reusable upstream skill,
+the curating shell may search and file the recommendation directly without
+asking the FnB first.
+
+Search all upstream issues before opening anything. Add evidence to a matching
+recommendation, or open one titled `skills: recommend <topic>` containing the
+trigger, repeated incidents, proposed ownership boundary, expected users, why
+existing skills do not cover it, and a compact candidate procedure.
+
+This route recommends; it never creates or promotes a skill. Keep one compressed
+L&S entry until a reviewed upstream skill ships and is granted. If issue search
+or creation is unavailable, surface the failure to the FnB, keep the L&S, and
+create no local skill or asset. Deliberate fork-specific authoring remains the
+administrator-owned workflow in `local_skill_management`.
+
 ## Rules
 
 - One defect per issue. Batch nothing.
 - Observed failure = the bar for filing unasked; enhancement ideas ("the
-  engine should…") go to your FnB first.
+  engine should…") go to your FnB first, except the authorized curation
+  recommendation route above.
 - Filing ≠ unblocked: defect blocks work -> also open a fork flag linking the
   issue URL.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -957,7 +957,7 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'curate',
-  'The periodic L&S sweep. Run when the STATUS L&S line says "curation due" — resolve contradictions, merge entries stating one rule, promote a recurring process to a skill, move environment facts out, then stamp `sc mem curated`. Yours alone; never delegate it.',
+  'The periodic L&S sweep. Run when the STATUS L&S line says "curation due" — resolve contradictions, merge entries stating one rule, recommend recurring processes upstream, move environment facts out, then stamp `sc mem curated`. Yours alone; never delegate it.',
   'substrate',
   NULL,
   1,
@@ -967,7 +967,7 @@ Write-time triage (`--supersedes` / `--new`) catches contradiction and
 restatement pairwise, at the moment of writing. It **cannot** catch the
 emergent cluster: five entries can each be a valid distinct rule and only in
 aggregate be five instances of one principle. That is this pass''s job, along
-with promotion, category drift, and size drift.
+with recommendation, category drift, and size drift.
 
 **Yours alone.** Law 3 and Law 7 reserve curation to the shell. Never hand this
 to a subagent, never let another shell run it for you, never accept a proposed
@@ -1012,28 +1012,52 @@ The incidents behind the entries are already in the narrative. They do not need
 a second home, and the merged rule must not try to carry them: an entry is the
 rule, ≤500 chars, hard-enforced.
 
-## Pass 3 — Promote
+## Pass 3 — Recommend
 
 A cluster of three or more that keeps **recurring across sessions** is a
-*process*, not a lesson. Author it as a skill and keep one L&S rule pointing at
-it:
+candidate reusable process. Curation never creates or promotes a skill
+directly. Deduplicate against all upstream issues first:
 
-```
-sc skill add <you>_<topic> --file <path.md> --desc "<one line>"
+```bash
+gh issue list --repo jedbjorn/subfloor --state all --search "skills: recommend <topic>"
 ```
 
-Local skills are DB-only and namespaced by your shortname — the command
-enforces both. This is the pressure valve that makes a hard budget survivable:
-knowledge relocates to a lazy surface instead of being deleted.
+An existing recommendation gets the new evidence in a comment. Otherwise open
+one issue titled `skills: recommend <topic>` containing:
+
+- the trigger that makes the procedure useful;
+- the repeated incidents that exposed the need;
+- the proposed ownership boundary;
+- the expected users;
+- why existing skills do not cover it; and
+- a compact candidate procedure.
+
+```bash
+gh issue comment <number> --repo jedbjorn/subfloor --body "<new evidence>"
+gh issue create --repo jedbjorn/subfloor \
+  --title "skills: recommend <topic>" \
+  --body "<trigger, incidents, ownership, users, coverage gap, procedure>"
+```
+
+Keep one compressed L&S entry carrying the knowledge until a reviewed upstream
+skill ships **and is granted**. Filing or updating an issue is not grounds to
+retire it. If issue search or creation is unavailable, surface the failure to
+the FnB, keep the L&S, and create no local skill or asset.
+
+Deliberate fork-specific skill authoring is separate from curation and remains
+administrator-owned. The admin follows `local_skill_management`: authored
+asset → explicit seed → grant → snapshot → render.
 
 ## Pass 4 — Category
 
 An entry that is an **environment fact** (a routing quirk, a term to avoid, a
-path) is not an operating principle. It belongs in a skill, not in L&S. Retire
-it and put the fact where it is looked up.
+path) is not an operating principle. Move it into an existing authoritative
+skill when one owns that fact. Otherwise keep one compressed entry and include
+the missing ownership in a recommendation; do not invent a local skill during
+curation.
 
 ```
-sc mem retire <entry_id>
+sc mem retire <entry_id>  # only after the authoritative replacement is live
 ```
 
 ## Stamp
@@ -1049,7 +1073,8 @@ you would learn to ignore it. The stamp says "I looked," not "I cut."
 ## Stance
 
 Curate the set toward ~12–14 entries, not toward the cap. Cap 20 is a ceiling
-never to reach — if you ever hit it, this sweep is not running.
+never to reach — if you ever hit it, this sweep is not running. Recommendation
+issues do not bypass the cap by deleting knowledge before its replacement ships.
 
 The trigger firing often does not mean the threshold is wrong; it means entries
 are being written faster than they are reconciled. Fix that at write time, with
@@ -2213,11 +2238,30 @@ No `gh` / no network from your seat -> save the identical body as a fork flag:
 `sc mem flag open "[Engine] <symptom> | Blocker for: <x>" --name UP-###`, then
 message the **admin** shell to relay it upstream (see `messaging`).
 
+## Authorized curation recommendation
+
+The `curate` skill has one FnB-authorized exception to the normal enhancement
+gate below. When a recurring L&S cluster may warrant a reusable upstream skill,
+the curating shell may search and file the recommendation directly without
+asking the FnB first.
+
+Search all upstream issues before opening anything. Add evidence to a matching
+recommendation, or open one titled `skills: recommend <topic>` containing the
+trigger, repeated incidents, proposed ownership boundary, expected users, why
+existing skills do not cover it, and a compact candidate procedure.
+
+This route recommends; it never creates or promotes a skill. Keep one compressed
+L&S entry until a reviewed upstream skill ships and is granted. If issue search
+or creation is unavailable, surface the failure to the FnB, keep the L&S, and
+create no local skill or asset. Deliberate fork-specific authoring remains the
+administrator-owned workflow in `local_skill_management`.
+
 ## Rules
 
 - One defect per issue. Batch nothing.
 - Observed failure = the bar for filing unasked; enhancement ideas ("the
-  engine should…") go to your FnB first.
+  engine should…") go to your FnB first, except the authorized curation
+  recommendation route above.
 - Filing ≠ unblocked: defect blocks work -> also open a fork flag linking the
   issue URL.',
   0

--- a/.super-coder/migrations/0156_reseed_curation_governance.sql
+++ b/.super-coder/migrations/0156_reseed_curation_governance.sql
@@ -1,0 +1,265 @@
+-- 0156 — publish recommendations-only L&S curation governance.
+--
+-- Full-body UPSERTs converge existing installations after the DB-only
+-- `sc skill add` authoring surface is removed.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'curate',
+  'The periodic L&S sweep. Run when the STATUS L&S line says "curation due" — resolve contradictions, merge entries stating one rule, recommend recurring processes upstream, move environment facts out, then stamp `sc mem curated`. Yours alone; never delegate it.',
+  'substrate',
+  NULL,
+  1,
+  '# curate — the L&S sweep
+
+Write-time triage (`--supersedes` / `--new`) catches contradiction and
+restatement pairwise, at the moment of writing. It **cannot** catch the
+emergent cluster: five entries can each be a valid distinct rule and only in
+aggregate be five instances of one principle. That is this pass''s job, along
+with recommendation, category drift, and size drift.
+
+**Yours alone.** Law 3 and Law 7 reserve curation to the shell. Never hand this
+to a subagent, never let another shell run it for you, never accept a proposed
+retirement from anyone else. Read your own set; decide yourself.
+
+Trigger: `## STATUS` says `L&S: … — curation due`. Nothing else fires it.
+
+## Load the set
+
+```
+sc mem get lns          # entry ids + bodies — the active set, all of it
+```
+
+Read every entry before deciding anything. This is one cheap read; the whole
+set is already in your boot doc anyway.
+
+## Pass 1 — Consistency
+
+Find entries that **contradict** each other. One of them is the newer
+understanding; the other is superseded and still rendering as live guidance.
+
+```
+sc mem lns "<the surviving rule>" --supersedes <old_id>
+```
+
+Write-time triage should prevent most of these from ever forming. What you find
+here predates the loop or crossed in while two sessions ran.
+
+## Pass 2 — Cluster
+
+Group entries that state **one rule**. Merge each group to a single imperative
+rule:
+
+```
+sc mem lns "<the one rule>" --supersedes 30,33,34,37,38
+```
+
+Three or more members is the bar. Two statements of a rule are often
+legitimately two rules — merging at two is usually wrong.
+
+The incidents behind the entries are already in the narrative. They do not need
+a second home, and the merged rule must not try to carry them: an entry is the
+rule, ≤500 chars, hard-enforced.
+
+## Pass 3 — Recommend
+
+A cluster of three or more that keeps **recurring across sessions** is a
+candidate reusable process. Curation never creates or promotes a skill
+directly. Deduplicate against all upstream issues first:
+
+```bash
+gh issue list --repo jedbjorn/subfloor --state all --search "skills: recommend <topic>"
+```
+
+An existing recommendation gets the new evidence in a comment. Otherwise open
+one issue titled `skills: recommend <topic>` containing:
+
+- the trigger that makes the procedure useful;
+- the repeated incidents that exposed the need;
+- the proposed ownership boundary;
+- the expected users;
+- why existing skills do not cover it; and
+- a compact candidate procedure.
+
+```bash
+gh issue comment <number> --repo jedbjorn/subfloor --body "<new evidence>"
+gh issue create --repo jedbjorn/subfloor \
+  --title "skills: recommend <topic>" \
+  --body "<trigger, incidents, ownership, users, coverage gap, procedure>"
+```
+
+Keep one compressed L&S entry carrying the knowledge until a reviewed upstream
+skill ships **and is granted**. Filing or updating an issue is not grounds to
+retire it. If issue search or creation is unavailable, surface the failure to
+the FnB, keep the L&S, and create no local skill or asset.
+
+Deliberate fork-specific skill authoring is separate from curation and remains
+administrator-owned. The admin follows `local_skill_management`: authored
+asset → explicit seed → grant → snapshot → render.
+
+## Pass 4 — Category
+
+An entry that is an **environment fact** (a routing quirk, a term to avoid, a
+path) is not an operating principle. Move it into an existing authoritative
+skill when one owns that fact. Otherwise keep one compressed entry and include
+the missing ownership in a recommendation; do not invent a local skill during
+curation.
+
+```
+sc mem retire <entry_id>  # only after the authoritative replacement is live
+```
+
+## Stamp
+
+```
+sc mem curated
+```
+
+**Stamp even if you retired nothing.** A clean set is a legitimate outcome; if
+an honest sweep left the counter running, the advisory would stand forever and
+you would learn to ignore it. The stamp says "I looked," not "I cut."
+
+## Stance
+
+Curate the set toward ~12–14 entries, not toward the cap. Cap 20 is a ceiling
+never to reach — if you ever hit it, this sweep is not running. Recommendation
+issues do not bypass the cap by deleting knowledge before its replacement ships.
+
+The trigger firing often does not mean the threshold is wrong; it means entries
+are being written faster than they are reconciled. Fix that at write time, with
+`--supersedes`.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'issue_reporting',
+  'Report engine defects upstream — the moment a sc command fails or lies, a skill contradicts your reality, the API blocks a documented workflow, or you work around the engine to proceed. File a GitHub issue on super-coder; your repo''s app bugs stay in the fork.',
+  'substrate',
+  NULL,
+  1,
+  '# issue_reporting — the backwards flow
+
+An engine defect fixed upstream reaches every fork via `sc update`; worked
+around silently, every fork re-derives the workaround. File the issue while
+the failure is on screen — NEVER batch to session end.
+
+A workaround IS a report: deviating from a skill''s steps, wrapping a command,
+or hand-patching state to proceed -> you hold the exact repro; file it now.
+
+## Boundary — engine vs fork
+
+| Where | What |
+|---|---|
+| **Upstream — file it** | anything the engine materializes/owns: `.super-coder/`, `sc` + every subcommand, engine skills (this catalogue), the boot doc render, the sandbox / dev kit, `sc update` + migrations, the `_sc` API + `sc mem` |
+| **Fork — don''t** | the repo''s app code, fork-local skills (see `local_skill_management`), operator-owned host config |
+
+Unsure -> "would the same problem hit any other fork?" yes = upstream.
+
+## Triggers
+
+Each row = a real engine defect filed by a fork shell doing ordinary work.
+Match the left column -> file.
+
+| You hit | Real case |
+|---|---|
+| A `sc` command fails out of the box | `sc verify` always aborted — its own render step needed `SC_ADMIN` it never set (#227) |
+| A command exits green without doing the work | `sc test` silently fell back to unittest when pytest was missing — green-washed suites (#219) |
+| The documented remedy is a closed loop | `sc lint` said "run `sc deps` first," but deps skips pip in the sandbox — tool unobtainable from inside the box (#246) |
+| A skill instructs tools/paths your seat doesn''t have | `configure_winbox` drove raw `ssh`/`virsh` — neither exists in the broker-only sandbox (#248) |
+| A skill contradicts what the engine actually does | skills still taught raw `sqlite3` against the substrate DB after memory went API-only (#226) |
+| The API refuses what the skills document | `sc mem doc add` 400''d standalone docs the docs + onboard skills both document (#245) |
+| A permission wall mid-workflow | a dev shell could read a planner-owned feature but 404''d advancing its status (#224) |
+| Every write suddenly 401s | rebuild didn''t re-mint api_keys — all live shells locked out until an API bounce (#214) |
+| `sc update` / migrate wedges or half-applies | migration failed partway, retry died on `duplicate column name` (#229); update aborted crossing a commit that deleted an engine file (#209) |
+| A structural foot-gun keeps re-biting you | the cwd trap — `cd` to root for `sc`, then bare git hit the wrong tree, "my edits vanished" (#225) |
+| The sandbox can reach something it shouldn''t | `do_push` src/dest weren''t contained — sandbox→host escape (#228) |
+
+Stale guidance (skill says X, engine does Y) files the same as a crash.
+
+## Capture — while the failure is on screen
+
+- **engine ref** = `sc engine-ref` — first line of every report
+- **staleness** = compare that ref to upstream head:
+  `git ls-remote https://github.com/jedbjorn/subfloor HEAD` — write
+  `current` or `behind head <sha7>`. Behind + the symptom is a missing
+  command or a skill/engine mismatch -> the fix may already be shipped:
+  ask your FnB for `sc update` first, and file only if the defect
+  survives the update (or updating isn''t an option — then the staleness
+  note carries that caveat). Triage reads this line to tell a live
+  engine defect from a stale fork build.
+- **fork + seat**: repo name, shell flavor, sandbox/host
+- **ran / followed**: the exact command, or skill name + step
+- **expected vs actual**: exact output, trimmed to the failing lines
+- **workaround**: what unblocked you, or "blocked, none found"
+
+The issue is public: NEVER paste api keys, tokens, secrets, or private paths.
+
+## File it
+
+```bash
+# 1. dedup — someone may have hit it first
+gh issue list --repo jedbjorn/subfloor --search "<symptom keywords>" --state all
+
+# 2. file — title: [<fork>] <area>: <one-line symptom>
+gh issue create --repo jedbjorn/subfloor \
+  --title "[<fork>] <area>: <symptom>" \
+  --body "$(cat <<''EOF''
+- engine ref: <sha from .sc-state/engine.ref> · <current | behind head <sha7>>
+- fork/seat: <repo> · <shell flavor> · <sandbox|host>
+
+**Ran / followed:** <command or skill+step>
+**Expected:** <what the docs/skill promise>
+**Actual:** <exact trimmed output>
+**Workaround:** <what unblocked you, or "blocked">
+EOF
+)"
+```
+
+`jedbjorn/subfloor` = engine upstream; confirm: `git remote get-url super-coder`.
+
+Dedup hit -> comment your engine ref + repro on the existing issue; do NOT
+file a duplicate.
+
+No `gh` / no network from your seat -> save the identical body as a fork flag:
+`sc mem flag open "[Engine] <symptom> | Blocker for: <x>" --name UP-###`, then
+message the **admin** shell to relay it upstream (see `messaging`).
+
+## Authorized curation recommendation
+
+The `curate` skill has one FnB-authorized exception to the normal enhancement
+gate below. When a recurring L&S cluster may warrant a reusable upstream skill,
+the curating shell may search and file the recommendation directly without
+asking the FnB first.
+
+Search all upstream issues before opening anything. Add evidence to a matching
+recommendation, or open one titled `skills: recommend <topic>` containing the
+trigger, repeated incidents, proposed ownership boundary, expected users, why
+existing skills do not cover it, and a compact candidate procedure.
+
+This route recommends; it never creates or promotes a skill. Keep one compressed
+L&S entry until a reviewed upstream skill ships and is granted. If issue search
+or creation is unavailable, surface the failure to the FnB, keep the L&S, and
+create no local skill or asset. Deliberate fork-specific authoring remains the
+administrator-owned workflow in `local_skill_management`.
+
+## Rules
+
+- One defect per issue. Batch nothing.
+- Observed failure = the bar for filing unasked; enhancement ideas ("the
+  engine should…") go to your FnB first, except the authorized curation
+  recommendation route above.
+- Filing ≠ unblocked: defect blocks work -> also open a fork flag linking the
+  issue URL.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -12,8 +12,8 @@ Naming a standard shell targets its shared flavor pack; naming a Bespoke shell
 targets only that shell.
 
 Catalogue rows themselves are authored as assets + `./sc seed-skills`
-(engine + fork-local alike); this command manages what's GRANTED where,
-and retires local skills.
+(engine + administrator-authored fork-local alike); this command manages
+what's GRANTED where, and retires local skills.
 
 ENGINE skills can't be `rm`'d (the seed resurrects them on every update) —
 they retire via the fork retire list instead (#238): `retire` writes the
@@ -23,21 +23,8 @@ The list is re-applied after every seed sync/heal/rebuild, so it rides
 `./sc update` the same way flavor overlays do. Grant rows stay in place
 (inert) so `unretire` restores who-had-what.
 
-`add` authors a LOCAL skill straight into the DB. It exists for the `curate`
-skill's promote pass: a cluster of L&S entries that keeps recurring across
-sessions is a *process*, not a lesson, and relocating it to a skill is the
-pressure valve that makes a hard L&S budget survivable — knowledge moves to a
-lazy surface instead of being deleted. Local means "name absent from the engine
-seed", which is already the engine/local boundary every heal path respects
-(seed_skills._engine_specs / stale_engine_skills / sync_engine_skills), so an
-added skill survives migrate, sync, and rebuild with no new column or marker.
-It writes NO asset file, deliberately: `./sc seed-skills` upserts every asset
-under assets/skills/, so a file would put a local skill back on the seed path.
-
 Usage:
     ./sc skill list                        catalogue: origin, common, grants
-    ./sc skill add <name> --file <path>    author a LOCAL skill (DB-only) + grant it
-                  [--desc "…"] [--category …] [--for <shell>] [--opt-in]
     ./sc skill grant  <name> <shell>...    grant via shell reference (flavor/Bespoke)
     ./sc skill revoke <name> <shell>...    revoke via shell reference
     ./sc skill rm     <name>               soft-delete a LOCAL skill + revoke all grants
@@ -46,10 +33,7 @@ Usage:
 """
 from __future__ import annotations
 
-import argparse
 import json
-import os
-import re
 import sys
 from pathlib import Path
 
@@ -200,105 +184,6 @@ def cmd_list_api() -> int:
     return print_catalogue(mem._api("GET", "/_sc/skills").get("skills") or [])
 
 
-def resolve_author(con, ref: "str | None") -> tuple[int, str]:
-    """Who is authoring this skill. `--for` when given, else the shell whose
-    api_key is the SC_API_TOKEN run.py injected at boot — the same identity the
-    memory API resolves, so a shell never names itself. A host seat with neither
-    is told to say who it means rather than silently authoring an orphan."""
-    if ref:
-        return resolve_shell(con, ref)
-    token = os.environ.get("SC_API_TOKEN", "")
-    if token:
-        row = con.execute(
-            "SELECT shell_id, COALESCE(shortname, display_name, shell_id) FROM shells "
-            "WHERE api_key=? AND COALESCE(is_deleted,0)=0", (token,)).fetchone()
-        if row:
-            return row[0], str(row[1])
-    sys.exit("sc skill add: can't tell who is authoring — no SC_API_TOKEN "
-             "resolves to a shell. Pass --for <shell>.")
-
-
-def cmd_add(con, argv: list[str]) -> int:
-    ap = argparse.ArgumentParser(prog="sc skill add", add_help=False)
-    ap.add_argument("name")
-    ap.add_argument("--file", required=True, help="markdown body → skills.content")
-    ap.add_argument("--desc", help="one-line summary (boot SKILLS block + catalogue)")
-    ap.add_argument("--category")
-    ap.add_argument("--command")
-    ap.add_argument("--for", dest="author", help="author/grantee shell (default: your token)")
-    ap.add_argument("--opt-in", action="store_true",
-                    help="not a common skill (default: common, like the engine catalogue)")
-    args = ap.parse_args(argv)
-    name = args.name.strip()
-
-    author_id, author = resolve_author(con, args.author)
-
-    # Guard 1 — never shadow an engine name. The seed UPSERTs BY NAME, so
-    # authoring over one would silently overwrite the upstream skill here and
-    # then be silently overwritten back on the next update.
-    if name in set(seed_skills.seeded_skill_names()):
-        sys.exit(f"sc skill add: '{name}' is an ENGINE skill — the seed owns that "
-                 "name and upserts it on every update. Pick a different one "
-                 f"(e.g. {author}_{name}).")
-    if name in set(seed_skills.tombstoned_skill_names()):
-        sys.exit(f"sc skill add: '{name}' is a retired ENGINE skill — its name "
-                 "is permanently reserved by the upstream tombstone registry. "
-                 "Pick a different namespaced name.")
-    # Guard 2 — namespace by shortname. A future upstream release claiming a
-    # bare name would clobber this shell's content on the next sync; a
-    # shortname prefix is a name upstream will never mint.
-    if not re.match(rf"^{re.escape(author)}_[a-z0-9_]+$", name):
-        sys.exit(f"sc skill add: local skills are namespaced — name it "
-                 f"'{author}_<topic>' (lowercase, underscores). A bare name is "
-                 "one an upstream release could claim, and the sync would then "
-                 "overwrite your content.")
-    # Guard 3 — a name on the fork retire list is re-asserted is_deleted=1 by
-    # every heal, so the skill would vanish the first time anything synced.
-    if name in set(seed_skills.retired_skill_names()):
-        sys.exit(f"sc skill add: '{name}' is on the fork retire list "
-                 f"({_display_retire_file()}) — every heal re-asserts is_deleted "
-                 f"on it. `./sc skill unretire {name}` first, or pick another name.")
-    # Guard 4 — DB-only. `./sc seed-skills` passes ALL asset specs, so an asset
-    # file under assets/skills/<name>/ would put this local skill back on the
-    # seed path. Refuse rather than write a row that a later seed can rewrite.
-    asset = ENGINE / "assets" / "skills" / name
-    if asset.exists():
-        sys.exit(f"sc skill add: {asset.relative_to(ENGINE.parent)} exists — an "
-                 "asset file puts the skill on the seed path. `sc skill add` is "
-                 "DB-only; remove the asset dir or pick another name.")
-
-    src = Path(args.file).expanduser()
-    if not src.is_file():
-        sys.exit(f"sc skill add: no such file '{args.file}'")
-    content = src.read_text().strip()
-    if not content:
-        sys.exit(f"sc skill add: {args.file} is empty — a skill with no procedure "
-                 "is a row nobody can read.")
-
-    row = con.execute("SELECT is_deleted FROM skills WHERE name=?", (name,)).fetchone()
-    con.execute(
-        "INSERT INTO skills (name, description, category, command, common, content, "
-        "is_deleted) VALUES (?, ?, ?, ?, ?, ?, 0) "
-        "ON CONFLICT(name) DO UPDATE SET description=excluded.description, "
-        "category=excluded.category, command=excluded.command, "
-        "common=excluded.common, content=excluded.content, is_deleted=0",
-        (name, args.desc, args.category, args.command,
-         0 if args.opt_in else 1, content))
-    skill_id = con.execute("SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0]
-    # Guard 5 — auto-grant to the author's owning pack, or the promotion
-    # produces a skill nobody can read.
-    _, scope = set_target_grant(con, author_id, author, skill_id, True)
-    con.commit()
-    verb = "updated" if row else "added"
-    print(f"add: {name} {verb} (local, DB-only, {len(content)} chars) "
-          f"→ granted to {scope}")
-    if not args.desc:
-        print("  ⚠ no --desc — the boot SKILLS block lists the name with an empty "
-              "summary; re-run with --desc to make it findable.")
-    persist_note()
-    return 0
-
-
 def cmd_grant(con, name: str, shell_refs: list[str]) -> int:
     skill_id = resolve_skill(con, name)
     for ref in shell_refs:
@@ -400,8 +285,8 @@ def cmd_rm(con, name: str) -> int:
 
 
 def main(argv: list[str]) -> int:
-    usage = ("usage: ./sc skill list | add <name> --file <path> [--desc …] | "
-             "grant <name> <shell>... | revoke <name> <shell>... | rm <name> | "
+    usage = ("usage: ./sc skill list | grant <name> <shell>... | "
+             "revoke <name> <shell>... | rm <name> | "
              "retire <name> | unretire <name>")
     if not argv or argv[0] in ("-h", "--help", "help"):
         print(usage)
@@ -413,8 +298,6 @@ def main(argv: list[str]) -> int:
     try:
         if cmd == "list" and not args:
             return cmd_list(con)
-        if cmd == "add" and args:
-            return cmd_add(con, args)
         if cmd == "grant" and len(args) >= 2:
             return cmd_grant(con, args[0], args[1:])
         if cmd == "revoke" and len(args) >= 2:

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -144,11 +144,22 @@ shell, `--message send <shortname> <body>`; mark an item read with
 
 On boot, if the `## STATUS` `L&S:` line says **curation due**, run the `curate`
 skill before the session's work — it is a short pass over your own active set:
-resolve contradictions, merge entries that state one rule, promote a recurring
-process to a skill, move environment facts out. Curation is yours alone (Law 3,
-Law 7) — never delegate it to a subagent, and never let another shell do it for
-you. Finish by stamping `sc mem curated`, even if you retired nothing: an honest
-clean sweep must clear the counter, or the advisory stands forever.
+resolve contradictions, merge entries that state one rule, and turn a recurring
+process into a deduplicated upstream recommendation issue. Keep one compressed
+L&S entry until the reviewed upstream skill ships and is granted — filing an
+issue is not grounds to retire the knowledge. Curation never creates a local
+skill or asset; deliberate fork-specific skill authoring remains an
+administrator-owned asset → seed → grant → snapshot → render workflow under
+`local_skill_management`. Curation is yours alone (Law 3, Law 7) — never
+delegate it to a subagent, and never let another shell do it for you. Finish by
+stamping `sc mem curated`, even if you retired nothing: an honest clean sweep
+must clear the counter, or the advisory stands forever.
+
+The recommendation route is the one authorized exception to the ordinary
+"enhancement ideas go to the FnB first" gate in `issue_reporting`. Search all
+upstream issues before opening `skills: recommend <topic>`; add evidence to an
+existing issue when one matches. If search or creation is unavailable, surface
+the failure to the FnB, keep the L&S, and create no local skill or asset.
 
 This is an advisory, not a block. If the line is quiet, there is nothing to do.
 If it fires every few sessions, that is the signal reporting on itself —

--- a/tests/test_lns_curation.py
+++ b/tests/test_lns_curation.py
@@ -322,98 +322,86 @@ class LnsCurationTest(unittest.TestCase):
         self.assertIn("chars", compose.render_lns_status(self.counts()))
 
 
-class SkillAddTest(unittest.TestCase):
-    """`sc skill add` — the promote pass's landing place. Each guard is proven
-    by trying the thing it forbids."""
+class CurationGovernanceTest(unittest.TestCase):
+    """Curation recommends upstream; only admins author durable fork skills."""
 
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp())
-        self.db = self.tmp / "shell_db.db"
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "shell_db.db"
         build_engine_db(self.db)
+        self.saved_db = skill_cmd.DB_PATH
         skill_cmd.DB_PATH = self.db
-        self.body = self.tmp / "proc.md"
-        self.body.write_text("# a procedure\n\nsteps.\n")
 
-    def add(self, *argv) -> str:
-        """Run `skill add`; return stdout on success or the refusal text."""
-        out, err = io.StringIO(), io.StringIO()
-        con = skill_cmd.connect()
+    def tearDown(self):
+        skill_cmd.DB_PATH = self.saved_db
+        self.tmp.cleanup()
+
+    def test_skill_help_and_execution_have_no_add_surface(self):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.assertEqual(skill_cmd.main(["--help"]), 0)
+        self.assertNotIn(" add ", f" {out.getvalue()} ")
+
+        with self.assertRaisesRegex(SystemExit, "usage: ./sc skill list"):
+            skill_cmd.main(["add", "tc_sweep", "--file", "candidate.md"])
+        con = sqlite3.connect(self.db)
         try:
-            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
-                try:
-                    skill_cmd.cmd_add(con, list(argv))
-                except SystemExit as e:
-                    return str(e or "")
+            self.assertIsNone(
+                con.execute("SELECT 1 FROM skills WHERE name='tc_sweep'").fetchone()
+            )
         finally:
             con.close()
-        return out.getvalue()
 
-    def q(self, sql, *params):
-        c = sqlite3.connect(self.db)
-        c.row_factory = sqlite3.Row
+    def test_curate_recommends_and_retains_lns_until_delivery(self):
+        text = (ENGINE / "assets" / "skills" / "curate" / "SKILL.md").read_text()
+        self.assertIn("gh issue list --repo jedbjorn/subfloor --state all", text)
+        self.assertIn("skills: recommend <topic>", text)
+        self.assertIn("trigger that makes the procedure useful", text)
+        self.assertIn("proposed ownership boundary", text)
+        self.assertIn("why existing skills do not cover it", text)
+        self.assertIn("until a reviewed upstream\nskill ships **and is granted**", text)
+        self.assertIn("create no local skill or asset", text)
+        self.assertNotIn("sc skill add", text)
+
+    def test_boot_and_issue_reporting_publish_the_authorized_exception(self):
+        boot = (ENGINE / "templates" / "boot.md").read_text()
+        reporting = (
+            ENGINE / "assets" / "skills" / "issue_reporting" / "SKILL.md"
+        ).read_text()
+        for text in (boot, reporting):
+            self.assertIn("skills: recommend <topic>", text)
+            self.assertIn("keep the l&s", text.lower())
+            self.assertIn("create no local skill or asset", text)
+        self.assertIn("FnB-authorized exception", reporting)
+        self.assertIn("administrator-owned", reporting)
+
+    def test_admin_asset_seed_snapshot_workflow_remains_explicit(self):
+        text = (
+            ENGINE / "assets" / "skills" / "local_skill_management" / "SKILL.md"
+        ).read_text()
+        self.assertIn("file -> seed -> grant -> local snapshot", text)
+        self.assertIn("SC_ADMIN=1 sc snapshot", text)
+
+    def test_trailing_migration_matches_changed_skill_assets_exactly(self):
+        con = sqlite3.connect(self.db)
+        con.row_factory = sqlite3.Row
         try:
-            return c.execute(sql, params).fetchone()
+            for name in ("curate", "issue_reporting"):
+                expected = skill_cmd.seed_skills.parse_skill(
+                    ENGINE / "assets" / "skills" / name / "SKILL.md"
+                )
+                actual = con.execute(
+                    "SELECT description, category, command, common, content "
+                    "FROM skills WHERE name=?",
+                    (name,),
+                ).fetchone()
+                self.assertIsNotNone(actual)
+                self.assertEqual(dict(actual), {
+                    key: expected[key]
+                    for key in ("description", "category", "command", "common", "content")
+                })
         finally:
-            c.close()
-
-    def test_adds_a_namespaced_local_skill_and_grants_it_to_the_author(self):
-        out = self.add("tc_sweep", "--file", str(self.body),
-                       "--desc", "one line", "--for", "tc")
-        self.assertIn("granted to Bespoke tc", out)
-        row = self.q("SELECT skill_id, description, content, is_deleted "
-                     "FROM skills WHERE name='tc_sweep'")
-        self.assertIsNotNone(row)
-        self.assertEqual(row["description"], "one line")
-        self.assertIn("a procedure", row["content"])
-        self.assertIsNotNone(self.q(
-            "SELECT 1 FROM shell_skills WHERE shell_id=1 AND skill_id=?",
-            row["skill_id"]))
-
-    def test_writes_no_asset_file(self):
-        """DB-only is load-bearing: `./sc seed-skills` upserts every asset, so
-        a file would put a local skill back on the seed path."""
-        self.add("tc_sweep", "--file", str(self.body), "--for", "tc")
-        self.assertFalse((ENGINE / "assets" / "skills" / "tc_sweep").exists())
-
-    def test_refuses_an_engine_name(self):
-        msg = self.add("memory", "--file", str(self.body), "--for", "tc")
-        self.assertIn("ENGINE skill", msg)
-        self.assertIsNone(self.q("SELECT 1 FROM skills WHERE name='memory' "
-                                 "AND content LIKE '%a procedure%'"))
-
-    def test_refuses_a_bare_unnamespaced_name(self):
-        msg = self.add("sweep", "--file", str(self.body), "--for", "tc")
-        self.assertIn("namespaced", msg)
-        self.assertIsNone(self.q("SELECT 1 FROM skills WHERE name='sweep'"))
-
-    def test_refuses_a_name_on_the_fork_retire_list(self):
-        real = skill_cmd.seed_skills.retired_skill_names
-        skill_cmd.seed_skills.retired_skill_names = lambda: ["tc_sweep"]
-        try:
-            msg = self.add("tc_sweep", "--file", str(self.body), "--for", "tc")
-        finally:
-            skill_cmd.seed_skills.retired_skill_names = real
-        self.assertIn("retire list", msg)
-        self.assertIsNone(self.q("SELECT 1 FROM skills WHERE name='tc_sweep'"))
-
-    def test_refuses_an_empty_or_missing_body(self):
-        self.assertIn("no such file", self.add(
-            "tc_sweep", "--file", str(self.tmp / "nope.md"), "--for", "tc"))
-        blank = self.tmp / "blank.md"
-        blank.write_text("   \n")
-        self.assertIn("empty", self.add(
-            "tc_sweep", "--file", str(blank), "--for", "tc"))
-
-    def test_unknown_author_refuses_rather_than_orphaning_the_skill(self):
-        import os
-        saved = os.environ.pop("SC_API_TOKEN", None)
-        try:
-            msg = self.add("tc_sweep", "--file", str(self.body))
-        finally:
-            if saved is not None:
-                os.environ["SC_API_TOKEN"] = saved
-        self.assertIn("--for", msg)
-        self.assertIsNone(self.q("SELECT 1 FROM skills WHERE name='tc_sweep'"))
+            con.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_skill_tombstones.py
+++ b/tests/test_skill_tombstones.py
@@ -13,7 +13,6 @@ from pathlib import Path
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 sys.path.insert(0, str(ENGINE / "scripts"))
 seed_skills = importlib.import_module("seed_skills")
-skill_mod = importlib.import_module("skill")
 
 
 TOMBSTONES = [
@@ -283,17 +282,6 @@ class ReservedAssetTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "engine_surgery"):
             seed_skills.sync_engine_skills(self.con, specs=[spec])
         self.assertEqual(self.con.execute("SELECT * FROM skills").fetchall(), [])
-
-    def test_db_creation_path_refuses_reserved_name_before_writing(self):
-        body = seed_skills.TOMBSTONES_FILE.parent / "candidate.md"
-        body.write_text("candidate body\n")
-        with self.assertRaisesRegex(SystemExit, "permanently reserved"):
-            skill_mod.cmd_add(
-                self.con,
-                ["retired_name", "--file", str(body), "--for", "DEV1"],
-            )
-        self.assertEqual(self.con.execute("SELECT * FROM skills").fetchall(), [])
-
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- remove the DB-only `sc skill add` parser, author resolution, write path, and promotion tests
- rewrite `curate`, boot curation guidance, and `issue_reporting` around deduplicated upstream recommendation issues while retaining L&S until delivery
- preserve the administrator-owned asset → seed → grant → snapshot workflow and publish byte-exact skill updates through migration 0156

## Verification
- `.venv/bin/pytest -q tests/test_lns_curation.py tests/test_skill_tombstones.py tests/test_skills_freshness.py tests/test_local_skill_persistence.py tests/test_skill_retire.py tests/test_skill_lifecycle_convergence.py` — 74 passed, 19 subtests
- `./sc test` — 1543 passed, 1 skipped (pre-rebase; focused gates rerun after rebase)
- `./sc render-check`
- `git diff --check`

## Trade-off
The curation workflow keeps a compressed L&S entry until a reviewed skill ships, so the hard cap may retain one process summary longer; this preserves knowledge across the recommendation/review gap without a live-only catalogue write.

## Follow-up
- #919 tracks linked-worktree `./sc seed-skills` dispatching to shared-checkout source; this PR used the caller script directly to regenerate 0001.