### PR TITLE
test(sprint): pin FnB completion deferral

### DIFF
--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -300,6 +300,7 @@ def close_for_terminal_lifecycle(
                     },
                     run_id=run_id,
                 )
+            # Completion defers the owning Planner even when FnB called complete.
             if (
                 lifecycle == "completed"
                 and int(active["shell_id"]) == owning_planner_shell_id

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -1206,6 +1206,56 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
                     ).fetchone()[0],
                 )
 
+    def test_fnb_completion_still_defers_owning_planner_run(self):
+        sprint_id, _ = self.create_sprint()
+        self.store.arm(sprint_id, 3)
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (5,'FnB','FNB','admin','prompt',1)"
+        )
+        self.con.commit()
+        _, planner_run = self.add_live_run(sprint_id, 3)
+        _, developer_run = self.add_live_run(sprint_id, 1)
+        interrupts: list[int] = []
+        lifecycle = sprint_domain.SprintLifecycleStore(
+            self.con,
+            interrupt_run=lambda run_id: interrupts.append(run_id) or True,
+            notify_commit=lambda: True,
+        )
+
+        self.assertTrue(
+            lifecycle.transition(
+                sprint_id,
+                "completed",
+                sprint_domain.LifecycleActor("fnb", 5),
+                reason="FnB accepts the completed Sprint",
+                terminal_outcome="accepted",
+            )
+        )
+
+        self.assertEqual([developer_run], interrupts)
+        self.assertEqual(
+            [(developer_run,)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT run_id FROM conversation_events "
+                    "WHERE event_type='run.interrupt.requested' ORDER BY run_id"
+                )
+            ],
+        )
+        self.assertEqual(
+            [(planner_run,), (developer_run,)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT run_id FROM conversation_events "
+                    "WHERE event_type='conversation.close.requested' ORDER BY run_id"
+                )
+            ],
+        )
+
     def test_abort_interrupts_owning_planner_and_other_active_participants(self):
         sprint_id, _ = self.create_sprint()
         self.store.arm(sprint_id, 3)


### PR DESCRIPTION
## Summary

- make the owning-Planner key explicit at terminal cleanup
- add an FnB-caller regression proving only other participants are interrupted
- record the ratified doctrine in feature document #81 under feature #31

## Tests

- focused FnB regression: 1 passed
- tests/test_sprint_recovery.py: 20 passed
- full ./sc test: 1611 passed, 1 skipped
- ./sc render-check
- git diff --check
- scoped Ruff passes except pre-existing B023 filed as #942

## Notes

The existing frozen Sprint board was not edited. No editable Sprints v2 feature doc existed, so PLN1 ratified a new concise feature-scoped doctrine doc. The linked-worktree ./sc verify refusal is tracked in #769; full branch-local pytest and hosted CI are the safe verification gates.