### PR TITLE
fix(sprint): recover busy wake contention

### DIFF
--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -30,6 +30,8 @@ EDITING_UNIT_DISPOSITIONS = frozenset(
     {"active", "in_review", "fixing", "merge_ready"}
 )
 WORK_UNIT_OUTPUT_KINDS = frozenset({"code", "report_only", "no_code"})
+WAKE_CONTENTION_BACKOFF_SECONDS = (15, 60, 180, 300)
+WAKE_CONTENTION_ATTEMPTS = 5
 
 
 class SprintLifecycleError(ValueError):
@@ -77,6 +79,12 @@ class ResumeReceipt:
     resolved_review_message_ids: tuple[int, ...]
     spec_drift_document_ids: tuple[int, ...]
     anomalies: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _WakeReconcileResult:
+    wake_ids: tuple[int, ...]
+    pause_receipt: PauseReceipt | None = None
 
 
 @dataclass(frozen=True)
@@ -366,6 +374,7 @@ class SprintLifecycleStore:
         )
         all_anomalies = anomalies
         notice_conversations: tuple[str, ...] = ()
+        pause_receipt: PauseReceipt | None = None
         with db_driver.write_transaction(self.con, "sprint.resume"):
             sprint = self._sprint(sprint_id)
             current = str(sprint["lifecycle"])
@@ -389,12 +398,16 @@ class SprintLifecycleStore:
             )
             if reconcile_in_transaction is not None:
                 reconcile_in_transaction(self.con)
