### PR TITLE
fix(sprint): harden terminal and review liveness

### DIFF
--- a/.super-coder/migrations/0158_sprint_terminal_liveness_hardening.sql
+++ b/.super-coder/migrations/0158_sprint_terminal_liveness_hardening.sql
@@ -1,0 +1,55 @@
+-- 0158 — Hand Developer liveness to Review when work enters in_review.
+--
+-- Migration 0149 resolved accepted assignments only at terminal work-unit
+-- dispositions.  A successful review handoff now ends the Developer lane, so
+-- resolve its accepted assignment (and any accepted changes-requested wake)
+-- while leaving the Reviewer's independent request expectation active.
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_sprint_liveness_work_terminal;
+
+CREATE TRIGGER trg_sprint_liveness_work_terminal
+AFTER UPDATE OF disposition ON sprint_work_units
+WHEN NEW.disposition IN ('in_review','completed','cancelled')
+  AND OLD.disposition <> NEW.disposition
+BEGIN
+  UPDATE sprint_liveness_expectations
+  SET resolved_at=datetime('now'),
+      resolution='work_unit.' || NEW.disposition,
+      next_evaluation_at=NULL
+  WHERE resolved_at IS NULL
+    AND message_id IN (
+      SELECT message.message_id
+      FROM sprint_messages message
+      JOIN sprint_participants participant
+        ON participant.participant_id=message.to_participant_id
+      WHERE message.work_unit_id=NEW.work_unit_id
+        AND (
+          message.message_kind='work_assignment'
+          OR (
+            message.message_kind='notification'
+            AND participant.role='developer'
+            AND participant.shell_id=NEW.assigned_shell_id
+          )
+        )
+    );
+END;
+
+-- Converge assignments that reached Review before this migration landed.
+UPDATE sprint_liveness_expectations
+SET resolved_at=datetime('now'),
+    resolution='work_unit.in_review',
+    next_evaluation_at=NULL
+WHERE resolved_at IS NULL
+  AND message_id IN (
+    SELECT message.message_id
+    FROM sprint_messages message
+    JOIN sprint_work_units unit
+      ON unit.work_unit_id=message.work_unit_id
+     AND unit.sprint_id=message.sprint_id
+    WHERE message.message_kind='work_assignment'
+      AND unit.disposition='in_review'
+  );
+
+COMMIT;

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -20,7 +20,7 @@ from sprint_domain import SprintInvariantError, SprintLifecycleStore
 
 wake_prompt = sprint_participant_chats.wake_prompt
 
-ACTIONABLE_KINDS = frozenset({"work_assignment", "review_request"})
+ACTIONABLE_KINDS = frozenset({"work_assignment", "review_request", "notification"})
 
 
 @dataclass(frozen=True)
