### PR TITLE
feat: add migration authoring guardrails

### DIFF
--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -2627,8 +2627,7 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
 
 Migrations live in `.super-coder/migrations/`, apply in numeric order, tracked
 by the `schema_migrations` ledger table. Engine updates apply pending
-migrations automatically; apply locally without a fetch via
-`sc update --no-fetch`.
+migrations automatically; apply local pending migrations with `./sc migrate`.
 
 **Scope:** fork-specific changes — tables, columns, constraints, or
 system-content seeds (skills, flavor defaults) this fork needs that will not
@@ -2637,14 +2636,19 @@ from you.
 
 ## Authoring a migration
 
-1. **Find the next number:**
+1. **Create it through the guardrail:**
    ```bash
-   ls .super-coder/migrations/ | sort | tail -5
+   ./sc migration new <slug>
    ```
-   Name the file `NNNN_<slug>.sql`, NNNN = next integer zero-padded to 4
-   digits (e.g. `0012`).
+   Use a lowercase `snake_case` slug. The command refuses unexpected duplicate
+   number prefixes, allocates the next free zero-padded number, writes the
+   standard transaction/idempotence skeleton, and (in the subfloor source
+   repo) updates the source removal-test allowlist in the same act. The
+   exact historical `0155` pair is frozen and explicitly allowed; never
+   renumber an applied migration.
 
-2. **Write the file** at `.super-coder/migrations/NNNN_<slug>.sql`:
+2. **Fill in the generated file** at
+   `.super-coder/migrations/NNNN_<slug>.sql`:
    - Wrap in `BEGIN; ... COMMIT;`
    - Idempotent: `CREATE TABLE IF NOT EXISTS`, `INSERT OR IGNORE`,
      `CREATE INDEX IF NOT EXISTS`, `DROP TABLE IF EXISTS` before recreate
@@ -2655,9 +2659,12 @@ from you.
 
 3. **Apply locally:**
    ```bash
-   sc update --no-fetch
+   ./sc migrate
    ```
-   Skips the upstream fetch; applies all pending local migrations in order.
+   This takes a WAL-safe `premigrate` backup before opening the migration
+   chain and keeps the newest 5 backups in that lifecycle class. `./sc update`
+   retains its separate `preupdate` backup and does not double-back up during
+   the same update run. Both paths apply pending migrations in order.
    Confirm it landed:
    ```sql
    SELECT * FROM schema_migrations ORDER BY applied_at DESC LIMIT 5;
@@ -2665,7 +2672,7 @@ from you.
 
 4. **Verify:**
    ```bash