-            requeued = self._reconcile_unread_wakes_in_transaction(
+            reconciliation = self._reconcile_unread_wakes_in_transaction(
                 sprint_id,
                 trigger="resume",
             )
-            projected, resolved = self._reconcile_registered_prs_in_transaction(
-                sprint_id
+            requeued = reconciliation.wake_ids
+            pause_receipt = reconciliation.pause_receipt
+            projected, resolved = (
+                self._reconcile_registered_prs_in_transaction(sprint_id)
+                if pause_receipt is None
+                else ((), ())
             )
             drift = self._spec_drift(sprint_id)
             all_anomalies = tuple(
@@ -415,7 +428,7 @@ class SprintLifecycleStore:
                 actor,
                 evidence,
             )
-            if drift or all_anomalies or requeued:
+            if pause_receipt is None and (drift or all_anomalies or requeued):
                 _, notice_conversations = self._queue_planner_notice(
                     sprint_id,
                     body=(
@@ -428,25 +441,30 @@ class SprintLifecycleStore:
                         f"sprint-resume:{sprint_id}:v{int(sprint['version']) + 1}"
                     ),
                 )
-            planner = self._planner_participant_id(sprint_id)
-            dispatched = tuple(
-                SprintWorkUnitStore(self.con)._dispatch_ready_locked(
-                    sprint_id,
-                    planner_participant_id=planner,
+            dispatched: tuple[int, ...] = ()
+            if pause_receipt is None:
+                planner = self._planner_participant_id(sprint_id)
+                dispatched = tuple(
+                    SprintWorkUnitStore(self.con)._dispatch_ready_locked(
+                        sprint_id,
+                        planner_participant_id=planner,
+                    )
                 )
-            )
-            self._event(
-                sprint_id,
-                "lifecycle.armed",
-                actor,
-                {
-                    "from": current,
-                    "reason": reason,
-                    "reconciled": True,
-                    "dispatched_wake_ids": list(dispatched),
-                },
-            )
-        self._signal_notifications(notice_conversations)
+                self._event(
+                    sprint_id,
+                    "lifecycle.armed",
+                    actor,
+                    {
+                        "from": current,
+                        "reason": reason,
+                        "reconciled": True,
+                        "dispatched_wake_ids": list(dispatched),
+                    },
+                )
+        if pause_receipt is not None:
+            self._signal_interrupts_and_notifications(pause_receipt)
+        else:
+            self._signal_notifications(notice_conversations)
         return ResumeReceipt(
             True,
             dispatched,
@@ -635,6 +653,7 @@ class SprintLifecycleStore:
             lifecycle = str(row["lifecycle"])
             run_ids: tuple[int, ...] = ()
             conversations: tuple[str, ...] = ()
+            pause_receipt: PauseReceipt | None = None
             if lifecycle in {"armed", "paused"}:
                 with db_driver.write_transaction(
                     self.con, "sprint.recover.startup"
@@ -644,12 +663,16 @@ class SprintLifecycleStore:
                             sprint_id
                         )
                     else:
-                        self._reconcile_unread_wakes_in_transaction(
+                        reconciliation = self._reconcile_unread_wakes_in_transaction(
                             sprint_id,
                             trigger="startup",
                         )
-                        self._reconcile_registered_prs_in_transaction(sprint_id)
-            if run_ids or conversations:
+                        pause_receipt = reconciliation.pause_receipt
+                        if pause_receipt is None:
+                            self._reconcile_registered_prs_in_transaction(sprint_id)
+            if pause_receipt is not None:
+                self._signal_interrupts_and_notifications(pause_receipt)
+            elif run_ids or conversations:
                 self._signal_interrupts_and_notifications(
                     PauseReceipt(True, None, run_ids, conversations)
                 )
@@ -667,11 +690,17 @@ class SprintLifecycleStore:
         with db_driver.write_transaction(self.con, "sprint.wake.pickup_recover"):
             sprint = self._sprint(sprint_id)
             if sprint["lifecycle"] != "armed":
-                return ()
-            return self._reconcile_unread_wakes_in_transaction(
-                sprint_id,
-                trigger=trigger,
+                reconciliation = _WakeReconcileResult(())
+            else:
+                reconciliation = self._reconcile_unread_wakes_in_transaction(
+                    sprint_id,
+                    trigger=trigger,
+                )
+        if reconciliation.pause_receipt is not None:
+            self._signal_interrupts_and_notifications(
+                reconciliation.pause_receipt
             )
+        return reconciliation.wake_ids
 
     def _pause_in_transaction(
         self,
@@ -680,6 +709,7 @@ class SprintLifecycleStore:
         *,
         reason: str,
         detail: dict,
+        notice_body: str | None = None,
     ) -> PauseReceipt:
         if not self.con.in_transaction:
             raise RuntimeError("pause requires an active transaction")
@@ -705,7 +735,7 @@ class SprintLifecycleStore:
         )
         _, notice_conversations = self._queue_planner_notice(
             sprint_id,
-            body=f"Sprint {sprint_id} paused: {reason}",
+            body=notice_body or f"Sprint {sprint_id} paused: {reason}",
             idempotency_key=(
                 f"sprint-pause:{sprint_id}:v{int(sprint['version']) + 1}"
             ),
@@ -927,7 +957,7 @@ class SprintLifecycleStore:
         sprint_id: int,
         *,
         trigger: str,
-    ) -> tuple[int, ...]:
+    ) -> _WakeReconcileResult:
         if not self.con.in_transaction:
             raise RuntimeError("wake reconciliation requires an active transaction")
         rows = self.con.execute(
@@ -946,25 +976,101 @@ class SprintLifecycleStore:
             old_wake_id = int(row["wake_id"])
             participant_id = int(row["participant_id"])
             wake_key = str(row["idempotency_key"])
-            if wake_key.startswith("sprint-recovery:") or ":failed-wake:" in wake_key:
-                continue
             turn = self._wake_turn_evidence(old_wake_id)
+            shell_busy = (
+                turn["run_state"] == "failed"
+                and turn["error_code"] == "SHELL_BUSY"
+            )
+            busy_prefix = f"sprint-recovery:{sprint_id}:busy:"
+            busy_recovery = wake_key.startswith(busy_prefix)
+            if (
+                (wake_key.startswith("sprint-recovery:") and not busy_recovery)
+                or ":failed-wake:" in wake_key
+            ):
+                continue
+            if busy_recovery and not shell_busy:
+                continue
             if self._participant_has_pickup_turn(participant_id):
                 continue
+            classification: dict[str, str | int] = {}
+            if shell_busy:
+                original_wake_id = (
+                    self._busy_recovery_origin(wake_key, sprint_id)
+                    if busy_recovery
+                    else old_wake_id
+                )
+                key_prefix = f"{busy_prefix}{original_wake_id}:"
+                recovery_count = int(
+                    self.con.execute(
+                        "SELECT COUNT(*) FROM sprint_wake_outbox "
+                        "WHERE sprint_id=? AND idempotency_key LIKE ?",
+                        (sprint_id, f"{key_prefix}%"),
+                    ).fetchone()[0]
+                )
+                current_attempt = 1 + recovery_count
+                if current_attempt >= WAKE_CONTENTION_ATTEMPTS:
+                    slot_state = self._busy_slot_state(turn["error_detail"])
+                    shell = str(
+                        self.con.execute(
+                            "SELECT sh.shortname FROM sprint_participants p "
+                            "JOIN shells sh USING (shell_id) "
+                            "WHERE p.participant_id=?",
+                            (participant_id,),
+                        ).fetchone()[0]
+                    )
+                    pause_receipt = self._pause_in_transaction(
+                        self._sprint(sprint_id),
+                        LifecycleActor("system"),
+                        reason="wake_contention_exhausted",
+                        detail={
+                            "wake_id": old_wake_id,
+                            "original_wake_id": original_wake_id,
+                            "participant_id": participant_id,
+                            "shell": shell,
+                            "attempts": current_attempt,
+                            "slot_state": slot_state,
+                            "last_error": turn["error_detail"],
+                        },
+                        notice_body=(
+                            f"Sprint {sprint_id} paused: wake contention exhausted "
+                            f"for shell {shell} after {current_attempt} attempts; "
+                            f"last slot state: {slot_state}."
+                        ),
+                    )
+                    return _WakeReconcileResult(
+                        tuple(sorted(set(replacements))),
+                        pause_receipt,
+                    )
+                next_attempt = current_attempt + 1
+                backoff_seconds = WAKE_CONTENTION_BACKOFF_SECONDS[
+                    next_attempt - 2
+                ]
+                recovery_key = f"{key_prefix}{next_attempt}"
+                classification = {
+                    "classification": "shell_busy",
+                    "attempt": next_attempt,
+                    "backoff_seconds": backoff_seconds,
+                }
+            else:
+                recovery_key = (
+                    f"sprint-resume:{sprint_id}:failed-wake:{old_wake_id}"
+                    if row["state"] == "failed"
+                    else f"sprint-recovery:{sprint_id}:delivered-unread:{old_wake_id}"
+                )
             deliverable = self.con.execute(
-                "SELECT wake_id FROM sprint_wake_outbox WHERE sprint_id=? "
-                "AND participant_id=? AND state IN ('pending','delivering') "
-                "ORDER BY wake_id LIMIT 1",
+                "SELECT wake_id,idempotency_key FROM sprint_wake_outbox "
+                "WHERE sprint_id=? AND participant_id=? "
+                + (
+                    "AND state='pending' "
+                    if shell_busy
+                    else "AND state IN ('pending','delivering') "
+                )
+                + "ORDER BY wake_id LIMIT 1",
                 (sprint_id, participant_id),
             ).fetchone()
-            recovery_key = (
-                f"sprint-resume:{sprint_id}:failed-wake:{old_wake_id}"
-                if row["state"] == "failed"
-                else f"sprint-recovery:{sprint_id}:delivered-unread:{old_wake_id}"
-            )
             if deliverable is None:
                 prior_recovery = self.con.execute(
-                    "SELECT wake_id,state FROM sprint_wake_outbox "
+                    "SELECT wake_id,state,idempotency_key FROM sprint_wake_outbox "
                     "WHERE idempotency_key=?",
                     (recovery_key,),
                 ).fetchone()
@@ -974,15 +1080,48 @@ class SprintLifecycleStore:
                     deliverable = prior_recovery
             created = deliverable is None
             if created:
-                new_wake_id = int(
-                    self.con.execute(
-                        "INSERT INTO sprint_wake_outbox "
-                        "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
-                        (sprint_id, participant_id, recovery_key),
-                    ).lastrowid
-                )
+                if shell_busy:
+                    new_wake_id = int(
+                        self.con.execute(
+                            "INSERT INTO sprint_wake_outbox "
+                            "(sprint_id,participant_id,idempotency_key,available_at) "
+                            "VALUES (?,?,?,datetime('now', ?))",
+                            (
+                                sprint_id,
+                                participant_id,
+                                recovery_key,
+                                f"+{backoff_seconds} seconds",
+                            ),
+                        ).lastrowid
+                    )
+                else:
+                    new_wake_id = int(
+                        self.con.execute(
+                            "INSERT INTO sprint_wake_outbox "
+                            "(sprint_id,participant_id,idempotency_key) "
+                            "VALUES (?,?,?)",
+                            (sprint_id, participant_id, recovery_key),
+                        ).lastrowid
+                    )
             else:
                 new_wake_id = int(deliverable["wake_id"])
+            if self._wake_requeue_recorded(sprint_id, old_wake_id, new_wake_id):
+                continue
+            if (
+                shell_busy
+                and not created
+                and deliverable["idempotency_key"] != recovery_key
+            ):
+                self.con.execute(
+                    "UPDATE sprint_wake_outbox SET idempotency_key=?,"
+                    "available_at=datetime('now', ?) "
+                    "WHERE wake_id=? AND state='pending'",
+                    (
+                        recovery_key,
+                        f"+{backoff_seconds} seconds",
+                        new_wake_id,
+                    ),
+                )
             self.con.execute(
                 "UPDATE sprint_wake_messages SET wake_id=? "
                 "WHERE sprint_id=? AND wake_id=?",
@@ -1007,6 +1146,7 @@ class SprintLifecycleStore:
                     "replacement_wake_id": new_wake_id,
                     "replacement_created": created,
                     "replacement_conversation_id": route.conversation_id,
+                    **classification,
                     **(
                         {"failed_wake_id": old_wake_id}
                         if row["state"] == "failed"
@@ -1079,7 +1219,39 @@ class SprintLifecycleStore:
                 },
             )
             replacements.append(new_wake_id)
-        return tuple(sorted(set(replacements)))
+        return _WakeReconcileResult(tuple(sorted(set(replacements))))
+
+    @staticmethod
+    def _busy_recovery_origin(wake_key: str, sprint_id: int) -> int:
+        prefix = f"sprint-recovery:{sprint_id}:busy:"
+        origin, separator, attempt = wake_key.removeprefix(prefix).partition(":")
+        if not separator or not origin.isdigit() or not attempt.isdigit():
+            raise SprintInvariantError(
+                f"invalid SHELL_BUSY recovery key: {wake_key}"
+            )
+        return int(origin)
+
+    @staticmethod
+    def _busy_slot_state(error_detail: str | int | None) -> str:
+        detail = str(error_detail or "").lower()
+        return "orphan" if "(orphan)" in detail else "busy"
+
+    def _wake_requeue_recorded(
+        self,
+        sprint_id: int,
+        prior_wake_id: int,
+        replacement_wake_id: int,
+    ) -> bool:
+        rows = self.con.execute(
+            "SELECT payload FROM sprint_events WHERE sprint_id=? "
+            "AND event_type='wake.requeued' ORDER BY event_id",
+            (sprint_id,),
+        ).fetchall()
+        return any(
+            payload.get("prior_wake_id") == prior_wake_id
+            and payload.get("replacement_wake_id") == replacement_wake_id
+            for payload in (json.loads(row["payload"]) for row in rows)
+        )
 
     def _participant_has_pickup_turn(self, participant_id: int) -> bool:
         return self.con.execute(
@@ -1116,6 +1288,8 @@ class SprintLifecycleStore:
                 "attempt_outcome": None,
                 "message_state": None,
                 "run_state": None,
+                "error_code": None,
+                "error_detail": None,
             }
         message = self.con.execute(
             "SELECT message_id,state FROM conversation_messages "
@@ -1123,13 +1297,19 @@ class SprintLifecycleStore:
             (attempt["target_conversation_id"], wake["idempotency_key"]),
         ).fetchone()
         run_state = None
+        error_code = None
+        error_detail = None
         if message is not None:
             run = self.con.execute(
-                "SELECT state FROM conversation_runs WHERE trigger_message_id=? "
+                "SELECT state,error_code,error_detail FROM conversation_runs "
+                "WHERE trigger_message_id=? "
                 "ORDER BY attempt DESC LIMIT 1",
                 (message["message_id"],),
             ).fetchone()
-            run_state = str(run["state"]) if run is not None else None
+            if run is not None:
+                run_state = str(run["state"])
+                error_code = run["error_code"]
+                error_detail = run["error_detail"]
         return {
             "attempt_number": int(attempt["attempt_number"]),
             "target_conversation_id": attempt["target_conversation_id"],
@@ -1137,6 +1317,8 @@ class SprintLifecycleStore:
             "attempt_outcome": str(attempt["outcome"]),
             "message_state": str(message["state"]) if message is not None else None,
             "run_state": run_state,
+            "error_code": error_code,
+            "error_detail": error_detail,
         }
 
     def _resolve_review_expectations_in_transaction(

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -534,9 +534,11 @@ class SprintLifecycleStore:
         )
         self._event(
             sprint_id,
-            "wake.contention_episode_reset",
+            "wake.requeued",
             actor,
             {
+                "trigger": "resume",
+                "classification": "contention_episode_reset",
                 "prior_wake_id": wake_id,
                 "replacement_wake_id": replacement_wake_id,
                 "prior_idempotency_key": str(wake["idempotency_key"]),

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -396,13 +396,19 @@ class SprintLifecycleStore:
                 target="armed",
                 outcome=None,
             )
+            reset_wake_ids = self._reset_contention_episode_in_transaction(
+                sprint_id,
+                actor,
+            )
             if reconcile_in_transaction is not None:
                 reconcile_in_transaction(self.con)
             reconciliation = self._reconcile_unread_wakes_in_transaction(
                 sprint_id,
                 trigger="resume",
             )
-            requeued = reconciliation.wake_ids
+            requeued = tuple(
+                sorted(set(reset_wake_ids) | set(reconciliation.wake_ids))
+            )
             pause_receipt = reconciliation.pause_receipt
             projected, resolved = (
                 self._reconcile_registered_prs_in_transaction(sprint_id)
@@ -466,7 +472,7 @@ class SprintLifecycleStore:
         else:
             self._signal_notifications(notice_conversations)
         return ResumeReceipt(
-            True,
+            pause_receipt is None,
             dispatched,
             requeued,
             tuple(projected),
@@ -474,6 +480,71 @@ class SprintLifecycleStore:
             tuple(sorted(drift)),
             all_anomalies,
         )
+
+    def _reset_contention_episode_in_transaction(
+        self,
+        sprint_id: int,
+        actor: LifecycleActor,
+    ) -> tuple[int, ...]:
+        """Make a human resume the durable anchor of a fresh busy episode."""
+        report = self.con.execute(
+            "SELECT body FROM sprint_reports WHERE sprint_id=? "
+            "AND report_kind='pause' ORDER BY report_id DESC LIMIT 1",
+            (sprint_id,),
+        ).fetchone()
+        if report is None:
+            return ()
+        pause = json.loads(str(report["body"]))
+        if pause.get("reason") != "wake_contention_exhausted":
+            return ()
+        wake_id = int(pause["detail"]["wake_id"])
+        wake = self.con.execute(
+            "SELECT w.participant_id,w.idempotency_key "
+            "FROM sprint_wake_outbox w "
+            "WHERE w.sprint_id=? AND w.wake_id=? "
+            "AND w.state IN ('delivered','failed') AND EXISTS ("
+            "SELECT 1 FROM sprint_wake_messages wm "
+            "JOIN sprint_messages m USING (message_id) "
+            "WHERE wm.sprint_id=w.sprint_id AND wm.wake_id=w.wake_id "
+            "AND m.read_at IS NULL)",
+            (sprint_id, wake_id),
+        ).fetchone()
+        if wake is None:
+            return ()
+        reset_key = f"sprint-resume:{sprint_id}:contention-episode:{wake_id}"
+        replacement_wake_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_wake_outbox "
+                "(sprint_id,participant_id,idempotency_key,available_at) "
+                "VALUES (?,?,?,datetime('now'))",
+                (sprint_id, int(wake["participant_id"]), reset_key),
+            ).lastrowid
+        )
+        self.con.execute(
+            "UPDATE sprint_wake_messages SET wake_id=? "
+            "WHERE sprint_id=? AND wake_id=?",
+            (replacement_wake_id, sprint_id, wake_id),
+        )
+        route = sprint_participant_chats.ensure_wake_conversation(
+            self.con,
+            int(wake["participant_id"]),
+            idempotency_key=(
+                f"sprint:{sprint_id}:wake:{replacement_wake_id}:conversation"
+            ),
+        )
+        self._event(
+            sprint_id,
+            "wake.contention_episode_reset",
+            actor,
+            {
+                "prior_wake_id": wake_id,
+                "replacement_wake_id": replacement_wake_id,
+                "prior_idempotency_key": str(wake["idempotency_key"]),
+                "idempotency_key": reset_key,
+                "replacement_conversation_id": route.conversation_id,
+            },
+        )
+        return (replacement_wake_id,)
 
     def abort(
         self,

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -373,6 +373,40 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
 
 
 class WakeDeliveryTest(SprintMessageCase):
+    def test_claim_respects_available_at_backoff_boundary(self) -> None:
+        sent = self.send("backoff-boundary")
+        clock = [datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc)]
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET available_at='2099-07-31 12:00:15' "
+            "WHERE wake_id=?",
+            (sent.wake_id,),
+        )
+        self.con.commit()
+        service = delivery.SprintWakeDeliveryService(
+            self.con,
+            now=lambda: clock[0],
+        )
+
+        self.assertIsNone(service.claim_next("before-backoff"))
+        self.assertEqual(
+            "pending",
+            self.con.execute(
+                "SELECT state FROM sprint_wake_outbox WHERE wake_id=?",
+                (sent.wake_id,),
+            ).fetchone()[0],
+        )
+        clock[0] += timedelta(seconds=15)
+        lease = service.claim_next("at-backoff")
+        self.assertIsNotNone(lease)
+        self.assertEqual(sent.wake_id, lease.wake_id)
+        self.assertEqual(
+            "delivering",
+            self.con.execute(
+                "SELECT state FROM sprint_wake_outbox WHERE wake_id=?",
+                (sent.wake_id,),
+            ).fetchone()[0],
+        )
+
     def test_role_aware_prompt_and_target_are_durable_delivery_evidence(self) -> None:
         sent = self.send("deliver")
         observed: list[tuple[str, str, str]] = []

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -558,6 +558,148 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ).fetchone()[0],
         )
 
+        receipt = self.coordinator().resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="the orphaned slot was cleared",
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual(1, len(receipt.requeued_wake_ids))
+        reset_wake = receipt.requeued_wake_ids[0]
+        self.assertNotEqual(current, reset_wake)
+        self.assertEqual(
+            (
+                "armed",
+                "pending",
+                f"sprint-resume:{self.sprint_id}:contention-episode:{current}",
+                0,
+                None,
+                1,
+                None,
+                None,
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,w.state,w.idempotency_key,w.attempt_count,"
+                    "w.last_error,w.available_at<=datetime('now'),"
+                    "w.delivered_at,w.failed_at FROM sprints s "
+                    "JOIN sprint_wake_outbox w ON w.sprint_id=s.sprint_id "
+                    "WHERE s.sprint_id=? AND w.wake_id=?",
+                    (self.sprint_id, reset_wake),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            ("delivered", 0, 1),
+            tuple(
+                self.con.execute(
+                    "SELECT w.state,COUNT(wm.message_id),"
+                    "(SELECT COUNT(*) FROM sprint_wake_attempts a "
+                    "WHERE a.wake_id=w.wake_id) "
+                    "FROM sprint_wake_outbox w LEFT JOIN sprint_wake_messages wm "
+                    "USING (wake_id) WHERE w.wake_id=? GROUP BY w.wake_id",
+                    (current,),
+                ).fetchone()
+            ),
+        )
+        reset = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='wake.contention_episode_reset'",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual(
+            (
+                current,
+                reset_wake,
+                f"sprint-recovery:{self.sprint_id}:busy:{original}:5",
+                f"sprint-resume:{self.sprint_id}:contention-episode:{current}",
+            ),
+            (
+                reset["prior_wake_id"],
+                reset["replacement_wake_id"],
+                reset["prior_idempotency_key"],
+                reset["idempotency_key"],
+            ),
+        )
+
+        self.fail_wake_turn(reset_wake, error_code="SHELL_BUSY")
+        fresh_retry = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="fresh-episode-attempt-2",
+        )
+        self.assertEqual(1, len(fresh_retry))
+        self.assertEqual(
+            (
+                "armed",
+                f"sprint-recovery:{self.sprint_id}:busy:{reset_wake}:2",
+                4,
+            ),
+            (
+                self.con.execute(
+                    "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                    (self.sprint_id,),
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT idempotency_key FROM sprint_wake_outbox "
+                    "WHERE wake_id=?",
+                    (fresh_retry[0],),
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT COUNT(*) FROM sprint_wake_outbox "
+                    "WHERE sprint_id=? AND idempotency_key LIKE ?",
+                    (
+                        self.sprint_id,
+                        f"sprint-recovery:{self.sprint_id}:busy:{original}:%",
+                    ),
+                ).fetchone()[0],
+            ),
+        )
+
+    def test_resume_reports_unchanged_when_reconciliation_repauses(self):
+        message = self.send("busy-chain-under-manual-pause")
+        current = int(message.wake_id)
+        for attempt in range(2, 6):
+            self.fail_wake_turn(current, error_code="SHELL_BUSY")
+            current = self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger=f"prepare-attempt-{attempt}",
+            )[0]
+            self.con.execute(
+                "UPDATE sprint_wake_outbox SET available_at="
+                "datetime('now','-1 second') WHERE wake_id=?",
+                (current,),
+            )
+            self.con.commit()
+        self.fail_wake_turn(current, error_code="SHELL_BUSY")
+        coordinator = self.coordinator()
+        coordinator.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="manual pause before the contention pulse",
+        )
+
+        receipt = coordinator.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+
+        self.assertFalse(receipt.changed)
+        self.assertEqual((), receipt.requeued_wake_ids)
+        self.assertEqual(
+            ("paused", "wake_contention_exhausted"),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,json_extract(r.body,'$.reason') "
+                    "FROM sprints s JOIN sprint_reports r USING (sprint_id) "
+                    "WHERE s.sprint_id=? ORDER BY r.report_id DESC LIMIT 1",
+                    (self.sprint_id,),
+                ).fetchone()
+            ),
+        )
+
     def test_read_message_stops_pending_shell_busy_chain(self):
         message = self.send("busy-chain-read")
         original = int(message.wake_id)

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -160,6 +160,55 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             (wake_id,),
         ).fetchone()[0]
 
