### PR TITLE
fix: harden first-attempt update recovery

### DIFF
--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -22,7 +22,7 @@ Flow:
        never prevent an engine update.
     2. capture the restore point: the current `engine.ref` → `engine.ref.prev`.
     3. materialize the engine paths at the new ref into the
-       gitignored `.super-coder/` dir; write the new `engine.ref`. Per-instance
+       gitignored `.super-coder/` dir. Per-instance
        content (`.sc-state/`, the DB, instance.json) is never in the materialize
        set, so it survives untouched. --no-fetch reconciles the working tree as-is.
     4. back up the live DB (the other half of the restore point).
@@ -34,6 +34,7 @@ Flow:
        project-local skills are left intact.
     7. re-grant common skills to every flavor pack + Bespoke shell.
     8. wire the auto-remap hooks + map the repo + snapshot the (live) state.
+    9. only after every step succeeds, atomically publish the new `engine.ref`.
 
 Then review + commit (only `.sc-state/` — content.sql + engine.ref — moves; the
 engine is ignored). Restart the session to boot onto the new floor.
@@ -107,10 +108,12 @@ def git(
     return r
 
 
-def run_script(name: str) -> None:
+def run_script(name: str, *, update_target_ref: str | None = None) -> None:
     # update is an admin operation — pass SC_ADMIN so snapshot/render clear the
     # serialize guard (harmless for non-serializing scripts like map_setup.py).
     env = {**os.environ, "SC_ADMIN": "1"}
+    if update_target_ref is not None:
+        env["SC_UPDATE_TARGET_REF"] = update_target_ref
     if subprocess.run([PY, str(ENGINE / "scripts" / name)], env=env).returncode != 0:
         sys.exit(f"update: {name} failed.")
 
@@ -299,7 +302,11 @@ def super_coder_remote() -> str:
         if len(parts) < 2:
             continue
         name, url = parts[0], parts[1]
-        if any(n in url for n in install_mod.SOURCE_REPO_NAMES):
+        repo_name = (
+            url.rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+            .removesuffix(".git")
+        )
+        if repo_name in install_mod.SOURCE_REPO_NAMES:
             return name
         if name in install_mod.SOURCE_REPO_NAMES:
             named = name
@@ -681,7 +688,21 @@ def fetch_update_ref(branch: str, ref: str | None = None) -> str:
     return sha
 
 
-def materialize_fetched_engine(sha: str, *, force: bool = False) -> None:
+def publish_engine_ref(sha: str) -> None:
+    """Atomically record a fully successful update as the current engine pin."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    pending = STATE_DIR / "engine.ref.pending"
+    pending.write_text(sha + "\n")
+    os.replace(pending, ENGINE_REF)
+    print(f"  engine pinned at {sha[:12]} (.sc-state/engine.ref)")
+
+
+def materialize_fetched_engine(
+    sha: str,
+    *,
+    force: bool = False,
+    publish_ref: bool = True,
+) -> None:
     """Lay an already-fetched ref onto the installed floor."""
 
     check_local_edits(force, target_ref=sha)
@@ -722,7 +743,6 @@ def materialize_fetched_engine(sha: str, *, force: bool = False) -> None:
         expected_ref=sha,
         context="update",
     )
-    ENGINE_REF.write_text(sha + "\n")
     n = engine_manifest.write_manifest(
         materialized_paths,
         files=_engine_files_at(
@@ -731,7 +751,97 @@ def materialize_fetched_engine(sha: str, *, force: bool = False) -> None:
             engine_paths=materialized_paths,
         ),
     )
-    print(f"  engine pinned at {sha[:12]} (.sc-state/engine.ref) · manifest over {n} files")
+    if publish_ref:
+        publish_engine_ref(sha)
+        print(f"  manifest covers {n} files")
+    else:
+        print(
+            f"  engine materialized at {sha[:12]} · manifest over {n} files · "
+            "pin pending successful update"
+        )
+
+
+def _linked_worktree_paths() -> tuple[Path, ...]:
+    listed = git("worktree", "list", "--porcelain", check=False)
+    if listed.returncode != 0:
+        print(
+            "  WARNING: could not list linked worktrees for dispatcher repair: "
+            + listed.stderr.strip(),
+            file=sys.stderr,
+        )
+        return ()
+    root = REPO_ROOT.resolve()
+    paths = []
+    for line in listed.stdout.splitlines():
+        if not line.startswith("worktree "):
+            continue
+        path = Path(line.removeprefix("worktree ")).resolve()
+        if path != root:
+            paths.append(path)
+    return tuple(paths)
+
+
+def reconcile_linked_dispatchers(
+    sha: str,
+    *,
+    worktrees: tuple[Path, ...] | None = None,
+) -> tuple[Path, ...]:
+    """Lay the current dispatcher into clean linked-worktree launcher copies.
+
+    A shell branch keeps the tracked ``sc`` from its branch point. Updating the
+    live engine therefore leaves direct ``./sc`` calls on retired behavior even
+    though PATH resolves the main checkout correctly. Only a dispatcher whose
+    bytes still match that worktree's own ``HEAD:sc`` is engine-managed here;
+    local edits are preserved and named rather than overwritten.
+    """
+    shown = git("show", f"{sha}:sc", check=False)
+    if shown.returncode != 0:
+        print(
+            f"  WARNING: target {sha[:12]} has no dispatcher to reconcile",
+            file=sys.stderr,
+        )
+        return ()
+    target = shown.stdout.encode()
+    canonical = REPO_ROOT / "sc"
+    try:
+        canonical_mode = canonical.stat().st_mode
+    except OSError as exc:
+        print(f"  WARNING: cannot stat canonical dispatcher: {exc}", file=sys.stderr)
+        return ()
+
+    changed = []
+    pinned = callable_floor.read_engine_ref(REPO_ROOT)
+    pinned_dispatcher = None
+    if pinned is not None:
+        prior = git("show", f"{pinned}:sc", check=False)
+        if prior.returncode == 0:
+            pinned_dispatcher = prior.stdout.encode()
+    candidates = worktrees if worktrees is not None else _linked_worktree_paths()
+    for worktree in candidates:
+        dispatcher = worktree / "sc"
+        head = git("show", "HEAD:sc", check=False, repo_root=worktree)
+        try:
+            current = dispatcher.read_bytes()
+        except OSError:
+            current = None
+        managed_versions = {head.stdout.encode()} if head.returncode == 0 else set()
+        if pinned_dispatcher is not None:
+            managed_versions.add(pinned_dispatcher)
+        if current not in managed_versions:
+            print(
+                f"  WARNING: dispatcher locally edited, left stale: {dispatcher}",
+                file=sys.stderr,
+            )
+            continue
+        if current == target:
+            continue
+        dispatcher.write_bytes(target)
+        os.chmod(dispatcher, canonical_mode)
+        changed.append(worktree)
+
+    if changed:
+        print(f"→ reconciled current dispatcher into {len(changed)} linked worktree(s)")
+    return tuple(changed)
 
 
 def repair_callable_dispatcher(sha: str) -> bool:
@@ -1061,7 +1171,7 @@ def main(argv: list[str]) -> int:
     # Reconcile every shell worktree before any pull or engine materialization.
     # A whole fork move preserves the directories but invalidates Git's absolute
     # links; update is the one command that must heal the entire set every time.
-    repair_git_worktrees()
+    worktrees = repair_git_worktrees()
 
     # Keep the app/source checkout current before reconciling its engine. This
     # is deliberately advisory: dirty, detached, offline, or diverged checkouts
@@ -1095,7 +1205,15 @@ def main(argv: list[str]) -> int:
               "(engine + engine.ref unchanged)")
     else:
         assert target_sha is not None
-        materialize_fetched_engine(target_sha, force=force)
+        materialize_fetched_engine(target_sha, force=force, publish_ref=False)
+
+    dispatcher_ref = target_sha
+    if source:
+        dispatcher_ref = git("rev-parse", "HEAD").stdout.strip()
+    elif no_fetch:
+        dispatcher_ref = callable_floor.read_engine_ref(REPO_ROOT)
+    if dispatcher_ref and not source:
+        reconcile_linked_dispatchers(dispatcher_ref, worktrees=worktrees)
 
     workflow_action, workflow_changes = ensure_workflows(source_repo=source)
     if workflow_action == "seeded":
@@ -1146,7 +1264,7 @@ def main(argv: list[str]) -> int:
         "retain previously loaded skill text until reboot"
     )
     print("→ wire map automation + map the repo")
-    run_script("map_setup.py")
+    run_script("map_setup.py", update_target_ref=target_sha)
     print("→ snapshot the live state")
     run_script("snapshot.py")
 
@@ -1156,6 +1274,9 @@ def main(argv: list[str]) -> int:
     if not source:
         print("→ wire make aliases (dos- command standard)")
         print(f"  {install_mod.wire_make_aliases()}")
+
+    if target_sha is not None:
+        publish_engine_ref(target_sha)
 
     print("\nupdate: done — new floor laid in place; your rows are intact.")
     if source:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -810,12 +810,22 @@ def reconcile_linked_dispatchers(
         return ()
 
     changed = []
-    pinned = callable_floor.read_engine_ref(REPO_ROOT)
-    pinned_dispatcher = None
-    if pinned is not None:
-        prior = git("show", f"{pinned}:sc", check=False)
+    managed_dispatchers = set()
+    managed_refs = [callable_floor.read_engine_ref(REPO_ROOT)]
+    try:
+        previous = (
+            REPO_ROOT / ".sc-state" / "engine.ref.prev"
+        ).read_text().strip()
+    except OSError:
+        previous = None
+    if previous and re.fullmatch(r"[0-9a-fA-F]{40}", previous):
+        managed_refs.append(previous)
+    for managed_ref in managed_refs:
+        if managed_ref is None:
+            continue
+        prior = git("show", f"{managed_ref}:sc", check=False)
         if prior.returncode == 0:
-            pinned_dispatcher = prior.stdout.encode()
+            managed_dispatchers.add(prior.stdout.encode())
     candidates = worktrees if worktrees is not None else _linked_worktree_paths()
     for worktree in candidates:
         dispatcher = worktree / "sc"
@@ -825,8 +835,7 @@ def reconcile_linked_dispatchers(
         except OSError:
             current = None
         managed_versions = {head.stdout.encode()} if head.returncode == 0 else set()
-        if pinned_dispatcher is not None:
-            managed_versions.add(pinned_dispatcher)
+        managed_versions.update(managed_dispatchers)
         if current not in managed_versions:
             print(
                 f"  WARNING: dispatcher locally edited, left stale: {dispatcher}",
@@ -1207,14 +1216,6 @@ def main(argv: list[str]) -> int:
         assert target_sha is not None
         materialize_fetched_engine(target_sha, force=force, publish_ref=False)
 
-    dispatcher_ref = target_sha
-    if source:
-        dispatcher_ref = git("rev-parse", "HEAD").stdout.strip()
-    elif no_fetch:
-        dispatcher_ref = callable_floor.read_engine_ref(REPO_ROOT)
-    if dispatcher_ref and not source:
-        reconcile_linked_dispatchers(dispatcher_ref, worktrees=worktrees)
-
     workflow_action, workflow_changes = ensure_workflows(source_repo=source)
     if workflow_action == "seeded":
         print("→ visual QA: seeded the managed workflow shim")
@@ -1277,6 +1278,11 @@ def main(argv: list[str]) -> int:
 
     if target_sha is not None:
         publish_engine_ref(target_sha)
+        reconcile_linked_dispatchers(target_sha, worktrees=worktrees)
+    elif not source:
+        dispatcher_ref = callable_floor.read_engine_ref(REPO_ROOT)
+        if dispatcher_ref:
+            reconcile_linked_dispatchers(dispatcher_ref, worktrees=worktrees)
 
     print("\nupdate: done — new floor laid in place; your rows are intact.")
     if source:

--- a/.super-coder/scripts/update_compat.py
+++ b/.super-coder/scripts/update_compat.py
@@ -38,12 +38,15 @@ def _read_ref(path: Path) -> str | None:
     return value if _SHA_RE.fullmatch(value) else None
 
 
+def _pending_update_ref() -> str | None:
+    """Return a current updater's valid, not-yet-published target."""
+    pending = os.environ.get("SC_UPDATE_TARGET_REF", "").strip()
+    return pending if _SHA_RE.fullmatch(pending) else None
+
+
 def _current_update_ref() -> str | None:
     """Prefer the not-yet-published target supplied by a current updater."""
-    pending = os.environ.get("SC_UPDATE_TARGET_REF", "").strip()
-    if _SHA_RE.fullmatch(pending):
-        return pending
-    return _read_ref(ENGINE_REF)
+    return _pending_update_ref() or _read_ref(ENGINE_REF)
 
 
 def _ref_contains_bridge(ref: str) -> bool:
@@ -69,6 +72,7 @@ def needs_legacy_bridge() -> tuple[bool, str | None]:
 
 
 def main() -> int:
+    pending = _pending_update_ref()
     current = _current_update_ref()
     if current is not None:
         # Unlike the path-repair migration below, dispatcher coherence is a
@@ -77,7 +81,12 @@ def main() -> int:
         import update
 
         update.repair_callable_dispatcher(current)
-        update.reconcile_linked_dispatchers(current)
+        # A current updater publishes only after migrate + snapshot. Defer its
+        # linked-worktree overlays until then so a crash cannot leave bytes that
+        # neither the old pin nor a later target recognizes. A legacy updater
+        # supplies no pending ref and has already published before this bridge.
+        if pending is None:
+            update.reconcile_linked_dispatchers(current)
 
     needed, current = needs_legacy_bridge()
     if not needed:

--- a/.super-coder/scripts/update_compat.py
+++ b/.super-coder/scripts/update_compat.py
@@ -15,6 +15,7 @@ previous ref.
 """
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -35,6 +36,14 @@ def _read_ref(path: Path) -> str | None:
     except OSError:
         return None
     return value if _SHA_RE.fullmatch(value) else None
+
+
+def _current_update_ref() -> str | None:
+    """Prefer the not-yet-published target supplied by a current updater."""
+    pending = os.environ.get("SC_UPDATE_TARGET_REF", "").strip()
+    if _SHA_RE.fullmatch(pending):
+        return pending
+    return _read_ref(ENGINE_REF)
 
 
 def _ref_contains_bridge(ref: str) -> bool:
@@ -60,7 +69,7 @@ def needs_legacy_bridge() -> tuple[bool, str | None]:
 
 
 def main() -> int:
-    current = _read_ref(ENGINE_REF)
+    current = _current_update_ref()
     if current is not None:
         # Unlike the path-repair migration below, dispatcher coherence is a
         # standing invariant. Existing forks may already carry the v1 marker
@@ -68,6 +77,7 @@ def main() -> int:
         import update
 
         update.repair_callable_dispatcher(current)
+        update.reconcile_linked_dispatchers(current)
 
     needed, current = needs_legacy_bridge()
     if not needed:

--- a/sc
+++ b/sc
@@ -470,15 +470,26 @@ sc_test() {
   venv="$here/.venv"
   python_tests=""
   _sc_has_python_tests && python_tests=1
-  # Self-heal: a fork with python tests but no .venv/bin/pytest is an unprovisioned
-  # worktree (the .venv is only populated by the first `./sc deps`), NOT a fork that
-  # opted out of pytest. Provision the dev kit + fork deps rather than silently
-  # downgrading to stdlib unittest — under which a pytest-based suite fails with
-  # ModuleNotFoundError (pytest / the fork's own libs) that reads as a real test
-  # failure. We gate on the pytest binary, not sc_deps' exit code, so a partial
-  # provision (e.g. npm leg fails) still runs pytest if it landed.
-  if [ ! -x "$venv/bin/pytest" ] && [ -n "$python_tests" ]; then
-    echo "→ test: $venv/bin/pytest missing — provisioning first (./sc deps)"
+  # Self-heal an unprovisioned OR unrunnable host venv before selecting a test
+  # runner. A dangling interpreter leaves the pytest shim executable, so -x is
+  # not evidence that the venv can run. On the host the repo-local .venv is ours
+  # to rebuild; in the sandbox a host-managed venv stays untouched and sc_deps'
+  # existing ownership check chooses the safe PATH fallback.
+  provision_reason=""
+  if [ -n "$python_tests" ]; then
+    if [ ! -x "$venv/bin/pytest" ]; then
+      provision_reason=missing
+    elif ! _sc_venv_runnable; then
+      provision_reason=unrunnable
+    fi
+  fi
+  if [ -n "$provision_reason" ]; then
+    if [ "$provision_reason" = unrunnable ] && [ -z "${SC_SANDBOX:-}" ]; then
+      echo "→ test: $venv is not runnable — rebuilding before provisioning"
+      ( cd "$here" && rm -rf -- .venv )
+    else
+      echo "→ test: $venv/bin/pytest unavailable — provisioning first (./sc deps)"
+    fi
     sc_deps || echo "→ test: provisioning incomplete — continuing" >&2
   fi
   # Which pytest can we actually RUN? The .venv copy wins (fork pins + config)

--- a/tests/test_devkit_sc.py
+++ b/tests/test_devkit_sc.py
@@ -323,6 +323,43 @@ class VenvRunnabilityGateTest(unittest.TestCase):
             self.assertIn("_sc_venv_runnable", body[max(0, m.start() - 200):m.start()],
                           "the venv pytest was selected without the probe")
 
+    def test_sc_test_rebuilds_dangling_venv_before_running_pytest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            venv = root / ".venv"
+            (venv / "bin").mkdir(parents=True)
+            (venv / "lib" / "python3.12" / "site-packages").mkdir(parents=True)
+            (venv / "bin" / "python").symlink_to("missing-python")
+            pytest = venv / "bin" / "pytest"
+            pytest.write_text("#!/bin/sh\necho STALE-PYTEST-RAN\n")
+            pytest.chmod(0o755)
+            script = (
+                f'here="{root}"\nPY=/bin/false\nPATH=/usr/bin:/bin\n'
+                "_sc_has_python_tests() { return 0; }\n"
+                "_sc_find_manifests() { return 0; }\n"
+                "_sc_wants_pytest() { return 1; }\n"
+                f'{_extract("_sc_venv_runnable")}\n'
+                "sc_deps() {\n"
+                "  [ ! -e \"$here/.venv\" ] || { echo NOT-REBUILT >&2; return 91; }\n"
+                "  mkdir -p \"$here/.venv/bin\" \"$here/.venv/lib/python3.12/site-packages\"\n"
+                "  printf '#!/bin/sh\\necho 3.12\\n' > \"$here/.venv/bin/python\"\n"
+                "  printf '#!/bin/sh\\necho FRESH-PYTEST-RAN\\n' > \"$here/.venv/bin/pytest\"\n"
+                "  chmod +x \"$here/.venv/bin/python\" \"$here/.venv/bin/pytest\"\n"
+                "  echo PROVISIONED\n"
+                "}\n"
+                f'{_extract("sc_test")}\n'
+                "sc_test\n"
+            )
+            done = subprocess.run(
+                ["sh", "-c", script], capture_output=True, text=True, check=False,
+            )
+
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+        self.assertEqual(done.stderr, "")
+        self.assertIn("PROVISIONED\n", done.stdout)
+        self.assertIn("FRESH-PYTEST-RAN\n", done.stdout)
+        self.assertNotIn("STALE-PYTEST-RAN", done.stdout)
+
 
 class DepsHostManagedVerifyTest(unittest.TestCase):
     """#314/#324/#339 — the sandbox pip-skip must never green-lie: declared

--- a/tests/test_source_repo_guard.py
+++ b/tests/test_source_repo_guard.py
@@ -74,6 +74,18 @@ class SourceRepoGuardTest(unittest.TestCase):
         finally:
             update.git = orig
 
+    def test_update_remote_matcher_rejects_fork_name_containing_source_name(self):
+        orig = update.git
+        try:
+            update.git = lambda *a, **k: SimpleNamespace(
+                stdout="origin\thttps://github.com/jedbjorn/subfloor-marketing.git (fetch)\n"
+                       "engine\tgit@github.com:jedbjorn/subfloor.git (fetch)\n",
+                returncode=0,
+            )
+            self.assertEqual(update.super_coder_remote(), "engine")
+        finally:
+            update.git = orig
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_update_legacy_compat.py
+++ b/tests/test_update_legacy_compat.py
@@ -238,7 +238,7 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 self.assertEqual(0, update_compat.main())
 
         repair_dispatcher.assert_called_once_with(pending)
-        reconcile_dispatchers.assert_called_once_with(pending)
+        reconcile_dispatchers.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_update_legacy_compat.py
+++ b/tests/test_update_legacy_compat.py
@@ -82,6 +82,8 @@ class LegacyUpdateCompatTest(unittest.TestCase):
             ), mock.patch.object(
                 update, "repair_callable_dispatcher"
             ) as repair_dispatcher, mock.patch.object(
+                update, "reconcile_linked_dispatchers"
+            ) as reconcile_dispatchers, mock.patch.object(
                 update, "repair_git_worktrees"
             ) as repair, mock.patch.object(
                 update, "refresh_installed_brokers"
@@ -91,6 +93,10 @@ class LegacyUpdateCompatTest(unittest.TestCase):
 
             self.assertEqual(
                 repair_dispatcher.call_args_list,
+                [mock.call(new_ref), mock.call(new_ref)],
+            )
+            self.assertEqual(
+                reconcile_dispatchers.call_args_list,
                 [mock.call(new_ref), mock.call(new_ref)],
             )
             repair.assert_called_once_with()
@@ -138,6 +144,8 @@ class LegacyUpdateCompatTest(unittest.TestCase):
             ), mock.patch.object(
                 update, "repair_callable_dispatcher"
             ) as repair_dispatcher, mock.patch.object(
+                update, "reconcile_linked_dispatchers"
+            ) as reconcile_dispatchers, mock.patch.object(
                 update, "repair_git_worktrees"
             ) as repair, mock.patch.object(
                 update, "refresh_installed_brokers"
@@ -145,6 +153,7 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 self.assertEqual(0, update_compat.main())
 
             repair_dispatcher.assert_called_once_with(current_ref)
+            reconcile_dispatchers.assert_called_once_with(current_ref)
             repair.assert_not_called()
             refresh.assert_not_called()
             self.assertFalse(marker.exists())
@@ -173,6 +182,7 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 "def repair_git_worktrees(): _record('repair')\n"
                 "def refresh_installed_brokers(): _record('brokers')\n"
                 "def repair_callable_dispatcher(ref): _record('dispatcher')\n"
+                "def reconcile_linked_dispatchers(ref): _record('worktrees')\n"
             )
             (scripts / "map_repo.py").write_text(
                 "def main(): return 0\n"
@@ -198,12 +208,37 @@ class LegacyUpdateCompatTest(unittest.TestCase):
             )
 
             self.assertEqual(0, completed.returncode, completed.stderr)