@@ -90,7 +90,8 @@ class SprintMessageStore:
             raise ValueError("Sprint message idempotency key is empty")
         if actionable and message_kind not in ACTIONABLE_KINDS:
             raise SprintInvariantError(
-                "only work assignments and review requests are actionable"
+                "only work assignments, review requests, and notifications "
+                "are actionable"
             )
         with db_driver.write_transaction(self.con, "sprint.message.send"):
             return self.send_in_transaction(
@@ -210,7 +211,8 @@ class SprintMessageStore:
             raise ValueError("Sprint message idempotency key is empty")
         if actionable and message_kind not in ACTIONABLE_KINDS:
             raise SprintInvariantError(
-                "only work assignments and review requests are actionable"
+                "only work assignments, review requests, and notifications "
+                "are actionable"
             )
         return self._send(
             sprint_id,

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -251,6 +251,12 @@ def close_for_terminal_lifecycle(
         raise RuntimeError("Sprint conversation cleanup requires a transaction")
     if lifecycle not in {"completed", "aborted"}:
         raise ValueError("Sprint conversation cleanup requires a terminal lifecycle")
+    owning_planner_shell_id = int(
+        con.execute(
+            "SELECT originating_planner_shell_id FROM sprints WHERE sprint_id=?",
+            (sprint_id,),
+        ).fetchone()[0]
+    )
     rows = con.execute(
         "SELECT DISTINCT c.conversation_id,c.state "
         "FROM sprint_participant_conversations pc "
@@ -270,14 +276,13 @@ def close_for_terminal_lifecycle(
         conversation_ids.append(conversation_id)
         cancelled = _cancel_queued_turns(con, conversation_id)
         active = con.execute(
-            "SELECT run_id FROM conversation_runs WHERE conversation_id=? "
+            "SELECT run_id,shell_id FROM conversation_runs WHERE conversation_id=? "
             "AND state IN ('leased','starting','running') "
             "ORDER BY run_id DESC LIMIT 1",
             (conversation_id,),
         ).fetchone()
         if active is not None:
             run_id = int(active["run_id"])
-            run_ids.append(run_id)
             close_requested = con.execute(
                 "SELECT 1 FROM conversation_events WHERE conversation_id=? "
                 "AND event_type='conversation.close.requested' LIMIT 1",
@@ -295,6 +300,12 @@ def close_for_terminal_lifecycle(
                     },
                     run_id=run_id,
                 )
+            if (
+                lifecycle == "completed"
+                and int(active["shell_id"]) == owning_planner_shell_id
+            ):
+                continue
+            run_ids.append(run_id)
             conversation_broker.BrokerStore.request_interrupt_in_transaction(
                 con,
                 run_id,

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -159,7 +159,7 @@ class SprintReviewLoopStore:
                 work_unit_id=int(lane["work_unit_id"]),
                 message_kind="notification",
                 body=notification,
-                actionable=False,
+                actionable=verdict == "changes_requested",
                 active=True,
                 idempotency_key=idempotency_key,
             )

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -11,6 +11,7 @@
     ".super-coder/migrations/0153_harden_sprint_handoff_skills.sql",
     ".super-coder/migrations/0154_remove_tombstoned_skills.sql",
     ".super-coder/migrations/0155_sprint_conversation_generations.sql",
+    ".super-coder/migrations/0158_sprint_terminal_liveness_hardening.sql",
     ".super-coder/assets/skills/sprint_prep/SKILL.md",
     ".super-coder/assets/skills/sprint_pln/SKILL.md",
     ".super-coder/assets/skills/sprint_dev/SKILL.md",

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -663,8 +663,161 @@ class DeliveryAndActivationTest(SprintLivenessCase):
         self.assertEqual("work_unit.completed", expectation["resolution"])
         self.assertIsNone(expectation["next_evaluation_at"])
 
+    def test_in_review_resolves_assignment_before_liveness_nudge(self) -> None:
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='in_review',"
+            "updated_at=datetime('now') WHERE work_unit_id=?",
+            (self.unit_id,),
+        )
+        self.con.commit()
+
+        expectation = self.expectation()
+        self.assertIsNotNone(expectation["resolved_at"])
+        self.assertEqual("work_unit.in_review", expectation["resolution"])
+        self.assertIsNone(expectation["next_evaluation_at"])
+
+        self.advance(20)
+        self.assertEqual((), self.monitor().evaluate(self.sprint_id))
+        self.assertEqual([], self.message_rows("nudge"))
+
 
 class MigrationGateTest(unittest.TestCase):
+    def test_in_review_upgrade_backfills_dirty_assignment_once(self) -> None:
+        con = sqlite3.connect(":memory:")
+        self.addCleanup(con.close)
+        con.row_factory = sqlite3.Row
+        con.executescript((ENGINE / "schema.sql").read_text())
+        target = "0158_sprint_terminal_liveness_hardening.sql"
+        for migration in sorted(MIGRATIONS.glob("*.sql")):
+            if migration.name >= target:
+                break
+            con.executescript(migration.read_text())
+        con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        con.executemany(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (?,?,?,?,?,1)",
+            (
+                (1, "Developer", "DEV1", "dev", "prompt"),
+                (2, "Reviewer", "REV1", "reviewer", "prompt"),
+                (3, "Planner", "PLN1", "planner", "prompt"),
+            ),
+        )
+        feature_id = int(
+            con.execute(
+                "INSERT INTO roadmap (title,roadmap_status) "
+                "VALUES ('Feature','in_progress')"
+            ).lastrowid
+        )
+        body = "governing spec"
+        document_id = int(
+            con.execute(
+                "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                "VALUES (?,'spec',1,'Spec',?)",
+                (feature_id, body),
+            ).lastrowid
+        )
+        revision = hashlib.sha256(body.encode()).hexdigest()
+        approval_id = int(
+            con.execute(
+                "INSERT INTO sprint_spec_approvals "
+                "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+                "VALUES (?,?,2,'pass')",
+                (document_id, revision),
+            ).lastrowid
+        )
+        sprint_id = int(
+            con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+        )
+        con.execute(
+            "INSERT INTO sprint_specs "
+            "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+            "VALUES (?,?,?,?)",
+            (sprint_id, document_id, revision, approval_id),
+        )
+        con.executemany(
+            "INSERT INTO sprint_participants "
+            "(sprint_id,shell_id,role,harness) VALUES (?,?,?,?)",
+            (
+                (sprint_id, 3, "planner", "codex"),
+                (sprint_id, 1, "developer", "codex"),
+                (sprint_id, 2, "reviewer", "kimi"),
+            ),
+        )
+        task_id = int(
+            con.execute(
+                "INSERT INTO spec_tasks (feature_id,document_id,seq,title) "
+                "VALUES (?,?,1,'Task')",
+                (feature_id, document_id),
+            ).lastrowid
+        )
+        unit_id = int(
+            con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output,output_kind) "
+                "VALUES (?,1,2,'Unit','Ship it','no_code')",
+                (sprint_id,),
+            ).lastrowid
+        )
+        con.execute(
+            "INSERT INTO sprint_work_unit_tasks (sprint_id,work_unit_id,task_id) "
+            "VALUES (?,?,?)",
+            (sprint_id, unit_id, task_id),
+        )
+        con.commit()
+        wake_id = sprint_domain.SprintLifecycleStore(con).arm(sprint_id, 3)[0]
+        assignment_message_id = int(
+            con.execute(
+                "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",
+                (wake_id,),
+            ).fetchone()[0]
+        )
+        messages = sprint_message_delivery.SprintMessageStore(con)
+        self.assertEqual("accepted", messages.mark_read(assignment_message_id, 1))
+        con.execute(
+            "UPDATE sprint_work_units SET disposition='in_review',"
+            "updated_at='2026-08-02 00:00:00' WHERE work_unit_id=?",
+            (unit_id,),
+        )
+        con.commit()
+        self.assertIsNone(
+            con.execute(
+                "SELECT resolved_at FROM sprint_liveness_expectations "
+                "WHERE message_id=?",
+                (assignment_message_id,),
+            ).fetchone()[0]
+        )
+
+        migration_sql = (MIGRATIONS / target).read_text()
+        con.executescript(migration_sql)
+        first = tuple(
+            con.execute(
+                "SELECT resolved_at,resolution,next_evaluation_at "
+                "FROM sprint_liveness_expectations WHERE message_id=?",
+                (assignment_message_id,),
+            ).fetchone()
+        )
+        self.assertIsNotNone(first[0])
+        self.assertEqual(("work_unit.in_review", None), first[1:])
+
+        con.executescript(migration_sql)
+        self.assertEqual(
+            first,
+            tuple(
+                con.execute(
+                    "SELECT resolved_at,resolution,next_evaluation_at "
+                    "FROM sprint_liveness_expectations WHERE message_id=?",
+                    (assignment_message_id,),
+                ).fetchone()
+            ),
+        )
+
     def test_upgrade_backfills_only_armed_nonterminal_expectations(self) -> None:
         con = sqlite3.connect(":memory:")
         self.addCleanup(con.close)

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -191,12 +191,14 @@ class MessageTransactionTest(SprintMessageCase):
             ).fetchone()[0],
         )
 
