### PR TITLE
fix(update): sweep dormant skill projections on adoption

### DIFF
--- a/.super-coder/scripts/update_compat.py
+++ b/.super-coder/scripts/update_compat.py
@@ -11,7 +11,9 @@ otherwise would wait for a second update.
 The bridge is needed exactly when the current engine ref contains this file but
 the previous engine ref did not. A local marker prevents manual map-setup runs
 from repeating broker restarts before the next engine update advances the
-previous ref.
+previous ref. A separate ref marker makes each newly materialized engine run
+its own managed-skill sweep once, so new tombstones are interpreted by the new
+projection code even when the parent updater was already loaded.
 """
 from __future__ import annotations
 
@@ -26,6 +28,7 @@ STATE_DIR = REPO_ROOT / ".sc-state"
 ENGINE_REF = STATE_DIR / "engine.ref"
 ENGINE_REF_PREV = STATE_DIR / "engine.ref.prev"
 MARKER = STATE_DIR / "local" / "update-compat-v1.done"
+SKILL_SWEEP_MARKER = STATE_DIR / "local" / "update-compat-skill-sweep.ref"
 BRIDGE_PATH = ".super-coder/scripts/update_compat.py"
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 
@@ -87,6 +90,14 @@ def main() -> int:
         # supplies no pending ref and has already published before this bridge.
         if pending is None:
             update.reconcile_linked_dispatchers(current)
+        if _read_ref(SKILL_SWEEP_MARKER) != current:
+            print(
+                "→ update compatibility: reconcile managed skill projections "
+                f"at {current[:12]}"
+            )
+            update.reconcile_skill_projections()
+            SKILL_SWEEP_MARKER.parent.mkdir(parents=True, exist_ok=True)
+            SKILL_SWEEP_MARKER.write_text(f"{current}\n")
 
     needed, current = needs_legacy_bridge()
     if not needed:

--- a/tests/test_update_legacy_compat.py
+++ b/tests/test_update_legacy_compat.py
@@ -7,18 +7,27 @@ import contextlib
 import io
 import os
 import shutil
+import sqlite3
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import closing
 from pathlib import Path
 from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".super-coder" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(ROOT / "tests"))
 import update  # noqa: E402
 import update_compat  # noqa: E402
+from skill_convergence_fixtures import (  # noqa: E402
+    LOCAL_SKILL_DESCRIPTION,
+    LOCAL_SKILL_NAME,
+    TOMBSTONE_SKILLS,
+    build_dirty_skill_fork,
+)
 
 GIT_ENV = {
     **os.environ,
@@ -69,6 +78,7 @@ class LegacyUpdateCompatTest(unittest.TestCase):
             engine_ref = state / "engine.ref"
             engine_ref_prev = state / "engine.ref.prev"
             marker = state / "local" / "update-compat-v1.done"
+            skill_sweep_marker = state / "local" / "update-compat-skill-sweep.ref"
             engine_ref.write_text(new_ref + "\n")
             engine_ref_prev.write_text(old_ref + "\n")
 
@@ -79,11 +89,14 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 ENGINE_REF=engine_ref,
                 ENGINE_REF_PREV=engine_ref_prev,
                 MARKER=marker,
+                SKILL_SWEEP_MARKER=skill_sweep_marker,
             ), mock.patch.object(
                 update, "repair_callable_dispatcher"
             ) as repair_dispatcher, mock.patch.object(
                 update, "reconcile_linked_dispatchers"
             ) as reconcile_dispatchers, mock.patch.object(
+                update, "reconcile_skill_projections", return_value={}
+            ) as reconcile_skills, mock.patch.object(
                 update, "repair_git_worktrees"
             ) as repair, mock.patch.object(
                 update, "refresh_installed_brokers"
@@ -99,6 +112,8 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 reconcile_dispatchers.call_args_list,
                 [mock.call(new_ref), mock.call(new_ref)],
             )
+            reconcile_skills.assert_called_once_with()
+            self.assertEqual(new_ref + "\n", skill_sweep_marker.read_text())
             repair.assert_called_once_with()
             refresh.assert_called_once_with()
             self.assertEqual(new_ref + "\n", marker.read_text())
@@ -131,6 +146,7 @@ class LegacyUpdateCompatTest(unittest.TestCase):
             engine_ref = state / "engine.ref"
             engine_ref_prev = state / "engine.ref.prev"
             marker = state / "local" / "update-compat-v1.done"
+            skill_sweep_marker = state / "local" / "update-compat-skill-sweep.ref"
             engine_ref.write_text(current_ref + "\n")
             engine_ref_prev.write_text(bridge_ref + "\n")
 
@@ -141,11 +157,14 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 ENGINE_REF=engine_ref,
                 ENGINE_REF_PREV=engine_ref_prev,
                 MARKER=marker,
+                SKILL_SWEEP_MARKER=skill_sweep_marker,
             ), mock.patch.object(
                 update, "repair_callable_dispatcher"
             ) as repair_dispatcher, mock.patch.object(
                 update, "reconcile_linked_dispatchers"
             ) as reconcile_dispatchers, mock.patch.object(
+                update, "reconcile_skill_projections", return_value={}
+            ) as reconcile_skills, mock.patch.object(
                 update, "repair_git_worktrees"
             ) as repair, mock.patch.object(
                 update, "refresh_installed_brokers"
@@ -154,6 +173,8 @@ class LegacyUpdateCompatTest(unittest.TestCase):
 
             repair_dispatcher.assert_called_once_with(current_ref)
             reconcile_dispatchers.assert_called_once_with(current_ref)
+            reconcile_skills.assert_called_once_with()
+            self.assertEqual(current_ref + "\n", skill_sweep_marker.read_text())
             repair.assert_not_called()
             refresh.assert_not_called()
             self.assertFalse(marker.exists())
@@ -183,6 +204,7 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 "def refresh_installed_brokers(): _record('brokers')\n"
                 "def repair_callable_dispatcher(ref): _record('dispatcher')\n"
                 "def reconcile_linked_dispatchers(ref): _record('worktrees')\n"
+                "def reconcile_skill_projections(): _record('skills')\n"
             )
             (scripts / "map_repo.py").write_text(
                 "def main(): return 0\n"
@@ -209,7 +231,11 @@ class LegacyUpdateCompatTest(unittest.TestCase):
 
             self.assertEqual(0, completed.returncode, completed.stderr)
             self.assertEqual(
-                "dispatcher\nworktrees\nrepair\nbrokers\n", log.read_text()
+                "dispatcher\nworktrees\nskills\nrepair\nbrokers\n", log.read_text()
+            )
+            self.assertEqual(
+                current_ref + "\n",
+                (state / "local" / "update-compat-skill-sweep.ref").read_text(),
             )
             self.assertEqual(
                 current_ref + "\n",
@@ -223,22 +249,118 @@ class LegacyUpdateCompatTest(unittest.TestCase):
             state = Path(td)
             engine_ref = state / "engine.ref"
             engine_ref.write_text("a" * 40 + "\n")
+            skill_sweep_marker = state / "update-compat-skill-sweep.ref"
+            skill_sweep_marker.write_text("a" * 40 + "\n")
             with mock.patch.multiple(
                 update_compat,
                 ENGINE_REF=engine_ref,
                 ENGINE_REF_PREV=state / "engine.ref.prev",
                 MARKER=state / "update-compat-v1.done",
+                SKILL_SWEEP_MARKER=skill_sweep_marker,
             ), mock.patch.dict(
                 os.environ, {"SC_UPDATE_TARGET_REF": pending}
             ), mock.patch.object(
                 update, "repair_callable_dispatcher"
             ) as repair_dispatcher, mock.patch.object(
                 update, "reconcile_linked_dispatchers"
-            ) as reconcile_dispatchers:
+            ) as reconcile_dispatchers, mock.patch.object(
+                update, "reconcile_skill_projections", return_value={}
+            ) as reconcile_skills:
+                self.assertEqual(0, update_compat.main())
+                self.assertEqual(0, update_compat.main())
+                skill_sweep_ref = skill_sweep_marker.read_text()
+
+        self.assertEqual(
+            repair_dispatcher.call_args_list, [mock.call(pending), mock.call(pending)]
+        )
+        reconcile_dispatchers.assert_not_called()
+        reconcile_skills.assert_called_once_with()
+        self.assertEqual(pending + "\n", skill_sweep_ref)
+
+    def test_first_adoption_sweeps_main_and_dormant_skill_projections(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            fixture = build_dirty_skill_fork(Path(td) / "downstream")
+            with closing(sqlite3.connect(fixture.database)) as con:
+                update.seed_skills.reconcile_tombstoned_skills(con)
+                con.commit()
+
+            shell_authored = (
+                fixture.root
+                / ".sc-worktrees/dev9/.claude/skills/shell_notes/notes.txt"
+            )
+            shell_authored.parent.mkdir()
+            shell_authored.write_text("shell-owned\n")
+            real_projection = update.skill_projection.reconcile_existing_checkouts
+            real_catalogue = update.flat.render_visibility
+
+            def reconcile(con):
+                return real_projection(con, repo_root=fixture.root)
+
+            def render_catalogue(con):
+                return real_catalogue(con, root=fixture.catalogue_root.parent)
+
+            skill_sweep_marker = fixture.root / ".sc-state/local/skill-sweep.done"
+            with mock.patch.multiple(
+                update_compat,
+                ENGINE_REF=fixture.root / ".sc-state/engine.ref",
+                ENGINE_REF_PREV=fixture.root / ".sc-state/engine.ref.prev",
+                MARKER=fixture.root / ".sc-state/local/update-compat-v1.done",
+                SKILL_SWEEP_MARKER=skill_sweep_marker,
+            ), mock.patch.object(
+                update, "DB_PATH", fixture.database
+            ), mock.patch.object(
+                update.skill_projection,
+                "reconcile_existing_checkouts",
+                side_effect=reconcile,
+            ) as projection, mock.patch.object(
+                update.flat, "render_visibility", side_effect=render_catalogue
+            ), mock.patch.object(
+                update, "repair_callable_dispatcher"
+            ), mock.patch.object(
+                update, "reconcile_linked_dispatchers"
+            ), mock.patch.object(
+                update_compat, "needs_legacy_bridge", return_value=(False, None)
+            ):
+                self.assertEqual(0, update_compat.main())
+                first_projection = {
+                    str(path.relative_to(fixture.root)): path.read_bytes()
+                    for root in fixture.native_skill_roots
+                    for path in root.rglob("*")
+                    if path.is_file()
+                }
                 self.assertEqual(0, update_compat.main())
 
-        repair_dispatcher.assert_called_once_with(pending)
-        reconcile_dispatchers.assert_not_called()
+            self.assertEqual(projection.call_count, 1)
+            self.assertEqual(
+                skill_sweep_marker.read_text(),
+                (fixture.root / ".sc-state/engine.ref").read_text(),
+            )
+            self.assertEqual(shell_authored.read_text(), "shell-owned\n")
+            self.assertEqual(
+                {
+                    str(path.relative_to(fixture.root)): path.read_bytes()
+                    for root in fixture.native_skill_roots
+                    for path in root.rglob("*")
+                    if path.is_file()
+                },
+                first_projection,
+            )
+            expected_local = (
+                (
+                    f"---\nname: {LOCAL_SKILL_NAME}\n"
+                    f"description: {LOCAL_SKILL_DESCRIPTION}\n---\n\n"
+                ).encode()
+                + fixture.expected_local_content
+            )
+            for skills_root in fixture.native_skill_roots:
+                self.assertEqual(
+                    skills_root.joinpath(LOCAL_SKILL_NAME, "SKILL.md").read_bytes(),
+                    expected_local,
+                )
+                for retired in TOMBSTONE_SKILLS:
+                    self.assertFalse(skills_root.joinpath(retired).exists())
+            for control in fixture.control_files:
+                self.assertEqual(control.read_bytes(), fixture.expected_control_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- run the managed-skill projection sweep from the freshly materialized compatibility process
- key the compatibility sweep by target engine ref so retries are idempotent and future tombstones use the new registry
- cover a clean DB with stale main and dormant-worktree projections while preserving shell-authored adjacent files

## Verification

- 46 focused tests passed, plus 2 subtests
- `./sc map`
- `./sc render-check`
- `./sc verify`
- full `./sc test`: 1643 passed; 2 known main-baseline failures tracked by #947

Sprint 79 Unit 6. Fleet remediation remains PLN1 post-merge scope.