### PR TITLE
fix: keep incomplete PR checks pending

### DIFF
--- a/.super-coder/scripts/github_pull_requests.py
+++ b/.super-coder/scripts/github_pull_requests.py
@@ -37,6 +37,10 @@ _FAILED_CHECKS = frozenset(
         "TIMED_OUT",
     }
 )
+_PENDING_CHECKS = frozenset(
+    {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
+)
+_SUCCESSFUL_CHECKS = frozenset({"NEUTRAL", "SKIPPED", "SUCCESS"})
 _READ_ONLY_ENV = {
     **os.environ,
     "GH_PROMPT_DISABLED": "1",
@@ -141,18 +145,18 @@ def _check_state(raw: Any) -> tuple[str | None, bool]:
     for item in raw:
         if not isinstance(item, dict):
             continue
-        state = item.get("conclusion") or item.get("state")
+        state = item.get("conclusion") or item.get("state") or item.get("status")
         if state:
             states.append(str(state).upper())
     if any(state in _FAILED_CHECKS for state in states):
         return "FAILURE", True
-    if any(
-        state in {"PENDING", "EXPECTED", "IN_PROGRESS", "QUEUED"} for state in states
-    ):
+    if any(state in _PENDING_CHECKS for state in states):
         return "PENDING", False
-    if states and all(state in {"SUCCESS", "NEUTRAL", "SKIPPED"} for state in states):
-        return "SUCCESS", False
-    return (states[0], False) if states else (None, False)
+    if "COMPLETED" in states:
+        return "PENDING", False
+    if any(state not in _SUCCESSFUL_CHECKS for state in states):
+        return "PENDING", False
+    return ("SUCCESS", False) if states else (None, False)
 
 
 def normalize_pull_request(raw: dict[str, Any]) -> PullRequest:

--- a/tests/fixtures/review/github_prs.json
+++ b/tests/fixtures/review/github_prs.json
@@ -13,6 +13,10 @@
       "reviewDecision": "",
       "statusCheckRollup": [
         {
+          "context": "legacy/tests",
+          "state": "SUCCESS"
+        },
+        {
           "name": "tests",
           "status": "COMPLETED",
           "conclusion": "SUCCESS"
@@ -32,9 +36,8 @@
       "reviewDecision": "CHANGES_REQUESTED",
       "statusCheckRollup": [
         {
-          "name": "tests",
-          "status": "COMPLETED",
-          "conclusion": "FAILURE"
+          "context": "legacy/tests",
+          "state": "FAILURE"
         }
       ]
     },
@@ -93,6 +96,48 @@
       "url": "https://example.test/pulls/825",
       "reviewDecision": "",
       "statusCheckRollup": []
+    },
+    {
+      "number": 827,
+      "headRefName": "feature/queued-check",
+      "baseRefName": "main",
+      "headRefOid": "9999999999999999999999999999999999999999",
+      "state": "OPEN",
+      "mergedAt": null,
+      "mergeCommit": null,
+      "title": "Queued-check fixture",
+      "url": "https://example.test/pulls/827",
+      "reviewDecision": "",
+      "statusCheckRollup": [
+        {
+          "name": "fast-tests",
+          "status": "COMPLETED",
+          "conclusion": "SUCCESS"
+        },
+        {
+          "name": "pytest",
+          "status": "QUEUED",
+          "conclusion": null
+        }
+      ]
+    },
+    {
+      "number": 828,
+      "headRefName": "feature/pending-status",
+      "baseRefName": "main",
+      "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "state": "OPEN",
+      "mergedAt": null,
+      "mergeCommit": null,
+      "title": "Pending-status fixture",
+      "url": "https://example.test/pulls/828",
+      "reviewDecision": "",
+      "statusCheckRollup": [
+        {
+          "context": "legacy/tests",
+          "state": "PENDING"
+        }
+      ]
     }
   ],
   "patches": {

--- a/tests/test_git_review.py
+++ b/tests/test_git_review.py
@@ -20,6 +20,7 @@ from github_pull_requests import (
     GitHubPullRequestReader,
     GitHubReadError,
     GitHubResponseTooLarge,
+    _check_state,
     normalize_pull_request,
 )
 from review_fixtures import MockGitHub, ReviewRepository
@@ -40,6 +41,41 @@ class FixtureGitHubReader:
 
 
 class GitHubReaderTest(unittest.TestCase):
+    def test_check_rollups_stay_pending_until_every_item_succeeds(self) -> None:
+        fixture = MockGitHub()
+        queued = fixture.pr(827)["statusCheckRollup"]
+        failed = fixture.pr(822)["statusCheckRollup"]
+        cases = (
+            (queued, ("PENDING", False)),
+            ([{"status": "QUEUED", "conclusion": None}], ("PENDING", False)),
+            ([{"status": "IN_PROGRESS", "conclusion": None}], ("PENDING", False)),
+            ([{"status": "WAITING", "conclusion": None}], ("PENDING", False)),
+            ([{"status": "REQUESTED", "conclusion": None}], ("PENDING", False)),
+            ([{"status": "COMPLETED", "conclusion": None}], ("PENDING", False)),
+            ([{"state": "UNKNOWN"}], ("PENDING", False)),
+            (failed + queued, ("FAILURE", True)),
+            (
+                [
+                    {"status": "COMPLETED", "conclusion": "SUCCESS"},
+                    {"status": "COMPLETED", "conclusion": "NEUTRAL"},
+                ],
+                ("SUCCESS", False),
+            ),
+            (fixture.pr(821)["statusCheckRollup"], ("SUCCESS", False)),
+            (fixture.pr(828)["statusCheckRollup"], ("PENDING", False)),
+            ([{"state": "SUCCESS"}], ("SUCCESS", False)),
+            ([{"state": "FAILURE"}], ("FAILURE", True)),
+            (
+                [{"conclusion": "SUCCESS", "state": "FAILURE", "status": "QUEUED"}],
+                ("SUCCESS", False),
+            ),
+            ([], (None, False)),
+        )
+
+        for rollup, expected in cases:
+            with self.subTest(rollup=rollup):
+                self.assertEqual(expected, _check_state(rollup))
+
     def test_list_normalizes_full_projection_with_read_only_command(self) -> None:
         payload = json.dumps(MockGitHub().list_prs()).encode()
         calls = []

--- a/tests/test_review_contract_fixtures.py
+++ b/tests/test_review_contract_fixtures.py
@@ -275,21 +275,37 @@ class GitComparisonFixtureTest(unittest.TestCase):
 
 
 class MockGitHubFixtureTest(unittest.TestCase):
-    def test_open_and_failing_check_rollups_are_explicit(self) -> None:
+    def test_checkrun_and_status_context_rollups_are_explicit(self) -> None:
         github = MockGitHub()
         open_pr = github.pr(821)
         failing_pr = github.pr(822)
         closed_pr = github.pr(826)
+        queued_pr = github.pr(827)
+        pending_pr = github.pr(828)
 
         self.assertEqual(open_pr["state"], "OPEN")
         self.assertEqual(
-            open_pr["statusCheckRollup"][0]["conclusion"],
+            open_pr["statusCheckRollup"][0]["state"],
+            "SUCCESS",
+        )
+        self.assertNotIn("conclusion", open_pr["statusCheckRollup"][0])
+        self.assertEqual(
+            open_pr["statusCheckRollup"][1]["conclusion"],
             "SUCCESS",
         )
         self.assertEqual(failing_pr["state"], "OPEN")
         self.assertEqual(
-            failing_pr["statusCheckRollup"][0]["conclusion"],
+            failing_pr["statusCheckRollup"][0]["state"],
             "FAILURE",
+        )
+        self.assertNotIn("conclusion", failing_pr["statusCheckRollup"][0])
+        self.assertEqual(
+            queued_pr["statusCheckRollup"][1],
+            {"name": "pytest", "status": "QUEUED", "conclusion": None},
+        )
+        self.assertEqual(
+            pending_pr["statusCheckRollup"][0],
+            {"context": "legacy/tests", "state": "PENDING"},
         )
         self.assertEqual(closed_pr["state"], "CLOSED")
         self.assertIsNone(closed_pr["mergedAt"])

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -14,7 +14,7 @@ sys.path[:0] = [str(SCRIPTS), str(ROOT / "tests")]
 import sprint_domain
 import sprint_message_delivery
 import sprint_pr_watcher
-from github_pull_requests import GitHubReadError, PullRequest
+from github_pull_requests import GitHubReadError, PullRequest, normalize_pull_request
 from test_sprint_message_delivery import SprintMessageCase
 
 
@@ -88,6 +88,15 @@ class SprintPRWatcherCase(SprintMessageCase):
             pr_number=number,
             work_unit_ids=(self.unit_id,),
         )
+
+    def _states(self) -> list[str]:
+        return [
+            str(row[0])
+            for row in self.con.execute(
+                "SELECT normalized_state FROM sprint_pr_transitions "
+                "ORDER BY transition_id"
+            )
+        ]
 
 
 class RegistrationTest(SprintPRWatcherCase):
@@ -212,6 +221,58 @@ class RegistrationTest(SprintPRWatcherCase):
 
 
 class TransitionRoutingTest(SprintPRWatcherCase):
+    def test_queued_checkrun_stays_pending_without_green_owner_wake(self):
+        raw = {
+            "number": 42,
+            "headRefName": "feature/pr-42",
+            "baseRefName": "main",
+            "headRefOid": "a" * 40,
+            "state": "OPEN",
+            "mergedAt": None,
+            "mergeCommit": None,
+            "title": "PR 42",
+            "url": "https://github.example/acme/repo/pull/42",
+            "reviewDecision": None,
+            "statusCheckRollup": [
+                {
+                    "name": "fast-tests",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                },
+                {"name": "pytest", "status": "QUEUED", "conclusion": None},
+            ],
+        }
+        self.reader.current = normalize_pull_request(raw)
+
+        self.register()
+
+        self.assertEqual(["pending"], self._states())
+        active_recipients = self.con.execute(
+            "SELECT m.to_participant_id FROM sprint_messages m "
+            "JOIN sprint_wake_messages wm USING (message_id) "
+            "WHERE m.idempotency_key LIKE 'pr-transition:%'"
+        ).fetchall()
+        self.assertEqual([], active_recipients)
+
+        raw["statusCheckRollup"][1] = {
+            "name": "pytest",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+        }
+        self.reader.current = normalize_pull_request(raw)
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(["pending", "green"], self._states())
+        active_recipients = self.con.execute(
+            "SELECT m.to_participant_id FROM sprint_messages m "
+            "JOIN sprint_wake_messages wm USING (message_id) "
+            "WHERE m.idempotency_key LIKE 'pr-transition:%'"
+        ).fetchall()
+        self.assertEqual(
+            [(self.developer_id,)],
+            [tuple(row) for row in active_recipients],
+        )
+
     def test_first_red_routes_one_active_owner_wake_and_passive_evidence(self):
         self.register()
 
@@ -429,16 +490,6 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
             "WHERE m.idempotency_key LIKE 'pr-transition:%'"
         ).fetchone()
         self.assertEqual(self.developer_id, int(active_recipient[0]))
