### PR TITLE
fix: preserve Sprint state across rebuilds

### DIFF
--- a/.super-coder/scripts/rebuild.py
+++ b/.super-coder/scripts/rebuild.py
@@ -39,6 +39,35 @@ BACKUP_DIR = db_backup_mod.preferred_home_dir(REPO_ROOT)
 SNAPSHOT = artifact_policy.content_path()
 
 
+def _promote_legacy_update_restore_point(target: Path) -> None:
+    """Bridge one update launched by the pre-prefix engine.
+
+    The update process imports its old ``rebuild`` module before materializing
+    this release, so that first adoption still writes a ``prerebuild`` backup.
+    Before a later verify can create a newer backup with the same legacy class,
+    preserve the existing latest row as the engine-paired ``preupdate`` point.
+    """
+    engine_ref_prev = REPO_ROOT / ".sc-state" / "engine.ref.prev"
+    if not engine_ref_prev.exists():
+        return
+    if db_backup_mod.latest_backup(REPO_ROOT, "shell_db.preupdate.*.db"):
+        return
+    legacy = db_backup_mod.latest_backup(REPO_ROOT, "shell_db.prerebuild.*.db")
+    if legacy is None:
+        return
+    promoted_name = legacy.name.replace(
+        "shell_db.prerebuild.", "shell_db.preupdate.", 1
+    )
+    promoted = target / promoted_name
+    if not promoted.exists():
+        backup_db(promoted, src=legacy)
+        print(
+            "rebuild: preserved legacy update restore point -> "
+            f"{promoted}"
+        )
+    prune_backups("shell_db.preupdate", target)
+
+
 def snapshot_path() -> Path:
     artifact_policy.prepare_local_state()
     if SNAPSHOT.exists():
@@ -148,14 +177,23 @@ def backup_db(dst: Path, src: Path | None = None) -> None:
         src_con.close()
 
 
-def backup_existing() -> None:
+def backup_existing(prefix: str = "prerebuild") -> None:
+    """Back up the live DB under the lifecycle-specific restore-point class.
+
+    Direct rebuild/verify backups are diagnostics and must not outrank the
+    pre-update DB that pairs with ``engine.ref.prev`` during rollback.
+    """
     if not DB_PATH.exists():
         return
+    if prefix not in {"prerebuild", "preupdate"}:
+        raise ValueError(f"unsupported DB backup prefix: {prefix}")
     target = backup_dir()
+    if prefix == "prerebuild":
+        _promote_legacy_update_restore_point(target)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    dst = target / f"shell_db.prerebuild.{ts}.db"
+    dst = target / f"shell_db.{prefix}.{ts}.db"
     backup_db(dst)
-    prune_backups("shell_db.prerebuild", target)
+    prune_backups(f"shell_db.{prefix}", target)
     print(f"rebuild: backed up existing DB -> {dst}")
 
 

--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -8,7 +8,8 @@ restores both:
 
     1. back up the CURRENT (post-bad-update) DB first — so rollback is itself
        reversible; you can never lose state by rolling back.
-    2. restore the DB from the most recent shell_db.prerebuild.<ts>.db.
+    2. restore the DB from the most recent shell_db.preupdate.<ts>.db
+       (falling back to legacy prerebuild restore points).
     3. re-materialize the engine at .sc-state/engine.ref.prev; restore engine.ref.
     4. clear the -wal/-shm sidecars (the restored .db is a complete snapshot).
 
@@ -38,11 +39,11 @@ ENGINE_REF = STATE_DIR / "engine.ref"
 ENGINE_REF_PREV = STATE_DIR / "engine.ref.prev"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
-import db_backup as db_backup_mod  # noqa: E402
 import callable_floor  # noqa: E402
+import db_backup as db_backup_mod  # noqa: E402
 import engine_manifest  # noqa: E402
 import rebuild as rebuild_mod  # noqa: E402  (BACKUP_DIR, backup_db, prune_backups, KEEP_BACKUPS)
-import update as update_mod    # noqa: E402  (materialize_engine, super_coder_remote, git)
+import update as update_mod  # noqa: E402  (materialize_engine, super_coder_remote, git)
 
 # Compatibility alias for callers that inspect the preferred location. Runtime
 # reads/writes use rebuild_mod.backup_dir() so restricted seats share the same
@@ -51,9 +52,10 @@ BACKUP_DIR = rebuild_mod.BACKUP_DIR
 
 
 def latest_db_restore_point() -> Path | None:
-    return db_backup_mod.latest_backup(
-        REPO_ROOT, "shell_db.prerebuild.*.db"
-    )
+    paired = db_backup_mod.latest_backup(REPO_ROOT, "shell_db.preupdate.*.db")
+    if paired is not None:
+        return paired
+    return db_backup_mod.latest_backup(REPO_ROOT, "shell_db.prerebuild.*.db")
 
 
 def backup_current_db() -> None:
@@ -249,7 +251,8 @@ def main(argv: list[str] | None = None) -> int:
 
     src = latest_db_restore_point()
     if src is None:
-        sys.exit("rollback: no shell_db.prerebuild.*.db restore point found in "
+        sys.exit("rollback: no shell_db.preupdate.*.db (or legacy prerebuild) "
+                 "restore point found in "
                  f"{rebuild_mod.backup_dir()} — nothing to roll back to.")
 
     print("→ rolling back the last update (DB + engine pair-restore)")

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -268,6 +268,86 @@ def _insert_line(table: str, cols: list[str], row) -> str:
     return f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({vals});"
 
 
+def _dependency_ordered_rows(
+    rows,
+    cols: list[str],
+    *,
+    table: str,
+    identity: str,
+    parent: str,
+    scope: tuple[str, ...],
+):
+    """Order immutable self-references parent-first for trigger-safe replay."""
+    identity_index = cols.index(identity)
+    parent_index = cols.index(parent)
+    scope_indexes = tuple(cols.index(column) for column in scope)
+
+    def row_key(row) -> tuple:
+        return tuple(row[index] for index in scope_indexes) + (row[identity_index],)
+
+    by_key = {row_key(row): row for row in rows}
+    if len(by_key) != len(rows):
+        raise RuntimeError(f"snapshot: duplicate dependency identity in {table}")
+
+    keys = [row_key(row) for row in rows]
+    children: dict[tuple, list[tuple]] = {key: [] for key in keys}
+    indegree = {key: 0 for key in keys}
+    for key, row in zip(keys, rows):
+        parent_identity = row[parent_index]
+        if parent_identity is not None:
+            parent_key = tuple(row[index] for index in scope_indexes) + (
+                parent_identity,
+            )
+            if parent_key not in by_key:
+                raise RuntimeError(
+                    f"snapshot: missing dependency in {table}: {parent_key!r}"
+                )
+            children[parent_key].append(key)
+            indegree[key] += 1
+
+    ready = [key for key in keys if indegree[key] == 0]
+    ordered = []
+    cursor = 0
+    while cursor < len(ready):
+        key = ready[cursor]
+        cursor += 1
+        ordered.append(by_key[key])
+        for child_key in children[key]:
+            indegree[child_key] -= 1
+            if indegree[child_key] == 0:
+                ready.append(child_key)
+    if len(ordered) != len(rows):
+        raise RuntimeError(f"snapshot: dependency cycle in {table}")
+    return ordered
+
+
+def dump_dependency_ordered_table(
+    con,
+    table: str,
+    *,
+    identity: str,
+    parent: str,
+    scope: tuple[str, ...],
+) -> list[str]:
+    """Dump a self-referential table in legal immutable-insert order."""
+    cols = _table_columns(con, table)
+    rows = con.execute(
+        f"SELECT {', '.join(cols)} FROM {table} ORDER BY rowid"
+    ).fetchall()
+    ordered = _dependency_ordered_rows(
+        rows,
+        cols,
+        table=table,
+        identity=identity,
+        parent=parent,
+        scope=scope,
+    )
+    lines = [f"DELETE FROM {table};"]
+    lines.extend(_insert_line(table, cols, row) for row in ordered)
+    lines.append("")
+    return lines
+
+
 def dump_sprints(con) -> list[str]:
     """Serialize lifecycle rows through their legal transition path.
 
@@ -352,7 +432,13 @@ def dump_sprint_participants(con) -> list[str]:
 
 def dump_sprint_participant_conversations(con) -> list[str]:
     """Restore immutable links, then select the participants' exact pointers."""
-    lines = dump_plain_table(con, "sprint_participant_conversations")
+    lines = dump_dependency_ordered_table(
+        con,
+        "sprint_participant_conversations",
+        identity="conversation_id",
+        parent="parent_conversation_id",
+        scope=("sprint_participant_id",),
+    )
     pointers = con.execute(
         "SELECT participant_id,persistent_conversation_id,current_conversation_id "
         "FROM sprint_participants "
@@ -396,6 +482,14 @@ def dump_table(con, table: str) -> list[str]:
         return dump_flavor_skills(con)
     if table == "shell_skills":
         return dump_shell_skills(con)
+    if table == "conversation_messages":
+        return dump_dependency_ordered_table(
+            con,
+            table,
+            identity="message_id",
+            parent="caused_by_message_id",
+            scope=("conversation_id",),
+        )
     if table == "sprints":
         return dump_sprints(con)
     if table == "sprint_participants":

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -40,6 +40,35 @@ OUT_PATH = artifact_policy.content_path()
 # copy, remove it once we write the new one so it can't shadow or drift.
 LEGACY_PATH = ENGINE / "snapshot" / "content.sql"
 
+# Every durable Sprints v2 table.  Keep this as the one snapshot authority for
+# the domain: tests compare it to the migrated schema so a future sprint_*
+# table cannot silently fall out of rebuilds.  Generic conversations are
+# listed before this group in PER_INSTANCE_TABLES because participant links,
+# pointers, and wake attempts reference them.
+SPRINT_INSTANCE_TABLES = [
+    "sprint_spec_approvals",
+    "sprints",
+    "sprint_specs",
+    "sprint_participants",
+    "sprint_participant_conversations",
+    "sprint_work_units",
+    "sprint_work_unit_tasks",
+    "sprint_work_unit_dependencies",
+    "sprint_messages",
+    "sprint_wake_outbox",
+    "sprint_wake_messages",
+    "sprint_wake_attempts",
+    "sprint_liveness_expectations",
+    "sprint_registered_prs",
+    "sprint_pr_work_units",
+    "sprint_pr_transitions",
+    "sprint_judgments",
+    "sprint_reports",
+    "sprint_followups",
+    "sprint_events",
+]
+
+
 # Per-instance tables, parents-before-children for readability.
 # `schema_migrations` is excluded. Engine-authored skills are system content
 # seeded from migrations; project-local skills are serialized by the special
@@ -84,6 +113,11 @@ PER_INSTANCE_TABLES = [
     "conversation_runs",
     "conversation_events",
     "conversation_outbox",
+    # Sprints are durable orchestration truth, not a derived runtime cache.
+    # This includes terminal rows and append-only evidence: numeric allocators,
+    # exact approvals, active routes, retries, reports, and history must all
+    # survive update/rebuild together.
+    *SPRINT_INSTANCE_TABLES,
     # NOTE: dr_section is authored navigation but lives in the MAP DB now
     # (.sc-state/map.db), not shell_db.db — it is serialized separately to
     # .sc-state/local/map/content.sql by snapshot_map() below, not here.
@@ -225,6 +259,136 @@ SENSITIVE_COLUMNS = {
 }
 
 
+def _table_columns(con, table: str) -> list[str]:
+    return [r[1] for r in con.execute(f"PRAGMA table_info({table})")]
+
+
+def _insert_line(table: str, cols: list[str], row) -> str:
+    vals = ", ".join(quote(v) for v in row)
+    return f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({vals});"
+
+
+def dump_sprints(con) -> list[str]:
+    """Serialize lifecycle rows through their legal transition path.
+
+    The schema correctly refuses inserting an armed/terminal Sprint directly.
+    A rebuild therefore inserts the exact row as prepared (with no terminal
+    outcome), then replays only the lifecycle edges needed to restore its
+    projection.  All timestamps, generation identity, version, and plan fields
+    are inserted at their original values and remain byte-for-byte unchanged.
+    """
+    table = "sprints"
+    cols = _table_columns(con, table)
+    rows = con.execute(
+        f"SELECT {', '.join(cols)} FROM {table} ORDER BY rowid"
+    ).fetchall()
+    lifecycle_index = cols.index("lifecycle")
+    outcome_index = cols.index("terminal_outcome")
+    lines = [f"DELETE FROM {table};"]
+    restores: list[tuple[str, list[str]]] = []
+    for original in rows:
+        row = list(original)
+        lifecycle = str(row[lifecycle_index])
+        outcome = row[outcome_index]
+        sprint_id = row[cols.index("sprint_id")]
+        if lifecycle != "prepared":
+            row[lifecycle_index] = "prepared"
+            row[outcome_index] = None
+        lines.append(_insert_line(table, cols, row))
+        transitions: list[str] = []
+        if lifecycle in {"armed", "paused", "completed"}:
+            transitions.append(
+                f"UPDATE sprints SET lifecycle='armed' WHERE sprint_id={quote(sprint_id)};"
+            )
+        if lifecycle == "paused":
+            transitions.append(
+                f"UPDATE sprints SET lifecycle='paused' WHERE sprint_id={quote(sprint_id)};"
+            )
+        elif lifecycle == "completed":
+            transitions.append(
+                "UPDATE sprints SET lifecycle='completed', terminal_outcome="
+                f"{quote(outcome)} WHERE sprint_id={quote(sprint_id)};"
+            )
+        elif lifecycle == "aborted":
+            transitions.append(
+                "UPDATE sprints SET lifecycle='aborted', terminal_outcome="
+                f"{quote(outcome)} WHERE sprint_id={quote(sprint_id)};"
+            )
+        restores.append((lifecycle, transitions))
+    # The unique partial index permits only one armed Sprint.  Restore every
+    # row that finishes non-armed first, then the current armed row.  This is
+    # independent of creation order (an older paused Sprint can be resumed
+    # after a newer Sprint is paused).
+    for lifecycle, transitions in restores:
+        if lifecycle != "armed":
+            lines.extend(transitions)
+    for lifecycle, transitions in restores:
+        if lifecycle == "armed":
+            lines.extend(transitions)
+    lines.append("")
+    return lines
+
+
+def dump_sprint_participants(con) -> list[str]:
+    """Insert participants before immutable links, with pointers deferred."""
+    table = "sprint_participants"
+    cols = _table_columns(con, table)
+    rows = con.execute(
+        f"SELECT {', '.join(cols)} FROM {table} ORDER BY rowid"
+    ).fetchall()
+    pointer_indexes = (
+        cols.index("persistent_conversation_id"),
+        cols.index("current_conversation_id"),
+    )
+    lines = [f"DELETE FROM {table};"]
+    for original in rows:
+        row = list(original)
+        for index in pointer_indexes:
+            row[index] = None
+        lines.append(_insert_line(table, cols, row))
+    lines.append("")
+    return lines
+
+
+def dump_sprint_participant_conversations(con) -> list[str]:
+    """Restore immutable links, then select the participants' exact pointers."""
+    lines = dump_plain_table(con, "sprint_participant_conversations")
+    pointers = con.execute(
+        "SELECT participant_id,persistent_conversation_id,current_conversation_id "
+        "FROM sprint_participants "
+        "WHERE persistent_conversation_id IS NOT NULL "
+        "OR current_conversation_id IS NOT NULL ORDER BY participant_id"
+    ).fetchall()
+    if pointers:
+        lines.pop()  # keep pointer selection in the same readable table block
+    for participant_id, persistent, current in pointers:
+        lines.append(
+            "UPDATE sprint_participants SET persistent_conversation_id="
+            f"{quote(persistent)}, current_conversation_id={quote(current)} "
+            f"WHERE participant_id={quote(participant_id)};"
+        )
+    if pointers:
+        lines.append("")
+    return lines
+
+
+def dump_plain_table(con, table: str) -> list[str]:
+    cols = _table_columns(con, table)
+    cols = [c for c in cols if c not in SENSITIVE_COLUMNS.get(table, ())]
+    if not cols:
+        return []
+    collist = ", ".join(cols)
+    where = SNAPSHOT_ROW_FILTERS.get(table, "")
+    rows = con.execute(
+        f"SELECT {collist} FROM {table} {where} ORDER BY rowid"
+    ).fetchall()
+    lines = [f"DELETE FROM {table};"]
+    for row in rows:
+        lines.append(_insert_line(table, cols, row))
+    lines.append("")
+    return lines
+
+
 def dump_table(con, table: str) -> list[str]:
     if table == "skills":
         return dump_local_skills(con)
@@ -232,21 +396,13 @@ def dump_table(con, table: str) -> list[str]:
         return dump_flavor_skills(con)
     if table == "shell_skills":
         return dump_shell_skills(con)
-    cols = [r[1] for r in con.execute(f"PRAGMA table_info({table})")]
-    cols = [c for c in cols if c not in SENSITIVE_COLUMNS.get(table, ())]
-    if not cols:
-        return []
-    collist = ", ".join(cols)
-    where = SNAPSHOT_ROW_FILTERS.get(table, "")
-    rows = con.execute(
-        f"SELECT {collist} FROM {table} "
-        f"{where} ORDER BY rowid").fetchall()
-    lines = [f"DELETE FROM {table};"]
-    for row in rows:
-        vals = ", ".join(quote(v) for v in row)
-        lines.append(f"INSERT INTO {table} ({collist}) VALUES ({vals});")
-    lines.append("")
-    return lines
+    if table == "sprints":
+        return dump_sprints(con)
+    if table == "sprint_participants":
+        return dump_sprint_participants(con)
+    if table == "sprint_participant_conversations":
+        return dump_sprint_participant_conversations(con)
+    return dump_plain_table(con, table)
 
 
 def snapshot_map() -> None:
@@ -283,16 +439,10 @@ def snapshot_map() -> None:
         con.close()
 
 
-def main() -> int:
-    require_admin("snapshot")
-    copied = artifact_policy.prepare_local_state()
-    if copied:
-        print(f"snapshot: localized {len(copied)} existing artifact(s)")
-    if not DB_PATH.exists():
-        raise SystemExit(f"snapshot: no live DB at {DB_PATH} — run `./sc rebuild` first.")
-    con = db_driver.connect(DB_PATH)
+def serialize_instance(con) -> str:
+    """Render one coherent read view of every per-instance table."""
+    con.execute("BEGIN")
     try:
-        reconciled = seed_skills.reconcile_tombstoned_skills(con)
         out = [
             "-- super-coder per-instance snapshot — GENERATED by scripts/snapshot.py.",
             "-- Idempotent: DELETE-then-INSERT per table, PK order. Loaded by rebuild.py.",
@@ -308,7 +458,24 @@ def main() -> int:
             if table_exists(con, table):
                 out.extend(dump_table(con, table))
         out.extend(["COMMIT;", "PRAGMA foreign_keys=ON;"])
-        artifact_policy.atomic_write_text(OUT_PATH, "\n".join(out) + "\n")
+        return "\n".join(out) + "\n"
+    finally:
+        # End the fixed read view without taking ownership of any live writes.
+        con.rollback()
+
+
+def main() -> int:
+    require_admin("snapshot")
+    copied = artifact_policy.prepare_local_state()
+    if copied:
+        print(f"snapshot: localized {len(copied)} existing artifact(s)")
+    if not DB_PATH.exists():
+        raise SystemExit(f"snapshot: no live DB at {DB_PATH} — run `./sc rebuild` first.")
+    con = db_driver.connect(DB_PATH)
+    try:
+        reconciled = seed_skills.reconcile_tombstoned_skills(con)
+        content = serialize_instance(con)
+        artifact_policy.atomic_write_text(OUT_PATH, content)
     finally:
         con.close()
     if reconciled.changed_names:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -843,7 +843,10 @@ def migrate_or_rebuild() -> None:
         print("→ no live DB (fresh fork) — building from text")
         rebuild_mod.main([])
         return
-    rebuild_mod.backup_existing()  # restore point before any structural change
+    # This restore point pairs with engine.ref.prev.  Keep it distinct from a
+    # later verify/rebuild diagnostic backup so rollback cannot combine a
+    # current-schema DB with the previous engine.
+    rebuild_mod.backup_existing(prefix="preupdate")
     print("→ migrate in place (pending migrations → the live DB; data preserved)")
     migrate_mod.migrate(str(DB_PATH))
 

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -46,6 +46,7 @@
     "tests/test_sprint_close.py",
     "tests/test_sprint_cli.py",
     "tests/test_sprint_skills.py",
+    "tests/test_sprint_snapshot_rebuild.py",
     "tests/test_sprint_live_proof.py",
     "tests/test_sprint_board_api.py",
     "tests/test_sprint_board_ui.py",

--- a/tests/test_backup_dir.py
+++ b/tests/test_backup_dir.py
@@ -18,6 +18,7 @@ Run:
 """
 from __future__ import annotations
 
+import os
 import sqlite3
 import sys
 import tempfile
@@ -30,6 +31,7 @@ sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
 import db_backup  # noqa: E402
 import rebuild  # noqa: E402
 import rollback  # noqa: E402
+import update  # noqa: E402
 
 
 class BackupDirTest(unittest.TestCase):
@@ -118,6 +120,94 @@ class BackupDirTest(unittest.TestCase):
             )
 
             self.assertEqual(found, expected)
+
+    def test_rollback_prefers_update_pair_over_newer_verify_backup(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "repo"
+            backups = base / "home" / "db_backups" / repo.name
+            backups.mkdir(parents=True)
+            paired = backups / "shell_db.preupdate.20260801_230000.db"
+            verify = backups / "shell_db.prerebuild.20260801_233000.db"
+            paired.touch()
+            verify.touch()
+            os.utime(paired, ns=(1, 1))
+            os.utime(verify, ns=(2, 2))
+            with mock.patch.object(rollback, "REPO_ROOT", repo), mock.patch.dict(
+                os.environ,
+                {"HOME": str(base / "home"), "SC_DB_BACKUP_DIR": ""},
+            ):
+                found = rollback.latest_db_restore_point()
+            self.assertEqual(found, paired)
+
+    def test_rollback_uses_legacy_prerebuild_when_no_update_pair_exists(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "repo"
+            backups = base / "home" / "db_backups" / repo.name
+            backups.mkdir(parents=True)
+            legacy = backups / "shell_db.prerebuild.20260731_120000.db"
+            legacy.touch()
+            with mock.patch.object(rollback, "REPO_ROOT", repo), mock.patch.dict(
+                os.environ,
+                {"HOME": str(base / "home"), "SC_DB_BACKUP_DIR": ""},
+            ):
+                found = rollback.latest_db_restore_point()
+            self.assertEqual(found, legacy)
+
+    def test_update_backup_is_classed_as_engine_paired_preupdate(self):
+        with tempfile.TemporaryDirectory() as td:
+            db = Path(td) / "shell_db.db"
+            db.write_bytes(b"live")
+            with mock.patch.object(update, "DB_PATH", db), mock.patch.object(
+                update.rebuild_mod, "backup_existing"
+            ) as backup, mock.patch.object(update.migrate_mod, "migrate"):
+                update.migrate_or_rebuild()
+            backup.assert_called_once_with(prefix="preupdate")
+
+    def test_first_new_verify_promotes_pre_prefix_update_backup(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "repo"
+            state = root / ".sc-state"
+            backups = state / "db_backups"
+            backups.mkdir(parents=True)
+            state.joinpath("engine.ref.prev").write_text("old-engine\n")
+            live = root / "shell_db.db"
+            with sqlite3.connect(live) as con:
+                con.execute("CREATE TABLE marker (value TEXT)")
+                con.execute("INSERT INTO marker VALUES ('current-before-verify')")
+            legacy = backups / "shell_db.prerebuild.20260801_230000.db"
+            with sqlite3.connect(legacy) as con:
+                con.execute("CREATE TABLE marker (value TEXT)")
+                con.execute("INSERT INTO marker VALUES ('pre-update-pair')")
+
+            with mock.patch.multiple(
+                rebuild, REPO_ROOT=root, DB_PATH=live
+            ), mock.patch.object(
+                rebuild, "backup_dir", return_value=backups
+            ), mock.patch.dict(
+                os.environ,
+                {"HOME": str(Path(td) / "unwritable-home"), "SC_DB_BACKUP_DIR": ""},
+            ):
+                rebuild.backup_existing()
+
+            promoted = backups / "shell_db.preupdate.20260801_230000.db"
+            self.assertTrue(promoted.is_file())
+            with sqlite3.connect(promoted) as con:
+                self.assertEqual(
+                    con.execute("SELECT value FROM marker").fetchone()[0],
+                    "pre-update-pair",
+                )
+            latest_verify = next(
+                path
+                for path in backups.glob("shell_db.prerebuild.*.db")
+                if path != legacy
+            )
+            with sqlite3.connect(latest_verify) as con:
+                self.assertEqual(
+                    con.execute("SELECT value FROM marker").fetchone()[0],
+                    "current-before-verify",
+                )
 
 
 class WalSafeBackupTest(unittest.TestCase):

--- a/tests/test_sprint_snapshot_rebuild.py
+++ b/tests/test_sprint_snapshot_rebuild.py
@@ -339,6 +339,90 @@ class SprintSnapshotRebuildTest(unittest.TestCase):
     def test_armed_in_flight_sprint_roundtrips_every_v2_table_exactly(self) -> None:
         self.assert_roundtrip(armed=True)
 
+    def test_causal_message_parent_with_higher_id_roundtrips_exactly(self) -> None:
+        con = sqlite3.connect(self.db)
+        try:
+            seed_prepared(con)
+            con.execute(
+                "INSERT INTO conversations "
+                "(conversation_id,shell_id,owner_user_id,harness,provider,model,"
+                "effort,worktree,title,creation_idempotency_key,"
+                "creation_request_hash) VALUES "
+                "('cv_causal',1,1,'codex','test','model','high','/worktree',"
+                "'Causal order','causal-conversation','causal-request')"
+            )
+            con.execute(
+                "INSERT INTO conversation_messages "
+                "(message_id,conversation_id,sender_kind,sender_ref,message_kind,"
+                "body,idempotency_key,request_hash) VALUES "
+                "(100,'cv_causal','user','operator','prompt','parent',"
+                "'causal-parent','parent-hash')"
+            )
+            con.execute(
+                "INSERT INTO conversation_messages "
+                "(message_id,conversation_id,sender_kind,sender_ref,message_kind,"
+                "body,idempotency_key,request_hash,caused_by_message_id) VALUES "
+                "(1,'cv_causal','engine','runtime','result','child',"
+                "'causal-child','child-hash',100)"
+            )
+            con.commit()
+        finally:
+            con.close()
+        compared = ["conversations", "conversation_messages"]
+        before = rows_by_table(self.db, compared)
+
+        self.snapshot_and_rebuild()
+
+        self.assertEqual(before, rows_by_table(self.db, compared))
+
+    def test_participant_link_parent_with_higher_id_restores_before_pointers(
+        self,
+    ) -> None:
+        con = sqlite3.connect(self.db)
+        try:
+            seed_prepared(con)
+            con.executemany(
+                "INSERT INTO conversations "
+                "(conversation_id,shell_id,owner_user_id,harness,provider,model,"
+                "effort,worktree,title,creation_idempotency_key,"
+                "creation_request_hash,conversation_scope) VALUES "
+                "(?,1,1,'codex','test','model','high','/worktree','Sprint link',"
+                "?,?,'sprint')",
+                (
+                    ("cv_parent", "link-parent", "link-parent-hash"),
+                    ("cv_child", "link-child", "link-child-hash"),
+                ),
+            )
+            con.execute(
+                "INSERT INTO sprint_participant_conversations "
+                "(participant_conversation_id,sprint_participant_id,"
+                "conversation_id,purpose) VALUES (100,2,'cv_parent','work')"
+            )
+            con.execute(
+                "INSERT INTO sprint_participant_conversations "
+                "(participant_conversation_id,sprint_participant_id,"
+                "conversation_id,purpose,parent_conversation_id) "
+                "VALUES (1,2,'cv_child','fix','cv_parent')"
+            )
+            con.execute(
+                "UPDATE sprint_participants SET persistent_conversation_id="
+                "'cv_parent', current_conversation_id='cv_child' "
+                "WHERE participant_id=2"
+            )
+            con.commit()
+        finally:
+            con.close()
+        compared = [
+            "conversations",
+            "sprint_participants",
+            "sprint_participant_conversations",
+        ]
+        before = rows_by_table(self.db, compared)
+
+        self.snapshot_and_rebuild()
+
+        self.assertEqual(before, rows_by_table(self.db, compared))
+
     def test_paused_and_terminal_lifecycle_rows_replay_exactly(self) -> None:
         con = sqlite3.connect(self.db)
         try:

--- a/tests/test_sprint_snapshot_rebuild.py
+++ b/tests/test_sprint_snapshot_rebuild.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Lossless Sprints v2 snapshot/rebuild regressions (#918)."""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCHEMA = ENGINE / "schema.sql"
+MIGRATIONS = ENGINE / "migrations"
+sys.path.insert(0, str(ENGINE / "scripts"))
+import db_driver  # noqa: E402
+import rebuild  # noqa: E402
+import snapshot  # noqa: E402
+
+
+def apply_engine_schema(path: Path) -> None:
+    con = sqlite3.connect(path)
+    try:
+        con.executescript(SCHEMA.read_text())
+        for migration in sorted(MIGRATIONS.glob("*.sql")):
+            con.executescript(migration.read_text())
+        con.execute("PRAGMA foreign_keys=ON")
+        con.commit()
+    finally:
+        con.close()
+
+
+def rows_by_table(path: Path, tables: list[str]) -> dict[str, list[tuple]]:
+    con = sqlite3.connect(path)
+    try:
+        return {
+            table: [
+                tuple(row)
+                for row in con.execute(f"SELECT * FROM {table} ORDER BY rowid")
+            ]
+            for table in tables
+        }
+    finally:
+        con.close()
+
+
+def seed_prepared(con: sqlite3.Connection) -> int:
+    con.execute("PRAGMA foreign_keys=ON")
+    con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+    con.executemany(
+        "INSERT INTO shells "
+        "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+        "VALUES (?,?,?,?,?,1)",
+        (
+            (1, "Developer", "DEV1", "dev", "dev prompt"),
+            (2, "Reviewer", "REV1", "reviewer", "review prompt"),
+            (3, "Planner", "PLN1", "planner", "plan prompt"),
+        ),
+    )
+    feature_id = con.execute(
+        "INSERT INTO roadmap (feature_id,title,roadmap_status) "
+        "VALUES (19,'Tiny Sprint feature','in_progress')"
+    ).lastrowid
+    body = "# Exact Sprint governing spec\n\nOne bounded unit."
+    document_id = con.execute(
+        "INSERT INTO documents (document_id,feature_id,kind,seq,title,body) "
+        "VALUES (56,?,'spec',1,'Sprint spec',?)",
+        (feature_id, body),
+    ).lastrowid
+    revision = hashlib.sha256(body.encode()).hexdigest()
+    approval_id = con.execute(
+        "INSERT INTO sprint_spec_approvals "
+        "(approval_id,document_id,revision_sha256,reviewer_shell_id,verdict) "
+        "VALUES (2,?,?,2,'pass')",
+        (document_id, revision),
+    ).lastrowid
+    sprint_id = con.execute(
+        "INSERT INTO sprints "
+        "(sprint_id,feature_id,originating_planner_shell_id,merge_grant_enabled) "
+        "VALUES (1,?,3,1)",
+        (feature_id,),
+    ).lastrowid
+    con.execute(
+        "INSERT INTO sprint_specs "
+        "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+        "VALUES (?,?,?,?)",
+        (sprint_id, document_id, revision, approval_id),
+    )
+    con.executemany(
+        "INSERT INTO sprint_participants "
+        "(participant_id,sprint_id,shell_id,role,harness,model,effort,route) "
+        "VALUES (?,1,?,?,?,?,?,?)",
+        (
+            (1, 3, "planner", "codex", "gpt-5.6-sol", "high", "sol"),
+            (2, 1, "developer", "kimi", "kimi-code/k3", "high", "kimi"),
+            (3, 2, "reviewer", "claude", "opus", "high", "opus-5"),
+        ),
+    )
+    con.executemany(
+        "INSERT INTO spec_tasks "
+        "(task_id,feature_id,document_id,seq,title,status,shell_id) "
+        "VALUES (?,?,?,?,?,'pending',?)",
+        (
+            (30, feature_id, document_id, 1, "Implement tiny change", 1),
+            (31, feature_id, document_id, 2, "Verify tiny change", 1),
+        ),
+    )
+    con.executemany(
+        "INSERT INTO sprint_work_units "
+        "(work_unit_id,sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+        "expected_output,planned_wave,output_kind) "
+        "VALUES (?,1,1,2,?,?,?,?)",
+        (
+            (1, "Implement", "One focused PR", 0, "code"),
+            (2, "Verify", "A verification report", 1, "report_only"),
+        ),
+    )
+    con.executemany(
+        "INSERT INTO sprint_work_unit_tasks (sprint_id,work_unit_id,task_id) "
+        "VALUES (1,?,?)",
+        ((1, 30), (2, 31)),
+    )
+    con.execute(
+        "INSERT INTO sprint_work_unit_dependencies "
+        "(sprint_id,work_unit_id,depends_on_work_unit_id) VALUES (1,2,1)"
+    )
+    con.execute(
+        "INSERT INTO sprint_events "
+        "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+        "VALUES (1,'sprint.declared','planner',3,'{\"feature_id\":19}')"
+    )
+    con.commit()
+    return int(sprint_id)
+
+
+def arm_with_representative_state(con: sqlite3.Connection) -> None:
+    conversations = (
+        ("cv_plan", 3, "planner-work"),
+        ("cv_dev", 1, "developer-work"),
+        ("cv_rev", 2, "reviewer-work"),
+    )
+    con.executemany(
+        "INSERT INTO conversations "
+        "(conversation_id,shell_id,owner_user_id,harness,provider,model,effort,"
+        "worktree,state,title,creation_idempotency_key,creation_request_hash,"
+        "conversation_scope) "
+        "VALUES (?,?,1,'codex','test','model','high','/worktree','idle',"
+        "'Sprint work',?,'request-hash','sprint')",
+        conversations,
+    )
+    con.execute(
+        "UPDATE conversations SET state='queued' WHERE conversation_id='cv_dev'"
+    )
+    con.execute(
+        "INSERT INTO conversation_messages "
+        "(message_id,conversation_id,sender_kind,sender_ref,message_kind,body,"
+        "idempotency_key,request_hash,state) VALUES "
+        "(1,'cv_dev','engine','sprint-runtime','prompt','Sprint wake prompt',"
+        "'native-wake-1','native-request-1','queued')"
+    )
+    con.execute(
+        "INSERT INTO conversation_events "
+        "(event_id,conversation_id,sequence,event_type,payload,message_id) "
+        "VALUES (1,'cv_dev',1,'message.queued','{\"sprint_id\":1}',1)"
+    )
+    con.execute(
+        "INSERT INTO conversation_outbox "
+        "(outbox_id,conversation_id,message_id,state) "
+        "VALUES (1,'cv_dev',1,'pending')"
+    )
+    con.executemany(
+        "INSERT INTO sprint_participant_conversations "
+        "(sprint_participant_id,conversation_id,purpose) VALUES (?,?,'work')",
+        ((1, "cv_plan"), (2, "cv_dev"), (3, "cv_rev")),
+    )
+    con.executemany(
+        "UPDATE sprint_participants SET persistent_conversation_id=?,"
+        "current_conversation_id=?,disposition=?,updated_at=? "
+        "WHERE participant_id=?",
+        (
+            ("cv_plan", "cv_plan", "active", "2026-08-01 21:00:00", 1),
+            ("cv_dev", "cv_dev", "active", "2026-08-01 21:00:01", 2),
+            ("cv_rev", "cv_rev", "idle", "2026-08-01 21:00:02", 3),
+        ),
+    )
+    con.execute(
+        "UPDATE sprints SET lifecycle='armed',armed_at='2026-08-01 21:00:00',"
+        "updated_at='2026-08-01 21:00:00',version=2 WHERE sprint_id=1"
+    )
+    con.execute(
+        "UPDATE sprint_work_units SET disposition='active',"
+        "updated_at='2026-08-01 21:01:00' WHERE work_unit_id=1"
+    )
+    con.execute(
+        "INSERT INTO sprint_messages "
+        "(message_id,sprint_id,from_participant_id,to_participant_id,work_unit_id,"
+        "message_kind,body,actionable,disposition,read_at,idempotency_key) "
+        "VALUES (1,1,1,2,1,'work_assignment','Implement now',1,'accepted',"
+        "'2026-08-01 21:01:00','assignment-1')"
+    )
+    con.execute(
+        "INSERT INTO sprint_wake_outbox "
+        "(wake_id,sprint_id,participant_id,state,attempt_count,idempotency_key,"
+        "delivered_at) VALUES (1,1,2,'delivered',1,'wake-1',"
+        "'2026-08-01 21:01:01')"
+    )
+    con.execute(
+        "INSERT INTO sprint_wake_messages (sprint_id,wake_id,message_id) "
+        "VALUES (1,1,1)"
+    )
+    con.execute(
+        "INSERT INTO sprint_wake_attempts "
+        "(attempt_id,wake_id,attempt_number,target_conversation_id,native_run_ref,"
+        "outcome,attempted_at) VALUES (1,1,1,'cv_dev','run-1','delivered',"
+        "'2026-08-01 21:01:01')"
+    )
+    con.execute(
+        "INSERT INTO sprint_liveness_expectations "
+        "(message_id,sprint_id,participant_id,accepted_at,last_strong_at,"
+        "last_strong_key,next_evaluation_at) VALUES (1,1,2,"
+        "'2026-08-01 21:01:00','2026-08-01 21:01:00','accepted-1',"
+        "'2026-08-01 21:06:00')"
+    )
+    con.execute(
+        "INSERT INTO sprint_registered_prs "
+        "(registered_pr_id,sprint_id,owner_participant_id,repository,pr_number) "
+        "VALUES (1,1,2,'jedbjorn/dos-app',54)"
+    )
+    con.execute(
+        "INSERT INTO sprint_pr_work_units "
+        "(sprint_id,registered_pr_id,work_unit_id) VALUES (1,1,1)"
+    )
+    con.execute(
+        "INSERT INTO sprint_pr_transitions "
+        "(transition_id,registered_pr_id,normalized_state,transition_key,"
+        "observed_head_sha,evidence,observed_at) VALUES "
+        "(1,1,'green','pr-54-green','aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',"
+        "'{\"checks\":\"green\"}','2026-08-01 21:05:00')"
+    )
+    con.execute(
+        "INSERT INTO sprint_judgments "
+        "(judgment_id,sprint_id,participant_id,work_unit_id,kind,body) "
+        "VALUES (1,1,2,1,'decision','Ready for review')"
+    )
+    con.execute(
+        "INSERT INTO sprint_reports "
+        "(report_id,sprint_id,report_kind,author_shell_id,body,idempotency_key) "
+        "VALUES (1,1,'conformance',2,'Representative finding','report-1')"
+    )
+    con.execute(
+        "INSERT INTO sprint_followups "
+        "(followup_id,sprint_id,source_report_id,severity,title,body,"
+        "spec_document_id,work_unit_id,idempotency_key) "
+        "VALUES (1,1,1,'Medium','Follow-up','Inspect after close',56,1,'followup-1')"
+    )
+    con.execute(
+        "INSERT INTO sprint_events "
+        "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+        "VALUES (1,'fixture.in_flight','system',NULL,'{\"head\":\"aaaaaaaa\"}')"
+    )
+    con.commit()
+
+
+class SprintSnapshotRebuildTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.db = self.root / "shell_db.db"
+        self.content = self.root / ".sc-state" / "local" / "content.sql"
+        self.content.parent.mkdir(parents=True)
+        apply_engine_schema(self.db)
+
+    def snapshot_and_rebuild(self) -> None:
+        with mock.patch.multiple(
+            snapshot,
+            DB_PATH=self.db,
+            OUT_PATH=self.content,
+            LEGACY_PATH=self.root / "missing-legacy.sql",
+            REPO_ROOT=self.root,
+        ), mock.patch.object(
+            snapshot, "require_admin"
+        ), mock.patch.object(
+            snapshot.artifact_policy, "prepare_local_state", return_value=[]
+        ), mock.patch.object(snapshot, "snapshot_map"):
+            self.assertEqual(snapshot.main(), 0)
+
+        with mock.patch.multiple(
+            rebuild,
+            ENGINE=self.root / ".super-coder",
+            REPO_ROOT=self.root,
+            DB_PATH=self.db,
+            SNAPSHOT=self.content,
+            SNAPSHOT_LEGACY=self.root / "missing-legacy.sql",
+        ), mock.patch.object(
+            rebuild.artifact_policy, "prepare_local_state", return_value=[]
+        ), mock.patch.object(rebuild.map_repo, "main"):
+            self.assertEqual(rebuild.main(["--no-backup"]), 0)
+
+    def assert_roundtrip(self, *, armed: bool) -> None:
+        con = sqlite3.connect(self.db)
+        try:
+            seed_prepared(con)
+            if armed:
+                arm_with_representative_state(con)
+        finally:
+            con.close()
+        compared = [
+            *snapshot.SPRINT_INSTANCE_TABLES,
+            "conversations",
+            "conversation_git_targets",
+            "conversation_messages",
+            "conversation_runs",
+            "conversation_events",
+            "conversation_outbox",
+        ]
+        before = rows_by_table(self.db, compared)
+        if armed:
+            self.assertTrue(
+                all(before[table] for table in snapshot.SPRINT_INSTANCE_TABLES),
+                "armed fixture must exercise every durable Sprint table",
+            )
+
+        self.snapshot_and_rebuild()
+
+        after = rows_by_table(self.db, compared)
+        self.assertEqual(before, after)
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual([], con.execute("PRAGMA foreign_key_check").fetchall())
+        finally:
+            con.close()
+
+    def test_prepared_sprint_roundtrips_without_plan_or_generation_drift(self) -> None:
+        self.assert_roundtrip(armed=False)
+
+    def test_armed_in_flight_sprint_roundtrips_every_v2_table_exactly(self) -> None:
+        self.assert_roundtrip(armed=True)
+
+    def test_paused_and_terminal_lifecycle_rows_replay_exactly(self) -> None:
+        con = sqlite3.connect(self.db)
+        try:
+            seed_prepared(con)
+            con.executemany(
+                "INSERT INTO sprints "
+                "(sprint_id,feature_id,originating_planner_shell_id,"
+                "merge_grant_enabled,created_at,updated_at) "
+                "VALUES (?,19,3,?, ?, ?)",
+                (
+                    (2, 1, "2026-08-01 20:00:00", "2026-08-01 20:03:00"),
+                    (3, 1, "2026-08-01 19:00:00", "2026-08-01 19:05:00"),
+                    (4, 0, "2026-08-01 18:00:00", "2026-08-01 18:01:00"),
+                ),
+            )
+            con.execute(
+                "UPDATE sprints SET lifecycle='armed',armed_at='2026-08-01 20:01:00' "
+                "WHERE sprint_id=2"
+            )
+            con.execute(
+                "UPDATE sprints SET lifecycle='paused',paused_at='2026-08-01 20:03:00' "
+                "WHERE sprint_id=2"
+            )
+            con.execute(
+                "UPDATE sprints SET lifecycle='armed',armed_at='2026-08-01 19:01:00' "
+                "WHERE sprint_id=3"
+            )
+            con.execute(
+                "UPDATE sprints SET lifecycle='completed',"
+                "terminal_outcome='shipped',completed_at='2026-08-01 19:05:00' "
+                "WHERE sprint_id=3"
+            )
+            con.execute(
+                "UPDATE sprints SET lifecycle='aborted',terminal_outcome='cancelled',"
+                "aborted_at='2026-08-01 18:01:00' WHERE sprint_id=4"
+            )
+            con.commit()
+        finally:
+            con.close()
+        before = rows_by_table(self.db, ["sprints"])
+
+        self.snapshot_and_rebuild()
+
+        self.assertEqual(before, rows_by_table(self.db, ["sprints"]))
+
+    def test_older_resumed_sprint_replays_after_newer_paused_row(self) -> None:
+        con = sqlite3.connect(self.db)
+        try:
+            seed_prepared(con)
+            con.executemany(
+                "INSERT INTO sprints "
+                "(sprint_id,feature_id,originating_planner_shell_id,"
+                "merge_grant_enabled,created_at,updated_at) "
+                "VALUES (?,19,3,1,?,?)",
+                (
+                    (2, "2026-08-01 19:00:00", "2026-08-01 20:04:00"),
+                    (3, "2026-08-01 20:00:00", "2026-08-01 20:03:00"),
+                ),
+            )
+            con.execute("UPDATE sprints SET lifecycle='armed' WHERE sprint_id=2")
+            con.execute("UPDATE sprints SET lifecycle='paused' WHERE sprint_id=2")
+            con.execute("UPDATE sprints SET lifecycle='armed' WHERE sprint_id=3")
+            con.execute("UPDATE sprints SET lifecycle='paused' WHERE sprint_id=3")
+            con.execute("UPDATE sprints SET lifecycle='armed' WHERE sprint_id=2")
+            con.commit()
+        finally:
+            con.close()
+        before = rows_by_table(self.db, ["sprints"])
+
+        self.snapshot_and_rebuild()
+
+        self.assertEqual(before, rows_by_table(self.db, ["sprints"]))
+
+    def test_snapshot_authority_names_every_persistent_sprint_table(self) -> None:
+        con = sqlite3.connect(self.db)
+        try:
+            actual = {
+                row[0]
+                for row in con.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND (name='sprints' OR name LIKE 'sprint_%')"
+                )
+            }
+        finally:
+            con.close()
+        self.assertEqual(actual, set(snapshot.SPRINT_INSTANCE_TABLES))
+        self.assertEqual(
+            len(snapshot.SPRINT_INSTANCE_TABLES),
+            len(set(snapshot.SPRINT_INSTANCE_TABLES)),
+        )
+        conversation_index = snapshot.PER_INSTANCE_TABLES.index("conversations")
+        link_index = snapshot.PER_INSTANCE_TABLES.index(
+            "sprint_participant_conversations"
+        )
+        self.assertLess(conversation_index, link_index)
+
+    def test_snapshot_uses_one_read_view_across_sprint_tables(self) -> None:
+        con = sqlite3.connect(self.db)
+        try:
+            seed_prepared(con)
+        finally:
+            con.close()
+        reader = db_driver.connect(self.db)
+        writer = sqlite3.connect(self.db)
+        writer.execute("PRAGMA journal_mode=WAL").fetchone()
+        original = snapshot.dump_table
+        mutated = False
+
+        def mutate_between_tables(connection, table: str):
+            nonlocal mutated
+            if table == "sprints" and not mutated:
+                writer.execute(
+                    "INSERT INTO sprint_events "
+                    "(sprint_id,event_type,actor_kind,payload) "
+                    "VALUES (1,'committed.after.snapshot','system','{}')"
+                )
+                writer.commit()
+                mutated = True
+            return original(connection, table)
+
+        try:
+            with mock.patch.object(snapshot, "dump_table", side_effect=mutate_between_tables):
+                content = snapshot.serialize_instance(reader)
+        finally:
+            writer.close()
+            reader.close()
+        self.assertTrue(mutated)
+        self.assertIn("sprint.declared", content)
+        self.assertNotIn("committed.after.snapshot", content)
+        self.assertEqual(
+            "committed.after.snapshot",
+            rows_by_table(self.db, ["sprint_events"])["sprint_events"][-1][2],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #918

## What changed
- snapshot all 20 persistent Sprints v2 tables plus their dependent generic conversation state
- serialize the full instance from one coherent SQLite read view
- replay Sprint lifecycle and participant-pointer constraints through legal transitions while preserving exact stored rows
- distinguish preupdate rollback restore points from direct prerebuild diagnostics, including a one-release bridge for backups created by the old updater
- prefer the engine-paired preupdate DB during rollback, with legacy prerebuild fallback

## Regression coverage
- exact prepared Sprint round trip matching the dos-app failure shape
- representative armed/in-flight Sprint with every v2 table populated
- paused, completed, aborted, and older-Sprint-resumed lifecycle orderings
- schema recurrence guard for every persistent Sprint table
- concurrent-write coherent snapshot test
- preupdate preference, legacy fallback, and first-adoption promotion tests

## Verification
- 380 tests + 331 subtests passed in the proportional Sprint/conversation/rebuild/update suite
- 20 focused snapshot/backup tests passed after final lifecycle-order review
- critical Ruff checks, compileall, sc map, sc render-check, and diff checks passed
- sc verify was intentionally refused by linked-worktree guard #769; the command made no changes, while the regressions exercise real snapshot and rebuild entrypoints against isolated engine databases