-            self.assertEqual("dispatcher\nrepair\nbrokers\n", log.read_text())
+            self.assertEqual(
+                "dispatcher\nworktrees\nrepair\nbrokers\n", log.read_text()
+            )
             self.assertEqual(
                 current_ref + "\n",
                 (state / "local" / "update-compat-v1.done").read_text(),
             )
             self.assertIn("legacy update bridge", completed.stdout)
+
+    def test_pending_target_ref_drives_compat_before_pin_publication(self) -> None:
+        pending = "b" * 40
+        with tempfile.TemporaryDirectory() as td:
+            state = Path(td)
+            engine_ref = state / "engine.ref"
+            engine_ref.write_text("a" * 40 + "\n")
+            with mock.patch.multiple(
+                update_compat,
+                ENGINE_REF=engine_ref,
+                ENGINE_REF_PREV=state / "engine.ref.prev",
+                MARKER=state / "update-compat-v1.done",
+            ), mock.patch.dict(
+                os.environ, {"SC_UPDATE_TARGET_REF": pending}
+            ), mock.patch.object(
+                update, "repair_callable_dispatcher"
+            ) as repair_dispatcher, mock.patch.object(
+                update, "reconcile_linked_dispatchers"
+            ) as reconcile_dispatchers:
+                self.assertEqual(0, update_compat.main())
+
+        repair_dispatcher.assert_called_once_with(pending)
+        reconcile_dispatchers.assert_called_once_with(pending)
 
 
 if __name__ == "__main__":

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -1079,6 +1079,8 @@ class LinkedDispatcherReconciliationTest(unittest.TestCase):
         current.write_text("#!/bin/sh\necho next-dispatcher\n")
         current.chmod(0o755)
         next_sha = self._commit("next dispatcher")
