### PR TITLE
feat(conversations): add active chat registry

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -28,6 +28,7 @@ DB_PATH = ENGINE / "shell_db.db"
 SCRIPTS = ENGINE / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
+import active_chat_registry
 import conversation_broker
 import conversation_events
 import conversation_git_targets
@@ -498,12 +499,8 @@ def _reopen_conversation(con, operator: dict, conversation) -> list[str]:
             "shell is unknown, deleted, or unavailable to this operator",
         )
     _refuse_admin_browser_chat(shell)
-    open_conversations = con.execute(
-        "SELECT conversation_id,state FROM conversations "
-        "WHERE shell_id=? AND state!='closed' AND conversation_scope='normal'",
-        (conversation["shell_id"],),
-    ).fetchall()
-    if not open_conversations:
+    active = active_chat_registry.get(con, int(conversation["shell_id"]))
+    if active is None:
         live_state = _live_shell_session(shell)
         if live_state is not None:
             raise ApiError(
@@ -516,32 +513,31 @@ def _reopen_conversation(con, operator: dict, conversation) -> list[str]:
                     "state": live_state,
                 },
             )
-    running = [
-        row for row in open_conversations
-        if row["state"] in ("queued", "running")
-    ]
-    if running:
+    try:
+        closed = active_chat_registry.close_active(
+            con,
+            int(conversation["shell_id"]),
+        )
+    except active_chat_registry.ActiveChatBusy as exc:
         raise ApiError(
             409,
             "BROWSER_CHAT_BUSY",
-            "the open browser chat has a turn in progress",
-            {"conversation_id": running[0]["conversation_id"]},
-        )
+            "the active chat has a turn in progress",
+            {
+                "conversation_id": (
+                    active.chat_id if active is not None else None
+                )
+            },
+        ) from exc
     auto_closed = []
-    for row in open_conversations:
-        con.execute(
-            "UPDATE conversations SET state='closed',"
-            "closed_at=datetime('now'),last_activity_at=datetime('now'),"
-            "version=version+1 WHERE conversation_id=?",
-            (row["conversation_id"],),
-        )
+    if closed is not None:
         _append_event(
             con,
-            row["conversation_id"],
+            closed.chat_id,
             "conversation.closed",
             {"status": "closed", "reason": "another browser chat reopened"},
         )
-        auto_closed.append(row["conversation_id"])
+        auto_closed.append(closed.chat_id)
     con.execute(
         "UPDATE conversations SET state='idle',closed_at=NULL,"
         "last_activity_at=datetime('now'),version=version+1 "
@@ -553,6 +549,11 @@ def _reopen_conversation(con, operator: dict, conversation) -> list[str]:
         conversation_id,
         "conversation.reopened",
         {"state": "idle"},
+    )
+    active_chat_registry.register(
+        con,
+        int(conversation["shell_id"]),
+        str(conversation_id),
     )
     return auto_closed
 
@@ -754,12 +755,7 @@ def _create_conversation(con, operator: dict, headers, body: dict):
             "shell is unknown, deleted, or unavailable to this operator",
         )
     _refuse_admin_browser_chat(shell)
-    open_conversations = con.execute(
-        "SELECT conversation_id,state FROM conversations "
-        "WHERE shell_id=? AND state!='closed' AND conversation_scope='normal'",
-        (shell_id,),
-    ).fetchall()
-    if not open_conversations:
+    if active_chat_registry.get(con, shell_id) is None:
         live_state = _wait_for_cli_release(shell)
         if live_state is not None:
             raise ApiError(
@@ -817,8 +813,8 @@ def _create_conversation(con, operator: dict, headers, body: dict):
 
     conversation_id = "cv_" + uuid.uuid4().hex
     provider = run_mod.session_provider(harness, model)
-    auto_closed = []
-    with db_driver.write_transaction(con, "conversation.create"):
+    closed_id = None
+    with db_driver.write_transaction(con, "conversation.create.close_active"):
         existing = con.execute(
             "SELECT conversation_id,creation_request_hash FROM conversations "
             "WHERE owner_user_id=? "
@@ -864,13 +860,7 @@ def _create_conversation(con, operator: dict, headers, body: dict):
                 {"shell_id": shell_id},
             )
 
-        open_conversations = con.execute(
-            "SELECT conversation_id,state FROM conversations "
-            "WHERE shell_id=? AND state!='closed' "
-            "AND conversation_scope='normal'",
-            (shell_id,),
-        ).fetchall()
-        if not open_conversations:
+        if active_chat_registry.get(con, shell_id) is None:
             live_state = _live_shell_session(current_shell)
             if live_state is not None:
                 raise ApiError(
@@ -881,31 +871,62 @@ def _create_conversation(con, operator: dict, headers, body: dict):
                     {"shell_id": shell_id, "state": live_state},
                 )
 
-        running = [
-            row for row in open_conversations
-            if row["state"] in ("queued", "running")
-        ]
-        if running:
+        active = active_chat_registry.get(con, shell_id)
+        try:
+            closed = active_chat_registry.close_active(con, shell_id)
+        except active_chat_registry.ActiveChatBusy as exc:
             raise ApiError(
                 409,
                 "BROWSER_CHAT_BUSY",
-                "the open browser chat has a turn in progress",
-                {"conversation_id": running[0]["conversation_id"]},
-            )
-        for row in open_conversations:
-            con.execute(
-                "UPDATE conversations SET state='closed',"
-                "closed_at=datetime('now'),last_activity_at=datetime('now'),"
-                "version=version+1 WHERE conversation_id=?",
-                (row["conversation_id"],),
-            )
+                "the active chat has a turn in progress",
+                {
+                    "conversation_id": (
+                        active.chat_id if active is not None else None
+                    )
+                },
+            ) from exc
+        if closed is not None:
             _append_event(
                 con,
-                row["conversation_id"],
+                closed.chat_id,
                 "conversation.closed",
-                {"status": "closed", "reason": "another browser chat opened"},
+                {"status": "closed", "reason": "another chat opened"},
             )
