### PR TITLE
feat(chat): make admin shells deliberately CLI-only in the browser

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -497,6 +497,7 @@ def _reopen_conversation(con, operator: dict, conversation) -> list[str]:
             "SHELL_NOT_LAUNCHABLE",
             "shell is unknown, deleted, or unavailable to this operator",
         )
+    _refuse_admin_browser_chat(shell)
     open_conversations = con.execute(
         "SELECT conversation_id,state FROM conversations "
         "WHERE shell_id=? AND state!='closed' AND conversation_scope='normal'",
@@ -677,6 +678,28 @@ def _live_shell_session(shell) -> str | None:
     )
 
 
+def _refuse_admin_browser_chat(shell) -> None:
+    """Admin maintains main directly at the repo root — one working tree with
+    no per-shell attribution (any harness process under the root reads as "the
+    admin slot"), so a browser chat would surface timing-dependent SHELL_BUSY
+    refusals whenever anyone works anywhere in the repo. Refuse deliberately
+    instead, carrying the exact CLI commands the operator runs in its place."""
+    if shell["flavor"] != "admin":
+        return
+    root = str(run_mod.REPO_ROOT)
+    raise ApiError(
+        422,
+        "ADMIN_SHELL_CLI_ONLY",
+        f"shell {shell['shortname']!r} is admin-flavor and CLI-only; open a "
+        f"terminal and run: cd {root} && make dos-e s={shell['shortname']}",
+        {
+            "shell_id": int(shell["shell_id"]),
+            "shortname": shell["shortname"],
+            "repo_root": root,
+        },
+    )
+
+
 def _wait_for_cli_release(shell) -> str | None:
     """Drain a just-finished browser process, but never steal a live CLI slot."""
     state = _live_shell_session(shell)
@@ -730,6 +753,7 @@ def _create_conversation(con, operator: dict, headers, body: dict):
             "SHELL_NOT_LAUNCHABLE",
             "shell is unknown, deleted, or unavailable to this operator",
         )
+    _refuse_admin_browser_chat(shell)
     open_conversations = con.execute(
         "SELECT conversation_id,state FROM conversations "
         "WHERE shell_id=? AND state!='closed' AND conversation_scope='normal'",

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -3540,7 +3540,11 @@ class Handler(BaseHTTPRequestHandler):
             if path == "/api/health":
                 return self._send(200, health_payload())
             if path == "/api/shells":
-                return self._send(200, {"shells": get_shells(con)})
+                # repo_root rides along for the browser chat rail: admin
+                # shells are CLI-only there, and the notice shows the exact
+                # `cd <repo_root> && make dos-e s=<shortname>` to run instead.
+                return self._send(200, {"shells": get_shells(con),
+                                        "repo_root": str(REPO_ROOT)})
             if path == "/api/shell-templates":
                 return self._send(200, {"templates": shell_factory.flavors()})
             if path == "/api/flavor-defaults":

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2614,6 +2614,24 @@ function chatHeaderLabel(conversation) {
   ].filter(Boolean).join(" | ");
 }
 