+    def fail_wake_turn(
+        self,
+        wake_id: int,
+        *,
+        error_code: str,
+        slot_state: str = "busy",
+    ) -> None:
+        def deliver(conversation_id: str, prompt: str, key: str) -> str:
+            detail = (
+                "shell 'DEV1' already has a live CLI session "
+                f"({slot_state}); close it before starting a browser turn"
+            )
+            message_id = int(
+                self.con.execute(
+                    "INSERT INTO conversation_messages "
+                    "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                    "idempotency_key,request_hash,state,completed_at) "
+                    "VALUES (?,'engine','test','prompt',?,?,?,'failed',"
+                    "'2026-08-01 00:00:01')",
+                    (conversation_id, prompt, key, key),
+                ).lastrowid
+            )
+            run_id = int(
+                self.con.execute(
+                    "INSERT INTO conversation_runs "
+                    "(conversation_id,shell_id,trigger_message_id,state,"
+                    "lease_owner,lease_expires_at,started_at,ended_at,error_code,"
+                    "error_detail) SELECT ?,shell_id,?,'failed','test-broker',"
+                    "'2026-08-01 00:00:01','2026-08-01 00:00:00',"
+                    "'2026-08-01 00:00:01',?,? FROM conversations "
+                    "WHERE conversation_id=?",
+                    (
+                        conversation_id,
+                        message_id,
+                        error_code,
+                        detail,
+                        conversation_id,
+                    ),
+                ).lastrowid
+            )
+            self.con.commit()
+            return f"conversation-run:{run_id}"
+
+        outcome = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).deliver_once(f"failed-turn-{wake_id}", deliver)
+        self.assertIsNotNone(outcome)
+        self.assertEqual((wake_id, "delivered"), (outcome.wake_id, outcome.state))
+
     def test_participant_pause_atomically_persists_report_interrupt_and_notice(self):
         self.register()
         run_id = self.add_live_run()
