### PR TITLE
fix(sprint): make review verdict liveness atomic

### DIFF
--- a/.super-coder/scripts/sprint_liveness.py
+++ b/.super-coder/scripts/sprint_liveness.py
@@ -588,15 +588,21 @@ class SprintLivenessMonitor:
         return tuple(outcomes)
 
     def resolve(self, message_id: int, resolution: str) -> bool:
+        with db_driver.write_transaction(self.con, "sprint.liveness.resolve"):
+            return self.resolve_in_transaction(message_id, resolution)
+
+    def resolve_in_transaction(self, message_id: int, resolution: str) -> bool:
+        """Resolve one expectation inside the caller's active transaction."""
+        if not self.con.in_transaction:
+            raise RuntimeError("liveness resolution requires an active transaction")
         resolution = resolution.strip()
         if not resolution:
             raise ValueError("liveness expectation resolution is empty")
-        with db_driver.write_transaction(self.con, "sprint.liveness.resolve"):
-            changed = self.con.execute(
-                "UPDATE sprint_liveness_expectations SET resolved_at=?,resolution=?,"
-                "next_evaluation_at=NULL WHERE message_id=? AND resolved_at IS NULL",
-                (_stamp(self.now()), resolution, message_id),
-            ).rowcount
+        changed = self.con.execute(
+            "UPDATE sprint_liveness_expectations SET resolved_at=?,resolution=?,"
+            "next_evaluation_at=NULL WHERE message_id=? AND resolved_at IS NULL",
+            (_stamp(self.now()), resolution, message_id),
+        ).rowcount
         return changed == 1
 
     def resolve_review_requests_for_work_unit_in_transaction(

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -215,11 +215,10 @@ class SprintReviewLoopStore:
                 outcome = self._outcome_receipt(
                     lane, conversation_id, receipt, disposition
                 )
-
-        sprint_liveness.SprintLivenessMonitor(self.con).resolve(
-            review_message_id,
-            f"review submitted: {verdict}",
-        )
+            sprint_liveness.SprintLivenessMonitor(self.con).resolve_in_transaction(
+                review_message_id,
+                f"review submitted: {verdict}",
+            )
         return outcome
 
     def authorize_merge(

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
 
@@ -272,6 +273,13 @@ class ReviewHandoffTest(SprintReviewLoopCase):
             body="Clean on the reviewed head.",
             idempotency_key="idempotent-approval",
         )
+        resolved_once = tuple(
+            self.con.execute(
+                "SELECT resolved_at,resolution,next_evaluation_at "
+                "FROM sprint_liveness_expectations WHERE message_id=?",
+                (first.message_id,),
+            ).fetchone()
+        )
         approval_replay = self.loop.record_review(
             self.sprint_id,
             self.registered_pr_id,
@@ -285,6 +293,20 @@ class ReviewHandoffTest(SprintReviewLoopCase):
         self.assertFalse(approval_replay.created)
         self.assertEqual(approved.message_id, approval_replay.message_id)
         self.assertEqual(approved.conversation_id, approval_replay.conversation_id)
+        self.assertIsNotNone(resolved_once[0])
+        self.assertEqual(
+            ("review submitted: approved", None), resolved_once[1:]
+        )
+        self.assertEqual(
+            resolved_once,
+            tuple(
+                self.con.execute(
+                    "SELECT resolved_at,resolution,next_evaluation_at "
+                    "FROM sprint_liveness_expectations WHERE message_id=?",
+                    (first.message_id,),
+                ).fetchone()
+            ),
+        )
         self.assertEqual(
             (2, 2, 1),
             tuple(
@@ -305,6 +327,64 @@ class ReviewHandoffTest(SprintReviewLoopCase):
 
 
 class ReviewOutcomeTest(SprintReviewLoopCase):
+    def test_verdict_and_liveness_resolution_survive_post_commit_abort(self):
+        handoff = self.request_review("atomic-review-request")
+        self.accept_review(handoff.message_id)
+        real_write_transaction = sprint_review_loop.db_driver.write_transaction
+
+        @contextmanager
+        def abort_after_commit(con, operation):
+            with real_write_transaction(con, operation):
+                yield
+            raise SystemExit("simulated abort after verdict commit")
+
+        with mock.patch.object(
+            sprint_review_loop.db_driver,
+            "write_transaction",
+            abort_after_commit,
+        ), self.assertRaisesRegex(SystemExit, "after verdict commit"):
+            self.loop.record_review(
+                self.sprint_id,
+                self.registered_pr_id,
+                2,
+                verdict="approved",
+                body="Atomic verdict is clean.",
+                idempotency_key="atomic-review-verdict",
+            )
+
+        expectation = self.con.execute(
+            "SELECT resolved_at,resolution,next_evaluation_at "
+            "FROM sprint_liveness_expectations WHERE message_id=?",
+            (handoff.message_id,),
+        ).fetchone()
+        self.assertIsNotNone(expectation["resolved_at"])
+        self.assertEqual(
+            ("review submitted: approved", None),
+            (expectation["resolution"], expectation["next_evaluation_at"]),
+        )
+        self.assertEqual(
+            ("merge_ready", "decision", "Atomic verdict is clean."),
+            tuple(
+                self.con.execute(
+                    "SELECT u.disposition,j.kind,j.body "
+                    "FROM sprint_work_units u JOIN sprint_judgments j "
+                    "ON j.work_unit_id=u.work_unit_id "
+                    "WHERE u.work_unit_id=? ORDER BY j.judgment_id DESC LIMIT 1",
+                    (self.unit_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_liveness_expectations e "
+                "JOIN sprint_messages m USING(message_id) "
+                "WHERE m.work_unit_id=? AND m.message_kind='review_request' "
+                "AND e.resolved_at IS NULL",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+
     def test_changes_and_approval_select_fresh_linked_conversations(self):
         first = self.request_review()
         self.accept_review(first.message_id)


### PR DESCRIPTION
## Summary

- resolve the accepted Reviewer expectation inside the verdict transaction
- add a message-scoped in-transaction liveness helper without widening the work-unit helper
- prove post-commit abort safety and replay idempotency

Sprint #79 unit 1 · spec doc #78 · closes flag #123.

## Validation

- 33 focused review-loop/liveness tests passed
- 1,613 tests and 847 subtests passed
- ruff check passed
- render-check passed