### PR TITLE
feat(conversations): reap unlinked process groups

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -4324,14 +4324,17 @@ def main(argv):
             )
             sprint_pr_watcher.start_service(DB_PATH, repo_root=REPO_ROOT)
 
-        await transport.serve(
-            bind,
-            port,
-            dispatch_http,
-            _ws_unavailable,
-            on_started=start_runtime_services,
-            stream_handler=conversation_routes.stream_events,
-        )
+        try:
+            await transport.serve(
+                bind,
+                port,
+                dispatch_http,
+                _ws_unavailable,
+                on_started=start_runtime_services,
+                stream_handler=conversation_routes.stream_events,
+            )
+        finally:
+            conversation_reaper.stop_service()
 
     print(f"super-coder review layer → http://127.0.0.1:{port}  (bind {bind}, DB: {DB_PATH.name})")
     try:

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -63,6 +63,7 @@ import artifact_policy  # noqa: E402
 import backfill_shell_api_keys  # noqa: E402  (startup key provisioning)
 import conversation_broker  # noqa: E402  (Feature #24 durable turn service)
 import conversation_launch  # noqa: E402  (canonical shell launch preparation)
+import conversation_reaper  # noqa: E402  (Feature #31 orphan process ladder)
 import db_driver  # noqa: E402
 import git_hygiene  # noqa: E402  (live repo dirty/stale/clean snapshot)
 import mem_credentials  # noqa: E402  (runtime Admin credential provisioning, spec #30 req 11)
@@ -4263,10 +4264,11 @@ def require_loopback_bind(bind: str) -> None:
 
 def start_runtime_services() -> None:
     """Start commit-woken conversations and the armed Sprint services."""