@@ -385,6 +434,250 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                 (self.sprint_id,),
             ).fetchone()[0],
             "the bounded fallback does not become a recursive recovery loop",
+        )
+
+    def test_shell_busy_retries_durably_then_pauses_with_one_notice(self):
+        message = self.send("busy-recovery-chain")
+        original = int(message.wake_id)
+        notifications = []
+        store = sprint_domain.SprintLifecycleStore(
+            self.con,
+            interrupt_run=lambda _run_id: True,
+            notify_commit=lambda: notifications.append("notified") or True,
+        )
+        current = original
+
+        for attempt, backoff in zip(
+            range(2, 6),
+            sprint_domain.WAKE_CONTENTION_BACKOFF_SECONDS,
+            strict=True,
+        ):
+            self.fail_wake_turn(
+                current,
+                error_code="SHELL_BUSY",
+                slot_state="orphan" if attempt == 5 else "busy",
+            )
+            replacements = store.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger=f"attempt-{attempt}",
+            )
+            self.assertEqual(1, len(replacements))
+            current = replacements[0]
+            wake = self.con.execute(
+                "SELECT idempotency_key,"
+                "CAST(strftime('%s',available_at) AS INTEGER)-"
+                "CAST(strftime('%s',created_at) AS INTEGER) delay "
+                "FROM sprint_wake_outbox WHERE wake_id=?",
+                (current,),
+            ).fetchone()
+            self.assertEqual(
+                f"sprint-recovery:{self.sprint_id}:busy:{original}:{attempt}",
+                wake["idempotency_key"],
+            )
+            self.assertEqual(backoff, wake["delay"])
+            event = json.loads(
+                self.con.execute(
+                    "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                    "AND event_type='wake.requeued' ORDER BY event_id DESC LIMIT 1",
+                    (self.sprint_id,),
+                ).fetchone()[0]
+            )
+            self.assertEqual(
+                ("shell_busy", attempt, backoff, current),
+                (
+                    event["classification"],
+                    event["attempt"],
+                    event["backoff_seconds"],
+                    event["replacement_wake_id"],
+                ),
+            )
+            before_changes = self.con.total_changes
+            self.assertEqual(
+                (),
+                store.reconcile_unread_pickup(
+                    self.sprint_id,
+                    trigger="duplicate-pulse",
+                ),
+            )
+            self.assertEqual(before_changes, self.con.total_changes)
+            self.con.execute(
+                "UPDATE sprint_wake_outbox SET available_at="
+                "datetime('now','-1 second') WHERE wake_id=?",
+                (current,),
+            )
+            self.con.commit()
+            if attempt == 2:
+                store = sprint_domain.SprintLifecycleStore(
+                    self.con,
+                    interrupt_run=lambda _run_id: True,
+                    notify_commit=lambda: notifications.append("notified") or True,
+                )
+
+        self.fail_wake_turn(
+            current,
+            error_code="SHELL_BUSY",
+            slot_state="orphan",
+        )
+        self.assertEqual(
+            (),
+            store.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="attempt-5-exhausted",
+            ),
+        )
+        self.assertEqual(["notified"], notifications)
+        self.assertEqual(
+            ("paused", 5, "DEV1", "orphan"),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,"
+                    "json_extract(r.body,'$.detail.attempts'),"
+                    "json_extract(r.body,'$.detail.shell'),"
+                    "json_extract(r.body,'$.detail.slot_state') "
+                    "FROM sprints s JOIN sprint_reports r USING (sprint_id) "
+                    "WHERE s.sprint_id=? AND r.report_kind='pause'",
+                    (self.sprint_id,),
+                ).fetchone()
+            ),
+        )
+        notice = self.con.execute(
+            "SELECT body FROM sprint_messages WHERE sprint_id=? "
+            "AND idempotency_key LIKE 'sprint-pause:%'",
+            (self.sprint_id,),
+        ).fetchone()[0]
+        self.assertIn("shell DEV1", notice)
+        self.assertIn("5 attempts", notice)
+        self.assertIn("last slot state: orphan", notice)
+        self.assertEqual(
+            4,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='wake.requeued' "
+                "AND json_extract(payload,'$.classification')='shell_busy'",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+
+    def test_read_message_stops_pending_shell_busy_chain(self):
+        message = self.send("busy-chain-read")
+        original = int(message.wake_id)
+        self.fail_wake_turn(original, error_code="SHELL_BUSY")
+        replacement = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="first-busy-retry",
+        )[0]
+
+        self.messages.mark_read(message.message_id, 1)
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET available_at="
+            "datetime('now','-1 second') WHERE wake_id=?",
+            (replacement,),
+        )
+        self.con.commit()
+
+        self.assertIsNone(
+            sprint_message_delivery.SprintWakeDeliveryService(
+                self.con
+            ).claim_next("read-message")
+        )
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="read-message",
+            ),
+        )
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+
+    def test_shell_busy_chain_adopts_one_existing_pending_wake(self):
+        first = self.send("busy-with-followup")
+        original = int(first.wake_id)
+        self.fail_wake_turn(original, error_code="SHELL_BUSY")
+        followup = self.send("already-pending-followup")
+        wake_count = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_wake_outbox WHERE sprint_id=?",
+            (self.sprint_id,),
+        ).fetchone()[0]
+
+        replacements = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="coalesce-busy-recovery",
+        )
+
+        self.assertEqual((followup.wake_id,), replacements)
+        self.assertEqual(
+            wake_count,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_wake_outbox WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            (
+                f"sprint-recovery:{self.sprint_id}:busy:{original}:2",
+                15,
+                2,
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT w.idempotency_key,"
+                    "CAST(strftime('%s',w.available_at) AS INTEGER)-"
+                    "CAST(strftime('%s',w.created_at) AS INTEGER),"
+                    "COUNT(wm.message_id) FROM sprint_wake_outbox w "
+                    "JOIN sprint_wake_messages wm USING (wake_id) "
+                    "WHERE w.wake_id=? GROUP BY w.wake_id",
+                    (followup.wake_id,),
+                ).fetchone()
+            ),
+        )
+
+    def test_non_busy_failed_turn_keeps_one_shot_recovery(self):
+        wake_count = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_wake_outbox WHERE sprint_id=?",
+            (self.sprint_id,),
+        ).fetchone()[0]
+        message = self.send("non-busy-turn")
+        original = int(message.wake_id)
+        self.fail_wake_turn(original, error_code="HARNESS_ROUTE_MISMATCH")
+        replacement = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="non-busy",
+        )[0]
+        self.assertEqual(
+            f"sprint-recovery:{self.sprint_id}:delivered-unread:{original}",
+            self.con.execute(
+                "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
+                (replacement,),
+            ).fetchone()[0],
+        )
+
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET available_at="
+            "datetime('now','-1 second') WHERE wake_id=?",
+            (replacement,),
+        )
+        self.con.commit()
+        self.fail_wake_turn(replacement, error_code="HARNESS_ROUTE_MISMATCH")
+
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="non-busy-recovery-failed",
+            ),
+        )
+        self.assertEqual(
+            wake_count + 2,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_wake_outbox WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
         )
 
     def test_resume_repairs_delivered_unread_assignment_once(self):

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -606,7 +606,9 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         reset = json.loads(
             self.con.execute(
                 "SELECT payload FROM sprint_events WHERE sprint_id=? "
-                "AND event_type='wake.contention_episode_reset'",
+                "AND event_type='wake.requeued' "
+                "AND json_extract(payload,'$.classification')="
+                "'contention_episode_reset'",
                 (self.sprint_id,),
             ).fetchone()[0]
         )