-
-    def _states(self) -> list[str]:
-        return [
-            str(row[0])
-            for row in self.con.execute(
-                "SELECT normalized_state FROM sprint_pr_transitions "
-                "ORDER BY transition_id"
-            )
-        ]
-
 
 class BatchAndNormalizationTest(SprintPRWatcherCase):
     def test_multiple_registered_prs_share_one_repository_list_read(self):


### PR DESCRIPTION
## Summary

- classify GitHub rollup items via `conclusion -> state -> status`
- project queued, running, completed-without-conclusion, and unknown verdicts as pending
- preserve failure precedence and require every attached check to be positively terminal-successful before green
- cover CheckRun, StatusContext, mixed rollups, and watcher wake routing

## Expected downstream behavior

After deploy, a registered PR incorrectly projected green while a CheckRun is queued or running can record `green -> pending -> green` as the suite completes. Those append-only transitions and notifications are expected correction, not churn to suppress.

## Verification

- `python3 -m unittest tests.test_git_review tests.test_review_contract_fixtures tests.test_sprint_pr_watcher` (53 passed)
- targeted Ruff checks
- `./sc render-check`
- JSON fixture validation
- `git diff --check`

`./sc verify` is intentionally left to isolated GitHub CI because linked worktrees cannot safely target the shared live instance (tracked in #769).