-   sc verify
+   ./sc verify
    ```
    Headless boot proof — shells, memory, and schema intact.
 
@@ -2673,14 +2680,14 @@ from you.
    ```bash
    SC_ADMIN=1 sc snapshot
    ```
-   Commit only `migrations/NNNN_<slug>.sql`; the snapshot remains local.
-   - **Content-seed migration** (seeds system content that renders — skills,
-     flavor defaults) also changes the flat `_sc` mirrors, but only once the
-     new rows are in the DB: after `sc update --no-fetch`, run
-     `SC_ADMIN=1 sc render && sc render-check`. The `_sc` files remain ignored.
-     A render against a DB predating the seed passes
-     locally while CI''s hermetic rebuild goes red — the stale-mirror trap; see
-     the `snapshot` skill.
+   Commit the migration and any authoritative source asset it carries; the
+   snapshot remains local.
+   - **Engine skill seed:** edit `assets/skills/<name>/SKILL.md`, run
+     `./sc seed-skills` to regenerate `0001_seed_skills.sql`, and put the same
+     full-body UPSERT in the new trailing migration so existing installations
+     converge. Then run `./sc render-check`: its hermetic rebuild proves the
+     ignored local `skills_sc/` mirror, which is verification output rather
+     than a tracked artifact.
 
 ## What makes a good migration
 

--- a/.super-coder/migrations/0160_reseed_migration_management.sql
+++ b/.super-coder/migrations/0160_reseed_migration_management.sql
@@ -1,11 +1,17 @@
----
-name: migration_management
-description: Author and apply fork-specific DB schema migrations — naming, format, how to apply locally and verify.
-category: substrate
-common: false
----
+-- 0160 — route migration authors through the scaffold and document backups.
+--
+-- Full-body UPSERT converges existing installations; 0001_seed_skills.sql
+-- remains the fresh-install seed generated from the authoritative skill asset.
 
-# migration_management — fork-specific schema changes
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'migration_management',
+  'Author and apply fork-specific DB schema migrations — naming, format, how to apply locally and verify.',
+  'substrate',
+  NULL,
+  0,
+  '# migration_management — fork-specific schema changes
 
 Migrations live in `.super-coder/migrations/`, apply in numeric order, tracked
 by the `schema_migrations` ledger table. Engine updates apply pending
@@ -85,5 +91,13 @@ from you.
 
 No per-migration rollback. `sc rollback` restores the full DB + engine to the
 prior update point (`engine.ref.prev`). Use only when a migration is so broken
-the DB is corrupt or the app won't start; for logical errors, write a
-corrective migration instead.
+the DB is corrupt or the app won''t start; for logical errors, write a
+corrective migration instead.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/migrate.py
+++ b/.super-coder/scripts/migrate.py
@@ -21,9 +21,11 @@ import sys
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
 MIGRATIONS_DIR = ENGINE / "migrations"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import db_backup  # noqa: E402
 import db_driver  # noqa: E402
 
 # A migration file's own outermost transaction control (on its own line). A
@@ -96,7 +98,19 @@ def apply(con, path: Path) -> None:
             con.execute("PRAGMA foreign_keys=ON")
 
 
-def migrate(db_path: str) -> int:
+def backup_before_migrate(db_path: str) -> Path | None:
+    """Create the bare migrate command's WAL-safe, bounded restore point."""
+    source = Path(db_path).resolve()
+    if not source.exists():
+        return None
+    directory = db_backup.select_backup_dir(REPO_ROOT)
+    result = db_backup.backup_database(source, directory, "premigrate")
+    if result is not None:
+        print(f"migrate: backed up existing DB -> {result}")
+    return result
+
+
+def migrate(db_path: str, *, backup: bool = False) -> int:
     # Spec #68 req 5: name the two targets — WHICH database, and WHICH migration
     # source — before opening either, and again on the outcome. `./sc migrate`
     # run from a linked worktree used to maintain the main checkout's live DB and
@@ -106,6 +120,8 @@ def migrate(db_path: str) -> int:
     target = Path(db_path).resolve()
     print(f"migrate: db         {target}")
     print(f"migrate: migrations {MIGRATIONS_DIR}")
+    if backup:
+        backup_before_migrate(db_path)
     con = db_driver.connect(db_path)
     try:
         todo = pending(con)
@@ -128,6 +144,8 @@ HELP = f"""{USAGE}
 Apply every unstamped migration in {MIGRATIONS_DIR.name}/ to the named DB, in
 filename order, recording each in the schema_migrations ledger. Reports the
 absolute DB path and migration source directory before touching either.
+The bare command first takes a WAL-safe ``premigrate`` backup and retains the
+newest {db_backup.KEEP_BACKUPS} backups in that lifecycle class.
 
 Takes exactly one argument: the path to the database.
 """
@@ -154,4 +172,4 @@ def parse_args(argv: list[str]) -> str:
 if __name__ == "__main__":
     from cli_entry import run_cli
 
-    sys.exit(run_cli(lambda: migrate(parse_args(sys.argv[1:]))))
+    sys.exit(run_cli(lambda: migrate(parse_args(sys.argv[1:]), backup=True)))

--- a/.super-coder/scripts/migration.py
+++ b/.super-coder/scripts/migration.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Scaffold collision-safe super-coder migrations."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+ENGINE = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE.parent
+MIGRATIONS_DIR = ENGINE / "migrations"
+SPRINT_REMOVAL_MANIFEST = (
+    REPO_ROOT / "tests" / "fixtures" / "sprint_removal" / "manifest.json"
+)
+
+_MIGRATION_NAME = re.compile(
+    r"^(?P<number>\d{4})_(?P<slug>[a-z0-9]+(?:_[a-z0-9]+)*)\.sql$"
+)
+_SLUG = re.compile(r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+
+# Applied migrations are immutable. The only historical collision predates the
+# scaffold, so allow exactly these two files and reject any third 0155 entry.
+FROZEN_NUMBER_COLLISIONS = {
+    "0155": frozenset(
+        {
+            "0155_reseed_catalogue_cleanup.sql",
+            "0155_sprint_conversation_generations.sql",
+        }
+    )
+}
+
+
+class MigrationScaffoldError(RuntimeError):
+    """The migration tree cannot be scaffolded safely."""
+
+
+def _numbered_migrations(directory: Path) -> dict[str, set[str]]:
+    by_number: dict[str, set[str]] = {}
+    for path in directory.glob("*.sql"):
+        match = _MIGRATION_NAME.fullmatch(path.name)
+        if match is None:
+            continue
+        by_number.setdefault(match.group("number"), set()).add(path.name)
+    return by_number
+
+
+def validate_unique_numbers(directory: Path = MIGRATIONS_DIR) -> None:
+    """Reject duplicate numeric prefixes except the exact frozen 0155 pair."""
+    for number, names in sorted(_numbered_migrations(directory).items()):
+        if len(names) < 2:
+            continue
+        if names == FROZEN_NUMBER_COLLISIONS.get(number):
+            continue
+        joined = ", ".join(sorted(names))
+        raise MigrationScaffoldError(
+            f"duplicate migration number {number}: {joined}"
+        )
+
+
+def next_free_number(directory: Path = MIGRATIONS_DIR) -> str:
+    by_number = _numbered_migrations(directory)
+    highest = max((int(number) for number in by_number), default=0)
+    candidate = highest + 1
+    if candidate > 9999:
+        raise MigrationScaffoldError("migration number space exhausted")
+    return f"{candidate:04d}"
+
+
+def _skeleton(number: str, slug: str) -> str:
+    intent = slug.replace("_", " ")
+    return (
+        f"-- {number} — {intent}.\n"
+        "-- Intent: describe the durable schema or system-content change here.\n"
+        "-- Keep every statement idempotent (for example: IF NOT EXISTS or "
+        "INSERT OR IGNORE).\n\n"
+        "BEGIN;\n\n"
+        "-- Migration statements go here.\n\n"
+        "COMMIT;\n"
+    )
+
+
+def _load_manifest(path: Path) -> dict:
+    try:
+        manifest = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MigrationScaffoldError(
+            f"cannot read removal manifest {path}: {exc}"
+        ) from exc
+    allowed = manifest.get("allowed_reference_files")
+    if not isinstance(allowed, list) or not all(
+        isinstance(item, str) for item in allowed
+    ):
+        raise MigrationScaffoldError(
+            f"removal manifest {path} has no string allowed_reference_files list"
+        )
+    return manifest
+
+
+def _write_manifest(path: Path, manifest: dict) -> None:
+    temporary = path.with_name(f".{path.name}.migration-{os.getpid()}")
+    try:
+        temporary.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+        )
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def new_migration(
+    slug: str,
+    *,
+    migrations_dir: Path = MIGRATIONS_DIR,
+    manifest_path: Path = SPRINT_REMOVAL_MANIFEST,
+) -> Path:
+    if _SLUG.fullmatch(slug) is None:
+        raise MigrationScaffoldError(
+            "slug must be lowercase snake_case (letters, digits, underscores)"
+        )
+
+    validate_unique_numbers(migrations_dir)
+    number = next_free_number(migrations_dir)
+    filename = f"{number}_{slug}.sql"
+    relative = f".super-coder/migrations/{filename}"
+    manifest = _load_manifest(manifest_path) if manifest_path.exists() else None
+    if manifest is not None:
+        allowed = manifest["allowed_reference_files"]
+        if relative not in allowed:
+            allowed.append(relative)
+
+    path = migrations_dir / filename
+    created = False
+    try:
+        with path.open("x") as handle:
+            handle.write(_skeleton(number, slug))
+        created = True
+        # Close the allocation race for different slugs that chose the same
+        # number before either file existed. At most one scaffold survives.
+        validate_unique_numbers(migrations_dir)
+        if manifest is not None:
+            _write_manifest(manifest_path, manifest)
+    except Exception:
+        if created:
+            path.unlink(missing_ok=True)
+        raise
+    return path
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="./sc migration")
+    commands = parser.add_subparsers(dest="command", required=True)
+    create = commands.add_parser("new", help="allocate and scaffold a migration")
+    create.add_argument("slug", help="lowercase snake_case filename slug")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        path = new_migration(args.slug)
+    except (MigrationScaffoldError, OSError) as exc:
+        print(f"migration: {exc}", file=sys.stderr)
+        return 1
+    print(f"migration: created {path.relative_to(REPO_ROOT)}")
+    if SPRINT_REMOVAL_MANIFEST.exists():
+        print(
+            "migration: allowlisted in "
+            f"{SPRINT_REMOVAL_MANIFEST.relative_to(REPO_ROOT)}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -851,7 +851,9 @@ def migrate_or_rebuild() -> None:
     # current-schema DB with the previous engine.
     rebuild_mod.backup_existing(prefix="preupdate")
     print("→ migrate in place (pending migrations → the live DB; data preserved)")
-    migrate_mod.migrate(str(DB_PATH))
+    # The updater already owns the preupdate restore point above. Bare
+    # `./sc migrate` opts into its separate premigrate class at the CLI seam.
+    migrate_mod.migrate(str(DB_PATH), backup=False)
 
 
 def stop_pm2_review_server() -> tuple[str, str] | None:

--- a/sc
+++ b/sc
@@ -1153,6 +1153,7 @@ case "$cmd" in
                 exec "$PY" "$S/rebuild.py" "$@" ;;
   migrate)      sc_help_form "$@" || sc_refuse_linked migrate "$DB"
                 exec "$PY" "$S/migrate.py" "$DB" "$@" ;;
+  migration)    exec "$PY" "$CALLER_ENGINE/scripts/migration.py" "$@" ;;
   # snapshot/render name the artifact they would overwrite as well as the DB
   # they read; resolving that path costs a subprocess, so only the refusing
   # branch pays for it.
@@ -1571,6 +1572,8 @@ super-coder — forkable shell substrate
                              --dry-run previews; --yes skips confirmation, never safety gates
   ./sc rebuild             build the .db from schema + migrations + snapshot
   ./sc migrate             apply pending migrations to an existing .db
+  ./sc migration new <slug>
+                           allocate the next free migration number, write the standard skeleton, and update the source removal-test allowlist
   ./sc snapshot            dump per-instance tables to gitignored .sc-state/local/
                              live-state commands (rebuild · migrate · verify · snapshot · render · clean-db) act on the SHARED live
                              instance at the main checkout, so they REFUSE from a linked worktree rather than substitute it, naming

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -58,7 +58,10 @@
     "tests/fixtures/sprint_v2_acceptance.json",
     "tests/fixtures/sprint_handoff_hardening_acceptance.json",
     "tests/test_callable_floor.py",
-    "tests/test_update_materialize.py"
+    "tests/test_update_materialize.py",
+    ".super-coder/migrations/0160_reseed_migration_management.sql",
+    ".super-coder/scripts/migration.py",
+    "tests/test_migration_management.py"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -12,10 +12,13 @@ Run:
 """
 from __future__ import annotations
 
+import os
 import shutil
+import sqlite3
 import sys
 import tempfile
 import unittest
+from contextlib import closing
 from pathlib import Path
 from unittest import mock
 
@@ -43,9 +46,9 @@ class AtomicMigrateTests(unittest.TestCase):
     def _write(self, name: str, sql: str) -> None:
         (self.migdir / name).write_text(sql)
 
-    def _run(self):
+    def _run(self, *, backup: bool = False):
         with mock.patch.object(migrate, "MIGRATIONS_DIR", self.migdir):
-            return migrate.migrate(self.db)
+            return migrate.migrate(self.db, backup=backup)
 
     def _stamped(self) -> set[str]:
         con = db_driver.connect(self.db)
@@ -147,6 +150,67 @@ class AtomicMigrateTests(unittest.TestCase):
         finally:
             con.close()
         self.assertIn("0001_swap.sql", self._stamped())
+
+    def test_bare_migrate_takes_wal_safe_premigrate_backup_and_prunes_its_class(self):
+        self._write("0001_add_b.sql", "ALTER TABLE t ADD COLUMN b;\n")
+        backup_dir = self.tmp / "backups"
+        backup_dir.mkdir()
+        old_backups = []
+        for index in range(6):
+            old = backup_dir / f"shell_db.premigrate.20000101_00000{index}.db"
+            old.write_bytes(b"old")
+            old_backups.append(old)
+        preupdate = backup_dir / "shell_db.preupdate.20000101_000000.db"
+        preupdate.write_bytes(b"separate lifecycle")
+
+        writer = sqlite3.connect(self.db)
+        try:
+            writer.execute("PRAGMA journal_mode=WAL")
+            writer.execute("INSERT INTO t (a) VALUES (41)")
+            writer.commit()
+            with mock.patch.dict(
+                os.environ,
+                {"SC_DB_BACKUP_DIR": str(backup_dir)},
+            ):
+                self._run(backup=True)
+        finally:
+            writer.close()
+
+        backups = sorted(backup_dir.glob("shell_db.premigrate.*.db"))
+        self.assertEqual(len(backups), migrate.db_backup.KEEP_BACKUPS)
+        self.assertFalse(old_backups[0].exists())
+        self.assertFalse(old_backups[1].exists())
+        created = [path for path in backups if path not in old_backups]
+        self.assertEqual(len(created), 1)
+        self.assertTrue(preupdate.exists())
+
+        with closing(sqlite3.connect(created[0])) as restored:
+            self.assertEqual(restored.execute("SELECT a FROM t").fetchall(), [(41,)])
+            self.assertEqual(
+                [row[1] for row in restored.execute("PRAGMA table_info(t)")],
+                ["a"],
+            )
+        self.assertIn("b", self._cols())
+
+    def test_backup_failure_prevents_migration_application(self):
+        self._write("0001_add_b.sql", "ALTER TABLE t ADD COLUMN b;\n")
+        with mock.patch.object(
+            migrate.db_backup,
+            "select_backup_dir",
+            side_effect=migrate.db_backup.BackupDestinationError("no destination"),
+        ), self.assertRaisesRegex(
+            migrate.db_backup.BackupDestinationError,
+            "no destination",
+        ):
+            self._run(backup=True)
+
+        self.assertNotIn("b", self._cols())
+        with closing(sqlite3.connect(self.db)) as con:
+            ledger = con.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='schema_migrations'"
+            ).fetchall()
+        self.assertEqual(ledger, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_migration_management.py
+++ b/tests/test_migration_management.py
@@ -166,7 +166,7 @@ class MigrationScaffoldTest(unittest.TestCase):
 
 
 class MigrationCliTest(unittest.TestCase):
-    def test_help_uses_the_callers_engine_from_a_linked_worktree(self):
+    def test_help_is_available_from_the_repository_checkout(self):
         completed = subprocess.run(
             [str(ROOT / "sc"), "migration", "new", "--help"],
             cwd=ROOT,

--- a/tests/test_migration_management.py
+++ b/tests/test_migration_management.py
@@ -1,0 +1,236 @@
+"""Migration scaffold and migration-number guardrails."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import migration  # noqa: E402
+import seed_skills  # noqa: E402
+
+
+class MigrationNumberGuardTest(unittest.TestCase):
+    def test_current_tree_has_only_the_exact_frozen_0155_collision(self):
+        migration.validate_unique_numbers(ENGINE / "migrations")
+
+    def test_synthetic_duplicate_number_is_rejected_with_both_files_named(self):
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            (directory / "0160_first.sql").write_text("BEGIN; COMMIT;\n")
+            (directory / "0160_second.sql").write_text("BEGIN; COMMIT;\n")
+
+            with self.assertRaisesRegex(
+                migration.MigrationScaffoldError,
+                r"duplicate migration number 0160: 0160_first\.sql, 0160_second\.sql",
+            ):
+                migration.validate_unique_numbers(directory)
+
+    def test_frozen_number_rejects_an_unallowlisted_third_file(self):
+        with tempfile.TemporaryDirectory() as raw:
+            directory = Path(raw)
+            names = (*migration.FROZEN_NUMBER_COLLISIONS["0155"], "0155_third.sql")
+            for name in names:
+                (directory / name).write_text("BEGIN; COMMIT;\n")
+
+            with self.assertRaisesRegex(
+                migration.MigrationScaffoldError,
+                "duplicate migration number 0155",
+            ):
+                migration.validate_unique_numbers(directory)
+
+
+class MigrationScaffoldTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.migrations = self.root / ".super-coder" / "migrations"
+        self.migrations.mkdir(parents=True)
+        self.manifest = (
+            self.root
+            / "tests"
+            / "fixtures"
+            / "sprint_removal"
+            / "manifest.json"
+        )
+        self.manifest.parent.mkdir(parents=True)
+        self.manifest.write_text(
+            json.dumps({"allowed_reference_files": ["existing"]}) + "\n"
+        )
+        (self.migrations / "0159_existing.sql").write_text("BEGIN; COMMIT;\n")
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_new_allocates_writes_skeleton_and_allowlists_in_one_call(self):
+        created = migration.new_migration(
+            "reseed_migration_management",
+            migrations_dir=self.migrations,
+            manifest_path=self.manifest,
+        )
+
+        self.assertEqual(created.name, "0160_reseed_migration_management.sql")
+        self.assertEqual(
+            created.read_text(),
+            "-- 0160 — reseed migration management.\n"
+            "-- Intent: describe the durable schema or system-content change here.\n"
+            "-- Keep every statement idempotent (for example: IF NOT EXISTS or "
+            "INSERT OR IGNORE).\n\n"
+            "BEGIN;\n\n"
+            "-- Migration statements go here.\n\n"
+            "COMMIT;\n",
+        )
+        allowed = json.loads(self.manifest.read_text())["allowed_reference_files"]
+        self.assertEqual(
+            allowed,
+            [
+                "existing",
+                ".super-coder/migrations/0160_reseed_migration_management.sql",
+            ],
+        )
+        self.assertEqual(list(self.migrations.glob("0160_*.sql")), [created])
+
+    def test_invalid_slug_creates_neither_migration_nor_manifest_entry(self):
+        before = self.manifest.read_text()
+        with self.assertRaisesRegex(
+            migration.MigrationScaffoldError,
+            "lowercase snake_case",
+        ):
+            migration.new_migration(
+                "Bad-Slug",
+                migrations_dir=self.migrations,
+                manifest_path=self.manifest,
+            )
+
+        self.assertEqual(self.manifest.read_text(), before)
+        self.assertEqual(list(self.migrations.glob("0160_*.sql")), [])
+
+    def test_fork_without_source_test_manifest_still_gets_the_migration(self):
+        missing_manifest = self.root / "not-shipped" / "manifest.json"
+        created = migration.new_migration(
+            "fork_local_table",
+            migrations_dir=self.migrations,
+            manifest_path=missing_manifest,
+        )
+
+        self.assertEqual(created.name, "0160_fork_local_table.sql")
+        self.assertTrue(created.exists())
+        self.assertFalse(missing_manifest.exists())
+
+    def test_manifest_write_failure_removes_the_unallowlisted_migration(self):
+        with mock.patch.object(
+            migration,
+            "_write_manifest",
+            side_effect=OSError("disk full"),
+        ), self.assertRaisesRegex(OSError, "disk full"):
+            migration.new_migration(
+                "reseed_migration_management",
+                migrations_dir=self.migrations,
+                manifest_path=self.manifest,
+            )
+
+        self.assertEqual(list(self.migrations.glob("0160_*.sql")), [])
+        self.assertEqual(
+            json.loads(self.manifest.read_text())["allowed_reference_files"],
+            ["existing"],
+        )
+
+    def test_exclusive_create_loser_does_not_delete_the_winners_file(self):
+        winner = self.migrations / "0160_reseed_migration_management.sql"
+        winner.write_text("winner\n")
+        with mock.patch.object(
+            migration,
+            "next_free_number",
+            return_value="0160",
+        ), self.assertRaises(FileExistsError):
+            migration.new_migration(
+                "reseed_migration_management",
+                migrations_dir=self.migrations,
+                manifest_path=self.manifest,
+            )
+
+        self.assertEqual(winner.read_text(), "winner\n")
+        self.assertEqual(
+            json.loads(self.manifest.read_text())["allowed_reference_files"],
+            ["existing"],
+        )
+
+
+class MigrationCliTest(unittest.TestCase):
+    def test_help_uses_the_callers_engine_from_a_linked_worktree(self):
+        completed = subprocess.run(
+            [str(ROOT / "sc"), "migration", "new", "--help"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("usage: ./sc migration new", completed.stdout)
+        self.assertEqual(completed.stderr, "")
+
+
+class MigrationManagementReseedTest(unittest.TestCase):
+    def test_scaffold_created_reseed_is_allowlisted(self):
+        manifest = json.loads(
+            (ROOT / "tests/fixtures/sprint_removal/manifest.json").read_text()
+        )
+        self.assertIn(
+            ".super-coder/migrations/0160_reseed_migration_management.sql",
+            manifest["allowed_reference_files"],
+        )
+
+    def test_terminal_reseed_matches_the_authoritative_skill_asset(self):
+        expected = seed_skills.parse_skill(
+            ENGINE / "assets/skills/migration_management/SKILL.md"
+        )
+        con = sqlite3.connect(":memory:")
+        try:
+            con.executescript(
+                "CREATE TABLE skills ("
+                "skill_id INTEGER PRIMARY KEY, name TEXT UNIQUE, description TEXT, "
+                "category TEXT, command TEXT, common INTEGER, content TEXT, "
+                "is_deleted INTEGER DEFAULT 0);"
+            )
+            con.executescript(
+                (
+                    ENGINE
+                    / "migrations/0160_reseed_migration_management.sql"
+                ).read_text()
+            )
+            actual = con.execute(
+                "SELECT name,description,category,command,common,content,is_deleted "
+                "FROM skills WHERE name='migration_management'"
+            ).fetchone()
+        finally:
+            con.close()
+
+        self.assertEqual(
+            actual,
+            (
+                expected["name"],
+                expected["description"],
+                expected["category"],
+                expected["command"],
+                expected["common"],
+                expected["content"],
+                0,
+            ),
+        )
+        self.assertIn("./sc migration new <slug>", actual[5])
+        self.assertIn("WAL-safe `premigrate` backup", actual[5])
+        self.assertIn("separate `preupdate` backup", actual[5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_service_cutover.py
+++ b/tests/test_update_service_cutover.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import contextlib
 import io
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -18,6 +19,20 @@ class Stop(Exception):
 
 
 class UpdateServiceCutoverTest(unittest.TestCase):
+    def test_update_uses_only_its_preupdate_backup_class(self):
+        with tempfile.TemporaryDirectory() as raw:
+            database = Path(raw) / "shell_db.db"
+            database.write_bytes(b"database")
+            with mock.patch.object(update, "DB_PATH", database), mock.patch.object(
+                update.rebuild_mod, "backup_existing"
+            ) as backup, mock.patch.object(
+                update.migrate_mod, "migrate"
+            ) as migrate, contextlib.redirect_stdout(io.StringIO()):
+                update.migrate_or_rebuild()
+
+        backup.assert_called_once_with(prefix="preupdate")
+        migrate.assert_called_once_with(str(database), backup=False)
+
     def test_main_routes_migration_through_the_service_cutover(self):
         with mock.patch.object(update, "is_source_repo", return_value=True), \
                 mock.patch.object(update, "repair_git_worktrees") as repair, \

--- a/tests/test_worktree_targets.py
+++ b/tests/test_worktree_targets.py
@@ -185,6 +185,14 @@ class WorktreeFixture(unittest.TestCase):
         shutil.copytree(ENGINE, cls.main / ".super-coder", ignore=IGNORE)
         shutil.copy2(REPO / "sc", cls.main / "sc")
         (cls.main / "sc").chmod(0o755)
+        manifest = (
+            cls.main / "tests" / "fixtures" / "sprint_removal" / "manifest.json"
+        )
+        manifest.parent.mkdir(parents=True)
+        shutil.copy2(
+            REPO / "tests" / "fixtures" / "sprint_removal" / "manifest.json",
+            manifest,
+        )
         git = ["git", "-C", str(cls.main)]
         subprocess.run([*git, "init", "-q", "-b", "main"], check=True)
         subprocess.run([*git, "config", "user.email", "t@t"], check=True)
@@ -402,6 +410,53 @@ class RootCheckoutUnchangedTest(WorktreeFixture):
         self.assertLess(
             merged.index(str(self.live_db)), merged.index("REBUILD-RAN"),
             "verify disclosed its target only after rebuild had already run")
+
+
+class MigrationScaffoldRunsCallerSourceTest(WorktreeFixture):
+    """Migration authoring writes only to the checkout where it was invoked."""
+
+    def test_new_migration_authors_the_linked_worktree_only(self):
+        slug = "linked_worktree_target"
+        wt_manifest = (
+            self.wt / "tests" / "fixtures" / "sprint_removal" / "manifest.json"
+        )
+        main_manifest = (
+            self.main / "tests" / "fixtures" / "sprint_removal" / "manifest.json"
+        )
+        wt_manifest_before = wt_manifest.read_bytes()
+        main_manifest_before = main_manifest.read_bytes()
+        wt_migrations = self.wt / ".super-coder" / "migrations"
+        main_migrations = self.main / ".super-coder" / "migrations"
+        main_names_before = {path.name for path in main_migrations.glob("*.sql")}
+
+        def restore_fixture() -> None:
+            for root in (self.wt, self.main):
+                for path in root.joinpath(".super-coder", "migrations").glob(
+                    f"*_{slug}.sql"
+                ):
+                    path.unlink(missing_ok=True)
+            wt_manifest.write_bytes(wt_manifest_before)
+            main_manifest.write_bytes(main_manifest_before)
+
+        self.addCleanup(restore_fixture)
+
+        done = run_sc(self.wt, "migration", "new", slug)
+
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+        created = sorted(wt_migrations.glob(f"*_{slug}.sql"))
+        self.assertEqual(len(created), 1, done.stdout)
+        relative = f".super-coder/migrations/{created[0].name}"
+        self.assertIn(f"migration: created {relative}", done.stdout)
+        self.assertIn("-- Migration statements go here.", created[0].read_text())
+        allowed = json.loads(wt_manifest.read_text())["allowed_reference_files"]
+        self.assertEqual(allowed.count(relative), 1)
+
+        self.assertEqual(list(main_migrations.glob(f"*_{slug}.sql")), [])
+        self.assertEqual(
+            {path.name for path in main_migrations.glob("*.sql")},
+            main_names_before,
+        )
+        self.assertEqual(main_manifest.read_bytes(), main_manifest_before)
 
 
 class RenderCheckRunsCallerSourceTest(WorktreeFixture):


### PR DESCRIPTION
## Summary

- add ./sc migration new <slug> with strict snake-case names, exact frozen-0155 handling, duplicate-prefix refusal, exclusive creation, standard SQL skeletons, and source-manifest allowlisting
- make bare ./sc migrate take a WAL-safe premigrate backup through db_backup with per-prefix retention of 5; keep update on its single preupdate backup
- route migration authors through the scaffold and ship the skill change through the authoritative asset, regenerated 0001 seed, and scaffold-created 0160 terminal reseed

## Judgement

The spec still names a tracked skills_sc mirror, but generated renders have been local-only since PR #726. This change follows current source policy: 0001 plus the terminal reseed are tracked, while render-check proves the ignored local mirror. Forks do not ship the source test manifest, so the scaffold updates it when present and still creates fork-local migrations when absent.

## Verification

- python3 -W error::ResourceWarning -m unittest tests.test_migration_management tests.test_migrate tests.test_update_service_cutover tests.test_sprint_removal_manifest tests.test_skills_freshness tests.test_worktree_targets tests.test_update_materialize tests.test_cli_sigpipe
  - 112 tests passed
- python3 -m py_compile .super-coder/scripts/migration.py .super-coder/scripts/migrate.py .super-coder/scripts/update.py
- sh -n sc
- ./sc render-check
- git diff --check

The linked-worktree source-maintenance conflict for ./sc map and ./sc verify remains tracked as SC-019; CI supplies the clean-checkout verification gate.