### PR TITLE
fix(cli): harden deps help and nested test discovery

### DIFF
--- a/sc
+++ b/sc
@@ -269,6 +269,20 @@ _sc_find_manifests() {  # $1 = filename glob, e.g. 'requirements*.txt'
     -name "$1" -type f -print
 }
 
+# One map-independent presence gate for Python suites. Reuse the manifest walk
+# so tests inherit its engine, worktree, environment, dependency, and build
+# pruning; pytest still owns actual recursive collection from the repo root.
+_sc_has_python_tests() {
+  _sc_find_manifests 'test_*.py' | (
+    found=""
+    while IFS= read -r test_file; do
+      relative_test=${test_file#"$here"/}
+      case "$relative_test" in tests/*|*/tests/*) found=1 ;; esac
+    done
+    [ -n "$found" ]
+  )
+}
+
 # Is the repo .venv's tooling runnable BY THE INTERPRETER THAT RESOLVES HERE?
 # Existence is not runnability. A .venv is bind-mounted into the sandbox from
 # the host, and `python -m venv` records its interpreter as an UNVERSIONED
@@ -328,6 +342,10 @@ _sc_devtool() {  # $1 = tool name → prints the executable path, or fails
 # A map-backed fast path would read dr_filepath.path (dr_dependency.source_file is
 # basename-only, so it can't locate a manifest's dir).
 sc_deps() {
+  if sc_help_form "$@"; then
+    echo "Usage: ./sc deps [-h|--help]"
+    return 0
+  fi
   rc=0
   venv="$here/.venv"
   # In the sandbox, a .venv whose interpreter lives OUTSIDE the repo is host-built
@@ -451,6 +469,8 @@ _sc_wants_pytest() {
 # vitest in any package.json dir that declares a test script). Non-zero if any fail.
 sc_test() {
   venv="$here/.venv"
+  python_tests=""
+  _sc_has_python_tests && python_tests=1
   # Self-heal: a fork with python tests but no .venv/bin/pytest is an unprovisioned
   # worktree (the .venv is only populated by the first `./sc deps`), NOT a fork that
   # opted out of pytest. Provision the dev kit + fork deps rather than silently
@@ -458,7 +478,7 @@ sc_test() {
   # ModuleNotFoundError (pytest / the fork's own libs) that reads as a real test
   # failure. We gate on the pytest binary, not sc_deps' exit code, so a partial
   # provision (e.g. npm leg fails) still runs pytest if it landed.
-  if [ ! -x "$venv/bin/pytest" ] && ls "$here"/tests/test_*.py >/dev/null 2>&1; then
+  if [ ! -x "$venv/bin/pytest" ] && [ -n "$python_tests" ]; then
     echo "→ test: $venv/bin/pytest missing — provisioning first (./sc deps)"
     sc_deps || echo "→ test: provisioning incomplete — continuing" >&2
   fi
@@ -492,7 +512,7 @@ sc_test() {
     elif [ "$prc" -ne 0 ]; then
       rc=1
     fi
-  elif ls "$here"/tests/test_*.py >/dev/null 2>&1; then
+  elif [ -n "$python_tests" ]; then
     # pytest still unavailable after provisioning (venv create failed, or a
     # host-managed sandbox interpreter that skips pip). A fork that *declares*
     # pytest must not be green-washed through stdlib unittest — fail loud with the

--- a/tests/test_devkit_sc.py
+++ b/tests/test_devkit_sc.py
@@ -36,6 +36,15 @@ def _extract_find_manifests() -> str:
     return m.group(0)
 
 
+def _run_python_test_presence(root: Path) -> bool:
+    script = (
+        f'here="{root}"\n{_extract_find_manifests()}\n'
+        f'{_extract("_sc_has_python_tests")}\n'
+        "_sc_has_python_tests\n"
+    )
+    return subprocess.run(["sh", "-c", script], check=False).returncode == 0
+
+
 class FindManifestsTest(unittest.TestCase):
     def test_prunes_sc_worktrees_live(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -52,6 +61,85 @@ class FindManifestsTest(unittest.TestCase):
             self.assertEqual(out, [str(root / "app" / "package.json")],
                              "worktree copies must be pruned — one repo, one "
                              "manifest walk")
+
+
+class PythonTestPresenceTest(unittest.TestCase):
+    def test_nested_tests_directory_counts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            test = root / "nested" / "app" / "tests" / "test_health.py"
+            test.parent.mkdir(parents=True)
+            test.write_text("def test_health(): pass\n")
+            self.assertTrue(_run_python_test_presence(root))
+
+    def test_pruned_and_non_test_paths_do_not_count(self):
+        ignored = (
+            ".super-coder", ".sc-state", ".sc-worktrees/dev", ".git",
+            ".venv", "venv", "__pycache__", "node_modules", "dist", "build",
+            "vendor",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for directory in ignored:
+                test = root / directory / "tests" / "test_shadow.py"
+                test.parent.mkdir(parents=True)
+                test.write_text("raise AssertionError('must stay pruned')\n")
+            (root / "app").mkdir()
+            (root / "app" / "test_outside_tests.py").write_text("pass\n")
+            (root / "tests").mkdir()
+            (root / "tests" / "health.py").write_text("pass\n")
+            self.assertFalse(_run_python_test_presence(root))
+
+    def test_tests_component_in_repo_parent_does_not_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "tests" / "repo"
+            source = root / "app" / "test_health.py"
+            source.parent.mkdir(parents=True)
+            source.write_text("pass\n")
+            self.assertFalse(_run_python_test_presence(root))
+
+    def test_sc_test_caches_one_presence_result_for_both_gates(self):
+        body = _extract("sc_test")
+        self.assertEqual(body.count("_sc_has_python_tests"), 1)
+        self.assertEqual(body.count('[ -n "$python_tests" ]'), 2)
+        self.assertNotIn('ls "$here"/tests/test_*.py', body)
+
+    def test_nested_suite_provisions_then_runs_one_root_pytest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            test = root / "nested" / "app" / "tests" / "test_health.py"
+            test.parent.mkdir(parents=True)
+            test.write_text("def test_health(): pass\n")
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            pytest = fake_bin / "pytest"
+            pytest.write_text(
+                "#!/bin/sh\n"
+                "printf 'PYTEST cwd=%s args=%s\\n' \"$PWD\" \"$*\"\n"
+            )
+            pytest.chmod(0o755)
+            script = (
+                f'here="{root}"\nPY=python3\n'
+                f'PATH="{fake_bin}:$PATH"\nexport PATH\n'
+                f'{_extract_find_manifests()}\n'
+                f'{_extract("_sc_has_python_tests")}\n'
+                f'{_extract("_sc_wants_pytest")}\n'
+                "sc_deps() { echo PROVISIONED; }\n"
+                f'{_extract("sc_test")}\n'
+                "sc_test\n"
+            )
+            done = subprocess.run(
+                ["sh", "-c", script], capture_output=True, text=True,
+                check=False,
+            )
+            self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+            self.assertEqual(done.stderr, "")
+            self.assertEqual(done.stdout.count("PROVISIONED\n"), 1)
+            self.assertEqual(
+                [line for line in done.stdout.splitlines()
+                 if line.startswith("PYTEST ")],
+                [f"PYTEST cwd={root} args="],
+            )
 
 
 class DevtoolResolutionTest(unittest.TestCase):

--- a/tests/test_worktree_targets.py
+++ b/tests/test_worktree_targets.py
@@ -25,6 +25,7 @@ import hashlib
 import io
 import json
 import os
+import shlex
 import shutil
 import sqlite3
 import subprocess
@@ -35,8 +36,8 @@ import unittest
 from contextlib import ExitStack, redirect_stderr, redirect_stdout
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import urlparse
 from unittest import mock
+from urllib.parse import urlparse
 
 REPO = Path(__file__).resolve().parents[1]
 ENGINE = REPO / ".super-coder"
@@ -309,6 +310,44 @@ class HelpSurvivesTheRefusalTest(WorktreeFixture):
         done = run_sc(self.wt, "migrate", "--halp")
         self.assertEqual(done.returncode, 1)
         self.assertIn("./sc migrate refused", done.stderr)
+
+    def test_deps_help_is_read_only_and_byte_stable_from_both_checkouts(self):
+        probe_dir = Path(self._tmp) / "deps-help-probes"
+        shutil.rmtree(probe_dir, ignore_errors=True)
+        probe_dir.mkdir()
+        calls = probe_dir / "calls"
+        python_probe = probe_dir / "python3"
+        python_probe.write_text(
+            "#!/bin/sh\n"
+            f"if [ \"$1\" = -m ] && [ \"$2\" = venv ]; then echo venv >> {shlex.quote(str(calls))}; exit 97; fi\n"
+            f"exec {shlex.quote(sys.executable)} \"$@\"\n"
+        )
+        python_probe.chmod(0o755)
+        find_probe = probe_dir / "find"
+        find_probe.write_text(
+            "#!/bin/sh\n"
+            f"echo find >> {shlex.quote(str(calls))}\n"
+            f"exec {shlex.quote(shutil.which('find') or '/usr/bin/find')} \"$@\"\n"
+        )
+        find_probe.chmod(0o755)
+        env = {
+            "SC_PYTHON": str(python_probe),
+            "PATH": f"{probe_dir}:{os.environ['PATH']}",
+        }
+        before = state_digest(self.main)
+        outputs = []
+        for root in (self.main, self.wt):
+            for flag in ("-h", "--help"):
+                with self.subTest(root=root.name, flag=flag):
+                    done = run_sc(root, "deps", flag, env_overrides=env)
+                    self.assertEqual(done.returncode, 0, done.stderr)
+                    self.assertEqual(done.stderr, "")
+                    outputs.append(done.stdout)
+                    self.assertFalse((root / ".venv").exists())
+        self.assertEqual(outputs, ["Usage: ./sc deps [-h|--help]\n"] * 4)
+        self.assertFalse(calls.exists(),
+                         "help discovered manifests or touched .venv")
+        self.assertEqual(state_digest(self.main), before)
 
 
 class RootCheckoutUnchangedTest(WorktreeFixture):


### PR DESCRIPTION
Sprint 74 Unit 3 (spec #73).\n\n- return sc deps -h/--help before discovery or environment access\n- cache one pruned recursive Python-suite presence result for both sc test gates\n- cover main/linked help stability, nested tests, and ignored trees\n\nVerification: ./sc test (1595 passed, 1 skipped); ./sc render-check; sh -n sc; git diff --check.\n\nTrade-off: discovery consumes the existing pruned find walk once per test command; pytest remains one repository-root invocation and owns collection.