-            auto_closed.append(row["conversation_id"])
+            closed_id = closed.chat_id
+
+    # Closing is intentionally its own committed step.  If replacement
+    # creation fails, the old chat stays closed and no second chat exists.
+    if closed_id is not None:
+        conversation_events.notify(closed_id)
+
+    with db_driver.write_transaction(con, "conversation.create.register"):
+        existing = con.execute(
+            "SELECT conversation_id,creation_request_hash FROM conversations "
+            "WHERE owner_user_id=? AND creation_idempotency_key=?",
+            (operator["user_id"], key),
+        ).fetchone()
+        if existing is not None:
+            if existing["creation_request_hash"] != request_hash:
+                raise ApiError(
+                    409,
+                    "CONVERSATION_IDEMPOTENCY_CONFLICT",
+                    "Idempotency-Key was reused with a different request",
+                )
+            row = _require_conversation(
+                con, existing["conversation_id"], operator["user_id"]
+            )
+            return _json(
+                201,
+                _conversation_projection(row),
+                [("Location", f"/api/conversations/{row['conversation_id']}")],
+            )
+        if active_chat_registry.get(con, shell_id) is not None:
+            raise ApiError(
+                409,
+                "ACTIVE_CHAT_CHANGED",
+                "another chat became active while the replacement was prepared; retry",
+                {"shell_id": shell_id},
+            )
         con.execute(
             "INSERT INTO conversations "
             "(conversation_id,shell_id,owner_user_id,harness,provider,model,"
@@ -936,9 +957,8 @@ def _create_conversation(con, operator: dict, headers, body: dict):
                 "effort": effort,
             },
         )
+        active_chat_registry.register(con, shell_id, conversation_id)
 
-    for closed_id in auto_closed:
-        conversation_events.notify(closed_id)
     conversation_events.notify(conversation_id)
     conversation_git_targets.safely_observe_and_persist(
         DB_PATH,

--- a/.super-coder/migrations/0162_active_chat_registry.sql
+++ b/.super-coder/migrations/0162_active_chat_registry.sql
@@ -1,0 +1,112 @@
+-- 0162 — active chat registry.
+--
+-- The registry, rather than a scan of conversations or Sprint participant
+-- pointers, is the authority for the one active chat a shell may own.  Existing
+-- installs can contain one normal chat plus one or more Sprint chats for the
+-- same shell, so the migration preserves the most recently active row and
+-- closes every older open row before installing the registry entry.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS active_shell_chats (
+    shell_id             INTEGER PRIMARY KEY REFERENCES shells(shell_id)
+                         ON DELETE CASCADE,
+    chat_id              TEXT NOT NULL UNIQUE REFERENCES conversations(conversation_id)
+                         ON DELETE CASCADE,
+    process_pid          INTEGER CHECK (process_pid IS NULL OR process_pid > 0),
+    process_start_ticks  INTEGER
+                         CHECK (
+                           process_start_ticks IS NULL
+                           OR process_start_ticks >= 0
+                         ),
+    updated_at           TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK (
+      (process_pid IS NULL AND process_start_ticks IS NULL)
+      OR
+      (process_pid IS NOT NULL AND process_start_ticks IS NOT NULL)
+    )
+);
+
+CREATE TRIGGER IF NOT EXISTS trg_active_shell_chats_insert
+BEFORE INSERT ON active_shell_chats
+WHEN NOT EXISTS (
+    SELECT 1 FROM conversations c
+    WHERE c.conversation_id=NEW.chat_id
+      AND c.shell_id=NEW.shell_id
+      AND c.state<>'closed'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'active chat must be open and belong to its shell');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_active_shell_chats_update
+BEFORE UPDATE OF shell_id,chat_id ON active_shell_chats
+WHEN NOT EXISTS (
+    SELECT 1 FROM conversations c
+    WHERE c.conversation_id=NEW.chat_id
+      AND c.shell_id=NEW.shell_id
+      AND c.state<>'closed'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'active chat must be open and belong to its shell');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_conversations_clear_active_chat
+AFTER UPDATE OF state ON conversations
+WHEN NEW.state='closed' AND OLD.state<>'closed'
+BEGIN
+  DELETE FROM active_shell_chats WHERE chat_id=NEW.conversation_id;
+END;
+
+CREATE TEMP TABLE IF NOT EXISTS _active_shell_chat_seed (
+    shell_id INTEGER PRIMARY KEY,
+    chat_id  TEXT NOT NULL UNIQUE
+);
+DELETE FROM _active_shell_chat_seed;
+
+-- Preserve an existing registry choice on an idempotent replay, otherwise
+-- choose the newest open chat for each shell.
+INSERT OR IGNORE INTO _active_shell_chat_seed (shell_id,chat_id)
+SELECT shell_id,chat_id FROM active_shell_chats;
+INSERT OR IGNORE INTO _active_shell_chat_seed (shell_id,chat_id)
+SELECT c.shell_id,c.conversation_id
+FROM conversations c
+WHERE c.state<>'closed'
+  AND c.conversation_id=(
+    SELECT newest.conversation_id
+    FROM conversations newest
+    WHERE newest.shell_id=c.shell_id AND newest.state<>'closed'
+    ORDER BY newest.last_activity_at DESC,newest.rowid DESC
+    LIMIT 1
+  );
+
+-- Walk legal state edges before closing legacy extras.  This keeps the
+-- migration compatible with the conversation transition trigger.
+UPDATE conversations
+SET state='idle'
+WHERE state='queued'
+  AND NOT EXISTS (
+    SELECT 1 FROM _active_shell_chat_seed seed
+    WHERE seed.chat_id=conversations.conversation_id
+  );
+UPDATE conversations
+SET state='error'
+WHERE state='running'
+  AND NOT EXISTS (
+    SELECT 1 FROM _active_shell_chat_seed seed
+    WHERE seed.chat_id=conversations.conversation_id
+  );
+UPDATE conversations
+SET state='closed',closed_at=COALESCE(closed_at,datetime('now')),
+    last_activity_at=datetime('now'),version=version+1
+WHERE state<>'closed'
+  AND NOT EXISTS (
+    SELECT 1 FROM _active_shell_chat_seed seed
+    WHERE seed.chat_id=conversations.conversation_id
+  );
+
+INSERT OR IGNORE INTO active_shell_chats (shell_id,chat_id)
+SELECT shell_id,chat_id FROM _active_shell_chat_seed;
+DROP TABLE _active_shell_chat_seed;
+
+COMMIT;

--- a/.super-coder/migrations/0162_active_chat_registry.sql
+++ b/.super-coder/migrations/0162_active_chat_registry.sql
@@ -80,6 +80,28 @@ WHERE c.state<>'closed'
     LIMIT 1
   );
 