-    def test_only_task_messages_are_actionable_and_passive_has_no_wake(self) -> None:
+    def test_only_participant_handoffs_are_actionable_and_passive_has_no_wake(
+        self,
+    ) -> None:
         before = self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0]
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError, "only work assignments"
         ):
-            self.send("bad-action", actionable=True)
+            self.send("bad-action", kind="system", actionable=True)
         self.assertEqual(
             before,
             self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0],

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -2,13 +2,17 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import sys
+import tempfile
+from contextlib import closing
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".super-coder" / "scripts"
 sys.path[:0] = [str(SCRIPTS), str(ROOT / "tests")]
 
+import conversation_broker
 import sprint_domain
 import sprint_message_delivery
 import sprint_participant_chats
@@ -945,6 +949,55 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
             notify_commit=lambda: True,
         )
 
+    def add_live_run(self, sprint_id: int, shell_id: int) -> tuple[str, int]:
+        conversation_id = str(
+            self.con.execute(
+                "SELECT pc.conversation_id "
+                "FROM sprint_participant_conversations pc "
+                "JOIN sprint_participants participant "
+                "ON participant.participant_id=pc.sprint_participant_id "
+                "WHERE participant.sprint_id=? AND participant.shell_id=?",
+                (sprint_id, shell_id),
+            ).fetchone()[0]
+        )
+        token = int(
+            self.con.execute("SELECT COUNT(*)+1 FROM conversation_runs").fetchone()[0]
+        )
+        message_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state) "
+                "VALUES (?,'engine','test','prompt','active Sprint turn',?,?,"
+                "'running')",
+                (
+                    conversation_id,
+                    f"terminal-active:{token}",
+                    f"terminal-active:{token}",
+                ),
+            ).lastrowid
+        )
+        run_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,state,lease_owner,"
+                "lease_expires_at,started_at,heartbeat_at) "
+                "VALUES (?,?,?,'running','test-broker','2999-01-01 00:00:00',"
+                "'2026-08-02 00:00:00','2026-08-02 00:00:00')",
+                (conversation_id, shell_id, message_id),
+            ).lastrowid
+        )
+        self.con.execute(
+            "UPDATE conversations SET state='queued' WHERE conversation_id=?",
+            (conversation_id,),
+        )
+        self.con.execute(
+            "UPDATE conversations SET state='running' WHERE conversation_id=?",
+            (conversation_id,),
+        )
+        self.con.commit()
+        return conversation_id, run_id
+
     def test_prepared_abort_records_stub_report_and_preserves_plan(self):
         sprint_id, unit_id = self.create_sprint()
         coordinator = self.coordinator()