+// Admin shells stay on the rail but never chat here: they maintain main at
+// the repo root, whose single un-attributable session slot would make browser
+// turns refuse whenever anyone works anywhere in the repo. The notice hands
+// the operator the exact terminal commands instead.
+function chatAdminCliOnly(shell) {
+  return (shell?.flavor || "") === "admin";
+}
+
+function chatAdminCliOnlyNotice(shell, repoRoot) {
+  return el("div", { className: "chat-empty chat-admin-cli-only" },
+    el("b", {}, "Admin is CLI-only."),
+    el("div", {},
+      `${shell.display_name} maintains main directly at the repo root, `
+      + "so browser chats are disabled for it. Open a terminal and run:"),
+    el("pre", { className: "chat-admin-commands" },
+      `cd ${repoRoot || "<repo root>"}\nmake dos-e s=${shell.shortname}`));
+}
+
 function chatWorkingDots() {
   return el("span", { className: "chat-working-dots", ariaHidden: "true" },
     el("span", {}, "."),
@@ -4321,7 +4339,11 @@ async function renderInterface(root) {
       .then((conversation) => ({ conversation }))
       .catch((error) => ({ error }))
     : Promise.resolve({ conversation: null });
-  const [{ shells: allShells }, openPage, detailResult] = await Promise.all([
+  const [
+    { shells: allShells, repo_root: repoRoot },
+    openPage,
+    detailResult,
+  ] = await Promise.all([
     shellRequest,
     openRequest,
     detailRequest,
@@ -4439,15 +4461,19 @@ async function renderInterface(root) {
   }
 
   const side = el("aside", { className: "chat-history" });
+  const adminCliOnly = chatAdminCliOnly(shell);
   const newChat = el("button", {
     className: "act primary",
     type: "button",
     textContent: "＋ Chat",
+    disabled: adminCliOnly,
+    title: adminCliOnly ? "Admin is CLI-only — see the pane for the commands" : "",
   });
   const configure = el("button", {
     className: "chat-configure",
     type: "button",
     textContent: "Configure",
+    disabled: adminCliOnly,
   });
   newChat.onclick = async () => {
     if (!await chatCloseForSwitch(selectedConversation)) return;
@@ -4748,6 +4774,10 @@ async function renderInterface(root) {
   };
   chatHistoryPollTimer = setInterval(pollHistory, CHAT_HISTORY_POLL_MS);
 
+  if (adminCliOnly && (configuring || !selectedId)) {
+    pane.append(chatAdminCliOnlyNotice(shell, repoRoot));
+    return;
+  }
   if (configuring) {
     const loadConfiguration = async () => {
       pane.replaceChildren(

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -386,6 +386,16 @@ body.interface-view main {
   margin: auto; color: var(--dim); text-align: center; padding: 2rem;
 }
 .chat-no-selection { grid-row: 1 / -1; }
+.chat-admin-cli-only {
+  grid-row: 1 / -1; display: flex; flex-direction: column; gap: .6rem;
+  align-items: center; justify-content: center;
+}
+.chat-admin-cli-only b { color: var(--ink); }
+.chat-admin-commands {
+  margin: 0; padding: .7rem 1rem; border: 1px solid var(--line);
+  border-radius: 10px; background: var(--panel); color: var(--ink);
+  font-size: .78rem; text-align: left; user-select: all;
+}
 .chat-composer {
   padding: .8rem clamp(1rem, 4vw, 4rem) 1rem; border-top: 1px solid var(--line);
   background: var(--bg);

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -78,7 +78,8 @@ class ConversationApiCase(unittest.TestCase):
             "(shell_id,display_name,shortname,flavor,system_prompt,user_id,"
             "api_key) VALUES "
             "(1,'Dev','dev','dev','prompt',1,'shell-token'),"
-            "(2,'Review','review','dev','prompt',1,'review-token')"
+            "(2,'Review','review','dev','prompt',1,'review-token'),"
+            "(3,'Admin','ADM1','admin','prompt',1,'admin-token')"
         )
         con.commit()
         con.close()
@@ -551,6 +552,56 @@ class ConversationResourceTest(ConversationApiCase):
         self.assertEqual(status, 409)
         self.assertEqual(error["error"]["code"], "SHELL_BUSY")
         self.assertIn("live CLI session", error["error"]["message"])
+
+    def test_admin_shell_create_is_cli_only_with_exact_commands(self) -> None:
+        status, _, error = self.request(
+            "POST",
+            "/api/conversations",
+            body={"shell_id": 3, "harness": "codex"},
+            key="admin-cli-only-create",
+        )
+        self.assertEqual(status, 422)
+        self.assertEqual(error["error"]["code"], "ADMIN_SHELL_CLI_ONLY")
+        self.assertIn(f"cd {self.root}", error["error"]["message"])
+        self.assertIn("make dos-e s=ADM1", error["error"]["message"])
+        self.assertEqual(
+            error["error"]["details"],
+            {"shell_id": 3, "shortname": "ADM1", "repo_root": str(self.root)},
+        )
+        con = self.connect()
+        try:
+            count = con.execute(
+                "SELECT COUNT(*) FROM conversations WHERE shell_id=3"
+            ).fetchone()[0]
+        finally:
+            con.close()
+        self.assertEqual(count, 0)
+
+    def test_admin_shell_reopen_is_cli_only(self) -> None:
+        con = self.connect()
+        try:
+            conversation_id = self.seed_conversation(
+                con, number=901, shell_id=3, state="closed")
+            con.commit()
+        finally:
+            con.close()
+        status, _, error = self.request(
+            "POST",
+            f"/api/conversations/{conversation_id}/messages",
+            body={"text": "hello admin"},
+            key="admin-cli-only-reopen",
+        )
+        self.assertEqual(status, 422)
+        self.assertEqual(error["error"]["code"], "ADMIN_SHELL_CLI_ONLY")
+        con = self.connect()
+        try:
+            state = con.execute(
+                "SELECT state FROM conversations WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0]
+        finally:
+            con.close()
+        self.assertEqual(state, "closed")
 
     def test_creating_a_chat_closes_the_previous_idle_chat(self) -> None:
         first = self.create(key="first-chat", title="First")

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -38,6 +38,22 @@ def test_interface_is_a_first_class_reload_safe_view():
     assert "chatRouteConversation = decodeURIComponent(conversation)" in APP
 
 
+def test_admin_shells_stay_on_the_rail_but_chat_is_cli_only():
+    interface = APP[APP.index("async function renderInterface"):
+                    APP.index("// ── Tabs + boot")]
+    # The rail never filters admin out — the notice replaces the pane instead,
+    # and it hands over the exact terminal commands (repo_root from /api/shells).
+    assert "chatAdminCliOnly(shell)" in interface
+    assert "disabled: adminCliOnly" in interface
+    assert "chatAdminCliOnlyNotice(shell, repoRoot)" in interface
+    assert "repo_root: repoRoot" in interface
+    assert '(shell?.flavor || "") === "admin"' in APP
+    assert "cd ${repoRoot" in APP
+    assert "make dos-e s=${shell.shortname}" in APP
+    assert ".chat-admin-cli-only" in STYLE
+    assert ".chat-admin-commands" in STYLE
+
+
 def test_open_chat_restore_matches_the_flat_shell_projection():
     assert "item.shell_id === openConversation.shell.shell_id" in APP
     assert (


### PR DESCRIPTION
## Why

Browser chats with admin-flavor shells threw `SHELL_BUSY` seemingly at random. Root cause: admin boots at the repo root on main (no worktree), and liveness cannot attribute root pids per shell — any harness process anywhere under the repo root (an admin CLI session, an IDE-embedded session, a stray `claude` in a subdir, another admin shell's browser turn) marks **every** admin shell busy. Per-shell attribution at the root is structurally unavailable (launch claims are headless-only by design), and two concurrent sessions in the same working tree on main would be genuinely unsafe — so instead of patching the gate, browser chat for admin becomes a deliberate, explained boundary.

## What

- **API**: `_create_conversation` and `_reopen_conversation` refuse admin shells up front with `422 ADMIN_SHELL_CLI_ONLY`, message + details carrying the exact commands: `cd <repo_root> && make dos-e s=<shortname>`. The liveness busy-gate stays as backstop for pre-existing open admin chats.
- **API**: `GET /api/shells` now includes `repo_root` so the GUI can render the real path.
- **GUI**: admin shells stay on the Chats rail (per FnB direction); selecting one disables ＋ Chat / Configure and the pane shows an "Admin is CLI-only" notice with the copyable commands. Old admin conversations remain browsable.
- **Tests**: two API tests (create + reopen refusal, exact message/details), one UI source-contract test.

## Verification

- `tests/test_conversation_api.py` + `tests/test_conversation_launch.py`: 65 passed (repo venv pytest).
- `tests/test_conversation_ui.py` + `tests/test_conversation_diff_ui.py`: all pass incl. new contract test.
- Full backend suite: 587 passed; the one failure (`test_local_skill_persistence` grant/revoke roundtrip) pre-exists on a clean tree, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)