### PR TITLE
fix: preserve foreign root skill directories

### DIFF
--- a/.super-coder/scripts/skill_projection.py
+++ b/.super-coder/scripts/skill_projection.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 import artifact_policy
+import seed_skills
 
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
@@ -94,6 +95,24 @@ def _remove_tree(path: Path) -> None:
     shutil.rmtree(path)
 
 
+def _banner_owned_skill_directory(path: Path) -> bool:
+    """Return whether a real directory carries a managed SKILL.md banner."""
+    if path.is_symlink() or not path.is_dir():
+        return False
+    skill_file = path / "SKILL.md"
+    if skill_file.is_symlink() or not skill_file.is_file():
+        return False
+    try:
+        return RENDER_BANNER in skill_file.read_text()
+    except (OSError, UnicodeError):
+        return False
+
+
+def _upstream_skill_slugs() -> set[str]:
+    names = (*seed_skills.seeded_skill_names(), *seed_skills.tombstoned_skill_names())
+    return {name.strip().lower().replace(" ", "-") for name in names}
+
+
 def reconcile_root(
     con, shell_id: int | None, checkout: Path, relative: Path, *, create: bool
 ) -> dict:
@@ -115,6 +134,7 @@ def reconcile_root(
     written: list[Path] = []
     skipped: list[Path] = []
     deleted: list[Path] = []
+    root_sweep_names = _upstream_skill_slugs() if shell_id is None else set()
 
     if root.exists():
         for child in root.iterdir():
@@ -123,6 +143,12 @@ def reconcile_root(
                     raise ProjectionError(
                         f"granted skill directory is a symlink: {child}"
                     )
+                continue
+            if (
+                shell_id is None
+                and child.name not in root_sweep_names
+                and not _banner_owned_skill_directory(child)
+            ):
                 continue
             if child.is_dir() or child.is_symlink():
                 _remove_tree(child)

--- a/.super-coder/scripts/skill_projection.py
+++ b/.super-coder/scripts/skill_projection.py
@@ -101,9 +101,15 @@ def _banner_owned_skill_directory(path: Path) -> bool:
         return False
 
 
-def _upstream_skill_slugs() -> set[str]:
+def _managed_skill_slugs(con) -> set[str]:
+    """Return every upstream-reserved or DB-known managed directory name."""
     names = (*seed_skills.seeded_skill_names(), *seed_skills.tombstoned_skill_names())
-    return {name.strip().lower().replace(" ", "-") for name in names}
+    upstream = {name.strip().lower().replace(" ", "-") for name in names}
+    database = {
+        row[0].strip().lower().replace(" ", "-")
+        for row in con.execute("SELECT name FROM skills ORDER BY name")
+    }
+    return upstream | database
 
 
 def _remove_managed_tree(path: Path, managed_names: set[str]) -> bool:
@@ -138,7 +144,7 @@ def reconcile_root(
     written: list[Path] = []
     skipped: list[Path] = []
     deleted: list[Path] = []
-    managed_names = _upstream_skill_slugs()
+    managed_names = _managed_skill_slugs(con)
 
     if root.exists():
         for child in root.iterdir():

--- a/.super-coder/scripts/skill_projection.py
+++ b/.super-coder/scripts/skill_projection.py
@@ -88,13 +88,6 @@ def _skill_body(row) -> str:
     )
 
 
-def _remove_tree(path: Path) -> None:
-    if path.is_symlink():
-        path.unlink()
-        return
-    shutil.rmtree(path)
-
-
 def _banner_owned_skill_directory(path: Path) -> bool:
     """Return whether a real directory carries a managed SKILL.md banner."""
     if path.is_symlink() or not path.is_dir():
@@ -111,6 +104,17 @@ def _banner_owned_skill_directory(path: Path) -> bool:
 def _upstream_skill_slugs() -> set[str]:
     names = (*seed_skills.seeded_skill_names(), *seed_skills.tombstoned_skill_names())
     return {name.strip().lower().replace(" ", "-") for name in names}
+
+
+def _remove_managed_tree(path: Path, managed_names: set[str]) -> bool:
+    """Remove a proven engine-managed directory without following symlinks."""
+    if path.name not in managed_names and not _banner_owned_skill_directory(path):
+        return False
+    if path.is_symlink():
+        path.unlink()
+    else:
+        shutil.rmtree(path)
+    return True
 
 
 def reconcile_root(
@@ -134,7 +138,7 @@ def reconcile_root(
     written: list[Path] = []
     skipped: list[Path] = []
     deleted: list[Path] = []
-    root_sweep_names = _upstream_skill_slugs() if shell_id is None else set()
+    managed_names = _upstream_skill_slugs()
 
     if root.exists():
         for child in root.iterdir():
@@ -144,15 +148,9 @@ def reconcile_root(
                         f"granted skill directory is a symlink: {child}"
                     )
                 continue
-            if (
-                shell_id is None
-                and child.name not in root_sweep_names
-                and not _banner_owned_skill_directory(child)
+            if (child.is_dir() or child.is_symlink()) and _remove_managed_tree(
+                child, managed_names
             ):
-                continue
-            if child.is_dir() or child.is_symlink():
-                _remove_tree(child)
-                written.append(child)
                 deleted.append(child)
 
     for row in rows:

--- a/tests/test_skill_projection.py
+++ b/tests/test_skill_projection.py
@@ -122,6 +122,54 @@ class SkillProjectionTest(unittest.TestCase):
                 self.assertIn(removed, summary["deleted"])
             self.assertFalse(checkout.joinpath(".opencode/skills").exists())
 
+    def test_revocation_deletes_fork_local_skill_from_managed_roots(self) -> None:
+        shell_id = add_shell(self.con, "custom", None)
+        local_name = "fork_local_probe"
+        self.con.execute(
+            "INSERT INTO skills (name, description, content, common) "
+            "VALUES (?, 'Fork-local probe', 'local body', 0)",
+            (local_name,),
+        )
+        grant(self.con, shell_id, local_name)
+        with tempfile.TemporaryDirectory() as tmp:
+            checkout = Path(tmp)
+            skill_projection.reconcile_shell(
+                self.con,
+                shell_id,
+                checkout,
+                ensure_dirs=(".claude/skills", ".agents/skills"),
+            )
+            rendered = [
+                checkout / relative / local_name / "SKILL.md"
+                for relative in (".claude/skills", ".agents/skills")
+            ]
+            self.assertEqual(
+                [path.read_text() for path in rendered],
+                [
+                    (
+                        "---\nname: fork_local_probe\n"
+                        "description: Fork-local probe\n---\n\nlocal body\n"
+                    )
+                ]
+                * 2,
+            )
+
+            self.con.execute("DELETE FROM shell_skills WHERE shell_id=?", (shell_id,))
+            summary = skill_projection.reconcile_shell(self.con, shell_id, checkout)
+
+            removed = [path.parent for path in rendered]
+            self.assertEqual(summary["deleted"], removed)
+            self.assertEqual([path.exists() for path in removed], [False, False])
+            self.assertEqual(
+                tuple(
+                    self.con.execute(
+                        "SELECT name, content, is_deleted FROM skills WHERE name=?",
+                        (local_name,),
+                    ).fetchone()
+                ),
+                (local_name, "local body", 0),
+            )
+
     def test_symlink_root_is_refused_without_touching_target(self) -> None:
         shell_id = add_shell(self.con, "custom", None)
         grant(self.con, shell_id, "query_authoring_pg")

--- a/tests/test_skill_projection.py
+++ b/tests/test_skill_projection.py
@@ -172,7 +172,14 @@ class SkillProjectionTest(unittest.TestCase):
             root_live.write_text("preserve live unowned projection\n")
             root_retired = repo / ".claude/skills/retired_upstream/SKILL.md"
             root_retired.parent.mkdir()
-            root_retired.write_text("remove retired projection\n")
+            root_retired.write_text(
+                "---\nrendered_by: super-coder\n---\nremove retired projection\n"
+            )
+            foreign_control = (
+                repo / ".claude/skills/my_custom_tool/operator-control.txt"
+            )
+            foreign_control.parent.mkdir()
+            foreign_control.write_text("operator-owned\n")
             dev1_root = repo / ".sc-worktrees/dev1/.claude/skills"
             dev1_root.mkdir(parents=True)
             stale = dev1_root / "stale/SKILL.md"
@@ -190,6 +197,8 @@ class SkillProjectionTest(unittest.TestCase):
                 root_live.read_text(), "preserve live unowned projection\n"
             )
             self.assertFalse(root_retired.parent.exists())
+            self.assertEqual(foreign_control.read_text(), "operator-owned\n")
+            self.assertNotIn(foreign_control.parent, summary["deleted"])
             self.assertFalse((repo / ".sc-worktrees/dev2").exists())
             self.assertEqual(summary["checkouts"], [repo, repo / ".sc-worktrees/dev1"])
             self.assertEqual(

--- a/tests/test_skill_projection.py
+++ b/tests/test_skill_projection.py
@@ -74,9 +74,12 @@ class SkillProjectionTest(unittest.TestCase):
         grant(self.con, shell_id, "query_authoring_pg")
         with tempfile.TemporaryDirectory() as tmp:
             checkout = Path(tmp)
-            stale = checkout / ".opencode/skills/stale/nested/file.txt"
+            stale = checkout / ".opencode/skills/stale/SKILL.md"
             stale.parent.mkdir(parents=True)
-            stale.write_text("old")
+            stale.write_text("rendered_by: super-coder\nold\n")
+            foreign = checkout / ".opencode/skills/operator_tool/notes.txt"
+            foreign.parent.mkdir()
+            foreign.write_text("operator-owned\n")
 
             summary = skill_projection.reconcile_shell(
                 self.con,
@@ -91,6 +94,9 @@ class SkillProjectionTest(unittest.TestCase):
                 self.assertIn("name: query_authoring_pg", rendered.read_text())
             self.assertFalse((checkout / ".opencode/skills/stale").exists())
             self.assertIn(checkout / ".opencode/skills/stale", summary["deleted"])
+            self.assertNotIn(checkout / ".opencode/skills/stale", summary["written"])
+            self.assertEqual(foreign.read_text(), "operator-owned\n")
+            self.assertNotIn(foreign.parent, summary["deleted"])
             self.assertFalse(checkout.joinpath(".agents/skills").exists())
 
     def test_revocation_deletes_exact_grant_from_every_existing_managed_root(
@@ -145,7 +151,7 @@ class SkillProjectionTest(unittest.TestCase):
             target = Path(out)
             sentinel = target / "sentinel.txt"
             sentinel.write_text("foreign")
-            link = root / "stale"
+            link = root / "engine_surgery"
             link.symlink_to(target, target_is_directory=True)
 
             summary = skill_projection.reconcile_shell(self.con, shell_id, checkout)
@@ -184,7 +190,7 @@ class SkillProjectionTest(unittest.TestCase):
             dev1_root.mkdir(parents=True)
             stale = dev1_root / "stale/SKILL.md"
             stale.parent.mkdir()
-            stale.write_text("old")
+            stale.write_text("rendered_by: super-coder\nold\n")
 
             summary = skill_projection.reconcile_existing_checkouts(
                 self.con, repo_root=repo
@@ -197,6 +203,8 @@ class SkillProjectionTest(unittest.TestCase):
                 root_live.read_text(), "preserve live unowned projection\n"
             )
             self.assertFalse(root_retired.parent.exists())
+            self.assertIn(root_retired.parent, summary["deleted"])
+            self.assertNotIn(root_retired.parent, summary["written"])
             self.assertEqual(foreign_control.read_text(), "operator-owned\n")
             self.assertNotIn(foreign_control.parent, summary["deleted"])
             self.assertFalse((repo / ".sc-worktrees/dev2").exists())
@@ -209,6 +217,28 @@ class SkillProjectionTest(unittest.TestCase):
                 ).fetchone()[0],
                 1,
             )
+
+    def test_admin_owned_repo_root_preserves_foreign_directory(self) -> None:
+        add_shell(self.con, "admin1", "admin")
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            foreign = repo / ".claude/skills/operator_tool/notes.txt"
+            foreign.parent.mkdir(parents=True)
+            foreign.write_text("operator-owned\n")
+            stale = repo / ".claude/skills/stale/SKILL.md"
+            stale.parent.mkdir()
+            stale.write_text("rendered_by: super-coder\nold\n")
+
+            summary = skill_projection.reconcile_existing_checkouts(
+                self.con, repo_root=repo
+            )
+
+            self.assertEqual(foreign.read_text(), "operator-owned\n")
+            self.assertNotIn(foreign.parent, summary["deleted"])
+            self.assertFalse(stale.parent.exists())
+            self.assertIn(stale.parent, summary["deleted"])
+            self.assertNotIn(stale.parent, summary["written"])
+            self.assertEqual(summary["checkouts"], [repo])
 
     def test_legacy_cleanup_removes_only_banner_owned_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary\n- bound unowned/root projection cleanup to the active upstream namespace, permanent tombstones, or a super-coder banner\n- preserve foreign non-namespace directories and files while keeping owned shell projections exact\n- add the REV3 foreign control-directory regression for Sprint 70 unit 8 / flag #119\n\n## Verification\n- `.venv/bin/python -m pytest -q tests/test_skill_projection.py tests/test_skill_lifecycle_convergence.py tests/test_skill_convergence_fixture.py` (18 passed)\n- `.venv/bin/ruff check .super-coder/scripts/skill_projection.py`\n- `./sc render-check`\n- `git diff --check`\n\n## Trade-off\nOwnership is recomputed from the authoritative seed plus tombstone registry during unowned sweeps. This is slightly more work than deleting every non-live directory, but preserves J2's safety boundary without weakening exact per-shell reconciliation.\n\nNon-blocking tooling note: focused Ruff across the existing test module exposes pre-existing unused E402 suppressions; tracked separately in #927.