+        (state / "engine.ref.prev").write_text(self.target_sha + "\n")
+        (state / "engine.ref").write_text(next_sha + "\n")
         with mock.patch.object(update, "REPO_ROOT", self.root), \
                 contextlib.redirect_stdout(io.StringIO()):
             changed = update.reconcile_linked_dispatchers(
@@ -1097,9 +1099,11 @@ class UpdateRefPublicationTest(unittest.TestCase):
         ref = state / "engine.ref"
         ref.write_text(self.OLD + "\n")
         scripts = []
+        events = []
 
         def run_script(name: str, **kwargs) -> None:
             scripts.append((name, kwargs))
+            events.append(name)
             if fail == name:
                 raise RuntimeError(f"{name} failed")
 
@@ -1107,11 +1111,21 @@ class UpdateRefPublicationTest(unittest.TestCase):
             if kwargs.get("publish_ref", True):
                 ref.write_text(sha + "\n")
 
-        migration = (
-            mock.Mock(side_effect=RuntimeError("migration failed"))
-            if fail == "migration"
-            else mock.Mock()
-        )
+        def migrate() -> None:
+            events.append("migration")
+            if fail == "migration":
+                raise RuntimeError("migration failed")
+
+        def publish(sha: str) -> None:
+            events.append("publish")
+            ref.write_text(sha + "\n")
+
+        def reconcile(_sha: str, **_kwargs) -> tuple[Path, ...]:
+            events.append("reconcile")
+            if fail == "reconcile":
+                raise RuntimeError("reconcile failed")
+            return ()
+
         stack = contextlib.ExitStack()
         stack.enter_context(mock.patch.multiple(
             update,
@@ -1127,10 +1141,11 @@ class UpdateRefPublicationTest(unittest.TestCase):
             migrate_engine_untrack=mock.Mock(),
             migrate_generated_artifacts_local=mock.Mock(),
             materialize_fetched_engine=mock.Mock(side_effect=materialize),
-            reconcile_linked_dispatchers=mock.Mock(return_value=()),
+            publish_engine_ref=mock.Mock(side_effect=publish),
+            reconcile_linked_dispatchers=mock.Mock(side_effect=reconcile),
             ensure_workflows=mock.Mock(return_value=("current", [])),
             expire_sandbox_harnesses=mock.Mock(return_value=None),
-            migrate_with_service_cutover=migration,
+            migrate_with_service_cutover=mock.Mock(side_effect=migrate),
             refresh_installed_brokers=mock.Mock(),
             sync_skills=mock.Mock(),
             regrant=mock.Mock(return_value=0),
@@ -1146,23 +1161,38 @@ class UpdateRefPublicationTest(unittest.TestCase):
             wire_make_aliases=mock.Mock(return_value=()),
         ))
         stack.enter_context(contextlib.redirect_stdout(io.StringIO()))
-        return stack, ref, scripts
+        return stack, ref, scripts, events
 
-    def test_failed_migration_or_snapshot_does_not_publish_target_ref(self):
+    def test_failure_before_publication_never_overlays_linked_dispatchers(self):
         for failed in ("migration", "snapshot.py"):
             with self.subTest(failed=failed), tempfile.TemporaryDirectory() as raw:
                 state = Path(raw) / ".sc-state"
                 state.mkdir()
-                stack, ref, _scripts = self._patch_main(state, fail=failed)
+                stack, ref, _scripts, events = self._patch_main(state, fail=failed)
                 with stack, self.assertRaises(RuntimeError):
                     update.main([])
                 self.assertEqual(ref.read_text(), self.OLD + "\n")
+                self.assertNotIn("publish", events)
+                self.assertNotIn("reconcile", events)
 
-    def test_success_publishes_target_ref_after_snapshot(self):
+    def test_dispatcher_crash_keeps_published_target_recognizable(self):
         with tempfile.TemporaryDirectory() as raw:
             state = Path(raw) / ".sc-state"
             state.mkdir()
-            stack, ref, scripts = self._patch_main(state, fail=None)
+            stack, ref, _scripts, events = self._patch_main(
+                state, fail="reconcile"
+            )
+            with stack, self.assertRaisesRegex(RuntimeError, "reconcile failed"):
+                update.main([])
+
+            self.assertEqual(ref.read_text(), self.NEW + "\n")
+            self.assertEqual(events[-2:], ["publish", "reconcile"])
+
+    def test_ref_publishes_after_migrate_and_snapshot_before_dispatchers(self):
+        with tempfile.TemporaryDirectory() as raw:
+            state = Path(raw) / ".sc-state"
+            state.mkdir()
+            stack, ref, scripts, events = self._patch_main(state, fail=None)
             with stack:
                 update.main([])
             self.assertEqual(
@@ -1170,6 +1200,16 @@ class UpdateRefPublicationTest(unittest.TestCase):
                 [
                     ("map_setup.py", {"update_target_ref": self.NEW}),
                     ("snapshot.py", {}),
+                ],
+            )
+            self.assertEqual(
+                events,
+                [
+                    "migration",
+                    "map_setup.py",
+                    "snapshot.py",
+                    "publish",
+                    "reconcile",
                 ],
             )
             self.assertEqual(ref.read_text(), self.NEW + "\n")

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -981,6 +981,200 @@ class EnginePathsAtRefTest(unittest.TestCase):
             "materialized file manifest",
         )
 