-    conversation_broker.start_service(
+    broker = conversation_broker.start_service(
         DB_PATH,
         launch_preparer=conversation_launch.ConversationLaunchPreparer(DB_PATH),
     )
+    conversation_reaper.start_service(DB_PATH, native_interrupt=broker.interrupt)
     sprint_runtime.start_service(DB_PATH)
     sprint_pr_watcher.start_service(DB_PATH, repo_root=REPO_ROOT)
 

--- a/.super-coder/migrations/0163_conversation_run_process_identity.sql
+++ b/.super-coder/migrations/0163_conversation_run_process_identity.sql
@@ -1,0 +1,80 @@
+-- 0163 — durable conversation-run process identity and reaper ladder.
+--
+-- Process identity belongs on the run row as recovery evidence.  The active
+-- chat registry remains the protection authority; these columns let the
+-- reaper identify and escalate an unlinked turn after its broker disappears.
+
+BEGIN;
+
+ALTER TABLE conversation_runs
+ADD COLUMN process_pid INTEGER
+    CHECK (process_pid IS NULL OR process_pid > 0);
+
+ALTER TABLE conversation_runs
+ADD COLUMN process_start_ticks INTEGER
+    CHECK (process_start_ticks IS NULL OR process_start_ticks >= 0);
+
+ALTER TABLE conversation_runs
+ADD COLUMN process_group_id INTEGER
+    CHECK (process_group_id IS NULL OR process_group_id > 0);
+
+ALTER TABLE conversation_runs
+ADD COLUMN reaper_last_signal TEXT
+    CHECK (
+      reaper_last_signal IS NULL
+      OR reaper_last_signal IN ('interrupt','SIGTERM','SIGKILL')
+    );
+
+ALTER TABLE conversation_runs
+ADD COLUMN reaper_signaled_at TEXT;
+
+CREATE TRIGGER trg_conversation_runs_process_identity_insert
+BEFORE INSERT ON conversation_runs
+WHEN NOT (
+  (NEW.process_pid IS NULL
+   AND NEW.process_start_ticks IS NULL
+   AND NEW.process_group_id IS NULL)
+  OR
+  (NEW.process_pid IS NOT NULL
+   AND NEW.process_start_ticks IS NOT NULL
+   AND NEW.process_group_id IS NOT NULL)
+)
+BEGIN
+  SELECT RAISE(ABORT, 'conversation run process identity must be complete');
+END;
+
+CREATE TRIGGER trg_conversation_runs_process_identity_update
+BEFORE UPDATE OF process_pid,process_start_ticks,process_group_id
+ON conversation_runs
+WHEN NOT (
+  (NEW.process_pid IS NULL
+   AND NEW.process_start_ticks IS NULL
+   AND NEW.process_group_id IS NULL)
+  OR
+  (NEW.process_pid IS NOT NULL
+   AND NEW.process_start_ticks IS NOT NULL
+   AND NEW.process_group_id IS NOT NULL)
+)
+BEGIN
+  SELECT RAISE(ABORT, 'conversation run process identity must be complete');
+END;
+
+CREATE TRIGGER trg_conversation_runs_reaper_signal_insert
+BEFORE INSERT ON conversation_runs
+WHEN (NEW.reaper_last_signal IS NULL) <> (NEW.reaper_signaled_at IS NULL)
+BEGIN
+  SELECT RAISE(ABORT, 'conversation run reaper signal must have a timestamp');
+END;
+
+CREATE TRIGGER trg_conversation_runs_reaper_signal_update
+BEFORE UPDATE OF reaper_last_signal,reaper_signaled_at ON conversation_runs
+WHEN (NEW.reaper_last_signal IS NULL) <> (NEW.reaper_signaled_at IS NULL)
+BEGIN
+  SELECT RAISE(ABORT, 'conversation run reaper signal must have a timestamp');
+END;
+
+CREATE INDEX idx_conversation_runs_reaper
+    ON conversation_runs(state,process_pid,run_id)
+    WHERE process_pid IS NOT NULL;
+
+COMMIT;

--- a/.super-coder/scripts/active_chat_registry.py
+++ b/.super-coder/scripts/active_chat_registry.py
@@ -26,6 +26,13 @@ class ActiveChat:
     state: str
 
 
+@dataclass(frozen=True)
+class ProcessIdentity:
+    pid: int
+    start_ticks: int
+    process_group_id: int
+
+
 def get(con, shell_id: int) -> ActiveChat | None:
     row = con.execute(
         "SELECT a.shell_id,a.chat_id,c.state "
@@ -75,20 +82,31 @@ def register(con, shell_id: int, chat_id: str) -> None:
     )
 
 
-def process_identity(process_ref: str | None) -> tuple[int | None, int | None]:
-    """Resolve a numeric native process ref to Linux pid/start-ticks identity."""
+def process_details(process_ref: str | None) -> ProcessIdentity | None:
+    """Resolve a numeric native process ref from one Linux procfs snapshot."""
     if process_ref is None or not process_ref.isdecimal():
-        return None, None
+        return None
     pid = int(process_ref)
     if pid <= 0:
-        return None, None
+        return None
     try:
         stat = Path(f"/proc/{pid}/stat").read_text()
         fields_after_comm = stat.rsplit(")", 1)[1].split()
+        process_group_id = int(fields_after_comm[2])
         start_ticks = int(fields_after_comm[19])
     except (IndexError, OSError, ValueError):
+        return None
+    if process_group_id <= 0 or start_ticks < 0:
+        return None
+    return ProcessIdentity(pid, start_ticks, process_group_id)
+
+
+def process_identity(process_ref: str | None) -> tuple[int | None, int | None]:
+    """Resolve the registry's pid/start-ticks identity pair."""
+    details = process_details(process_ref)
+    if details is None:
         return None, None
-    return pid, start_ticks
+    return details.pid, details.start_ticks
 
 
 def set_process(

--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -12,6 +12,7 @@ import base64
 import json
 import os
 import re
+import signal
 import subprocess
 import threading
 import urllib.error
@@ -420,8 +421,72 @@ class ProcessRunner(Protocol):
     ) -> Any: ...
 
 
+def signal_owned_process(process: Any, value: signal.Signals) -> None:
+    """Signal the complete turn-owned process group, with a narrow fallback."""
+    process_group = getattr(process, "_sc_conversation_process_group", None)
+    if isinstance(process_group, int) and process_group > 0:
+        try:
+            os.killpg(process_group, value)
+            return
+        except ProcessLookupError:
+            return
+        except OSError:
+            pass
+    if value == signal.SIGTERM:
+        terminate = getattr(process, "terminate", None)
+        if callable(terminate):
+            terminate()
+            return
+    if value == signal.SIGKILL:
+        kill = getattr(process, "kill", None)
+        if callable(kill):
+            kill()
+            return
+    send_signal = getattr(process, "send_signal", None)
+    if callable(send_signal):
+        send_signal(value)
+
+
+def owned_process_group_alive(process: Any) -> bool:
+    process_group = getattr(process, "_sc_conversation_process_group", None)
+    if not isinstance(process_group, int) or process_group <= 0:
+        return False
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def cleanup_owned_process(process: Any, timeout: float) -> None:
+    """Apply the shared TERM/KILL cleanup ladder to an owned subprocess."""
+    poll = getattr(process, "poll", None)
+    running = callable(poll) and poll() is None
+    if running or owned_process_group_alive(process):
+        signal_owned_process(process, signal.SIGTERM)
+    wait = getattr(process, "wait", None)
+    if not callable(wait):
+        return
+    try:
+        wait(timeout=min(timeout, 1.0))
+    except TypeError:
+        wait()
+    except subprocess.TimeoutExpired:
+        pass
+    if owned_process_group_alive(process):
+        signal_owned_process(process, signal.SIGKILL)
+    elif callable(poll) and poll() is None:
+        signal_owned_process(process, signal.SIGKILL)
+    try:
+        wait(timeout=1.0)
+    except (TypeError, subprocess.TimeoutExpired):
+        pass
+
+
 class SubprocessRunner:
-    def __init__(self, *, start_new_session: bool = False) -> None:
+    def __init__(self, *, start_new_session: bool = True) -> None:
         self.start_new_session = start_new_session
 
     def spawn(
@@ -444,6 +509,19 @@ class SubprocessRunner:
         )
         if self.start_new_session:
             process.__dict__["_sc_conversation_process_group"] = process.pid
+
+            def reap_owned_group() -> None:
+                try:
+                    process.wait()
+                except (OSError, subprocess.SubprocessError):
+                    return
+                cleanup_owned_process(process, 1.0)
+
+            threading.Thread(
+                target=reap_owned_group,
+                name=f"conversation-process-group-{process.pid}",
+                daemon=True,
+            ).start()
         captured: list[str] = []
 
         def drain_stderr() -> None:

--- a/.super-coder/scripts/conversation_adapters/claude.py
+++ b/.super-coder/scripts/conversation_adapters/claude.py
@@ -28,6 +28,7 @@ from .base import (
     ensure_nonempty_message,
     load_manifest,
     merged_env,
+    signal_owned_process,
     terminal_outcome,
 )
 
@@ -361,7 +362,7 @@ class ClaudeAdapter(ConversationAdapter):
         process = turn.opaque
         if process is None or process.poll() is not None:
             return InterruptResult(False, "Claude process is not running")
-        process.send_signal(signal.SIGINT)
+        signal_owned_process(process, signal.SIGINT)
         return InterruptResult(True)
 
     def _session_path(self, session_ref: str, worktree: Path) -> Path:

--- a/.super-coder/scripts/conversation_adapters/codex.py
+++ b/.super-coder/scripts/conversation_adapters/codex.py
@@ -21,6 +21,7 @@ from .base import (
     ReconcileResult,
     SessionInspection,
     TERMINAL_EVENTS,
+    cleanup_owned_process,
     command_version,
     ensure_exact_session,
     ensure_nonempty_message,
@@ -61,7 +62,9 @@ class JsonLineRpcProcess:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
+            start_new_session=True,
         )
+        self.process.__dict__["_sc_conversation_process_group"] = self.process.pid
         self._write_lock = threading.Lock()
         self._pending: dict[int, queue.Queue[Any]] = {}
         self._pending_lock = threading.Lock()
@@ -205,12 +208,7 @@ class JsonLineRpcProcess:
     def close(self) -> None:
         if self.process.poll() is not None:
             return
-        self.process.terminate()
-        try:
-            self.process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            self.process.kill()
-            self.process.wait(timeout=5)
+        cleanup_owned_process(self.process, 5.0)
 
 
 class CodexAdapter(ConversationAdapter):

--- a/.super-coder/scripts/conversation_adapters/kimi.py
+++ b/.super-coder/scripts/conversation_adapters/kimi.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import signal
-import subprocess
 import threading
 import time
 from collections.abc import Iterator, Mapping
@@ -26,10 +24,12 @@ from .base import (
     ReconcileResult,
     SessionInspection,
     SubprocessRunner,
+    cleanup_owned_process,
     command_version,
     ensure_nonempty_message,
     load_manifest,
     merged_env,
+    signal_owned_process,
     terminal_outcome,
 )
 
@@ -267,77 +267,7 @@ class KimiAdapter(ConversationAdapter):
                 matches.append(marker)
         return matches
 
-    @staticmethod
-    def _signal_owned_process(process: Any, value: signal.Signals) -> None:
-        process_group = getattr(
-            process,
-            "_sc_conversation_process_group",
-            None,
-        )
-        if isinstance(process_group, int):
-            try:
-                os.killpg(process_group, value)
-                return
-            except ProcessLookupError:
-                return
-            except OSError:
-                pass
-        if value == signal.SIGTERM:
-            terminate = getattr(process, "terminate", None)
-            if callable(terminate):
-                terminate()
-                return
-        if value == signal.SIGKILL:
-            kill = getattr(process, "kill", None)
-            if callable(kill):
-                kill()
-                return
-        send_signal = getattr(process, "send_signal", None)
-        if callable(send_signal):
-            send_signal(value)
-
-    @staticmethod
-    def _process_group_alive(process: Any) -> bool:
-        process_group = getattr(
-            process,
-            "_sc_conversation_process_group",
-            None,
-        )
-        if not isinstance(process_group, int):
-            return False
-        try:
-            os.killpg(process_group, 0)
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            return True
-        return True
-
-    @classmethod
-    def _cleanup_process(cls, process: Any, timeout: float) -> None:
-        poll = getattr(process, "poll", None)
-        running = callable(poll) and poll() is None
-        if running:
-            cls._signal_owned_process(process, signal.SIGTERM)
-        wait = getattr(process, "wait", None)
-        if not callable(wait):
-            return
-        try:
-            wait(timeout=min(timeout, 1.0))
-        except TypeError:
-            wait()
-        except subprocess.TimeoutExpired:
-            pass
-        if cls._process_group_alive(process):
-            cls._signal_owned_process(process, signal.SIGKILL)
-        elif callable(poll) and poll() is None:
-            kill = getattr(process, "kill", None)
-            if callable(kill):
-                kill()
-        try:
-            wait(timeout=1.0)
-        except (TypeError, subprocess.TimeoutExpired):
-            pass
+    _cleanup_process = staticmethod(cleanup_owned_process)
 
     def _watch_native_completion(
         self,
@@ -979,7 +909,7 @@ class KimiAdapter(ConversationAdapter):
         process = turn.opaque
         if process is None or process.poll() is not None:
             return InterruptResult(False, "Kimi process is not running")
-        self._signal_owned_process(process, signal.SIGINT)
+        signal_owned_process(process, signal.SIGINT)
         turn.metadata["interrupt_acknowledged"] = True
         return InterruptResult(True)
 

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -384,6 +384,11 @@ class BrokerStore:
                 selected = con.execute(
                     self._run_select()
                     + "WHERE r.state IN ('leased','starting','running') "
+                    "AND (r.process_pid IS NULL OR EXISTS ("
+                    " SELECT 1 FROM active_shell_chats active "
+                    " WHERE active.process_pid=r.process_pid "
+                    " AND active.process_start_ticks=r.process_start_ticks"
+                    ")) "
                     "AND r.lease_expires_at<=? ORDER BY r.run_id LIMIT ?",
                     (now, limit),
                 ).fetchall()
@@ -482,8 +487,11 @@ class BrokerStore:
         # Filesystem normalization is external preparation, never writer-lock
         # work. Conversation creation stores an already-resolved absolute path.
         actual_worktree = Path(turn.worktree).resolve()
-        process_pid, process_start_ticks = active_chat_registry.process_identity(
-            turn.process_ref
+        process = active_chat_registry.process_details(turn.process_ref)
+        process_pid = process.pid if process is not None else None
+        process_start_ticks = process.start_ticks if process is not None else None
+        process_group_id = (
+            process.process_group_id if process is not None else None
         )
         con = self.connect()
         now, expires = self._times()
@@ -534,13 +542,17 @@ class BrokerStore:
                 changed = con.execute(
                     "UPDATE conversation_runs SET state='running',"
                     "harness_session_after=?,runner_ref=?,heartbeat_at=?,"
-                    "lease_expires_at=? WHERE run_id=? AND lease_owner=? "
+                    "lease_expires_at=?,process_pid=?,process_start_ticks=?,"
+                    "process_group_id=? WHERE run_id=? AND lease_owner=? "
                     "AND state='starting'",
                     (
                         turn.session_ref,
                         turn.run_ref,
                         now,
                         expires,
+                        process_pid,
+                        process_start_ticks,
+                        process_group_id,
                         run_id,
                         owner,
                     ),

--- a/.super-coder/scripts/conversation_reaper.py
+++ b/.super-coder/scripts/conversation_reaper.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Heartbeat reaper for unlinked browser-conversation process groups."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import threading
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import conversation_events
+import db_driver
+from conversation_state import require_transition
+
+TERMINAL_MESSAGE_STATES = frozenset({"completed", "failed", "cancelled"})
+DEFAULT_HEARTBEAT_SECONDS = 60.0
+DEFAULT_TERM_GRACE_SECONDS = 15.0
+DEFAULT_KILL_GRACE_SECONDS = 15.0
+DEFAULT_YOUNG_GRACE_SECONDS = 30.0
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _parse_stamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _configured_seconds(
+    env: Mapping[str, str],
+    name: str,
+    default: float,
+    *,
+    allow_zero: bool = False,
+) -> float:
+    raw = env.get(name, "").strip()
+    try:
+        value = default if not raw else float(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a number of seconds") from exc
+    if value < 0 or (value == 0 and not allow_zero):
+        qualifier = "non-negative" if allow_zero else "positive"
+        raise ValueError(f"{name} must be {qualifier}")
+    return value
+
+
+@dataclass(frozen=True)
+class ReaperConfig:
+    heartbeat_seconds: float = DEFAULT_HEARTBEAT_SECONDS
+    term_grace_seconds: float = DEFAULT_TERM_GRACE_SECONDS
+    kill_grace_seconds: float = DEFAULT_KILL_GRACE_SECONDS
+    young_grace_seconds: float = DEFAULT_YOUNG_GRACE_SECONDS
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> ReaperConfig:
+        values = os.environ if env is None else env
+        return cls(
+            heartbeat_seconds=_configured_seconds(
+                values,
+                "SC_REAPER_HEARTBEAT_SECONDS",
+                DEFAULT_HEARTBEAT_SECONDS,
+            ),
+            term_grace_seconds=_configured_seconds(
+                values,
+                "SC_REAPER_TERM_GRACE_SECONDS",
+                DEFAULT_TERM_GRACE_SECONDS,
+                allow_zero=True,
+            ),
+            kill_grace_seconds=_configured_seconds(
+                values,
+                "SC_REAPER_KILL_GRACE_SECONDS",
+                DEFAULT_KILL_GRACE_SECONDS,
+                allow_zero=True,
+            ),
+            young_grace_seconds=_configured_seconds(
+                values,
+                "SC_REAPER_YOUNG_GRACE_SECONDS",
+                DEFAULT_YOUNG_GRACE_SECONDS,
+                allow_zero=True,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ProcessSnapshot:
+    pid: int
+    start_ticks: int
+    process_group_id: int
+
+
+@dataclass(frozen=True)
+class ReaperCandidate:
+    run_id: int
+    conversation_id: str
+    message_id: int
+    pid: int
+    start_ticks: int
+    process_group_id: int
+    started_at: datetime
+    last_signal: str | None
+    signaled_at: datetime | None
+
+
+def read_process_snapshot(
+    pid: int,
+    *,
+    proc_root: Path = Path("/proc"),
+) -> ProcessSnapshot | None:
+    """Read pid, pgrp, and field-22 start ticks from one procfs snapshot."""
+    try:
+        stat = (proc_root / str(pid) / "stat").read_text()
+        fields_after_comm = stat.rsplit(")", 1)[1].split()
+        process_group_id = int(fields_after_comm[2])
+        start_ticks = int(fields_after_comm[19])
+    except (IndexError, OSError, ValueError):
+        return None
+    if pid <= 0 or process_group_id <= 0 or start_ticks < 0:
+        return None
+    return ProcessSnapshot(pid, start_ticks, process_group_id)
+
+
+class ReaperStore:
+    """Short SQLite reads and writes for the process-ladder state machine."""
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        connect: Callable[[], Any] | None = None,
+        clock: Callable[[], datetime] = _utcnow,
+    ) -> None:
+        self.db_path = str(db_path)
+        self._connect = connect
+        self.clock = clock
+
+    def connect(self):
+        return (
+            self._connect()
+            if self._connect is not None
+            else db_driver.connect(self.db_path)
+        )
+
+    @staticmethod
+    def _protected_sql() -> str:
+        return (
+            "EXISTS(SELECT 1 FROM active_shell_chats active "
+            "WHERE active.process_pid=r.process_pid "
+            "AND active.process_start_ticks=r.process_start_ticks)"
+        )
+
+    def candidates(self) -> list[ReaperCandidate]:
+        con = self.connect()
+        try:
+            rows = con.execute(
+                "SELECT r.run_id,r.conversation_id,r.trigger_message_id,"
+                "r.process_pid,r.process_start_ticks,r.process_group_id,"
+                "r.started_at,r.reaper_last_signal,r.reaper_signaled_at "
+                "FROM conversation_runs r "
+                "WHERE r.state IN ('starting','running') "
+                "AND r.process_pid IS NOT NULL "
+                f"AND NOT {self._protected_sql()} "
+                "ORDER BY r.run_id"
+            ).fetchall()
+        finally:
+            con.close()
+        return [
+            ReaperCandidate(
+                run_id=int(row["run_id"]),
+                conversation_id=str(row["conversation_id"]),
+                message_id=int(row["trigger_message_id"]),
+                pid=int(row["process_pid"]),
+                start_ticks=int(row["process_start_ticks"]),
+                process_group_id=int(row["process_group_id"]),
+                started_at=_parse_stamp(str(row["started_at"])),
+                last_signal=row["reaper_last_signal"],
+                signaled_at=(
+                    _parse_stamp(str(row["reaper_signaled_at"]))
+                    if row["reaper_signaled_at"] is not None
+                    else None
+                ),
+            )
+            for row in rows
+        ]
+
+    def heartbeat(self, interval_seconds: float) -> None:
+        con = self.connect()
+        try:
+            with db_driver.write_transaction(con, "conversation.reaper.heartbeat"):
+                con.execute(
+                    "INSERT INTO daemon_heartbeats (name,beat_at,interval_s) "
+                    "VALUES ('conversation-reaper',datetime('now'),?) "
+                    "ON CONFLICT(name) DO UPDATE SET beat_at=excluded.beat_at,"
+                    "interval_s=excluded.interval_s",
+                    (interval_seconds,),
+                )
+        finally:
+            con.close()
+
+    def eligible(self, candidate: ReaperCandidate) -> bool:
+        con = self.connect()
+        try:
+            return (
+                con.execute(
+                    "SELECT 1 FROM conversation_runs r "
+                    "WHERE r.run_id=? AND r.state IN ('starting','running') "
+                    "AND r.process_pid=? AND r.process_start_ticks=? "
+                    "AND r.process_group_id=? "
+                    f"AND NOT {self._protected_sql()}",
+                    (
+                        candidate.run_id,
+                        candidate.pid,
+                        candidate.start_ticks,
+                        candidate.process_group_id,
+                    ),
+                ).fetchone()
+                is not None
+            )
+        finally:
+            con.close()
+
+    def record_signal(self, candidate: ReaperCandidate, value: str) -> bool:
+        con = self.connect()
+        now = _stamp(self.clock())
+        try:
+            with db_driver.write_transaction(con, "conversation.reaper.signal"):
+                changed = con.execute(
+                    "UPDATE conversation_runs AS r SET reaper_last_signal=?,"
+                    "reaper_signaled_at=? WHERE run_id=? "
+                    "AND state IN ('starting','running') "
+                    "AND process_pid=? AND process_start_ticks=? "
+                    "AND process_group_id=? "
+                    f"AND NOT {self._protected_sql()}",
+                    (
+                        value,
+                        now,
+                        candidate.run_id,
+                        candidate.pid,
+                        candidate.start_ticks,
+                        candidate.process_group_id,
+                    ),
+                ).rowcount
+                return changed == 1
+        finally:
+            con.close()
+
+    @staticmethod
+    def _append_interrupted_event(con, candidate: ReaperCandidate, reason: str) -> None:
+        sequence = con.execute(
+            "SELECT COALESCE(MAX(sequence),0)+1 FROM conversation_events "
+            "WHERE conversation_id=?",
+            (candidate.conversation_id,),
+        ).fetchone()[0]
+        payload = json.dumps(
+            {
+                "interrupt_evidence": "operator",
+                "outcome": "cancelled",
+                "reaper": {
+                    "process_group_id": candidate.process_group_id,
+                    "reason": reason,
+                },
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        con.execute(
+            "INSERT INTO conversation_events "
+            "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+            "VALUES (?,?,'run.interrupted',?,?,?)",
+            (
+                candidate.conversation_id,
+                sequence,
+                payload,
+                candidate.message_id,
+                candidate.run_id,
+            ),
+        )
+
+    def finish_interrupted(self, candidate: ReaperCandidate, reason: str) -> bool:
+        """Write the reaper-owned terminal state iff identity stays unprotected."""
+        con = self.connect()
+        now = _stamp(self.clock())
+        try:
+            with db_driver.write_transaction(con, "conversation.reaper.finish"):
+                row = con.execute(
+                    "SELECT r.state,c.state AS conversation_state,m.state AS message_state "
+                    "FROM conversation_runs r "
+                    "JOIN conversations c ON c.conversation_id=r.conversation_id "
+                    "JOIN conversation_messages m "
+                    "ON m.message_id=r.trigger_message_id "
+                    "WHERE r.run_id=? AND r.state IN ('starting','running') "
+                    "AND r.process_pid=? AND r.process_start_ticks=? "
+                    "AND r.process_group_id=? "
+                    f"AND NOT {self._protected_sql()}",
+                    (
+                        candidate.run_id,
+                        candidate.pid,
+                        candidate.start_ticks,
+                        candidate.process_group_id,
+                    ),
+                ).fetchone()
+                if row is None:
+                    return False
+                require_transition("run", str(row["state"]), "cancelled")
+                con.execute(
+                    "UPDATE conversation_runs SET state='cancelled',ended_at=?,"
+                    "error_code='CONVERSATION_RUN_REAPED',error_detail=? "
+                    "WHERE run_id=?",
+                    (now, reason[:16384], candidate.run_id),
+                )
+                message_state = str(row["message_state"])
+                if message_state not in TERMINAL_MESSAGE_STATES:
+                    require_transition("message", message_state, "cancelled")
+                    con.execute(
+                        "UPDATE conversation_messages SET state='cancelled',"
+                        "completed_at=? WHERE message_id=?",
+                        (now, candidate.message_id),
+                    )
+                conversation_state = str(row["conversation_state"])
+                if conversation_state == "running":
+                    pending = (
+                        con.execute(
+                            "SELECT 1 FROM conversation_outbox WHERE conversation_id=? "
+                            "AND state IN ('pending','claimed') LIMIT 1",
+                            (candidate.conversation_id,),
+                        ).fetchone()
+                        is not None
+                    )
+                    target = "queued" if pending else "idle"
+                    require_transition("conversation", conversation_state, target)
+                    con.execute(
+                        "UPDATE conversations SET state=?,last_activity_at=?,"
+                        "version=version+1 WHERE conversation_id=?",
+                        (target, now, candidate.conversation_id),
+                    )
+                self._append_interrupted_event(con, candidate, reason)
+        finally:
+            con.close()
+        conversation_events.notify(candidate.conversation_id)
+        return True
+
+
+class ConversationReaper(threading.Thread):
+    """Advance each orphan one ladder rung per heartbeat without sleeping."""
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        store: ReaperStore | None = None,
+        config: ReaperConfig | None = None,
+        clock: Callable[[], datetime] = _utcnow,
+        process_reader: Callable[[int], ProcessSnapshot | None] = read_process_snapshot,
+        signal_group: Callable[[int, signal.Signals], None] = os.killpg,
+        native_interrupt: Callable[[int], Any] | None = None,
+    ) -> None:
+        super().__init__(name="conversation-reaper", daemon=True)
+        self.clock = clock
+        self.store = store or ReaperStore(db_path, clock=clock)
+        self.config = config or ReaperConfig.from_env()
+        self.process_reader = process_reader
+        self.signal_group = signal_group
+        self.native_interrupt = native_interrupt
+        self._stop_event = threading.Event()
+        self._started_once = threading.Event()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def wait_started(self, timeout: float = 5.0) -> bool:
+        return self._started_once.wait(timeout)
+
+    @staticmethod
+    def _matches(candidate: ReaperCandidate, snapshot: ProcessSnapshot | None) -> bool:
+        return snapshot is not None and (
+            snapshot.pid == candidate.pid
+            and snapshot.start_ticks == candidate.start_ticks
+            and snapshot.process_group_id == candidate.process_group_id
+        )
+
+    def _finish_if_gone(self, candidate: ReaperCandidate, reason: str) -> bool:
+        return self.store.finish_interrupted(candidate, reason)
+
+    def _native_step(self, candidate: ReaperCandidate) -> bool:
+        if not self.store.eligible(candidate):
+            return False
+        try:
+            if self.native_interrupt is not None:
+                self.native_interrupt(candidate.run_id)
+        except Exception as exc:  # noqa: BLE001 - adapter boundary stays live
+            print(
+                f"conversation-reaper: native interrupt failed for run "
+                f"{candidate.run_id} ({exc})",
+                flush=True,
+            )
+        return self.store.record_signal(candidate, "interrupt")
+
+    def _signal_step(
+        self,
+        candidate: ReaperCandidate,
+        value: signal.Signals,
+        label: str,
+    ) -> bool:
+        if not self.store.eligible(candidate):
+            return False
+        snapshot = self.process_reader(candidate.pid)
+        if not self._matches(candidate, snapshot):
+            return self._finish_if_gone(
+                candidate,
+                "recorded process identity exited or was recycled before signal",
+            )
+        try:
+            self.signal_group(candidate.process_group_id, value)
+        except ProcessLookupError:
+            return self._finish_if_gone(
+                candidate,
+                "recorded process group exited before signal",
+            )
+        changed = self.store.record_signal(candidate, label)
+        if changed and value == signal.SIGKILL:
+            return self._finish_if_gone(
+                candidate,
+                "reaper SIGKILL delivered to unlinked process group",
+            )
+        return changed
+
+    def sweep_once(self) -> int:
+        now = self.clock()
+        advanced = 0
+        for candidate in self.store.candidates():
+            try:
+                age = (now - candidate.started_at).total_seconds()
+                if age < self.config.young_grace_seconds:
+                    continue
+                snapshot = self.process_reader(candidate.pid)
+                if snapshot is None:
+                    advanced += int(
+                        self._finish_if_gone(
+                            candidate,
+                            "recorded process exited before reaper signal",
+                        )
+                    )
+                    continue
+                if not self._matches(candidate, snapshot):
+                    advanced += int(
+                        self._finish_if_gone(
+                            candidate,
+                            "recorded process identity exited or was recycled",
+                        )
+                    )
+                    continue
+                if candidate.last_signal is None:
+                    advanced += int(self._native_step(candidate))
+                    continue
+                elapsed = (
+                    (now - candidate.signaled_at).total_seconds()
+                    if candidate.signaled_at is not None
+                    else float("inf")
+                )
+                if candidate.last_signal == "interrupt":
+                    if elapsed >= self.config.term_grace_seconds:
+                        advanced += int(
+                            self._signal_step(
+                                candidate,
+                                signal.SIGTERM,
+                                "SIGTERM",
+                            )
+                        )
+                    continue
+                if candidate.last_signal == "SIGTERM":
+                    if elapsed >= self.config.kill_grace_seconds:
+                        advanced += int(
+                            self._signal_step(
+                                candidate,
+                                signal.SIGKILL,
+                                "SIGKILL",
+                            )
+                        )
+                    continue
+                if candidate.last_signal == "SIGKILL":
+                    advanced += int(
+                        self._finish_if_gone(
+                            candidate,
+                            "reaper SIGKILL delivered to unlinked process group",
+                        )
+                    )
+            except Exception as exc:  # noqa: BLE001 - isolate one candidate
+                print(
+                    f"conversation-reaper: run {candidate.run_id} sweep failed ({exc})",
+                    flush=True,
+                )
+        return advanced
+
+    def run(self) -> None:  # pragma: no cover - loop tested through sweep seam
+        try:
+            self.sweep_once()
+            self.store.heartbeat(self.config.heartbeat_seconds)
+        except Exception as exc:  # noqa: BLE001 - service must retry next beat
+            print(f"conversation-reaper: startup error ({exc})", flush=True)
+        self._started_once.set()
+        while not self._stop_event.wait(self.config.heartbeat_seconds):
+            try:
+                self.sweep_once()
+                self.store.heartbeat(self.config.heartbeat_seconds)
+            except Exception as exc:  # noqa: BLE001 - service must stay live
+                print(f"conversation-reaper: heartbeat error ({exc})", flush=True)
+
+
+_SERVICE_LOCK = threading.Lock()
+_SERVICE: ConversationReaper | None = None
+
+
+def start_service(
+    db_path: str | Path,
+    **kwargs: Any,
+) -> ConversationReaper:
+    global _SERVICE
+    with _SERVICE_LOCK:
+        if _SERVICE is not None and _SERVICE.is_alive():
+            return _SERVICE
+        _SERVICE = ConversationReaper(db_path, **kwargs)
+        _SERVICE.start()
+        return _SERVICE
+
+
+def service() -> ConversationReaper | None:
+    return _SERVICE

--- a/.super-coder/scripts/conversation_reaper.py
+++ b/.super-coder/scripts/conversation_reaper.py
@@ -535,5 +535,16 @@ def start_service(
         return _SERVICE
 
 
+def stop_service() -> None:
+    """Stop and join the process-wide service before its DB can disappear."""
+    global _SERVICE
+    with _SERVICE_LOCK:
+        if _SERVICE is None:
+            return
+        _SERVICE.stop()
+        _SERVICE.join()
+        _SERVICE = None
+
+
 def service() -> ConversationReaper | None:
     return _SERVICE

--- a/.super-coder/scripts/conversation_reaper.py
+++ b/.super-coder/scripts/conversation_reaper.py
@@ -161,6 +161,15 @@ class ReaperStore:
             "AND active.process_start_ticks=r.process_start_ticks)"
         )
 
+    @staticmethod
+    def _sweepable_sql() -> str:
+        return (
+            "(r.state IN ('starting','running') OR (r.state='unknown' "
+            "AND NOT EXISTS(SELECT 1 FROM conversation_events reaped "
+            "WHERE reaped.run_id=r.run_id "
+            "AND reaped.event_type='run.interrupted')))"
+        )
+
     def candidates(self) -> list[ReaperCandidate]:
         con = self.connect()
         try:
@@ -169,7 +178,7 @@ class ReaperStore:
                 "r.process_pid,r.process_start_ticks,r.process_group_id,"
                 "r.started_at,r.reaper_last_signal,r.reaper_signaled_at "
                 "FROM conversation_runs r "
-                "WHERE r.state IN ('starting','running') "
+                f"WHERE {self._sweepable_sql()} "
                 "AND r.process_pid IS NOT NULL "
                 f"AND NOT {self._protected_sql()} "
                 "ORDER BY r.run_id"
@@ -215,7 +224,7 @@ class ReaperStore:
             return (
                 con.execute(
                     "SELECT 1 FROM conversation_runs r "
-                    "WHERE r.run_id=? AND r.state IN ('starting','running') "
+                    f"WHERE r.run_id=? AND {self._sweepable_sql()} "
                     "AND r.process_pid=? AND r.process_start_ticks=? "
                     "AND r.process_group_id=? "
                     f"AND NOT {self._protected_sql()}",
@@ -239,7 +248,7 @@ class ReaperStore:
                 changed = con.execute(
                     "UPDATE conversation_runs AS r SET reaper_last_signal=?,"
                     "reaper_signaled_at=? WHERE run_id=? "
-                    "AND state IN ('starting','running') "
+                    f"AND {self._sweepable_sql()} "
                     "AND process_pid=? AND process_start_ticks=? "
                     "AND process_group_id=? "
                     f"AND NOT {self._protected_sql()}",
@@ -300,7 +309,7 @@ class ReaperStore:
                     "JOIN conversations c ON c.conversation_id=r.conversation_id "
                     "JOIN conversation_messages m "
                     "ON m.message_id=r.trigger_message_id "
-                    "WHERE r.run_id=? AND r.state IN ('starting','running') "
+                    f"WHERE r.run_id=? AND {self._sweepable_sql()} "
                     "AND r.process_pid=? AND r.process_start_ticks=? "
                     "AND r.process_group_id=? "
                     f"AND NOT {self._protected_sql()}",
@@ -313,38 +322,41 @@ class ReaperStore:
                 ).fetchone()
                 if row is None:
                     return False
-                require_transition("run", str(row["state"]), "cancelled")
-                con.execute(
-                    "UPDATE conversation_runs SET state='cancelled',ended_at=?,"
-                    "error_code='CONVERSATION_RUN_REAPED',error_detail=? "
-                    "WHERE run_id=?",
-                    (now, reason[:16384], candidate.run_id),
-                )
-                message_state = str(row["message_state"])
-                if message_state not in TERMINAL_MESSAGE_STATES:
-                    require_transition("message", message_state, "cancelled")
+                run_state = str(row["state"])
+                if run_state != "unknown":
+                    require_transition("run", run_state, "cancelled")
                     con.execute(
-                        "UPDATE conversation_messages SET state='cancelled',"
-                        "completed_at=? WHERE message_id=?",
-                        (now, candidate.message_id),
+                        "UPDATE conversation_runs SET state='cancelled',ended_at=?,"
+                        "error_code='CONVERSATION_RUN_REAPED',error_detail=? "
+                        "WHERE run_id=?",
+                        (now, reason[:16384], candidate.run_id),
                     )
-                conversation_state = str(row["conversation_state"])
-                if conversation_state == "running":
-                    pending = (
+                    message_state = str(row["message_state"])
+                    if message_state not in TERMINAL_MESSAGE_STATES:
+                        require_transition("message", message_state, "cancelled")
                         con.execute(
-                            "SELECT 1 FROM conversation_outbox WHERE conversation_id=? "
-                            "AND state IN ('pending','claimed') LIMIT 1",
-                            (candidate.conversation_id,),
-                        ).fetchone()
-                        is not None
-                    )
-                    target = "queued" if pending else "idle"
-                    require_transition("conversation", conversation_state, target)
-                    con.execute(
-                        "UPDATE conversations SET state=?,last_activity_at=?,"
-                        "version=version+1 WHERE conversation_id=?",
-                        (target, now, candidate.conversation_id),
-                    )
+                            "UPDATE conversation_messages SET state='cancelled',"
+                            "completed_at=? WHERE message_id=?",
+                            (now, candidate.message_id),
+                        )
+                    conversation_state = str(row["conversation_state"])
+                    if conversation_state == "running":
+                        pending = (
+                            con.execute(
+                                "SELECT 1 FROM conversation_outbox "
+                                "WHERE conversation_id=? "
+                                "AND state IN ('pending','claimed') LIMIT 1",
+                                (candidate.conversation_id,),
+                            ).fetchone()
+                            is not None
+                        )
+                        target = "queued" if pending else "idle"
+                        require_transition("conversation", conversation_state, target)
+                        con.execute(
+                            "UPDATE conversations SET state=?,last_activity_at=?,"
+                            "version=version+1 WHERE conversation_id=?",
+                            (target, now, candidate.conversation_id),
+                        )
                 self._append_interrupted_event(con, candidate, reason)
         finally:
             con.close()

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -62,7 +62,8 @@
     ".super-coder/migrations/0160_reseed_migration_management.sql",
     ".super-coder/scripts/migration.py",
     "tests/test_migration_management.py",
-    ".super-coder/migrations/0162_active_chat_registry.sql"
+    ".super-coder/migrations/0162_active_chat_registry.sql",
+    ".super-coder/migrations/0163_conversation_run_process_identity.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -25,6 +25,7 @@ from conversation_adapters import (  # noqa: E402
     ClaudeAdapter,
     CodexAdapter,
     ConversationContext,
+    JsonLineRpcProcess,
     KimiAdapter,
     NativeTurn,
     NormalizedEvent,
@@ -33,6 +34,7 @@ from conversation_adapters import (  # noqa: E402
     adapter_for,
 )
 from conversation_adapters import opencode as opencode_adapter
+from conversation_adapters.base import SubprocessRunner
 
 KIMI_FIXTURES = ROOT / "tests" / "fixtures" / "conversations" / "kimi"
 
@@ -1531,11 +1533,12 @@ class ConversationAdapterTest(unittest.TestCase):
     def test_kimi_default_runner_owns_and_cleans_up_process_group(self) -> None:
         adapter = KimiAdapter()
         self.assertTrue(adapter.runner.start_new_session)
+        self.assertTrue(ClaudeAdapter().runner.start_new_session)
         process = FakeKimiProcess([])
         process._sc_conversation_process_group = 4321
 
         with mock.patch(
-            "conversation_adapters.kimi.os.killpg"
+            "conversation_adapters.base.os.killpg"
         ) as kill_process_group:
             adapter._cleanup_process(process, 0.1)
 
@@ -1547,6 +1550,56 @@ class ConversationAdapterTest(unittest.TestCase):
                 mock.call(4321, signal.SIGKILL),
             ],
         )
+
+    def test_codex_app_server_owns_a_process_group(self) -> None:
+        process = mock.Mock()
+        process.pid = 4321
+        process.stdin = io.StringIO()
+        process.stdout = io.StringIO()
+        process.stderr = io.StringIO()
+        with (
+            mock.patch(
+                "conversation_adapters.codex.subprocess.Popen",
+                return_value=process,
+            ) as spawn,
+            mock.patch.object(JsonLineRpcProcess, "request", return_value={}),
+            mock.patch.object(JsonLineRpcProcess, "notify"),
+        ):
+            rpc = JsonLineRpcProcess(cwd=self.root, env={})
+
+        self.assertTrue(spawn.call_args.kwargs["start_new_session"])
+        self.assertEqual(
+            rpc.process._sc_conversation_process_group,
+            process.pid,
+        )
+
+    def test_shared_runner_reaps_group_after_leader_exit(self) -> None:
+        process = mock.Mock()
+        process.pid = 4321
+        process.stderr = io.StringIO()
+        process.wait.return_value = 0
+        cleaned = threading.Event()
+        with (
+            mock.patch(
+                "conversation_adapters.base.subprocess.Popen",
+                return_value=process,
+            ) as spawn,
+            mock.patch(
+                "conversation_adapters.base.cleanup_owned_process",
+                side_effect=lambda _process, _timeout: cleaned.set(),
+            ) as cleanup,
+        ):
+            returned = SubprocessRunner().spawn(
+                ["harness"],
+                cwd=self.root,
+                env={},
+            )
+            self.assertTrue(cleaned.wait(1))
+
+        self.assertIs(returned, process)
+        self.assertTrue(spawn.call_args.kwargs["start_new_session"])
+        self.assertEqual(process._sc_conversation_process_group, process.pid)
+        cleanup.assert_called_once_with(process, 1.0)
 
     def test_kimi_identity_mismatch_blocks_usage_reconciliation(self) -> None:
         adapter, runner = self.build("kimi")

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -551,15 +551,22 @@ class StoreContractTest(ConversationBrokerCase):
             "SELECT chat_id,process_pid,process_start_ticks "
             "FROM active_shell_chats WHERE shell_id=1"
         ).fetchone()
-        run_state = con.execute(
-            "SELECT state FROM conversation_runs WHERE run_id=?",
+        run_row = con.execute(
+            "SELECT state,process_pid,process_start_ticks,process_group_id "
+            "FROM conversation_runs WHERE run_id=?",
             (run.run_id,),
-        ).fetchone()[0]
+        ).fetchone()
         con.close()
         self.assertEqual(active["chat_id"], conversation_id)
         self.assertEqual(active["process_pid"], os.getpid())
         self.assertGreater(active["process_start_ticks"], 0)
-        self.assertEqual(run_state, "running")
+        self.assertEqual(run_row["state"], "running")
+        self.assertEqual(run_row["process_pid"], os.getpid())
+        self.assertEqual(
+            run_row["process_start_ticks"],
+            active["process_start_ticks"],
+        )
+        self.assertEqual(run_row["process_group_id"], os.getpgid(os.getpid()))
 
         store.finish_run(
             run.run_id,
@@ -577,6 +584,40 @@ class StoreContractTest(ConversationBrokerCase):
         ).fetchone()
         con.close()
         self.assertEqual(tuple(finalized), ("succeeded", None, None))
+
+    def test_recovery_leaves_unprotected_process_identity_for_reaper(self) -> None:
+        conversation_id, _message_id, run_id = self.add_live_run(
+            state="running",
+            session_after="native-session",
+            runner_ref="native-run",
+        )
+        con = self.connect()
+        con.execute(
+            "UPDATE conversation_runs SET process_pid=4242,"
+            "process_start_ticks=9001,process_group_id=4242 WHERE run_id=?",
+            (run_id,),
+        )
+        con.execute(
+            "UPDATE active_shell_chats SET process_pid=NULL,"
+            "process_start_ticks=NULL WHERE chat_id=?",
+            (conversation_id,),
+        )
+        con.commit()
+        con.close()
+
+        store = BrokerStore(self.db_path)
+        self.assertEqual(store.adopt_recoverable("new-broker", startup=True, limit=8), [])
+
+        con = self.connect()
+        con.execute(
+            "UPDATE active_shell_chats SET process_pid=4242,"
+            "process_start_ticks=9001 WHERE chat_id=?",
+            (conversation_id,),
+        )
+        con.commit()
+        con.close()
+        adopted = store.adopt_recoverable("new-broker", startup=True, limit=8)
+        self.assertEqual([run.run_id for run in adopted], [run_id])
 
     def test_process_registration_failure_rolls_back_run_start(self) -> None:
         conversation_id = self.add_conversation()

--- a/tests/test_conversation_reaper.py
+++ b/tests/test_conversation_reaper.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Feature #31 orphan-process reaper identity and ladder contracts."""
+
+from __future__ import annotations
+
+import signal
+import sqlite3
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCRIPTS = ENGINE / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from conversation_reaper import (
+    ConversationReaper,
+    ProcessSnapshot,
+    ReaperConfig,
+    ReaperStore,
+)
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+class MutableClock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def __call__(self) -> datetime:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += timedelta(seconds=seconds)
+
+
+class ConversationReaperTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "shell.db"
+        con = sqlite3.connect(self.db_path)
+        apply_schema(con)
+        con.execute("INSERT INTO users (user_id,username) VALUES (1,'operator')")
+        con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (1,'Dev','dev1','dev','prompt',1)"
+        )
+        con.commit()
+        con.close()
+        self.clock = MutableClock(datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc))
+        self.serial = 0
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def connect(self) -> sqlite3.Connection:
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        con.execute("PRAGMA foreign_keys=ON")
+        return con
+
+    def add_run(
+        self,
+        *,
+        pid: int = 4242,
+        start_ticks: int = 9001,
+        process_group_id: int = 4242,
+        age_seconds: float = 60.0,
+        protected: bool = False,
+    ) -> tuple[str, int, int]:
+        self.serial += 1
+        key = f"reaper-{self.serial}"
+        started = self.clock.value - timedelta(seconds=age_seconds)
+        con = self.connect()
+        con.execute(
+            "INSERT INTO conversations "
+            "(shell_id,owner_user_id,harness,worktree,state,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES (1,1,'codex','/tmp/reaper','running',?,?)",
+            (key, f"hash-{key}"),
+        )
+        conversation_id = str(
+            con.execute(
+                "SELECT conversation_id FROM conversations "
+                "WHERE creation_idempotency_key=?",
+                (key,),
+            ).fetchone()[0]
+        )
+        message_id = int(
+            con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state) "
+                "VALUES (?,'user','1','prompt','hello',?,?,'running')",
+                (conversation_id, f"message-{key}", f"message-hash-{key}"),
+            ).lastrowid
+        )
+        run_id = int(
+            con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,state,lease_owner,"
+                "lease_expires_at,started_at,heartbeat_at,process_pid,"
+                "process_start_ticks,process_group_id) "
+                "VALUES (?,1,?,'running','dead-broker','2000-01-01 00:00:00',"
+                "?,?,?,?,?)",
+                (
+                    conversation_id,
+                    message_id,
+                    started.strftime("%Y-%m-%d %H:%M:%S"),
+                    started.strftime("%Y-%m-%d %H:%M:%S"),
+                    pid,
+                    start_ticks,
+                    process_group_id,
+                ),
+            ).lastrowid
+        )
+        con.execute(
+            "INSERT INTO active_shell_chats "
+            "(shell_id,chat_id,process_pid,process_start_ticks) VALUES (1,?,?,?)",
+            (
+                conversation_id,
+                pid if protected else None,
+                start_ticks if protected else None,
+            ),
+        )
+        con.commit()
+        con.close()
+        return conversation_id, message_id, run_id
+
+    def build_reaper(
+        self,
+        snapshot: ProcessSnapshot | None,
+        *,
+        native_interrupt=None,
+        signal_group=None,
+        young_grace_seconds: float = 30.0,
+    ) -> ConversationReaper:
+        return ConversationReaper(
+            self.db_path,
+            store=ReaperStore(self.db_path, clock=self.clock),
+            config=ReaperConfig(
+                heartbeat_seconds=60,
+                term_grace_seconds=15,
+                kill_grace_seconds=15,
+                young_grace_seconds=young_grace_seconds,
+            ),
+            clock=self.clock,
+            process_reader=lambda _pid: snapshot,
+            native_interrupt=native_interrupt,
+            signal_group=signal_group or (lambda _group, _value: None),
+        )
+
+    def test_exact_registry_identity_is_the_only_protection(self) -> None:
+        _conversation, _message, protected_run = self.add_run(protected=True)
+        snapshot = ProcessSnapshot(4242, 9001, 4242)
+        reaper = self.build_reaper(snapshot)
+
+        self.assertEqual(reaper.sweep_once(), 0)
+
+        con = self.connect()
+        con.execute(
+            "UPDATE active_shell_chats SET process_pid=NULL,process_start_ticks=NULL"
+        )
+        con.commit()
+        con.close()
+        interrupted: list[int] = []
+        reaper = self.build_reaper(snapshot, native_interrupt=interrupted.append)
+
+        self.assertEqual(reaper.sweep_once(), 1)
+        self.assertEqual(interrupted, [protected_run])
+        con = self.connect()
+        row = con.execute(
+            "SELECT state,reaper_last_signal FROM conversation_runs WHERE run_id=?",
+            (protected_run,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(row), ("running", "interrupt"))
+
+    def test_young_process_grace_has_no_side_effects(self) -> None:
+        _conversation, _message, run_id = self.add_run(age_seconds=29)
+        interrupted: list[int] = []
+        signals: list[tuple[int, signal.Signals]] = []
+        reaper = self.build_reaper(
+            ProcessSnapshot(4242, 9001, 4242),
+            native_interrupt=interrupted.append,
+            signal_group=lambda group, value: signals.append((group, value)),
+        )
+
+        self.assertEqual(reaper.sweep_once(), 0)
+        self.assertEqual(interrupted, [])
+        self.assertEqual(signals, [])
+        con = self.connect()
+        row = con.execute(
+            "SELECT state,reaper_last_signal FROM conversation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(row), ("running", None))
+
+    def test_recycled_pid_is_never_signalled_and_finishes_interrupted(self) -> None:
+        conversation_id, message_id, run_id = self.add_run()
+        signals: list[tuple[int, signal.Signals]] = []
+        reaper = self.build_reaper(
+            ProcessSnapshot(4242, 9999, 4242),
+            signal_group=lambda group, value: signals.append((group, value)),
+        )
+
+        self.assertEqual(reaper.sweep_once(), 1)
+        self.assertEqual(signals, [])
+        con = self.connect()
+        run = con.execute(
+            "SELECT state,error_code FROM conversation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        message = con.execute(
+            "SELECT state FROM conversation_messages WHERE message_id=?",
+            (message_id,),
+        ).fetchone()[0]
+        event = con.execute(
+            "SELECT event_type,payload FROM conversation_events "
+            "WHERE conversation_id=? AND run_id=?",
+            (conversation_id, run_id),
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(run), ("cancelled", "CONVERSATION_RUN_REAPED"))
+        self.assertEqual(message, "cancelled")
+        self.assertEqual(event["event_type"], "run.interrupted")
+        self.assertIn(
+            '"reason":"recorded process identity exited or was recycled"',
+            event["payload"],
+        )
+
+    def test_ladder_persists_across_heartbeats_and_kills_process_group(self) -> None:
+        conversation_id, message_id, run_id = self.add_run()
+        snapshot = ProcessSnapshot(4242, 9001, 4242)
+        interrupted: list[int] = []
+        signals: list[tuple[int, signal.Signals]] = []
+
+        def reaper() -> ConversationReaper:
+            return self.build_reaper(
+                snapshot,
+                native_interrupt=interrupted.append,
+                signal_group=lambda group, value: signals.append((group, value)),
+            )
+
+        self.assertEqual(reaper().sweep_once(), 1)
+        self.assertEqual(interrupted, [run_id])
+        self.assertEqual(signals, [])
+
+        self.clock.advance(14)
+        self.assertEqual(reaper().sweep_once(), 0)
+        self.clock.advance(1)
+        self.assertEqual(reaper().sweep_once(), 1)
+        self.assertEqual(signals, [(4242, signal.SIGTERM)])
+
+        self.clock.advance(14)
+        self.assertEqual(reaper().sweep_once(), 0)
+        self.clock.advance(1)
+        self.assertEqual(reaper().sweep_once(), 1)
+        self.assertEqual(
+            signals,
+            [(4242, signal.SIGTERM), (4242, signal.SIGKILL)],
+        )
+
+        con = self.connect()
+        run = con.execute(
+            "SELECT state,reaper_last_signal,reaper_signaled_at "
+            "FROM conversation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        message = con.execute(
+            "SELECT state FROM conversation_messages WHERE message_id=?",
+            (message_id,),
+        ).fetchone()[0]
+        events = con.execute(
+            "SELECT event_type FROM conversation_events "
+            "WHERE conversation_id=? AND run_id=? ORDER BY sequence",
+            (conversation_id, run_id),
+        ).fetchall()
+        con.close()
+        self.assertEqual(run["state"], "cancelled")
+        self.assertEqual(run["reaper_last_signal"], "SIGKILL")
+        self.assertEqual(run["reaper_signaled_at"], "2026-08-02 12:00:30")
+        self.assertEqual(message, "cancelled")
+        self.assertEqual([row[0] for row in events], ["run.interrupted"])
+
+    def test_tunables_use_spec_defaults_and_accept_overrides(self) -> None:
+        self.assertEqual(
+            ReaperConfig.from_env({}),
+            ReaperConfig(60.0, 15.0, 15.0, 30.0),
+        )
+        self.assertEqual(
+            ReaperConfig.from_env(
+                {
+                    "SC_REAPER_HEARTBEAT_SECONDS": "5",
+                    "SC_REAPER_TERM_GRACE_SECONDS": "6",
+                    "SC_REAPER_KILL_GRACE_SECONDS": "7",
+                    "SC_REAPER_YOUNG_GRACE_SECONDS": "8",
+                }
+            ),
+            ReaperConfig(5.0, 6.0, 7.0, 8.0),
+        )
+
+    def test_service_heartbeat_is_durable(self) -> None:
+        store = ReaperStore(self.db_path, clock=self.clock)
+        store.heartbeat(60)
+        con = self.connect()
+        heartbeat = con.execute(
+            "SELECT name,interval_s FROM daemon_heartbeats "
+            "WHERE name='conversation-reaper'"
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(heartbeat), ("conversation-reaper", 60))
+
+    def test_schema_rejects_partial_identity_and_ladder_state(self) -> None:
+        _conversation, _message, run_id = self.add_run()
+        con = self.connect()
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "conversation run process identity must be complete",
+        ):
+            con.execute(
+                "UPDATE conversation_runs SET process_group_id=NULL WHERE run_id=?",
+                (run_id,),
+            )
+        con.rollback()
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError,
+            "conversation run reaper signal must have a timestamp",
+        ):
+            con.execute(
+                "UPDATE conversation_runs SET reaper_last_signal='interrupt' "
+                "WHERE run_id=?",
+                (run_id,),
+            )
+        con.rollback()
+        row = con.execute(
+            "SELECT process_pid,process_start_ticks,process_group_id,"
+            "reaper_last_signal,reaper_signaled_at FROM conversation_runs "
+            "WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(tuple(row), (4242, 9001, 4242, None, None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_conversation_reaper.py
+++ b/tests/test_conversation_reaper.py
@@ -18,6 +18,7 @@ SCRIPTS = ENGINE / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import conversation_reaper
+from conversation_broker import BrokerStore
 from conversation_reaper import (
     ConversationReaper,
     ProcessSnapshot,
@@ -161,6 +162,18 @@ class ConversationReaperTest(unittest.TestCase):
             signal_group=signal_group or (lambda _group, _value: None),
         )
 
+    def finish_unknown(self, run_id: int) -> None:
+        self.assertTrue(
+            BrokerStore(self.db_path, clock=self.clock).finish_run(
+                run_id,
+                "unknown",
+                event_type="run.unknown",
+                payload={"detail": "adopted outcome could not be proven"},
+                error_code="HARNESS_OUTCOME_UNKNOWN",
+                error_detail="adopted outcome could not be proven",
+            )
+        )
+
     def test_exact_registry_identity_is_the_only_protection(self) -> None:
         _conversation, _message, protected_run = self.add_run(protected=True)
         snapshot = ProcessSnapshot(4242, 9001, 4242)
@@ -240,6 +253,98 @@ class ConversationReaperTest(unittest.TestCase):
             '"reason":"recorded process identity exited or was recycled"',
             event["payload"],
         )