### PR DESCRIPTION
## Summary
- classify failed Sprint pickup turns with `error_code='SHELL_BUSY'` as transient contention
- retry one durable episode through attempts 2–5 with 15/60/180/300-second `available_at` backoff and one `wake.requeued` event per link
- pause once on attempt-5 exhaustion with Planner notice/report evidence naming the shell and `busy`/`orphan` slot state
- preserve broker behavior and non-contention one-shot recovery; dedupe recovery relinks/events

## Judgment
The original failed launch is attempt 1 and the four recovery wakes are attempts 2–5. PLN1 ratified this reading because it is the only one matching the five-attempt budget, four backoffs, and 555-second worst-case schedule. I used durable key-prefix row counts rather than a migration: the existing outbox already carries restart-safe ordinals, making this smaller and fully reversible.

## Verification
- `./sc test tests/test_sprint_recovery.py tests/test_sprint_message_delivery.py tests/test_sprint_v2_domain.py` — 64 passed
- `./sc test` — 1650 passed, 1 skipped
- `./sc render-check` — passed
- worktree-local `map_repo.py` — passed
- Python compile + `git diff --check` — passed

Known baseline gates remain outside this unit: repo-wide Ruff baseline #854 and linked-worktree `./sc verify` limitation #769. Broker files are untouched. Flag #136 is not included.

Sprint 86, unit 2. Spec #85; decisions #64 and #53.