+
+class LinkedDispatcherReconciliationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        _git(self.root, "init", "-b", "main")
+        _git(self.root, "config", "user.name", "Update Test")
+        _git(self.root, "config", "user.email", "update@example.invalid")
+
+        stale = self.root / "sc"
+        stale.write_text(
+            "#!/bin/sh\n"
+            "[ \"$1\" = deps ] && [ \"$2\" = --help ] && {\n"
+            "  : > retired-mutating-flow\n"
+            "  echo stale help\n"
+            "}\n"
+        )
+        stale.chmod(0o755)
+        old_sha = self._commit("stale dispatcher")
+        self.worktree = self.root / ".sc-worktrees" / "dev1"
+        _git(
+            self.root, "worktree", "add", "-b", "shell/dev1",
+            str(self.worktree), old_sha,
+        )
+
+        current = self.root / "sc"
+        current.write_text(
+            "#!/bin/sh\n"
+            "[ \"$1\" = deps ] && [ \"$2\" = --help ] && {\n"
+            "  echo 'Usage: ./sc deps [-h|--help]'\n"
+            "  exit 0\n"
+            "}\n"
+            "exit 2\n"
+        )
+        current.chmod(0o755)
+        self.target_sha = self._commit("current dispatcher")
+
+    def _commit(self, message: str) -> str:
+        _git(self.root, "add", "sc")
+        _git(self.root, "commit", "-m", message)
+        return _git(self.root, "rev-parse", "HEAD")
+
+    def test_clean_stale_worktree_dispatcher_runs_current_read_only_help(self):
+        with mock.patch.object(update, "REPO_ROOT", self.root), \
+                contextlib.redirect_stdout(io.StringIO()):
+            changed = update.reconcile_linked_dispatchers(
+                self.target_sha, worktrees=(self.worktree,)
+            )
+
+        done = subprocess.run(
+            [str(self.worktree / "sc"), "deps", "--help"],
+            cwd=self.worktree,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(changed, (self.worktree,))
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertEqual(done.stdout, "Usage: ./sc deps [-h|--help]\n")
+        self.assertFalse((self.worktree / "retired-mutating-flow").exists())
+        self.assertEqual(
+            (self.worktree / "sc").read_bytes(),
+            (self.root / "sc").read_bytes(),
+        )
+
+    def test_locally_edited_worktree_dispatcher_is_preserved(self):
+        custom = self.worktree / "sc"
+        custom.write_text("#!/bin/sh\necho operator-owned\n")
+        before = custom.read_bytes()
+        warning = io.StringIO()
+        with mock.patch.object(update, "REPO_ROOT", self.root), \
+                contextlib.redirect_stderr(warning):
+            changed = update.reconcile_linked_dispatchers(
+                self.target_sha, worktrees=(self.worktree,)
+            )
+
+        self.assertEqual(changed, ())
+        self.assertEqual(custom.read_bytes(), before)
+        self.assertIn(
+            f"dispatcher locally edited, left stale: {custom}",
+            warning.getvalue(),
+        )
+
+    def test_previous_managed_overlay_advances_on_the_next_update(self):
+        state = self.root / ".sc-state"
+        state.mkdir()
+        with mock.patch.object(update, "REPO_ROOT", self.root), \
+                contextlib.redirect_stdout(io.StringIO()):
+            update.reconcile_linked_dispatchers(
+                self.target_sha, worktrees=(self.worktree,)
+            )
+        (state / "engine.ref").write_text(self.target_sha + "\n")
+
+        current = self.root / "sc"
+        current.write_text("#!/bin/sh\necho next-dispatcher\n")
+        current.chmod(0o755)
+        next_sha = self._commit("next dispatcher")
+        with mock.patch.object(update, "REPO_ROOT", self.root), \
+                contextlib.redirect_stdout(io.StringIO()):
+            changed = update.reconcile_linked_dispatchers(
+                next_sha, worktrees=(self.worktree,)
+            )
+
+        self.assertEqual(changed, (self.worktree,))
+        self.assertEqual((self.worktree / "sc").read_bytes(), current.read_bytes())
+
+
+class UpdateRefPublicationTest(unittest.TestCase):
+    OLD = "a" * 40
+    NEW = "b" * 40
+
+    def _patch_main(self, state: Path, *, fail: str | None):
+        ref = state / "engine.ref"
+        ref.write_text(self.OLD + "\n")
+        scripts = []
+
+        def run_script(name: str, **kwargs) -> None:
+            scripts.append((name, kwargs))
+            if fail == name:
+                raise RuntimeError(f"{name} failed")
+
+        def materialize(sha: str, **kwargs) -> None:
+            if kwargs.get("publish_ref", True):
+                ref.write_text(sha + "\n")
+
+        migration = (
+            mock.Mock(side_effect=RuntimeError("migration failed"))
+            if fail == "migration"
+            else mock.Mock()
+        )
+        stack = contextlib.ExitStack()
+        stack.enter_context(mock.patch.multiple(
+            update,
+            REPO_ROOT=state.parent,
+            STATE_DIR=state,
+            ENGINE_REF=ref,
+            ENGINE_REF_PREV=state / "engine.ref.prev",
+            EJECTED_MARKER=state / "ejected",
+            is_source_repo=mock.Mock(return_value=False),
+            repair_git_worktrees=mock.Mock(return_value=()),
+            sync_repo_checkout=mock.Mock(),
+            fetch_update_ref=mock.Mock(return_value=self.NEW),
+            migrate_engine_untrack=mock.Mock(),
+            migrate_generated_artifacts_local=mock.Mock(),
+            materialize_fetched_engine=mock.Mock(side_effect=materialize),
+            reconcile_linked_dispatchers=mock.Mock(return_value=()),
+            ensure_workflows=mock.Mock(return_value=("current", [])),
+            expire_sandbox_harnesses=mock.Mock(return_value=None),
+            migrate_with_service_cutover=migration,
+            refresh_installed_brokers=mock.Mock(),
+            sync_skills=mock.Mock(),
+            regrant=mock.Mock(return_value=0),
+            reconcile_skill_projections=mock.Mock(
+                return_value={"written": [], "skipped": [], "checkouts": []}
+            ),
+            run_script=mock.Mock(side_effect=run_script),
+        ))
+        stack.enter_context(mock.patch.multiple(
+            update.install_mod,
+            ensure_gitignore=mock.Mock(return_value=False),
+            ensure_harnesses=mock.Mock(),
+            wire_make_aliases=mock.Mock(return_value=()),
+        ))
+        stack.enter_context(contextlib.redirect_stdout(io.StringIO()))
+        return stack, ref, scripts
+
+    def test_failed_migration_or_snapshot_does_not_publish_target_ref(self):
+        for failed in ("migration", "snapshot.py"):
+            with self.subTest(failed=failed), tempfile.TemporaryDirectory() as raw:
+                state = Path(raw) / ".sc-state"
+                state.mkdir()
+                stack, ref, _scripts = self._patch_main(state, fail=failed)
+                with stack, self.assertRaises(RuntimeError):
+                    update.main([])
+                self.assertEqual(ref.read_text(), self.OLD + "\n")
+
+    def test_success_publishes_target_ref_after_snapshot(self):
+        with tempfile.TemporaryDirectory() as raw:
+            state = Path(raw) / ".sc-state"
+            state.mkdir()
+            stack, ref, scripts = self._patch_main(state, fail=None)
+            with stack:
+                update.main([])
+            self.assertEqual(
+                scripts,
+                [
+                    ("map_setup.py", {"update_target_ref": self.NEW}),
+                    ("snapshot.py", {}),
+                ],
+            )
+            self.assertEqual(ref.read_text(), self.NEW + "\n")
+
+
 class GeneratedArtifactMigrationTest(unittest.TestCase):
     def test_legacy_artifacts_are_preserved_locally_then_untracked(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

- match engine remotes by exact repository basename, so subfloor-marketing cannot outrank the real upstream
- publish engine.ref atomically only after every update step succeeds
- reconcile clean linked-worktree dispatchers through the first-adoption bridge while preserving and naming local edits
- rebuild an unrunnable host venv before selecting pytest

## Verification

- 112 focused update, compatibility, dispatcher, and dev-kit tests passed
- 1,641 repository tests passed; 2 unrelated origin/main fixture failures deselected and filed as #947
- ./sc verify passed
- ./sc render-check passed
- git diff --check passed

Closes #935
Closes #936
Closes #937
Closes #938