+
+    def test_adopted_unknown_live_process_is_swept_once(self) -> None:
+        conversation_id, message_id, run_id = self.add_run()
+        self.finish_unknown(run_id)
+        interrupted: list[int] = []
+        signals: list[tuple[int, signal.Signals]] = []
+        reaper = self.build_reaper(
+            ProcessSnapshot(4242, 9001, 4242),
+            native_interrupt=interrupted.append,
+            signal_group=lambda group, value: signals.append((group, value)),
+        )
+
+        self.assertEqual(reaper.sweep_once(), 1)
+        self.clock.advance(15)
+        self.assertEqual(reaper.sweep_once(), 1)
+        self.clock.advance(15)
+        self.assertEqual(reaper.sweep_once(), 1)
+        self.assertEqual(reaper.sweep_once(), 0)
+        self.assertEqual(interrupted, [run_id])
+        self.assertEqual(
+            signals,
+            [(4242, signal.SIGTERM), (4242, signal.SIGKILL)],
+        )
+
+        con = self.connect()
+        run = con.execute(
+            "SELECT state,error_code,process_pid,process_start_ticks,"
+            "process_group_id,reaper_last_signal FROM conversation_runs "
+            "WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        message_state = con.execute(
+            "SELECT state FROM conversation_messages WHERE message_id=?",
+            (message_id,),
+        ).fetchone()[0]
+        conversation_state = con.execute(
+            "SELECT state FROM conversations WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()[0]
+        events = con.execute(
+            "SELECT event_type FROM conversation_events WHERE run_id=? "
+            "ORDER BY sequence",
+            (run_id,),
+        ).fetchall()
+        con.close()
+        self.assertEqual(
+            tuple(run),
+            ("unknown", "HARNESS_OUTCOME_UNKNOWN", 4242, 9001, 4242, "SIGKILL"),
+        )
+        self.assertEqual(message_state, "failed")
+        self.assertEqual(conversation_state, "error")
+        self.assertEqual(
+            [row["event_type"] for row in events],
+            ["run.unknown", "run.interrupted"],
+        )
+
+    def test_unknown_run_without_process_identity_is_untouched(self) -> None:
+        _conversation_id, _message_id, run_id = self.add_run()
+        self.finish_unknown(run_id)
+        con = self.connect()
+        con.execute(
+            "UPDATE conversation_runs SET process_pid=NULL,"
+            "process_start_ticks=NULL,process_group_id=NULL WHERE run_id=?",
+            (run_id,),
+        )
+        con.commit()
+        con.close()
+        interrupted: list[int] = []
+        signals: list[tuple[int, signal.Signals]] = []
+        reaper = self.build_reaper(
+            None,
+            native_interrupt=interrupted.append,
+            signal_group=lambda group, value: signals.append((group, value)),
+        )
+
+        self.assertEqual(reaper.sweep_once(), 0)
+        self.assertEqual(interrupted, [])
+        self.assertEqual(signals, [])
+        con = self.connect()
+        run = con.execute(
+            "SELECT state,process_pid,process_start_ticks,process_group_id,"
+            "reaper_last_signal FROM conversation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        events = con.execute(
+            "SELECT event_type FROM conversation_events WHERE run_id=? "
+            "ORDER BY sequence",
+            (run_id,),
+        ).fetchall()
+        con.close()
+        self.assertEqual(tuple(run), ("unknown", None, None, None, None))
+        self.assertEqual([row["event_type"] for row in events], ["run.unknown"])
 
     def test_ladder_persists_across_heartbeats_and_kills_process_group(self) -> None:
         conversation_id, message_id, run_id = self.add_run()

--- a/tests/test_conversation_reaper.py
+++ b/tests/test_conversation_reaper.py
@@ -10,12 +10,14 @@ import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 SCRIPTS = ENGINE / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
+import conversation_reaper
 from conversation_reaper import (
     ConversationReaper,
     ProcessSnapshot,
@@ -320,6 +322,17 @@ class ConversationReaperTest(unittest.TestCase):
         ).fetchone()
         con.close()
         self.assertEqual(tuple(heartbeat), ("conversation-reaper", 60))
+
+    def test_stop_service_stops_joins_and_clears_the_worker(self) -> None:
+        worker = mock.Mock()
+        with mock.patch.object(conversation_reaper, "_SERVICE", worker):
+            conversation_reaper.stop_service()
+            self.assertIsNone(conversation_reaper.service())
+
+        self.assertEqual(
+            worker.mock_calls,
+            [mock.call.stop(), mock.call.join()],
+        )
 
     def test_schema_rejects_partial_identity_and_ladder_state(self) -> None:
         _conversation, _message, run_id = self.add_run()

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -17,6 +17,7 @@ MIGRATIONS = ENGINE / "migrations"
 FOUNDATION = MIGRATIONS / "0132_conversation_foundation.sql"
 GIT_TARGETS = MIGRATIONS / "0142_conversation_git_targets.sql"
 ACTIVE_REGISTRY = MIGRATIONS / "0162_active_chat_registry.sql"
+REAPER_IDENTITY = MIGRATIONS / "0163_conversation_run_process_identity.sql"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import conversation_state  # noqa: E402
@@ -210,6 +211,54 @@ class MigrationAndShapeTest(ConversationDbCase):
             "conversation_outbox",
         }.issubset(tables))
         con.close()