@@ -987,6 +1040,202 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
                 "SELECT COUNT(*) FROM sprint_work_units WHERE work_unit_id=?",
                 (unit_id,),
             ).fetchone()[0],
+        )
+
+    def test_completed_defers_only_owning_planner_run_until_broker_finish(self):
+        sprint_id, _ = self.create_sprint()
+        self.store.arm(sprint_id, 3)
+        planner_conversation, planner_run = self.add_live_run(sprint_id, 3)
+        _, developer_run = self.add_live_run(sprint_id, 1)
+        queued_message_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state) "
+                "VALUES (?,'engine','test','prompt','queued follow-up',"
+                "'terminal-follow-up','terminal-follow-up','queued')",
+                (planner_conversation,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO conversation_outbox (conversation_id,message_id) "
+            "VALUES (?,?)",
+            (planner_conversation, queued_message_id),
+        )
+        self.con.commit()
+        interrupts: list[int] = []
+        lifecycle = sprint_domain.SprintLifecycleStore(
+            self.con,
+            interrupt_run=lambda run_id: interrupts.append(run_id) or True,
+            notify_commit=lambda: True,
+        )
+
+        self.assertTrue(
+            lifecycle.transition(
+                sprint_id,
+                "completed",
+                sprint_domain.LifecycleActor("planner", 3),
+                reason="final response follows",
+                terminal_outcome="accepted",
+            )
+        )
+
+        self.assertEqual([developer_run], interrupts)
+        self.assertEqual(
+            [(developer_run,)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT run_id FROM conversation_events "
+                    "WHERE event_type='run.interrupt.requested' ORDER BY run_id"
+                )
+            ],
+        )
+        self.assertEqual(
+            [(planner_run,), (developer_run,)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT run_id FROM conversation_events "
+                    "WHERE event_type='conversation.close.requested' ORDER BY run_id"
+                )
+            ],
+        )
+        self.assertEqual(
+            ("cancelled", "cancelled"),
+            tuple(
+                self.con.execute(
+                    "SELECT message.state,outbox.state "
+                    "FROM conversation_messages message "
+                    "JOIN conversation_outbox outbox USING(message_id) "
+                    "WHERE message.message_id=?",
+                    (queued_message_id,),
+                ).fetchone()
+            ),
+        )
+        terminal_fact_counts = tuple(
+            self.con.execute(
+                "SELECT "
+                "(SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                " AND event_type='lifecycle.completed'),"
+                "(SELECT COUNT(*) FROM conversation_events "
+                " WHERE event_type='conversation.close.requested')",
+                (sprint_id,),
+            ).fetchone()
+        )
+        self.assertFalse(
+            lifecycle.transition(
+                sprint_id,
+                "completed",
+                sprint_domain.LifecycleActor("planner", 3),
+                reason="retry",
+                terminal_outcome="accepted",
+            )
+        )
+        self.assertEqual(
+            terminal_fact_counts,
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                    " AND event_type='lifecycle.completed'),"
+                    "(SELECT COUNT(*) FROM conversation_events "
+                    " WHERE event_type='conversation.close.requested')",
+                    (sprint_id,),
+                ).fetchone()
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            db_path = Path(directory) / "terminal.db"
+            with closing(sqlite3.connect(db_path)) as target:
+                self.con.backup(target)
+            broker = conversation_broker.BrokerStore(db_path)
+            self.assertTrue(
+                broker.finish_run(
+                    planner_run,
+                    "succeeded",
+                    event_type="run.completed",
+                    payload={"final_output": "Sprint completed successfully."},
+                )
+            )
+            self.assertTrue(
+                broker.finish_run(
+                    developer_run,
+                    "cancelled",
+                    event_type="run.interrupted",
+                    payload={"interrupt_evidence": "sprint completion"},
+                )
+            )
+            with closing(sqlite3.connect(db_path)) as observed:
+                observed.row_factory = sqlite3.Row
+                self.assertEqual(
+                    [("closed", 1)] * 3,
+                    [
+                        tuple(row)
+                        for row in observed.execute(
+                            "SELECT conversation.state,"
+                            "conversation.closed_at IS NOT NULL "
+                            "FROM conversations conversation "
+                            "JOIN sprint_participant_conversations linked "
+                            "ON linked.conversation_id=conversation.conversation_id "
+                            "JOIN sprint_participants participant "
+                            "ON participant.participant_id=linked.sprint_participant_id "
+                            "WHERE participant.sprint_id=? "
+                            "ORDER BY conversation.conversation_id",
+                            (sprint_id,),
+                        )
+                    ],
+                )
+                planner_terminal = observed.execute(
+                    "SELECT event_type,payload FROM conversation_events "
+                    "WHERE conversation_id=? AND run_id=? "
+                    "AND event_type='run.completed'",
+                    (planner_conversation, planner_run),
+                ).fetchone()
+                self.assertEqual("run.completed", planner_terminal["event_type"])
+                self.assertEqual(
+                    "Sprint completed successfully.",
+                    json.loads(planner_terminal["payload"])["final_output"],
+                )
+                self.assertEqual(
+                    "cancelled",
+                    observed.execute(
+                        "SELECT state FROM conversation_runs WHERE run_id=?",
+                        (developer_run,),
+                    ).fetchone()[0],
+                )
+
+    def test_abort_interrupts_owning_planner_and_other_active_participants(self):
+        sprint_id, _ = self.create_sprint()
+        self.store.arm(sprint_id, 3)
+        _, planner_run = self.add_live_run(sprint_id, 3)
+        _, developer_run = self.add_live_run(sprint_id, 1)
+        interrupts: list[int] = []
+        lifecycle = sprint_domain.SprintLifecycleStore(
+            self.con,
+            interrupt_run=lambda run_id: interrupts.append(run_id) or True,
+            notify_commit=lambda: True,
+        )
+
+        receipt = lifecycle.abort(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="stop all work",
+            terminal_outcome="aborted",
+        )
+
+        self.assertEqual((planner_run, developer_run), receipt.interrupt_run_ids)
+        self.assertEqual([planner_run, developer_run], interrupts)
+        self.assertEqual(
+            [(planner_run,), (developer_run,)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT run_id FROM conversation_events "
+                    "WHERE event_type='run.interrupt.requested' ORDER BY run_id"
+                )
+            ],
         )
 
     def test_terminal_lifecycle_closes_every_sprint_conversation(self):

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -133,6 +133,13 @@ class ReviewHandoffTest(SprintReviewLoopCase):
         self.assertTrue(outcome.created)
 
     def test_green_readiness_commits_judgment_and_active_reviewer_request(self):
