### PR TITLE
test(sprint): deepen maintenance coverage

### DIFF
--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1848,7 +1848,7 @@ engine API) — there is no `sqlite3` path.
 ## Surface
 
 ```
-sc mem get flags          # your open flags — `#<id> [<label>] (<priority>) <description>`
+sc mem get flags          # open flags as five-line evidence blocks (identity/status + four detail lines)
 sc mem get flags --json   # same, as JSON
 sc mem get flags <id>     # exact non-deleted row, open or resolved
 sc mem get flags --feature <id> --resolved

--- a/.super-coder/migrations/0161_reseed_flags_output_guidance.sql
+++ b/.super-coder/migrations/0161_reseed_flags_output_guidance.sql
@@ -1,14 +1,20 @@
----
-name: flags
-description: Track blockers as flags — surface open ones, open new ones, edit long-lived ones, resolve them. Link a flag to the roadmap feature it blocks. Mirrors the GUI Flags tab. Use when something blocks progress or needs follow-up.
-category: substrate
-common: false
----
+-- 0161 — Keep the flags skill's output contract aligned with sc mem.
+--
+-- Existing installs have already ledgered the generated 0001 seed, so replay
+-- the authoritative flags asset through a trailing idempotent UPSERT.
 
-# flags — blockers & follow-ups
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'flags',
+  'Track blockers as flags — surface open ones, open new ones, edit long-lived ones, resolve them. Link a flag to the roadmap feature it blocks. Mirrors the GUI Flags tab. Use when something blocks progress or needs follow-up.',
+  'substrate',
+  NULL,
+  0,
+  '# flags — blockers & follow-ups
 
 flag = open question / blocker. `--feature <id>` set -> the flag is that
-feature's blocker (joined on the roadmap; shown on the Roadmap card + Flags
+feature''s blocker (joined on the roadmap; shown on the Roadmap card + Flags
 tab). `<self>` = your shell_id. All reads/writes go through `sc mem` (the
 engine API) — there is no `sqlite3` path.
 
@@ -23,7 +29,7 @@ sc mem get flags --feature <id> --resolved
 ```
 
 Each flag carries its `feature_id`; cross-reference `sc mem get roadmap` for
-the blocked feature's title.
+the blocked feature''s title.
 
 The default list forms are **open-only**. Exact and feature-scoped resolved
 reads include numeric id, display name, owner, feature, priority, description,
@@ -40,7 +46,7 @@ GET /_sc/mem/flags/{id}
 ## Open
 
 ```
-sc mem flag open "[Area] what's blocked | Blocker for: X" --name SC-001 --priority Medium [--feature <id>]
+sc mem flag open "[Area] what''s blocked | Blocker for: X" --name SC-001 --priority Medium [--feature <id>]
 ```
 
 - `--name` = short id, format `SC-###`.
@@ -62,7 +68,7 @@ Recipient = whoever the flag blocks:
 |---|---|
 | docs pending after ship | the **planner** |
 | a review failure on a diff | the **author dev** |
-| a blocker on another shell's work | **that shell** |
+| a blocker on another shell''s work | **that shell** |
 | an FnB decision / no shell owns it | **surface to the FnB** (no `send`) |
 
 Message pairs with the *open* only: NEVER re-message a flag that is already