+
+    def test_reaper_identity_migration_preserves_legacy_live_run(self) -> None:
+        with closing(sqlite3.connect(":memory:")) as con:
+            apply_schema(con, through="0162_active_chat_registry.sql")
+            con.execute("INSERT INTO users (user_id,username) VALUES (9,'legacy')")
+            con.execute(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (9,'Legacy','legacy','dev','prompt',9)"
+            )
+            con.execute(
+                "INSERT INTO conversations "
+                "(shell_id,owner_user_id,harness,worktree,state,"
+                "creation_idempotency_key,creation_request_hash) "
+                "VALUES (9,9,'codex','/tmp/legacy','running','legacy','hash')"
+            )
+            conversation_id = con.execute(
+                "SELECT conversation_id FROM conversations "
+                "WHERE creation_idempotency_key='legacy'"
+            ).fetchone()[0]
+            message_id = con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state) "
+                "VALUES (?,'user','9','prompt','live','message','hash','running')",
+                (conversation_id,),
+            ).lastrowid
+            run_id = con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,state,lease_owner,"
+                "lease_expires_at,started_at) VALUES "
+                "(?,9,?,'running','legacy-broker','2999-01-01 00:00:00',"
+                "'2026-08-02 00:00:00')",
+                (conversation_id, message_id),
+            ).lastrowid
+
+            con.executescript(REAPER_IDENTITY.read_text())
+
+            row = con.execute(
+                "SELECT state,process_pid,process_start_ticks,process_group_id,"
+                "reaper_last_signal,reaper_signaled_at FROM conversation_runs "
+                "WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+            self.assertEqual(
+                row,
+                ("running", None, None, None, None, None),
+            )
 
     def test_star_migration_defaults_legacy_rows_and_enforces_boolean_values(self) -> None:
         with closing(sqlite3.connect(":memory:")) as con:

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -320,8 +320,8 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
     def _start(self, bind, *, container=False, port=8800):
         """Run main([]) to the bind decision.
 
-        Returns refusal, served host, and whether the conversation broker and
-        armed Sprint runtime started after that successful bind.
+        Returns refusal, served host, and whether the conversation broker,
+        reaper, and armed Sprint services crossed their lifecycle boundaries.
         """
         served = []
 