+        assignment_message_id = int(
+            self.con.execute(
+                "SELECT message_id FROM sprint_messages WHERE work_unit_id=? "
+                "AND message_kind='work_assignment'",
+                (self.unit_id,),
+            ).fetchone()[0]
+        )
         handoff = self.request_review()
 
         self.assertTrue(handoff.created)
@@ -171,6 +178,19 @@ class ReviewHandoffTest(SprintReviewLoopCase):
             ),
             tuple(judgment),
         )
+        assignment_expectation = self.con.execute(
+            "SELECT resolved_at,resolution,next_evaluation_at "
+            "FROM sprint_liveness_expectations WHERE message_id=?",
+            (assignment_message_id,),
+        ).fetchone()
+        self.assertIsNotNone(assignment_expectation["resolved_at"])
+        self.assertEqual(
+            ("work_unit.in_review", None),
+            (
+                assignment_expectation["resolution"],
+                assignment_expectation["next_evaluation_at"],
+            ),
+        )
         lease = sprint_message_delivery.SprintWakeDeliveryService(
             self.con
         ).claim_next("stage6-review")
@@ -181,6 +201,15 @@ class ReviewHandoffTest(SprintReviewLoopCase):
         ).fetchone()[0]
         self.assertEqual(self.reviewer_id, lease.participant_id)
         self.assertEqual(reviewer_chat, lease.target_conversation_id)