+-- Closing a chat makes its queued work permanently unclaimable.  Mirror the
+-- runtime close path by cancelling pending/claimed delivery intent first.
+UPDATE conversation_messages
+SET state='cancelled',completed_at=datetime('now')
+WHERE state IN ('accepted','queued','running')
+  AND message_id IN (
+    SELECT outbox.message_id
+    FROM conversation_outbox outbox
+    WHERE outbox.state IN ('pending','claimed')
+      AND NOT EXISTS (
+        SELECT 1 FROM _active_shell_chat_seed seed
+        WHERE seed.chat_id=outbox.conversation_id
+      )
+  );
+UPDATE conversation_outbox
+SET state='cancelled',claim_owner=NULL,claimed_at=NULL,lease_expires_at=NULL
+WHERE state IN ('pending','claimed')
+  AND NOT EXISTS (
+    SELECT 1 FROM _active_shell_chat_seed seed
+    WHERE seed.chat_id=conversation_outbox.conversation_id
+  );
+
 -- Walk legal state edges before closing legacy extras.  This keeps the
 -- migration compatible with the conversation transition trigger.
 UPDATE conversations

--- a/.super-coder/scripts/active_chat_registry.py
+++ b/.super-coder/scripts/active_chat_registry.py
@@ -1,0 +1,120 @@
+"""Authoritative one-active-chat registry operations.
+
+Callers own transaction boundaries.  In particular, chat rotation must commit
+``close_active`` before beginning the transaction that inserts and registers a
+replacement chat.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class ActiveChatError(RuntimeError):
+    """The registry cannot perform the requested state change."""
+
+
+class ActiveChatBusy(ActiveChatError):
+    """The active chat owns queued or running work and cannot rotate."""
+
+
+@dataclass(frozen=True)
+class ActiveChat:
+    shell_id: int
+    chat_id: str
+    state: str
+
+
+def get(con, shell_id: int) -> ActiveChat | None:
+    row = con.execute(
+        "SELECT a.shell_id,a.chat_id,c.state "
+        "FROM active_shell_chats a JOIN conversations c "
+        "ON c.conversation_id=a.chat_id WHERE a.shell_id=?",
+        (shell_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return ActiveChat(int(row["shell_id"]), str(row["chat_id"]), str(row["state"]))
+
+
+def close_active(con, shell_id: int) -> ActiveChat | None:
+    """Close and unlink one shell's active chat inside the caller's write."""
+    active = get(con, shell_id)
+    if active is None:
+        return None
+    if active.state in {"queued", "running"}:
+        raise ActiveChatBusy(
+            f"active chat {active.chat_id} has a turn in progress"
+        )
+    changed = con.execute(
+        "UPDATE conversations SET state='closed',closed_at=datetime('now'),"
+        "last_activity_at=datetime('now'),version=version+1 "
+        "WHERE conversation_id=? AND state=?",
+        (active.chat_id, active.state),
+    ).rowcount
+    if changed != 1:
+        raise ActiveChatError(
+            f"active chat {active.chat_id} changed while it was closing"
+        )
+    # The migration trigger normally clears this row.  The explicit delete is
+    # both self-documenting and a fail-loud backstop for partially migrated DBs.
+    con.execute(
+        "DELETE FROM active_shell_chats WHERE shell_id=? AND chat_id=?",
+        (shell_id, active.chat_id),
+    )
+    if get(con, shell_id) is not None:
+        raise ActiveChatError(f"active chat {active.chat_id} did not unlink")
+    return active
+
+
+def register(con, shell_id: int, chat_id: str) -> None:
+    con.execute(
+        "INSERT INTO active_shell_chats (shell_id,chat_id) VALUES (?,?)",
+        (shell_id, chat_id),
+    )
+
+
+def process_identity(process_ref: str | None) -> tuple[int | None, int | None]:
+    """Resolve a numeric native process ref to Linux pid/start-ticks identity."""
+    if process_ref is None or not process_ref.isdecimal():
+        return None, None
+    pid = int(process_ref)
+    if pid <= 0:
+        return None, None
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        fields_after_comm = stat.rsplit(")", 1)[1].split()
+        start_ticks = int(fields_after_comm[19])
+    except (IndexError, OSError, ValueError):
+        return None, None
+    return pid, start_ticks
+
+
+def set_process(
+    con,
+    *,
+    shell_id: int,
+    chat_id: str,
+    pid: int | None,
+    start_ticks: int | None,
+) -> None:
+    changed = con.execute(
+        "UPDATE active_shell_chats SET process_pid=?,process_start_ticks=?,"
+        "updated_at=datetime('now') WHERE shell_id=? AND chat_id=?",
+        (pid, start_ticks, shell_id, chat_id),
+    ).rowcount
+    if changed != 1:
+        raise ActiveChatError(
+            f"chat {chat_id} is not active for shell {shell_id}"
+        )
+
+
+def clear_process(con, *, shell_id: int, chat_id: str) -> bool:
+    changed = con.execute(
+        "UPDATE active_shell_chats SET process_pid=NULL,"
+        "process_start_ticks=NULL,updated_at=datetime('now') "
+        "WHERE shell_id=? AND chat_id=?",
+        (shell_id, chat_id),
+    ).rowcount
+    return changed == 1

--- a/.super-coder/scripts/conversation_adapters/codex.py
+++ b/.super-coder/scripts/conversation_adapters/codex.py
@@ -300,12 +300,18 @@ class CodexAdapter(ConversationAdapter):
                 "HARNESS_PROTOCOL_ERROR",
                 "Codex turn/start returned no turn id",
             )
+        process = getattr(rpc, "process", None)
+        pid = getattr(process, "pid", None)
         return NativeTurn(
             harness=self.harness,
             session_ref=session_ref,
             run_ref=run_ref,
             worktree=context.checked_worktree(),
-            process_ref=f"app-server:{run_ref}",
+            process_ref=(
+                str(pid)
+                if isinstance(pid, int) and pid > 0
+                else f"app-server:{run_ref}"
+            ),
             metadata={"resumed": resumed},
         )
 

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -412,6 +412,12 @@ class OpenCodeAdapter(ConversationAdapter):
             session_ref=session_ref,
             run_ref=run_ref,
             worktree=worktree,
+            process_ref=(
+                str(_SERVER_PROCESS.pid)
+                if _SERVER_PROCESS is not None
+                and _SERVER_PROCESS.poll() is None
+                else None
+            ),
             metadata={
                 "context": context,
                 "event_stream": event_stream,

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -412,12 +412,9 @@ class OpenCodeAdapter(ConversationAdapter):
             session_ref=session_ref,
             run_ref=run_ref,
             worktree=worktree,
-            process_ref=(
-                str(_SERVER_PROCESS.pid)
-                if _SERVER_PROCESS is not None
-                and _SERVER_PROCESS.poll() is None
-                else None
-            ),
+            # The OpenCode server is shared across shells and turns, so it is
+            # not a turn-owned process the active-chat reaper may terminate.
+            process_ref=None,
             metadata={
                 "context": context,
                 "event_stream": event_stream,

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -28,6 +28,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
+import active_chat_registry
 import conversation_events
 import conversation_git_targets
 import db_driver
@@ -245,6 +246,9 @@ class BrokerStore:
                     "FROM conversation_outbox o "
                     "JOIN conversations c "
                     " ON c.conversation_id=o.conversation_id "
+                    "JOIN active_shell_chats active "
+                    " ON active.shell_id=c.shell_id "
+                    " AND active.chat_id=c.conversation_id "
                     "JOIN conversation_messages m ON m.message_id=o.message_id "
                     "WHERE o.state='pending' AND c.state='queued' "
                     "AND NOT EXISTS ("
@@ -478,6 +482,9 @@ class BrokerStore:
         # Filesystem normalization is external preparation, never writer-lock
         # work. Conversation creation stores an already-resolved absolute path.
         actual_worktree = Path(turn.worktree).resolve()
+        process_pid, process_start_ticks = active_chat_registry.process_identity(
+            turn.process_ref
+        )
         con = self.connect()
         now, expires = self._times()
         try:
@@ -486,7 +493,8 @@ class BrokerStore:
                 "conversation.broker.mark_native_started",
             ):
                 row = con.execute(
-                    "SELECT r.state,r.conversation_id,c.harness_session_ref,"
+                    "SELECT r.state,r.conversation_id,r.shell_id,"
+                    "c.harness_session_ref,"
                     "c.harness,c.worktree "
                     "FROM conversation_runs r JOIN conversations c "
                     "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
@@ -547,6 +555,13 @@ class BrokerStore:
                     "last_activity_at=?,version=version+1 "
                     "WHERE conversation_id=?",
                     (turn.session_ref, now, row["conversation_id"]),
+                )
+                active_chat_registry.set_process(
+                    con,
+                    shell_id=int(row["shell_id"]),
+                    chat_id=str(row["conversation_id"]),
+                    pid=process_pid,
+                    start_ticks=process_start_ticks,
                 )
         finally:
             con.close()
@@ -737,6 +752,11 @@ class BrokerStore:
                         (error_detail or "")[:16384] or None,
                         run_id,
                     ),
+                )
+                active_chat_registry.clear_process(
+                    con,
+                    shell_id=int(row["shell_id"]),
+                    chat_id=str(row["conversation_id"]),
                 )
                 con.execute(
                     "UPDATE conversation_messages SET state=?,completed_at=? "

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -108,6 +108,7 @@ PER_INSTANCE_TABLES = [
     # outbox work must all survive update/rebuild. Parents precede
     # children so a snapshot stays readable and foreign-key-valid when loaded.
     "conversations",
+    "active_shell_chats",
     "conversation_git_targets",
     "conversation_messages",
     "conversation_runs",

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -15,6 +15,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
+import active_chat_registry
 import conversation_broker
 import run as run_mod
 
@@ -461,6 +462,39 @@ def create_and_select(
         )
         return conversation_id
 
+    try:
+        closed = active_chat_registry.close_active(
+            con,
+            int(participant["shell_id"]),
+        )
+    except active_chat_registry.ActiveChatBusy as exc:
+        active = active_chat_registry.get(con, int(participant["shell_id"]))
+        if active is not None and _linked_to_participant(
+            con,
+            participant_id,
+            active.chat_id,
+        ):
+            # Delivery-time resolution protects a live turn: a declared New
+            # re-enters the linked active chat instead of displacing it.
+            con.execute(
+                "UPDATE sprint_participants SET current_conversation_id=?,"
+                "updated_at=datetime('now') WHERE participant_id=?",
+                (active.chat_id, participant_id),
+            )
+            return active.chat_id
+        raise SprintConversationError(str(exc)) from exc
+    if closed is not None:
+        _append_event(
+            con,
+            closed.chat_id,
+            "conversation.closed",
+            {
+                "state": "closed",
+                "reason": "another chat opened",
+                "sprint_id": int(participant["sprint_id"]),
+            },
+        )
+
     conversation_id = "cv_" + uuid.uuid4().hex
     con.execute(
         "INSERT INTO conversations "
@@ -515,6 +549,11 @@ def create_and_select(
         ).rowcount
     if updated != 1:
         raise SprintConversationError("Sprint participant disappeared during creation")
+    active_chat_registry.register(
+        con,
+        int(participant["shell_id"]),
+        conversation_id,
+    )
     return conversation_id
 
 

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -61,7 +61,8 @@
     "tests/test_update_materialize.py",
     ".super-coder/migrations/0160_reseed_migration_management.sql",
     ".super-coder/scripts/migration.py",
-    "tests/test_migration_management.py"
+    "tests/test_migration_management.py",
+    ".super-coder/migrations/0162_active_chat_registry.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -32,6 +32,7 @@ from conversation_adapters import (  # noqa: E402
     ReconcileResult,
     adapter_for,
 )
+from conversation_adapters import opencode as opencode_adapter
 
 KIMI_FIXTURES = ROOT / "tests" / "fixtures" / "conversations" / "kimi"
 
@@ -927,6 +928,21 @@ class ConversationAdapterTest(unittest.TestCase):
         recovered = adapter.reconcile(fresh, self.context)
         self.assertEqual(recovered.outcome, "unknown")
         self.assertFalse(recovered.proven)
+
+    def test_opencode_shared_server_is_not_the_turn_process(self) -> None:
+        adapter, _native = self.build("opencode")
+        shared_server = mock.Mock(pid=4242)
+        shared_server.poll.return_value = None
+
+        with mock.patch.object(
+            opencode_adapter,
+            "_SERVER_PROCESS",
+            shared_server,
+        ):
+            turn = adapter.start(self.context, "hello")
+
+        self.assertIsNone(turn.process_ref)
+        self.assertEqual(shared_server.poll.call_count, 0)
 
     def test_opencode_shell_tools_use_the_conversation_launch_identity(
         self,

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -613,12 +613,90 @@ class ConversationResourceTest(ConversationApiCase):
             rows = con.execute(
                 "SELECT conversation_id,state,closed_at FROM conversations"
             ).fetchall()
+            active = con.execute(
+                "SELECT shell_id,chat_id,process_pid,process_start_ticks "
+                "FROM active_shell_chats"
+            ).fetchall()
         finally:
             con.close()
         by_id = {row["conversation_id"]: row for row in rows}
         self.assertEqual(by_id[first["conversation_id"]]["state"], "closed")
         self.assertIsNotNone(by_id[first["conversation_id"]]["closed_at"])
         self.assertEqual(by_id[second["conversation_id"]]["state"], "idle")
+        self.assertEqual(
+            [tuple(row) for row in active],
+            [(1, second["conversation_id"], None, None)],
+        )
+
+    def test_close_failure_prevents_replacement_chat(self) -> None:
+        first = self.create(key="close-failure-first")
+        con = self.connect()
+        con.executescript(
+            "CREATE TRIGGER reject_active_close BEFORE UPDATE OF state "
+            "ON conversations WHEN OLD.conversation_id="
+            f"'{first['conversation_id']}' AND NEW.state='closed' "
+            "BEGIN SELECT RAISE(ABORT,'close rejected'); END;"
+        )
+        con.close()
+
+        status, _, error = self.request(
+            "POST",
+            "/api/conversations",
+            body={"shell_id": 1, "harness": "codex", "title": "Never created"},
+            key="close-failure-second",
+        )
+
+        self.assertEqual(status, 500, error)
+        con = self.connect()
+        durable = con.execute(
+            "SELECT c.state,a.chat_id,"
+            "(SELECT COUNT(*) FROM conversations) AS conversation_count "
+            "FROM conversations c JOIN active_shell_chats a "
+            "ON a.chat_id=c.conversation_id WHERE c.conversation_id=?",
+            (first["conversation_id"],),
+        ).fetchone()
+        con.close()
+        self.assertEqual(
+            tuple(durable),
+            ("idle", first["conversation_id"], 1),
+        )
+
+    def test_replacement_insert_failure_leaves_old_chat_closed(self) -> None:
+        first = self.create(key="insert-failure-first")
+        con = self.connect()
+        con.executescript(
+            "CREATE TRIGGER reject_replacement_insert BEFORE INSERT "
+            "ON conversations WHEN NEW.creation_idempotency_key="
+            "'insert-failure-second' BEGIN "
+            "SELECT RAISE(ABORT,'replacement rejected'); END;"
+        )
+        con.close()
+
+        status, _, error = self.request(
+            "POST",
+            "/api/conversations",
+            body={"shell_id": 1, "harness": "codex", "title": "Rejected"},
+            key="insert-failure-second",
+        )
+
+        self.assertEqual(status, 500, error)
+        con = self.connect()
+        old = con.execute(
+            "SELECT state,closed_at FROM conversations WHERE conversation_id=?",
+            (first["conversation_id"],),
+        ).fetchone()
+        active_count = con.execute(
+            "SELECT COUNT(*) FROM active_shell_chats WHERE shell_id=1"
+        ).fetchone()[0]
+        replacement_count = con.execute(
+            "SELECT COUNT(*) FROM conversations "
+            "WHERE creation_idempotency_key='insert-failure-second'"
+        ).fetchone()[0]
+        con.close()
+        self.assertEqual(old["state"], "closed")
+        self.assertIsNotNone(old["closed_at"])
+        self.assertEqual(active_count, 0)
+        self.assertEqual(replacement_count, 0)
 
     def test_each_shell_may_keep_one_browser_chat_open(self) -> None:
         first = self.create(key="first-shell-chat", title="Dev")

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import json
+import os
 import sqlite3
 import sys
 import tempfile
@@ -347,6 +348,12 @@ class ConversationBrokerCase(unittest.TestCase):
             "WHERE creation_idempotency_key=?",
             (key,),
         ).fetchone()[0]
+        if state != "closed":
+            con.execute(
+                "INSERT OR REPLACE INTO active_shell_chats (shell_id,chat_id) "
+                "VALUES (?,?)",
+                (shell_id, conversation_id),
+            )
         con.commit()
         con.close()
         return conversation_id
@@ -519,6 +526,101 @@ class StoreContractTest(ConversationBrokerCase):
             )
         finally:
             con.close()
+
+    def test_native_start_registers_process_and_finalize_clears_it(self) -> None:
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        store = BrokerStore(self.db_path)
+        run = store.claim_next("broker")
+        store.mark_starting(run.run_id, "broker")
+
+        store.mark_native_started(
+            run.run_id,
+            "broker",
+            NativeTurn(
+                "codex",
+                "native-session",
+                "native-run",
+                self.worktree,
+                process_ref=str(os.getpid()),
+            ),
+        )
+
+        con = self.connect()
+        active = con.execute(
+            "SELECT chat_id,process_pid,process_start_ticks "
+            "FROM active_shell_chats WHERE shell_id=1"
+        ).fetchone()
+        run_state = con.execute(
+            "SELECT state FROM conversation_runs WHERE run_id=?",
+            (run.run_id,),
+        ).fetchone()[0]
+        con.close()
+        self.assertEqual(active["chat_id"], conversation_id)
+        self.assertEqual(active["process_pid"], os.getpid())
+        self.assertGreater(active["process_start_ticks"], 0)
+        self.assertEqual(run_state, "running")
+
+        store.finish_run(
+            run.run_id,
+            "succeeded",
+            event_type="run.completed",
+        )
+
+        con = self.connect()
+        finalized = con.execute(
+            "SELECT r.state,a.process_pid,a.process_start_ticks "
+            "FROM conversation_runs r JOIN active_shell_chats a "
+            "ON a.shell_id=r.shell_id AND a.chat_id=r.conversation_id "
+            "WHERE r.run_id=?",
+            (run.run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(finalized), ("succeeded", None, None))
+
+    def test_process_registration_failure_rolls_back_run_start(self) -> None:
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        store = BrokerStore(self.db_path)
+        run = store.claim_next("broker")
+        store.mark_starting(run.run_id, "broker")
+        con = self.connect()
+        con.executescript(
+            "CREATE TRIGGER reject_process_registration "
+            "BEFORE UPDATE OF process_pid ON active_shell_chats "
+            "WHEN NEW.process_pid IS NOT NULL BEGIN "
+            "SELECT RAISE(ABORT,'process registration rejected'); END;"
+        )
+        con.close()
+
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "process registration rejected",
+        ):
+            store.mark_native_started(
+                run.run_id,
+                "broker",
+                NativeTurn(
+                    "codex",
+                    "native-session",
+                    "native-run",
+                    self.worktree,
+                    process_ref=str(os.getpid()),
+                ),
+            )
+
+        con = self.connect()
+        durable = con.execute(
+            "SELECT r.state,r.harness_session_after,c.harness_session_ref,"
+            "a.process_pid,a.process_start_ticks "
+            "FROM conversation_runs r JOIN conversations c "
+            "ON c.conversation_id=r.conversation_id "
+            "JOIN active_shell_chats a ON a.chat_id=c.conversation_id "
+            "WHERE r.run_id=?",
+            (run.run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(durable), ("starting", None, None, None, None))
 
     def test_prepared_shell_archive_is_bound_while_the_run_is_leased(self) -> None:
         conversation_id = self.add_conversation()
@@ -789,7 +891,7 @@ class StoreContractTest(ConversationBrokerCase):
         self.assertNotEqual(row["state"], "closed")
         self.assertIsNone(row["closed_at"])
 
-    def test_shell_mutation_lock_blocks_other_conversation(self) -> None:
+    def test_registry_excludes_an_unlinked_legacy_conversation(self) -> None:
         self.allow_legacy_duplicate_open_chats()
         first_conversation = self.add_conversation(shell_id=1)
         second_conversation = self.add_conversation(shell_id=1)
@@ -799,6 +901,7 @@ class StoreContractTest(ConversationBrokerCase):
 
         first = store.claim_next("broker")
         self.assertIsNotNone(first)
+        self.assertEqual(first.conversation_id, second_conversation)
         self.assertIsNone(store.claim_next("broker"))
         store.finish_run(
             first.run_id,
@@ -806,9 +909,17 @@ class StoreContractTest(ConversationBrokerCase):
             event_type="run.failed",
             error_code="TEST",
         )
-        second = store.claim_next("broker")
-        self.assertIsNotNone(second)
-        self.assertEqual(second.conversation_id, second_conversation)
+        self.assertIsNone(store.claim_next("broker"))
+        con = self.connect()
+        self.assertEqual(
+            con.execute(
+                "SELECT state FROM conversation_messages "
+                "WHERE conversation_id=?",
+                (first_conversation,),
+            ).fetchone()[0],
+            "queued",
+        )
+        con.close()
 
     def test_different_shells_can_hold_live_runs(self) -> None:
         first_conversation = self.add_conversation(shell_id=1)

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -366,13 +366,46 @@ class MigrationAndShapeTest(ConversationDbCase):
                 "INSERT INTO conversations "
                 "(conversation_id,shell_id,owner_user_id,harness,worktree,"
                 "conversation_scope,creation_idempotency_key,"
-                "creation_request_hash,last_activity_at) VALUES "
+                "creation_request_hash,state,last_activity_at) VALUES "
                 "('cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',9,9,'codex',"
-                "'/tmp/legacy','normal','legacy-normal','hash-normal',"
+                "'/tmp/legacy','normal','legacy-normal','hash-normal','queued',"
                 "'2026-08-02 10:00:00'),"
                 "('cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',9,9,'codex',"
-                "'/tmp/legacy','sprint','legacy-sprint','hash-sprint',"
-                "'2026-08-02 11:00:00')"
+                "'/tmp/legacy','sprint','legacy-running','hash-running','running',"
+                "'2026-08-02 11:00:00'),"
+                "('cv_cccccccccccccccccccccccccccccccc',9,9,'codex',"
+                "'/tmp/legacy','sprint','legacy-newest','hash-newest','idle',"
+                "'2026-08-02 12:00:00')"
+            )
+            con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state) VALUES "
+                "('cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','user','9','prompt',"
+                "'queued','queued-message','hash-queued','queued'),"
+                "('cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','user','9','prompt',"
+                "'running','running-message','hash-running','running'),"
+                "('cv_cccccccccccccccccccccccccccccccc','user','9','prompt',"
+                "'active','active-message','hash-active','queued')"
+            )
+            con.execute(
+                "INSERT INTO conversation_outbox "
+                "(conversation_id,message_id,state,claim_owner,claimed_at,"
+                "lease_expires_at) "
+                "SELECT conversation_id,message_id,'pending',NULL,NULL,NULL "
+                "FROM conversation_messages "
+                "WHERE conversation_id IN ("
+                "'cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',"
+                "'cv_cccccccccccccccccccccccccccccccc')"
+            )
+            con.execute(
+                "INSERT INTO conversation_outbox "
+                "(conversation_id,message_id,state,claim_owner,claimed_at,"
+                "lease_expires_at) "
+                "SELECT conversation_id,message_id,'claimed','broker',"
+                "'2026-08-02 11:01:00','2026-08-02 11:06:00' "
+                "FROM conversation_messages WHERE conversation_id="
+                "'cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'"
             )
 
             con.executescript(ACTIVE_REGISTRY.read_text())
@@ -392,7 +425,8 @@ class MigrationAndShapeTest(ConversationDbCase):
                 states,
                 {
                     "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": "closed",
-                    "cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": "idle",
+                    "cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": "closed",
+                    "cv_cccccccccccccccccccccccccccccccc": "idle",
                 },
             )
             self.assertEqual(
@@ -400,10 +434,46 @@ class MigrationAndShapeTest(ConversationDbCase):
                 [
                     (
                         9,
-                        "cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "cv_cccccccccccccccccccccccccccccccc",
                         None,
                         None,
                     )
+                ],
+            )
+            queued_work = [
+                tuple(row)
+                for row in con.execute(
+                    "SELECT m.conversation_id,m.state,o.state,"
+                    "m.completed_at IS NOT NULL,o.claim_owner "
+                    "FROM conversation_messages m "
+                    "JOIN conversation_outbox o USING (message_id) "
+                    "ORDER BY m.conversation_id"
+                )
+            ]
+            self.assertEqual(
+                queued_work,
+                [
+                    (
+                        "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "cancelled",
+                        "cancelled",
+                        1,
+                        None,
+                    ),
+                    (
+                        "cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "cancelled",
+                        "cancelled",
+                        1,
+                        None,
+                    ),
+                    (
+                        "cv_cccccccccccccccccccccccccccccccc",
+                        "queued",
+                        "pending",
+                        0,
+                        None,
+                    ),
                 ],
             )
 
@@ -423,7 +493,7 @@ class MigrationAndShapeTest(ConversationDbCase):
 
             con.execute(
                 "UPDATE conversations SET state='closed',closed_at=datetime('now') "
-                "WHERE conversation_id='cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'"
+                "WHERE conversation_id='cv_cccccccccccccccccccccccccccccccc'"
             )
             self.assertEqual(
                 con.execute("SELECT COUNT(*) FROM active_shell_chats").fetchone()[0],

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -16,6 +16,7 @@ SCHEMA = ENGINE / "schema.sql"
 MIGRATIONS = ENGINE / "migrations"
 FOUNDATION = MIGRATIONS / "0132_conversation_foundation.sql"
 GIT_TARGETS = MIGRATIONS / "0142_conversation_git_targets.sql"
+ACTIVE_REGISTRY = MIGRATIONS / "0162_active_chat_registry.sql"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import conversation_state  # noqa: E402
@@ -344,6 +345,89 @@ class MigrationAndShapeTest(ConversationDbCase):
                     "WHERE branch_name='feature/reused'"
                 ).fetchone()[0],
                 2,
+            )
+
+    def test_active_registry_migration_converges_legacy_open_chats(self) -> None:
+        with closing(sqlite3.connect(":memory:")) as con:
+            con.row_factory = sqlite3.Row
+            apply_schema(
+                con,
+                through="0161_reseed_flags_output_guidance.sql",
+            )
+            con.execute(
+                "INSERT INTO users (user_id,username) VALUES (9,'legacy')"
+            )
+            con.execute(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (9,'Legacy','legacy','dev','prompt',9)"
+            )
+            con.execute(
+                "INSERT INTO conversations "
+                "(conversation_id,shell_id,owner_user_id,harness,worktree,"
+                "conversation_scope,creation_idempotency_key,"
+                "creation_request_hash,last_activity_at) VALUES "
+                "('cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',9,9,'codex',"
+                "'/tmp/legacy','normal','legacy-normal','hash-normal',"
+                "'2026-08-02 10:00:00'),"
+                "('cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',9,9,'codex',"
+                "'/tmp/legacy','sprint','legacy-sprint','hash-sprint',"
+                "'2026-08-02 11:00:00')"
+            )
+
+            con.executescript(ACTIVE_REGISTRY.read_text())
+            con.executescript(ACTIVE_REGISTRY.read_text())
+
+            states = {
+                row["conversation_id"]: row["state"]
+                for row in con.execute(
+                    "SELECT conversation_id,state FROM conversations"
+                )
+            }
+            active = con.execute(
+                "SELECT shell_id,chat_id,process_pid,process_start_ticks "
+                "FROM active_shell_chats"
+            ).fetchall()
+            self.assertEqual(
+                states,
+                {
+                    "cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": "closed",
+                    "cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": "idle",
+                },
+            )
+            self.assertEqual(
+                [tuple(row) for row in active],
+                [
+                    (
+                        9,
+                        "cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        None,
+                        None,
+                    )
+                ],
+            )
+
+            with self.assertRaisesRegex(
+                sqlite3.IntegrityError,
+                "active chat must be open and belong to its shell",
+            ):
+                con.execute(
+                    "UPDATE active_shell_chats SET chat_id="
+                    "'cv_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' WHERE shell_id=9"
+                )
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute(
+                    "UPDATE active_shell_chats SET process_pid=123 "
+                    "WHERE shell_id=9"
+                )
+
+            con.execute(
+                "UPDATE conversations SET state='closed',closed_at=datetime('now') "
+                "WHERE conversation_id='cv_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'"
+            )
+            self.assertEqual(
+                con.execute("SELECT COUNT(*) FROM active_shell_chats").fetchone()[0],
+                0,
             )
 
     def test_conversation_requires_direct_user_owner(self) -> None:
@@ -789,6 +873,7 @@ class FenceAndEventTest(ConversationDbCase):
 class SnapshotPolicyTest(ConversationDbCase):
     TABLES = (
         "conversations",
+        "active_shell_chats",
         "conversation_git_targets",
         "conversation_messages",
         "conversation_runs",
@@ -806,6 +891,10 @@ class SnapshotPolicyTest(ConversationDbCase):
     def test_snapshot_round_trip_preserves_queue_and_recovery_evidence(
             self) -> None:
         conversation = self.add_conversation()
+        self.con.execute(
+            "INSERT INTO active_shell_chats (shell_id,chat_id) VALUES (1,?)",
+            (conversation,),
+        )
         message = self.add_message(conversation, state="queued")
         run = self.add_run(
             conversation, message, state="unknown"
@@ -839,6 +928,13 @@ class SnapshotPolicyTest(ConversationDbCase):
                 "SELECT state,harness,worktree FROM conversations"
             ).fetchone(),
             ("idle", "codex", "/tmp/worktree-1"),
+        )
+        self.assertEqual(
+            target.execute(
+                "SELECT shell_id,chat_id,process_pid,process_start_ticks "
+                "FROM active_shell_chats"
+            ).fetchone(),
+            (1, conversation, None, None),
         )
         self.assertEqual(
             target.execute(

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -575,7 +575,7 @@ class SprintLiveProof(unittest.TestCase):
         self.assertEqual("lifecycle.completed", event_types[-1])
         self.assertEqual(2, packet["pr_outcomes"]["total"])
         self.assertEqual(
-            ["work", "fix", "merge", "merge"],
+            ["work"],
             [
                 row[0]
                 for row in self.con.execute(

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -816,6 +816,11 @@ class MigrationGateTest(unittest.TestCase):
             (sprint_id, unit_id, task_id),
         )
         con.commit()
+        # Current runtime code reads the v2.1 active-chat authority even while
+        # this fixture isolates the older 0158 liveness migration.
+        con.executescript(
+            (MIGRATIONS / "0162_active_chat_registry.sql").read_text()
+        )
         wake_id = sprint_domain.SprintLifecycleStore(con).arm(sprint_id, 3)[0]
         assignment_message_id = int(
             con.execute(

--- a/tests/test_sprint_participant_chats.py
+++ b/tests/test_sprint_participant_chats.py
@@ -64,14 +64,36 @@ def substrate():
           creation_idempotency_key TEXT NOT NULL,
           creation_request_hash TEXT NOT NULL,
           conversation_scope TEXT NOT NULL DEFAULT 'normal',
+          closed_at TEXT,
+          last_activity_at TEXT NOT NULL DEFAULT (datetime('now')),
+          version INTEGER NOT NULL DEFAULT 1,
           UNIQUE(owner_user_id, creation_idempotency_key)
         );
+        CREATE TABLE active_shell_chats (
+          shell_id INTEGER PRIMARY KEY REFERENCES shells(shell_id),
+          chat_id TEXT NOT NULL UNIQUE REFERENCES conversations(conversation_id),
+          process_pid INTEGER,
+          process_start_ticks INTEGER,
+          updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+          CHECK (
+            (process_pid IS NULL AND process_start_ticks IS NULL)
+            OR
+            (process_pid IS NOT NULL AND process_start_ticks IS NOT NULL)
+          )
+        );
+        CREATE TRIGGER clear_active_chat_after_close
+        AFTER UPDATE OF state ON conversations
+        WHEN NEW.state='closed' AND OLD.state<>'closed'
+        BEGIN
+          DELETE FROM active_shell_chats WHERE chat_id=NEW.conversation_id;
+        END;
         CREATE TABLE conversation_events (
           event_id INTEGER PRIMARY KEY,
           conversation_id TEXT NOT NULL REFERENCES conversations(conversation_id),
           sequence INTEGER NOT NULL,
           event_type TEXT NOT NULL,
           payload TEXT NOT NULL,
+          run_id INTEGER,
           UNIQUE(conversation_id, sequence)
         );
         CREATE TABLE sprint_participants (
@@ -342,7 +364,7 @@ def test_caller_transaction_rolls_back_every_row_when_pointer_selection_fails() 
         )
 
 
-def test_fix_conversation_becomes_current_without_closing_persistent_work() -> None:
+def test_fix_conversation_closes_and_replaces_persistent_work() -> None:
     with substrate() as con:
         work = create(con, 101, "work", "s7:p101:work")
         fix = create(
@@ -360,8 +382,13 @@ def test_fix_conversation_becomes_current_without_closing_persistent_work() -> N
         ).fetchall()
         assert [tuple(row) for row in rows] == [
             (fix, "idle", "fix", work),
-            (work, "idle", "work", None),
+            (work, "closed", "work", None),
         ]
+        assert tuple(
+            con.execute(
+                "SELECT shell_id,chat_id FROM active_shell_chats"
+            ).fetchone()
+        ) == (10, fix)
         assert (
             con.execute(
                 "SELECT current_conversation_id FROM sprint_participants "
@@ -455,8 +482,13 @@ def test_fallback_replacement_retains_packet_route_and_history() -> None:
             con.execute(
                 "SELECT state FROM conversations WHERE conversation_id=?", (work,)
             ).fetchone()[0]
-            == "idle"
+            == "closed"
         )
+        assert tuple(
+            con.execute(
+                "SELECT shell_id,chat_id FROM active_shell_chats"
+            ).fetchone()
+        ) == (10, fallback)
         assert (
             con.execute(
                 "SELECT current_conversation_id FROM sprint_participants "

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -919,7 +919,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             ).fetchone()[0],
         )
 
-    def test_observed_merge_completes_board_and_assigns_next_in_persistent_lane(self):
+    def test_observed_merge_completes_board_and_assigns_next_in_fresh_active_lane(self):
         approved = self.approve()
         self.messages.mark_read(approved.message_id, 1)
         document = self.con.execute(
@@ -979,7 +979,18 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
         lease = sprint_message_delivery.SprintWakeDeliveryService(
             self.con
         ).claim_next("stage6-next")
-        self.assertEqual(self.developer_conversation_id, lease.target_conversation_id)
+        self.assertNotEqual(
+            self.developer_conversation_id,
+            lease.target_conversation_id,
+        )
+        active = self.con.execute(
+            "SELECT chat_id,process_pid,process_start_ticks "
+            "FROM active_shell_chats WHERE shell_id=1"
+        ).fetchone()
+        self.assertEqual(
+            tuple(active),
+            (lease.target_conversation_id, None, None),
+        )
         self.assertEqual(
             ["work_unit.completed", "work_unit.ready", "pr.transition"],
             [


### PR DESCRIPTION
## Summary

- add migration 0162 with one durable active chat per shell and dirty-install convergence
- make browser chat replacement close and commit before registering a replacement
- record PID plus Linux process-start ticks atomically with native run start and clear them on finalize
- make broker dispatch, Sprint chat selection, snapshots, and removal fixtures use the registry authority

## Verification

- focused conversation, adapter, migration, broker, and Sprint coverage: 191 passed, 184 subtests passed
- full suite: 1658 passed; 3 unrelated failures reproduced independently
  - #960 covers the two local-skill fixture failures caused by leaking a real worktree
  - #959 covers the existing restricted-restart backup fixture failure
- diff check, Python compilation, and focused Ruff check pass

## Scope note

The browser creation endpoint implements the required two-commit close/create boundary. The legacy Sprint helper still participates in its caller-owned domain transaction while adopting universal registry arbitration; Sprint 87 U2 owns replacement of the wake producer path.

Sprint 87 · U1 · task #260 · spec doc #89