@@ -370,6 +370,12 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                 broker_start = enter(mock.patch.object(
                     server.conversation_broker, "start_service"
                 ))
+                reaper_start = enter(mock.patch.object(
+                    server.conversation_reaper, "start_service"
+                ))
+                reaper_stop = enter(mock.patch.object(
+                    server.conversation_reaper, "stop_service"
+                ))
                 sprint_start = enter(mock.patch.object(
                     server.sprint_runtime, "start_service"
                 ))
@@ -388,6 +394,8 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
             refusal,
             served[0] if served else None,
             broker_start.called,
+            reaper_start.called,
+            reaper_stop.called,
             sprint_start.called,
             watcher_start.called,
         )
@@ -399,6 +407,8 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                     refusal,
                     served,
                     broker_started,
+                    reaper_started,
+                    reaper_stopped,
                     sprint_started,
                     watcher_started,
                 ) = self._start(bind)
@@ -415,6 +425,14 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
                     "conversation broker started before bind refusal",
                 )
                 self.assertFalse(
+                    reaper_started,
+                    "conversation reaper started before bind refusal",
+                )
+                self.assertFalse(
+                    reaper_stopped,
+                    "conversation reaper shutdown ran without a server",
+                )
+                self.assertFalse(
                     sprint_started,
                     "Sprint runtime started before bind refusal",
                 )