+        self.accept_review(handoff.message_id)
+        review_expectation = self.con.execute(
+            "SELECT resolved_at,resolution,next_evaluation_at "
+            "FROM sprint_liveness_expectations WHERE message_id=?",
+            (handoff.message_id,),
+        ).fetchone()
+        self.assertIsNone(review_expectation["resolved_at"])
+        self.assertIsNone(review_expectation["resolution"])
+        self.assertIsNotNone(review_expectation["next_evaluation_at"])
         self.assertEqual(
             0,
             self.con.execute(
@@ -295,7 +324,22 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             (changed.conversation_id,),
         ).fetchone()
         self.assertEqual(("fix", self.developer_conversation_id), tuple(fix_link))
-        self.assertIsNone(self.messages.mark_read(changed.message_id, 1))
+        self.assertEqual("accepted", self.messages.mark_read(changed.message_id, 1))
+        changed_expectation = self.con.execute(
+            "SELECT resolved_at,resolution,next_evaluation_at "
+            "FROM sprint_liveness_expectations WHERE message_id=?",
+            (changed.message_id,),
+        ).fetchone()
+        self.assertIsNone(changed_expectation["resolved_at"])
+        self.assertIsNone(changed_expectation["resolution"])
+        self.assertIsNotNone(changed_expectation["next_evaluation_at"])
+        assignment_expectation = self.con.execute(
+            "SELECT resolution FROM sprint_liveness_expectations expectation "
+            "JOIN sprint_messages message USING(message_id) "
+            "WHERE message.work_unit_id=? AND message.message_kind='work_assignment'",
+            (self.unit_id,),
+        ).fetchone()
+        self.assertEqual("work_unit.in_review", assignment_expectation["resolution"])
         self.assertEqual(
             ("review submitted: changes_requested", 0),
             tuple(
@@ -329,6 +373,15 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         )
         self.watcher.poll_once()
         second = self.request_review("review-2")
+        changed_expectation = self.con.execute(
+            "SELECT resolution,next_evaluation_at "
+            "FROM sprint_liveness_expectations WHERE message_id=?",
+            (changed.message_id,),
+        ).fetchone()
+        self.assertEqual(
+            ("work_unit.in_review", None),
+            tuple(changed_expectation),
+        )
         self.accept_review(second.message_id)
         approved = self.loop.record_review(
             self.sprint_id,


### PR DESCRIPTION
## Summary

- preserve close intent while deferring only the owning Planner run interrupt on successful Sprint completion
- resolve Developer assignment liveness at `in_review` and re-arm accepted changes-requested handoffs
- add ordered migration/backfill plus terminal, broker-finalization, retry, abort, review, and stale-nudge regressions

## Trade-off

Reuse the existing close-request, notification, acceptance, and disposition mechanisms; add no caller-run header, deferred-close state, or new message kind.

## Verification

- 1,596 tests + 836 subtests passed
- adjacent Sprint set: 155 tests + 30 subtests passed
- `./sc render-check` passed
- `git diff --check` passed
- `./sc verify` declined the linked worktree without mutation (known SC-019); hosted CI supplies that gate

Closes #923
Closes #929