@@ -92,7 +98,7 @@ progressively as gates clear).
 sc mem flag close <flag_id> --notes "…"
 ```
 
-`--notes` states *how* it was resolved — that's the trail.
+`--notes` states *how* it was resolved — that''s the trail.
 
 `close` prints the row it holds — id, label, priority, opened date, owner,
 description — BEFORE it writes. **Read that line and confirm it names the flag
@@ -107,7 +113,15 @@ verified the flag.
 
 ## Stance
 
-Open a flag the moment something blocks or needs follow-up — don't hold it in
+Open a flag the moment something blocks or needs follow-up — don''t hold it in
 your head. Open flags on a feature = its blockers; clear them all before
 calling the feature done. An opened flag with no message sent = a dropped
-handoff.
+handoff.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -21,6 +21,9 @@ from sprint_domain import SprintInvariantError, SprintLifecycleStore
 wake_prompt = sprint_participant_chats.wake_prompt
 
 ACTIONABLE_KINDS = frozenset({"work_assignment", "review_request", "notification"})
+ACTIONABLE_KIND_ERROR = (
+    "only work assignments, review requests, and notifications are actionable"
+)
 
 
 @dataclass(frozen=True)
@@ -89,10 +92,7 @@ class SprintMessageStore:
         if not key:
             raise ValueError("Sprint message idempotency key is empty")
         if actionable and message_kind not in ACTIONABLE_KINDS:
-            raise SprintInvariantError(
-                "only work assignments, review requests, and notifications "
-                "are actionable"
-            )
+            raise SprintInvariantError(ACTIONABLE_KIND_ERROR)
         with db_driver.write_transaction(self.con, "sprint.message.send"):
             return self.send_in_transaction(
                 sprint_id,
@@ -210,10 +210,7 @@ class SprintMessageStore:
         if not key:
             raise ValueError("Sprint message idempotency key is empty")
         if actionable and message_kind not in ACTIONABLE_KINDS:
-            raise SprintInvariantError(
-                "only work assignments, review requests, and notifications "
-                "are actionable"
-            )
+            raise SprintInvariantError(ACTIONABLE_KIND_ERROR)
         return self._send(
             sprint_id,
             to_participant_id=to_participant_id,

--- a/sc
+++ b/sc
@@ -274,12 +274,11 @@ _sc_find_manifests() {  # $1 = filename glob, e.g. 'requirements*.txt'
 # pruning; pytest still owns actual recursive collection from the repo root.
 _sc_has_python_tests() {
   _sc_find_manifests 'test_*.py' | (
-    found=""
     while IFS= read -r test_file; do
       relative_test=${test_file#"$here"/}
-      case "$relative_test" in tests/*|*/tests/*) found=1 ;; esac
+      case "$relative_test" in tests/*|*/tests/*) exit 0 ;; esac
     done
-    [ -n "$found" ]
+    exit 1
   )
 }
 

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -13,6 +13,7 @@
     ".super-coder/migrations/0155_sprint_conversation_generations.sql",
     ".super-coder/migrations/0158_sprint_terminal_liveness_hardening.sql",
     ".super-coder/migrations/0159_reseed_sprint_native_wake_skills.sql",
+    ".super-coder/migrations/0161_reseed_flags_output_guidance.sql",
     ".super-coder/assets/skills/sprint_prep/SKILL.md",
     ".super-coder/assets/skills/sprint_pln/SKILL.md",
     ".super-coder/assets/skills/sprint_dev/SKILL.md",

--- a/tests/test_devkit_sc.py
+++ b/tests/test_devkit_sc.py
@@ -98,11 +98,59 @@ class PythonTestPresenceTest(unittest.TestCase):
             source.write_text("pass\n")
             self.assertFalse(_run_python_test_presence(root))
 
+    def test_presence_stops_after_first_matching_test(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            marker = root / "walked-every-candidate"
+            first = root / "tests" / "test_first.py"
+            first.parent.mkdir()
+            first.write_text("pass\n")
+            script = (
+                f'here="{root}"\n'
+                "_sc_find_manifests() {\n"
+                f'  printf "%s\\n" "{first}"\n'
+                "  candidate=0\n"
+                "  while [ \"$candidate\" -lt 10000 ]; do\n"
+                f'    printf "%s\\n" "{root}/src/test_$candidate.py" || exit\n'
+                "    candidate=$((candidate + 1))\n"
+                "  done\n"
+                f'  : > "{marker}"\n'
+                "}\n"
+                f'{_extract("_sc_has_python_tests")}\n'
+                "_sc_has_python_tests\n"
+            )
+            done = subprocess.run(
+                ["sh", "-c", script], capture_output=True, text=True,
+                check=False, timeout=5,
+            )
+            self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+            self.assertFalse(marker.exists(),
+                             "presence detection consumed candidates after a match")
+
     def test_sc_test_caches_one_presence_result_for_both_gates(self):
-        body = _extract("sc_test")
-        self.assertEqual(body.count("_sc_has_python_tests"), 1)
-        self.assertEqual(body.count('[ -n "$python_tests" ]'), 2)
-        self.assertNotIn('ls "$here"/tests/test_*.py', body)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls = root / "presence-calls"
+            pytest = root / ".venv" / "bin" / "pytest"
+            pytest.parent.mkdir(parents=True)
+            pytest.write_text("#!/bin/sh\nexit 0\n")
+            pytest.chmod(0o755)
+            script = (
+                f'here="{root}"\nPY=python3\n'
+                f'_sc_has_python_tests() {{ echo called >> "{calls}"; return 0; }}\n'
+                "_sc_venv_runnable() { return 0; }\n"
+                "_sc_find_manifests() { return 0; }\n"
+                "_sc_wants_pytest() { return 1; }\n"
+                "sc_deps() { echo unexpected provisioning >&2; return 99; }\n"
+                f'{_extract("sc_test")}\n'
+                "sc_test\n"
+            )
+            done = subprocess.run(
+                ["sh", "-c", script], capture_output=True, text=True,
+                check=False,
+            )
+            self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+            self.assertEqual(calls.read_text().splitlines(), ["called"])
 
     def test_nested_suite_provisions_then_runs_one_root_pytest(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_devkit_sc.py
+++ b/tests/test_devkit_sc.py
@@ -128,6 +128,12 @@ class PythonTestPresenceTest(unittest.TestCase):
                              "presence detection consumed candidates after a match")
 
     def test_sc_test_caches_one_presence_result_for_both_gates(self):
+        body = _extract("sc_test")
+        self.assertEqual(body.count("_sc_has_python_tests"), 1)
+        self.assertEqual(body.count('[ -n "$python_tests" ]'), 2)
+        self.assertNotIn('ls "$here"/tests/test_*.py', body)
+
+    def test_sc_test_calls_presence_probe_once_at_runtime(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             calls = root / "presence-calls"

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -285,6 +285,35 @@ class ApiMemTest(unittest.TestCase):
         self.run_mem("flag", "close", str(fid), "--notes", "fixed")
         self.assertEqual(self.q("SELECT resolved FROM flags WHERE flag_id=?", fid)[0], 1)
 
+    def test_flag_exact_id_reads_open_row_with_complete_human_evidence(self):
+        self.run_mem("roadmap", "add", "open evidence feature")
+        feature = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='open evidence feature'"
+        )[0]
+        self.run_mem(
+            "flag", "open", "[audit] open evidence | Blocker for: review",
+            "--name", "SC-922-OPEN-EXACT", "--priority", "Low",
+            "--feature", str(feature),
+        )
+        flag_id = self.q(
+            "SELECT flag_id FROM flags WHERE display_name='SC-922-OPEN-EXACT'"
+        )[0]
+        created = self.q(
+            "SELECT created_date FROM flags WHERE flag_id=?", flag_id
+        )[0]
+
+        human = io.StringIO()
+        with contextlib.redirect_stdout(human):
+            self.run_mem("get", "flags", str(flag_id))
+        self.assertEqual(
+            human.getvalue(),
+            f"#{flag_id} [SC-922-OPEN-EXACT] @tc (Low) [open]\n"
+            f"  feature: #{feature} — open evidence feature\n"
+            f"  opened: {created} · resolved: —\n"
+            "  description: [audit] open evidence | Blocker for: review\n"
+            "  closure notes: —\n",
+        )
+
     def test_flag_exact_id_reads_resolved_row_with_complete_human_and_json_evidence(self):
         self.run_mem("roadmap", "add", "resolved evidence feature")
         feature = self.q(
@@ -380,6 +409,23 @@ class ApiMemTest(unittest.TestCase):
         self.assertNotIn(still_open, [row["flag_id"] for row in rows])
         self.assertNotIn(other, [row["flag_id"] for row in rows])
         self.assertNotIn(deleted, [row["flag_id"] for row in rows])
+
+        dates = self.q(
+            "SELECT created_date, resolved_date FROM flags WHERE flag_id=?", wanted
+        )
+        human = io.StringIO()
+        with contextlib.redirect_stdout(human):
+            self.run_mem(
+                "get", "flags", "--feature", str(feature_a), "--resolved"
+            )
+        self.assertEqual(
+            human.getvalue(),
+            f"#{wanted} [SC-922-WANTED] @tc (Medium) [resolved]\n"
+            f"  feature: #{feature_a} — flag history A\n"
+            f"  opened: {dates['created_date']} · resolved: {dates['resolved_date']}\n"
+            "  description: [history] SC-922-WANTED | Blocker for: audit\n"
+            "  closure notes: wanted closure\n",
+        )
         with self.assertRaises(SystemExit):
             self.run_mem("get", "flags", str(deleted))
 

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -663,6 +663,51 @@ class DeliveryAndActivationTest(SprintLivenessCase):
         self.assertEqual("work_unit.completed", expectation["resolution"])
         self.assertIsNone(expectation["next_evaluation_at"])
 
+    def test_cancelled_work_unit_resolves_assignment_expectation(self) -> None:
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='cancelled',"
+            "updated_at=datetime('now') WHERE work_unit_id=?",
+            (self.unit_id,),
+        )
+        self.con.commit()
+
+        expectation = self.expectation()
+        self.assertIsNotNone(expectation["resolved_at"])
+        self.assertEqual("work_unit.cancelled", expectation["resolution"])
+        self.assertIsNone(expectation["next_evaluation_at"])
+
+    def test_reassignment_does_not_resolve_former_developer_notification(self) -> None:
+        notification = self.messages.send(
+            self.sprint_id,
+            to_participant_id=self.developer_id,
+            from_participant_id=self.reviewer_id,
+            work_unit_id=self.unit_id,
+            message_kind="notification",
+            body="Review changes requested",
+            actionable=True,
+            active=False,
+            idempotency_key="changes-requested:former-developer",
+        )
+        self.assertEqual("accepted", self.messages.mark_read(notification.message_id, 1))
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (4,'Replacement Developer','DEV2','dev','prompt',1)"
+        )
+        self.con.execute(
+            "UPDATE sprint_work_units SET assigned_shell_id=4,"
+            "disposition='in_review',updated_at=datetime('now') "
+            "WHERE work_unit_id=?",
+            (self.unit_id,),
+        )
+        self.con.commit()
+
+        self.assertIsNotNone(self.expectation()["resolved_at"])
+        former = self.expectation(notification.message_id)
+        self.assertIsNone(former["resolved_at"])
+        self.assertIsNone(former["resolution"])
+        self.assertIsNotNone(former["next_evaluation_at"])
+
     def test_in_review_resolves_assignment_before_liveness_nudge(self) -> None:
         self.con.execute(
             "UPDATE sprint_work_units SET disposition='in_review',"

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -195,10 +195,23 @@ class MessageTransactionTest(SprintMessageCase):
         self,
     ) -> None:
         before = self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0]
-        with self.assertRaisesRegex(
-            sprint_domain.SprintInvariantError, "only work assignments"
-        ):
+        with self.assertRaises(sprint_domain.SprintInvariantError) as direct:
             self.send("bad-action", kind="system", actionable=True)
+        self.con.execute("BEGIN")
+        try:
+            with self.assertRaises(sprint_domain.SprintInvariantError) as nested:
+                self.messages.send_in_transaction(
+                    self.sprint_id,
+                    to_participant_id=self.developer_id,
+                    message_kind="system",
+                    body="bad nested action",
+                    idempotency_key="bad-nested-action",
+                    actionable=True,
+                )
+        finally:
+            self.con.rollback()
+        self.assertEqual(str(direct.exception), delivery.ACTIONABLE_KIND_ERROR)
+        self.assertEqual(str(nested.exception), delivery.ACTIONABLE_KIND_ERROR)
         self.assertEqual(
             before,
             self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0],

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -22,7 +22,7 @@ SKILLS = {
     "sprint_rev": "reviewer",
     "sprint_close": "planner",
 }
-RESEEDED_SKILLS = set(SKILLS) | {"db_map", "flags"}
+RESEEDED_SKILLS = set(SKILLS) | {"db_map"}
 
 
 class SprintSkillTest(unittest.TestCase):
@@ -134,6 +134,43 @@ class SprintSkillTest(unittest.TestCase):
                     self.assertEqual(tuple(rows[0]), (expected, 0))
         finally:
             con.close()
+
+    def test_flags_output_reseed_matches_fresh_seed_and_replays_idempotently(self):
+        upgraded = sqlite3.connect(":memory:")
+        fresh = sqlite3.connect(":memory:")
+        try:
+            for con in (upgraded, fresh):
+                con.executescript((ENGINE / "schema.sql").read_text())
+            fresh.executescript(
+                (ENGINE / "migrations" / "0001_seed_skills.sql").read_text()
+            )
+            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name >= "0161_reseed_flags_output_guidance.sql":
+                    break
+                upgraded.executescript(migration.read_text())
+            upgraded.execute(
+                "UPDATE skills SET content='stale flags guidance', is_deleted=1 "
+                "WHERE name='flags'"
+            )
+
+            migration = (
+                ENGINE / "migrations" / "0161_reseed_flags_output_guidance.sql"
+            ).read_text()
+            upgraded.executescript(migration)
+            upgraded.executescript(migration)
+
+            expected = seed_skills.parse_skill(
+                ASSETS / "flags" / "SKILL.md"
+            )["content"]
+            for con in (fresh, upgraded):
+                rows = con.execute(
+                    "SELECT content, is_deleted FROM skills WHERE name='flags'"
+                ).fetchall()
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(tuple(rows[0]), (expected, 0))
+        finally:
+            upgraded.close()
+            fresh.close()
 
     def test_reviewer_skill_owns_severity_and_conformance_never_fixes(self):
         reviewer = (ASSETS / "sprint_rev" / "SKILL.md").read_text()

--- a/tests/test_worktree_targets.py
+++ b/tests/test_worktree_targets.py
@@ -330,6 +330,14 @@ class HelpSurvivesTheRefusalTest(WorktreeFixture):
             f"exec {shlex.quote(shutil.which('find') or '/usr/bin/find')} \"$@\"\n"
         )
         find_probe.chmod(0o755)
+        for executable in ("pip", "npm"):
+            install_probe = probe_dir / executable
+            install_probe.write_text(
+                "#!/bin/sh\n"
+                f"echo {executable} >> {shlex.quote(str(calls))}\n"
+                "exit 97\n"
+            )
+            install_probe.chmod(0o755)
         env = {
             "SC_PYTHON": str(python_probe),
             "PATH": f"{probe_dir}:{os.environ['PATH']}",


### PR DESCRIPTION
Sprint 79 Unit 4 (spec #78).

Covers the cancellation resolution string and the ratified reassignment boundary; traps direct pip/npm help-path regressions; short-circuits Python test presence and replaces brittle source counting with live probes; centralizes the actionable-kind error; and aligns flags human-output guidance/tests through the generated seed plus idempotent migration 0161.

Judgement: F5 is test-depth only. A former assignee's accepted notification remains open when a replacement assignee hands off; no liveness behavior changes.

Verification: 1614 passed, 1 skipped via ./sc test; focused Sprint/CLI/flags/migration suites green; render-check green; sh -n sc; critical Ruff E9/F63/F7/F82 green; git diff --check. Full Ruff retains known baseline #878 findings unrelated to this diff.