@@ -426,7 +444,7 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
     def test_startup_serves_a_loopback_bind(self):
         self.assertEqual(
             self._start("127.0.0.1"),
-            (None, "127.0.0.1", True, True, True),
+            (None, "127.0.0.1", True, True, True, True, True),
         )
 
     def test_startup_imports_no_removed_scheduler(self):
@@ -447,7 +465,7 @@ class LoopbackBindStartupWiringTest(unittest.TestCase):
         # unbootable, so the sandbox exception has to survive the wiring too.
         self.assertEqual(
             self._start("0.0.0.0", container=True),
-            (None, "0.0.0.0", True, True, True),
+            (None, "0.0.0.0", True, True, True, True, True),
         )
 
     def test_startup_binds_the_csp_to_the_served_port(self):

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -721,6 +721,7 @@ class ProductionPulseTest(SprintWorkDispatchCase):
     def test_server_startup_wires_broker_before_sprint_runtime(self) -> None:
         order: list[str] = []
         preparer = object()
+        broker = mock.Mock()
         with (
             mock.patch.object(
                 server.conversation_launch,
@@ -730,8 +731,15 @@ class ProductionPulseTest(SprintWorkDispatchCase):
             mock.patch.object(
                 server.conversation_broker,
                 "start_service",
-                side_effect=lambda *_args, **_kwargs: order.append("broker"),
+                side_effect=lambda *_args, **_kwargs: (
+                    order.append("broker") or broker
+                ),
             ) as broker_start,
+            mock.patch.object(
+                server.conversation_reaper,
+                "start_service",
+                side_effect=lambda *_args, **_kwargs: order.append("reaper"),
+            ) as reaper_start,
             mock.patch.object(
                 server.sprint_runtime,
                 "start_service",
@@ -740,10 +748,14 @@ class ProductionPulseTest(SprintWorkDispatchCase):
         ):
             server.start_runtime_services()
 
-        self.assertEqual(["broker", "sprint"], order)
+        self.assertEqual(["broker", "reaper", "sprint"], order)
         broker_start.assert_called_once_with(
             server.DB_PATH,
             launch_preparer=preparer,
+        )
+        reaper_start.assert_called_once_with(
+            server.DB_PATH,
+            native_interrupt=broker.interrupt,
         )
         sprint_start.assert_called_once_with(server.DB_PATH)
         self.assertIn(


### PR DESCRIPTION
## Summary\n- persist run PID, /proc start ticks, process group, and reaper ladder state in migration 0163\n- start a configurable 60s reaper service beside the conversation broker; protect only exact active-registry identity matches and never signal recycled PIDs\n- advance harness interrupt → SIGTERM → SIGKILL across heartbeats, then commit cancelled durable state plus terminal run.interrupted evidence (never unknown)\n- give Claude, Codex, and Kimi turn-owned process groups and shared descendant cleanup; OpenCode's shared server intentionally remains NULL/unowned\n- leave unprotected process-bearing recovery rows to the reaper instead of broker reconciliation\n\n## Verification\n- 131 passed, 174 subtests: reaper, conversation schema/adapters/broker, runtime startup wiring, migration management, Sprint-removal manifest, and sandbox --init coverage\n- focused ruff check + format check for new files\n- focused mypy for conversation_reaper.py\n- git diff --check\n\n## Contract notes\nThe existing conversation run-state vocabulary stores interrupted outcomes as state=cancelled; the terminal semantic record is event_type=run.interrupted with reaper evidence. The reaper never writes unknown. Sandbox launch already uses Docker --init, and starting the reaper from the API runtime keeps /proc inspection inside the harness PID namespace.\n\nKnown unrelated test-isolation defect discovered during verification: #962 (SupervisionFixture inherits SC_ROOT and escapes its fake fork). The relevant sandbox --init supervision test passes.