### PR TITLE
feat(messages): unify wake delivery producer

### DIFF
--- a/.super-coder/migrations/0164_wake_message_delivery.sql
+++ b/.super-coder/migrations/0164_wake_message_delivery.sql
@@ -1,0 +1,389 @@
+-- 0164 — general wake messages and delivery-time routing.
+--
+-- Sprint messages become the engine-wide wake_message literal.  Sprint and
+-- participant columns remain as optional workflow context, while delivery and
+-- coalescing are keyed directly to the receiving shell.
+
+PRAGMA foreign_keys=OFF;
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_sprint_messages_acceptance_insert;
+DROP TRIGGER IF EXISTS trg_sprint_messages_acceptance_update;
+DROP TRIGGER IF EXISTS trg_sprint_liveness_acceptance;
+DROP TRIGGER IF EXISTS trg_sprint_liveness_work_terminal;
+DROP TRIGGER IF EXISTS trg_sprint_liveness_identity_immutable;
+DROP TRIGGER IF EXISTS trg_sprint_liveness_no_delete;
+DROP TRIGGER IF EXISTS trg_sprint_wake_delivery_state_insert;
+DROP TRIGGER IF EXISTS trg_sprint_wake_delivery_state_update;
+DROP INDEX IF EXISTS idx_sprint_wake_one_pending_participant;
+DROP INDEX IF EXISTS idx_sprint_wake_outbox_claim;
+DROP INDEX IF EXISTS idx_sprint_liveness_due;
+
+ALTER TABLE sprint_liveness_expectations
+  RENAME TO _wake_message_liveness_legacy;
+ALTER TABLE sprint_wake_attempts RENAME TO _wake_attempts_legacy;
+ALTER TABLE sprint_wake_messages RENAME TO _wake_messages_join_legacy;
+ALTER TABLE sprint_wake_outbox RENAME TO _wake_outbox_legacy;
+ALTER TABLE sprint_messages RENAME TO _wake_message_legacy;
+
+CREATE TABLE wake_message (
+    message_id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id               INTEGER REFERENCES sprints(sprint_id),
+    sender_shell_id         INTEGER REFERENCES shells(shell_id),
+    receiver_shell_id       INTEGER NOT NULL REFERENCES shells(shell_id),
+    from_participant_id     INTEGER REFERENCES sprint_participants(participant_id),
+    to_participant_id       INTEGER REFERENCES sprint_participants(participant_id),
+    work_unit_id            INTEGER REFERENCES sprint_work_units(work_unit_id),
+    message_kind            TEXT NOT NULL
+                            CHECK (message_kind IN
+                              ('work_assignment','review_request','notification',
+                               'nudge','escalation','system')),
+    body                    TEXT NOT NULL CHECK (length(body)>0),
+    declared_type           TEXT NOT NULL
+                            CHECK (declared_type IN ('new','re-enter')),
+    actionable              INTEGER NOT NULL DEFAULT 0
+                            CHECK (actionable IN (0,1)),
+    disposition             TEXT
+                            CHECK (disposition IN
+                              ('pending','accepted','declined')),
+    read_at                 TEXT,
+    delivered_at            TEXT,
+    decline_reason          TEXT,
+    idempotency_key         TEXT NOT NULL UNIQUE
+                            CHECK (length(idempotency_key) BETWEEN 1 AND 255),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK (
+      (actionable=1 AND disposition IS NOT NULL)
+      OR
+      (actionable=0 AND disposition IS NULL)
+    ),
+    CHECK (
+      disposition<>'declined' OR trim(COALESCE(decline_reason,''))<>''
+    ),
+    CHECK (
+      (sprint_id IS NULL AND from_participant_id IS NULL
+       AND to_participant_id IS NULL AND work_unit_id IS NULL)
+      OR
+      (sprint_id IS NOT NULL AND to_participant_id IS NOT NULL)
+    ),
+    UNIQUE (sprint_id, message_id),
+    FOREIGN KEY (sprint_id, from_participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id),
+    FOREIGN KEY (sprint_id, to_participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id),
+    FOREIGN KEY (sprint_id, work_unit_id)
+      REFERENCES sprint_work_units(sprint_id, work_unit_id)
+);
+CREATE INDEX idx_wake_message_inbox
+    ON wake_message(receiver_shell_id, read_at, message_id);
+CREATE INDEX idx_wake_message_delivery
+    ON wake_message(receiver_shell_id, delivered_at, message_id);
+
+INSERT INTO wake_message (
+    message_id,sprint_id,sender_shell_id,receiver_shell_id,
+    from_participant_id,to_participant_id,work_unit_id,message_kind,body,
+    declared_type,actionable,disposition,read_at,delivered_at,decline_reason,
+    idempotency_key,created_at
+)
+SELECT
+    message.message_id,message.sprint_id,sender.shell_id,receiver.shell_id,
+    message.from_participant_id,message.to_participant_id,message.work_unit_id,
+    message.message_kind,message.body,
+    CASE
+      WHEN message.message_kind IN ('work_assignment','review_request') THEN 'new'
+      ELSE 're-enter'
+    END,
+    message.actionable,message.disposition,message.read_at,
+    COALESCE(
+      (
+        SELECT wake.delivered_at
+        FROM _wake_messages_join_legacy joined
+        JOIN _wake_outbox_legacy wake ON wake.wake_id=joined.wake_id
+        WHERE joined.message_id=message.message_id
+          AND wake.state='delivered'
+        LIMIT 1
+      ),
+      CASE WHEN message.read_at IS NOT NULL THEN message.read_at END
+    ),
+    message.decline_reason,message.idempotency_key,message.created_at
+FROM _wake_message_legacy message
+LEFT JOIN sprint_participants sender
+  ON sender.participant_id=message.from_participant_id
+JOIN sprint_participants receiver
+  ON receiver.participant_id=message.to_participant_id;
+
+CREATE TABLE sprint_wake_outbox (
+    wake_id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id               INTEGER REFERENCES sprints(sprint_id),
+    participant_id          INTEGER REFERENCES sprint_participants(participant_id),
+    receiver_shell_id       INTEGER NOT NULL REFERENCES shells(shell_id),
+    state                   TEXT NOT NULL DEFAULT 'pending'
+                            CHECK (state IN
+                              ('pending','delivering','delivered','failed','cancelled')),
+    attempt_count           INTEGER NOT NULL DEFAULT 0
+                            CHECK (attempt_count BETWEEN 0 AND 3),
+    idempotency_key         TEXT NOT NULL UNIQUE
+                            CHECK (length(idempotency_key) BETWEEN 1 AND 255),
+    last_error              TEXT
+                            CHECK (last_error IS NULL OR length(last_error)<=16384),
+    created_at              TEXT NOT NULL DEFAULT (datetime('now')),
+    available_at            TEXT NOT NULL DEFAULT (datetime('now')),
+    delivered_at            TEXT,
+    failed_at               TEXT,
+    claim_owner             TEXT,
+    claimed_at              TEXT,
+    lease_expires_at        TEXT,
+    UNIQUE (sprint_id, wake_id),
+    FOREIGN KEY (sprint_id, participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id),
+    CHECK (
+      (sprint_id IS NULL AND participant_id IS NULL)
+      OR
+      (sprint_id IS NOT NULL AND participant_id IS NOT NULL)
+    )
+);
+CREATE INDEX idx_sprint_wake_outbox_claim
+    ON sprint_wake_outbox(state, available_at, wake_id);
+-- The historical index name is intentionally stable for update compatibility;
+-- the generalized uniqueness key is now the receiver shell.
+CREATE UNIQUE INDEX idx_sprint_wake_one_pending_participant
+    ON sprint_wake_outbox(receiver_shell_id)
+    WHERE state='pending';
+
+INSERT INTO sprint_wake_outbox (
+    wake_id,sprint_id,participant_id,receiver_shell_id,state,attempt_count,
+    idempotency_key,last_error,created_at,available_at,delivered_at,failed_at,
+    claim_owner,claimed_at,lease_expires_at
+)
+SELECT
+    wake.wake_id,wake.sprint_id,wake.participant_id,participant.shell_id,
+    wake.state,wake.attempt_count,wake.idempotency_key,wake.last_error,
+    wake.created_at,wake.available_at,wake.delivered_at,wake.failed_at,
+    wake.claim_owner,wake.claimed_at,wake.lease_expires_at
+FROM _wake_outbox_legacy wake
+JOIN sprint_participants participant
+  ON participant.participant_id=wake.participant_id;
+
+CREATE TABLE sprint_wake_messages (
+    sprint_id   INTEGER REFERENCES sprints(sprint_id),
+    wake_id     INTEGER NOT NULL REFERENCES sprint_wake_outbox(wake_id),
+    message_id  INTEGER NOT NULL UNIQUE REFERENCES wake_message(message_id),
+    PRIMARY KEY (wake_id, message_id)
+);
+INSERT INTO sprint_wake_messages (sprint_id,wake_id,message_id)
+SELECT sprint_id,wake_id,message_id FROM _wake_messages_join_legacy;
+
+CREATE TABLE sprint_wake_attempts (
+    attempt_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    wake_id           INTEGER NOT NULL REFERENCES sprint_wake_outbox(wake_id),
+    attempt_number    INTEGER NOT NULL CHECK (attempt_number BETWEEN 1 AND 3),
+    target_conversation_id TEXT REFERENCES conversations(conversation_id),
+    native_run_ref    TEXT,
+    outcome           TEXT NOT NULL
+                      CHECK (outcome IN ('delivered','failed','coalesced')),
+    error_detail      TEXT
+                      CHECK (error_detail IS NULL OR length(error_detail)<=16384),
+    attempted_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (wake_id, attempt_number)
+);
+INSERT INTO sprint_wake_attempts (
+    attempt_id,wake_id,attempt_number,target_conversation_id,native_run_ref,
+    outcome,error_detail,attempted_at
+)
+SELECT
+    attempt_id,wake_id,attempt_number,target_conversation_id,native_run_ref,
+    outcome,error_detail,attempted_at
+FROM _wake_attempts_legacy;
+
+CREATE TABLE sprint_liveness_expectations (
+    message_id             INTEGER PRIMARY KEY REFERENCES wake_message(message_id),
+    sprint_id              INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    participant_id         INTEGER NOT NULL REFERENCES sprint_participants(participant_id),
+    accepted_at            TEXT NOT NULL,
+    last_strong_at         TEXT NOT NULL,
+    last_strong_key        TEXT NOT NULL CHECK (trim(last_strong_key)<>''),
+    silence_episode        INTEGER NOT NULL DEFAULT 1 CHECK (silence_episode > 0),
+    nudge_at               TEXT,
+    escalated_at           TEXT,
+    last_evaluated_at      TEXT,
+    next_evaluation_at     TEXT,
+    last_supporting        TEXT NOT NULL DEFAULT '[]'
+                           CHECK (json_valid(last_supporting)
+                                  AND json_type(last_supporting)='array'),
+    last_unreadable        TEXT NOT NULL DEFAULT '[]'
+                           CHECK (json_valid(last_unreadable)
+                                  AND json_type(last_unreadable)='array'),
+    last_failure_key       TEXT,
+    resolved_at            TEXT,
+    resolution             TEXT,
+    UNIQUE (sprint_id, message_id),
+    FOREIGN KEY (sprint_id, participant_id)
+      REFERENCES sprint_participants(sprint_id, participant_id),
+    CHECK (
+      (resolved_at IS NULL AND resolution IS NULL)
+      OR
+      (resolved_at IS NOT NULL AND trim(COALESCE(resolution,''))<>'')
+    )
+);
+INSERT INTO sprint_liveness_expectations
+SELECT * FROM _wake_message_liveness_legacy;
+CREATE INDEX idx_sprint_liveness_due
+    ON sprint_liveness_expectations(
+      sprint_id, resolved_at, next_evaluation_at, message_id
+    );
+
+DROP TABLE _wake_message_liveness_legacy;
+DROP TABLE _wake_attempts_legacy;
+DROP TABLE _wake_messages_join_legacy;
+DROP TABLE _wake_outbox_legacy;
+DROP TABLE _wake_message_legacy;
+
+CREATE TRIGGER trg_wake_message_acceptance_insert
+BEFORE INSERT ON wake_message
+WHEN NOT (
+    (NEW.actionable=0 AND NEW.disposition IS NULL
+     AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='pending'
+     AND NEW.read_at IS NULL AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='accepted'
+     AND NEW.read_at IS NOT NULL AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='declined'
+     AND NEW.read_at IS NOT NULL
+     AND trim(COALESCE(NEW.decline_reason,''))<>'')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid wake message acceptance state');
+END;
+
+CREATE TRIGGER trg_wake_message_acceptance_update
+BEFORE UPDATE OF actionable, disposition, read_at, decline_reason
+ON wake_message
+WHEN NOT (
+    (NEW.actionable=0 AND NEW.disposition IS NULL
+     AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='pending'
+     AND NEW.read_at IS NULL AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='accepted'
+     AND NEW.read_at IS NOT NULL AND NEW.decline_reason IS NULL)
+    OR
+    (NEW.actionable=1 AND NEW.disposition='declined'
+     AND NEW.read_at IS NOT NULL
+     AND trim(COALESCE(NEW.decline_reason,''))<>'')
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid wake message acceptance state');
+END;
+
+CREATE TRIGGER trg_sprint_wake_delivery_state_insert
+BEFORE INSERT ON sprint_wake_outbox
+WHEN NOT (
+    (NEW.state='pending' AND NEW.claim_owner IS NULL
+     AND NEW.claimed_at IS NULL AND NEW.lease_expires_at IS NULL
+     AND NEW.delivered_at IS NULL AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='delivering' AND trim(COALESCE(NEW.claim_owner,''))<>''
+     AND NEW.claimed_at IS NOT NULL AND NEW.lease_expires_at IS NOT NULL
+     AND NEW.delivered_at IS NULL AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='delivered' AND NEW.delivered_at IS NOT NULL
+     AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='failed' AND NEW.failed_at IS NOT NULL)
+    OR
+    (NEW.state='cancelled' AND NEW.delivered_at IS NULL)
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid Sprint wake delivery state');
+END;
+
+CREATE TRIGGER trg_sprint_wake_delivery_state_update
+BEFORE UPDATE OF
+    state, claim_owner, claimed_at, lease_expires_at, delivered_at, failed_at
+ON sprint_wake_outbox
+WHEN NOT (
+    (NEW.state='pending' AND NEW.claim_owner IS NULL
+     AND NEW.claimed_at IS NULL AND NEW.lease_expires_at IS NULL
+     AND NEW.delivered_at IS NULL AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='delivering' AND trim(COALESCE(NEW.claim_owner,''))<>''
+     AND NEW.claimed_at IS NOT NULL AND NEW.lease_expires_at IS NOT NULL
+     AND NEW.delivered_at IS NULL AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='delivered' AND NEW.delivered_at IS NOT NULL
+     AND NEW.failed_at IS NULL)
+    OR
+    (NEW.state='failed' AND NEW.failed_at IS NOT NULL)
+    OR
+    (NEW.state='cancelled' AND NEW.delivered_at IS NULL)
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid Sprint wake delivery state');
+END;
+
+CREATE TRIGGER trg_sprint_liveness_acceptance
+AFTER UPDATE OF disposition,read_at ON wake_message
+WHEN NEW.sprint_id IS NOT NULL
+  AND NEW.actionable=1
+  AND NEW.disposition='accepted'
+  AND NEW.read_at IS NOT NULL
+  AND (OLD.disposition<>'accepted' OR OLD.read_at IS NULL)
+BEGIN
+  INSERT INTO sprint_liveness_expectations (
+      message_id,sprint_id,participant_id,accepted_at,
+      last_strong_at,last_strong_key,next_evaluation_at
+  ) VALUES (
+      NEW.message_id,NEW.sprint_id,NEW.to_participant_id,NEW.read_at,
+      NEW.read_at,'message.accepted:' || NEW.message_id,
+      datetime(NEW.read_at,'+5 minutes')
+  );
+END;
+
+CREATE TRIGGER trg_sprint_liveness_work_terminal
+AFTER UPDATE OF disposition ON sprint_work_units
+WHEN NEW.disposition IN ('in_review','completed','cancelled')
+  AND OLD.disposition <> NEW.disposition
+BEGIN
+  UPDATE sprint_liveness_expectations
+  SET resolved_at=datetime('now'),
+      resolution='work_unit.' || NEW.disposition,
+      next_evaluation_at=NULL
+  WHERE resolved_at IS NULL
+    AND message_id IN (
+      SELECT message.message_id
+      FROM wake_message message
+      JOIN sprint_participants participant
+        ON participant.participant_id=message.to_participant_id
+      WHERE message.work_unit_id=NEW.work_unit_id
+        AND (
+          message.message_kind='work_assignment'
+          OR (
+            message.message_kind='notification'
+            AND participant.role='developer'
+            AND participant.shell_id=NEW.assigned_shell_id
+          )
+        )
+    );
+END;
+
+CREATE TRIGGER trg_sprint_liveness_identity_immutable
+BEFORE UPDATE OF message_id,sprint_id,participant_id,accepted_at
+ON sprint_liveness_expectations
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint liveness expectation identity is immutable');
+END;
+
+CREATE TRIGGER trg_sprint_liveness_no_delete
+BEFORE DELETE ON sprint_liveness_expectations
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint liveness history is durable');
+END;
+
+COMMIT;
+
+PRAGMA foreign_keys=ON;

--- a/.super-coder/scripts/active_chat_registry.py
+++ b/.super-coder/scripts/active_chat_registry.py
@@ -24,6 +24,8 @@ class ActiveChat:
     shell_id: int
     chat_id: str
     state: str
+    process_pid: int | None
+    process_start_ticks: int | None
 
 
 @dataclass(frozen=True)
@@ -35,14 +37,35 @@ class ProcessIdentity:
 
 def get(con, shell_id: int) -> ActiveChat | None:
     row = con.execute(
-        "SELECT a.shell_id,a.chat_id,c.state "
+        "SELECT a.shell_id,a.chat_id,c.state,a.process_pid,"
+        "a.process_start_ticks "
         "FROM active_shell_chats a JOIN conversations c "
         "ON c.conversation_id=a.chat_id WHERE a.shell_id=?",
         (shell_id,),
     ).fetchone()
     if row is None:
         return None
-    return ActiveChat(int(row["shell_id"]), str(row["chat_id"]), str(row["state"]))
+    return ActiveChat(
+        int(row["shell_id"]),
+        str(row["chat_id"]),
+        str(row["state"]),
+        int(row["process_pid"]) if row["process_pid"] is not None else None,
+        (
+            int(row["process_start_ticks"])
+            if row["process_start_ticks"] is not None
+            else None
+        ),
+    )
+
+
+def has_live_process(active: ActiveChat) -> bool:
+    """Return true only when the registry pid still names the same process."""
+    if active.process_pid is None or active.process_start_ticks is None:
+        return False
+    return process_identity(str(active.process_pid)) == (
+        active.process_pid,
+        active.process_start_ticks,
+    )
 
 
 def close_active(con, shell_id: int) -> ActiveChat | None:
@@ -73,6 +96,44 @@ def close_active(con, shell_id: int) -> ActiveChat | None:
     if get(con, shell_id) is not None:
         raise ActiveChatError(f"active chat {active.chat_id} did not unlink")
     return active
+
+
+def close_for_wake(con, shell_id: int) -> ActiveChat | None:
+    """Close an idle/stale active chat for New delivery, never a live turn."""
+    active = get(con, shell_id)
+    if active is None:
+        return None
+    if has_live_process(active):
+        raise ActiveChatBusy(f"active chat {active.chat_id} has a live turn")
+    if active.state in {"queued", "running"}:
+        message_ids = [
+            int(row[0])
+            for row in con.execute(
+                "SELECT message_id FROM conversation_outbox "
+                "WHERE conversation_id=? AND state IN ('pending','claimed')",
+                (active.chat_id,),
+            )
+        ]
+        if message_ids:
+            marks = ",".join("?" for _ in message_ids)
+            con.execute(
+                "UPDATE conversation_messages SET state='cancelled',"
+                "completed_at=datetime('now') WHERE message_id IN (" + marks + ")",
+                message_ids,
+            )
+        con.execute(
+            "UPDATE conversation_outbox SET state='cancelled',claim_owner=NULL,"
+            "claimed_at=NULL,lease_expires_at=NULL "
+            "WHERE conversation_id=? AND state IN ('pending','claimed')",
+            (active.chat_id,),
+        )
+        target = "idle" if active.state == "queued" else "error"
+        con.execute(
+            "UPDATE conversations SET state=?,last_activity_at=datetime('now'),"
+            "version=version+1 WHERE conversation_id=? AND state=?",
+            (target, active.chat_id, active.state),
+        )
+    return close_active(con, shell_id)
 
 
 def register(con, shell_id: int, chat_id: str) -> None:

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -54,7 +54,7 @@ SPRINT_INSTANCE_TABLES = [
     "sprint_work_units",
     "sprint_work_unit_tasks",
     "sprint_work_unit_dependencies",
-    "sprint_messages",
+    "wake_message",
     "sprint_wake_outbox",
     "sprint_wake_messages",
     "sprint_wake_attempts",

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -448,7 +448,7 @@ class SprintBoardProjection:
         for row in self.con.execute(
             "WITH ranked AS ("
             " SELECT m.*,ROW_NUMBER() OVER (PARTITION BY m.work_unit_id "
-            " ORDER BY m.message_id DESC) rank FROM sprint_messages m "
+            " ORDER BY m.message_id DESC) rank FROM wake_message m "
             " WHERE m.sprint_id=? AND m.work_unit_id IS NOT NULL) "
             "SELECT ranked.*,sender.shell_id sender_shell_id,"
             "sender_shell.shortname sender_shortname,recipient.shell_id recipient_shell_id,"

--- a/.super-coder/scripts/sprint_close.py
+++ b/.super-coder/scripts/sprint_close.py
@@ -294,7 +294,7 @@ class SprintCloseStore:
         ]
         pending_messages = self._rows(
             "SELECT message_id,to_participant_id,work_unit_id,message_kind,created_at "
-            "FROM sprint_messages WHERE sprint_id=? AND actionable=1 "
+            "FROM wake_message WHERE sprint_id=? AND actionable=1 "
             "AND disposition='pending' ORDER BY message_id",
             (sprint_id,),
         )
@@ -478,7 +478,7 @@ class SprintCloseStore:
         message_counts = {
             row[0]: int(row[1])
             for row in self.con.execute(
-                "SELECT message_kind,COUNT(*) FROM sprint_messages "
+                "SELECT message_kind,COUNT(*) FROM wake_message "
                 "WHERE sprint_id=? AND message_kind IN ('nudge','escalation') "
                 "GROUP BY message_kind ORDER BY message_kind",
                 (sprint_id,),

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -659,7 +659,7 @@ class SprintLifecycleStore:
         if not error:
             raise ValueError("wake failure requires an error")
         error = error[:16384]
-        pause_receipt: PauseReceipt | None = None
+        pause_receipts: list[PauseReceipt] = []
         with db_driver.write_transaction(self.con, "sprint.wake_failure"):
             row = self.con.execute(
                 "SELECT wake_id,sprint_id,state,attempt_count,claim_owner "
@@ -700,20 +700,29 @@ class SprintLifecycleStore:
                     wake_id,
                 ),
             )
-            if terminal and row["sprint_id"] is not None:
-                sprint = self._sprint(int(row["sprint_id"]))
-                if sprint["lifecycle"] == "armed":
-                    pause_receipt = self._pause_in_transaction(
-                        sprint,
-                        LifecycleActor("system"),
-                        reason="wake_delivery_exhausted",
-                        detail={
-                            "wake_id": wake_id,
-                            "attempts": 3,
-                            "last_error": error,
-                        },
+            if terminal:
+                affected_sprints = self.con.execute(
+                    "SELECT DISTINCT s.* FROM sprint_wake_messages wm "
+                    "JOIN wake_message m USING (message_id) "
+                    "JOIN sprints s ON s.sprint_id=m.sprint_id "
+                    "WHERE wm.wake_id=? AND m.delivered_at IS NULL "
+                    "AND s.lifecycle='armed' ORDER BY s.sprint_id",
+                    (wake_id,),
+                ).fetchall()
+                for sprint in affected_sprints:
+                    pause_receipts.append(
+                        self._pause_in_transaction(
+                            sprint,
+                            LifecycleActor("system"),
+                            reason="wake_delivery_exhausted",
+                            detail={
+                                "wake_id": wake_id,
+                                "attempts": 3,
+                                "last_error": error,
+                            },
+                        )
                     )
-        if pause_receipt is not None:
+        for pause_receipt in pause_receipts:
             self._signal_interrupts_and_notifications(pause_receipt)
         return attempt
 
@@ -1044,13 +1053,18 @@ class SprintLifecycleStore:
         if not self.con.in_transaction:
             raise RuntimeError("wake reconciliation requires an active transaction")
         rows = self.con.execute(
-            "SELECT DISTINCT w.wake_id,w.participant_id,w.state,w.idempotency_key "
+            "SELECT w.wake_id,w.sprint_id AS wake_sprint_id,"
+            "m.to_participant_id AS participant_id,w.state,w.idempotency_key,"
+            "CASE WHEN COUNT(*)=COUNT(m.delivered_at) "
+            "THEN MIN(m.delivered_at) END AS delivered_at "
             "FROM sprint_wake_outbox w "
-            "JOIN sprint_wake_messages wm ON wm.sprint_id=w.sprint_id "
-            "AND wm.wake_id=w.wake_id JOIN wake_message m "
-            "ON m.sprint_id=wm.sprint_id AND m.message_id=wm.message_id "
-            "WHERE w.sprint_id=? AND w.state IN ('failed','delivered') "
+            "JOIN sprint_wake_messages wm ON wm.wake_id=w.wake_id "
+            "JOIN wake_message m ON m.message_id=wm.message_id "
+            "WHERE m.sprint_id=? AND wm.sprint_id=m.sprint_id "
+            "AND w.state IN ('failed','delivered') "
             "AND m.read_at IS NULL "
+            "GROUP BY w.wake_id,w.sprint_id,m.to_participant_id,"
+            "w.state,w.idempotency_key "
             "ORDER BY w.wake_id",
             (sprint_id,),
         ).fetchall()
@@ -1060,6 +1074,12 @@ class SprintLifecycleStore:
             participant_id = int(row["participant_id"])
             wake_key = str(row["idempotency_key"])
             turn = self._wake_turn_evidence(old_wake_id)
+            if (
+                row["delivered_at"] is not None
+                and row["wake_sprint_id"] != sprint_id
+                and turn["run_state"] == "succeeded"
+            ):
+                continue
             shell_busy = (
                 turn["run_state"] == "failed"
                 and turn["error_code"] == "SHELL_BUSY"

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -700,7 +700,7 @@ class SprintLifecycleStore:
                     wake_id,
                 ),
             )
-            if terminal:
+            if terminal and row["sprint_id"] is not None:
                 sprint = self._sprint(int(row["sprint_id"]))
                 if sprint["lifecycle"] == "armed":
                     pause_receipt = self._pause_in_transaction(
@@ -1140,16 +1140,22 @@ class SprintLifecycleStore:
                     if row["state"] == "failed"
                     else f"sprint-recovery:{sprint_id}:delivered-unread:{old_wake_id}"
                 )
+            receiver_shell_id = _participant_shell_id(self.con, participant_id)
             deliverable = self.con.execute(
-                "SELECT wake_id,idempotency_key FROM sprint_wake_outbox "
-                "WHERE sprint_id=? AND participant_id=? "
+                "SELECT wake_id,idempotency_key FROM sprint_wake_outbox WHERE "
+                "(receiver_shell_id=? AND state='pending') "
                 + (
-                    "AND state='pending' "
+                    ""
                     if shell_busy
-                    else "AND state IN ('pending','delivering') "
+                    else "OR (sprint_id=? AND participant_id=? "
+                    "AND state='delivering') "
                 )
-                + "ORDER BY wake_id LIMIT 1",
-                (sprint_id, participant_id),
+                + "ORDER BY (state='pending') DESC,wake_id LIMIT 1",
+                (
+                    (receiver_shell_id,)
+                    if shell_busy
+                    else (receiver_shell_id, sprint_id, participant_id)
+                ),
             ).fetchone()
             if deliverable is None:
                 prior_recovery = self.con.execute(
@@ -1173,7 +1179,7 @@ class SprintLifecycleStore:
                             (
                                 sprint_id,
                                 participant_id,
-                                _participant_shell_id(self.con, participant_id),
+                                receiver_shell_id,
                                 recovery_key,
                                 f"+{backoff_seconds} seconds",
                             ),
@@ -1188,7 +1194,7 @@ class SprintLifecycleStore:
                             (
                                 sprint_id,
                                 participant_id,
-                                _participant_shell_id(self.con, participant_id),
+                                receiver_shell_id,
                                 recovery_key,
                             ),
                         ).lastrowid
@@ -1258,11 +1264,13 @@ class SprintLifecycleStore:
             participant_id = int(message["to_participant_id"])
             if self._participant_has_pickup_turn(participant_id):
                 continue
+            receiver_shell_id = _participant_shell_id(self.con, participant_id)
             deliverable = self.con.execute(
-                "SELECT wake_id FROM sprint_wake_outbox WHERE sprint_id=? "
-                "AND participant_id=? AND state IN ('pending','delivering') "
-                "ORDER BY wake_id LIMIT 1",
-                (sprint_id, participant_id),
+                "SELECT wake_id FROM sprint_wake_outbox WHERE "
+                "(receiver_shell_id=? AND state='pending') OR "
+                "(sprint_id=? AND participant_id=? AND state='delivering') "
+                "ORDER BY (state='pending') DESC,wake_id LIMIT 1",
+                (receiver_shell_id, sprint_id, participant_id),
             ).fetchone()
             created = deliverable is None
             if created:
@@ -1274,7 +1282,7 @@ class SprintLifecycleStore:
                         (
                             sprint_id,
                             participant_id,
-                            _participant_shell_id(self.con, participant_id),
+                            receiver_shell_id,
                             (
                                 f"sprint-recovery:{sprint_id}:unwoken:"
                                 f"{int(message['message_id'])}"
@@ -1561,14 +1569,13 @@ class SprintLifecycleStore:
         idempotency_key: str,
     ) -> tuple[int, tuple[str, ...]]:
         participant_id = self._planner_participant_id(sprint_id)
+        receiver_shell_id = _participant_shell_id(self.con, participant_id)
         from sprint_message_delivery import SprintMessageStore
 
-        receipt = SprintMessageStore(self.con).send_in_transaction(
-            sprint_id,
-            to_participant_id=participant_id,
+        receipt = SprintMessageStore(self.con).send_to_shell_in_transaction(
+            receiver_shell_id,
             message_kind="notification",
             body=body,
-            actionable=False,
             declared_type="re-enter",
             idempotency_key=idempotency_key,
         )

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -34,6 +34,16 @@ WAKE_CONTENTION_BACKOFF_SECONDS = (15, 60, 180, 300)
 WAKE_CONTENTION_ATTEMPTS = 5
 
 
+def _participant_shell_id(con: sqlite3.Connection, participant_id: int) -> int:
+    row = con.execute(
+        "SELECT shell_id FROM sprint_participants WHERE participant_id=?",
+        (participant_id,),
+    ).fetchone()
+    if row is None:
+        raise SprintInvariantError("Sprint participant does not exist")
+    return int(row[0])
+
+
 class SprintLifecycleError(ValueError):
     """Base class for a rejected Sprint lifecycle operation."""
 
@@ -250,9 +260,6 @@ class SprintLifecycleStore:
                 target="armed",
                 outcome=None,
             )
-            conversation_ids = sprint_participant_chats.provision_at_arming(
-                self.con, sprint_id
-            )
             wake_ids = self._release_initial_work(
                 sprint_id,
                 planner_participant_id=planner_participant,
@@ -262,7 +269,6 @@ class SprintLifecycleStore:
                 "lifecycle.armed",
                 actor,
                 {
-                    "initial_conversation_ids": conversation_ids,
                     "initial_wake_ids": wake_ids,
                 },
             )
@@ -504,7 +510,7 @@ class SprintLifecycleStore:
             "WHERE w.sprint_id=? AND w.wake_id=? "
             "AND w.state IN ('delivered','failed') AND EXISTS ("
             "SELECT 1 FROM sprint_wake_messages wm "
-            "JOIN sprint_messages m USING (message_id) "
+            "JOIN wake_message m USING (message_id) "
             "WHERE wm.sprint_id=w.sprint_id AND wm.wake_id=w.wake_id "
             "AND m.read_at IS NULL)",
             (sprint_id, wake_id),
@@ -515,22 +521,26 @@ class SprintLifecycleStore:
         replacement_wake_id = int(
             self.con.execute(
                 "INSERT INTO sprint_wake_outbox "
-                "(sprint_id,participant_id,idempotency_key,available_at) "
-                "VALUES (?,?,?,datetime('now'))",
-                (sprint_id, int(wake["participant_id"]), reset_key),
+                "(sprint_id,participant_id,receiver_shell_id,idempotency_key,"
+                "available_at) VALUES (?,?,?,?,datetime('now'))",
+                (
+                    sprint_id,
+                    int(wake["participant_id"]),
+                    _participant_shell_id(self.con, int(wake["participant_id"])),
+                    reset_key,
+                ),
             ).lastrowid
+        )
+        self.con.execute(
+            "UPDATE wake_message SET delivered_at=NULL WHERE message_id IN ("
+            "SELECT message_id FROM sprint_wake_messages "
+            "WHERE sprint_id=? AND wake_id=?)",
+            (sprint_id, wake_id),
         )
         self.con.execute(
             "UPDATE sprint_wake_messages SET wake_id=? "
             "WHERE sprint_id=? AND wake_id=?",
             (replacement_wake_id, sprint_id, wake_id),
-        )
-        route = sprint_participant_chats.ensure_wake_conversation(
-            self.con,
-            int(wake["participant_id"]),
-            idempotency_key=(
-                f"sprint:{sprint_id}:wake:{replacement_wake_id}:conversation"
-            ),
         )
         self._event(
             sprint_id,
@@ -543,7 +553,7 @@ class SprintLifecycleStore:
                 "replacement_wake_id": replacement_wake_id,
                 "prior_idempotency_key": str(wake["idempotency_key"]),
                 "idempotency_key": reset_key,
-                "replacement_conversation_id": route.conversation_id,
+                "replacement_conversation_id": None,
             },
         )
         return (replacement_wake_id,)
@@ -1037,7 +1047,7 @@ class SprintLifecycleStore:
             "SELECT DISTINCT w.wake_id,w.participant_id,w.state,w.idempotency_key "
             "FROM sprint_wake_outbox w "
             "JOIN sprint_wake_messages wm ON wm.sprint_id=w.sprint_id "
-            "AND wm.wake_id=w.wake_id JOIN sprint_messages m "
+            "AND wm.wake_id=w.wake_id JOIN wake_message m "
             "ON m.sprint_id=wm.sprint_id AND m.message_id=wm.message_id "
             "WHERE w.sprint_id=? AND w.state IN ('failed','delivered') "
             "AND m.read_at IS NULL "
@@ -1157,11 +1167,13 @@ class SprintLifecycleStore:
                     new_wake_id = int(
                         self.con.execute(
                             "INSERT INTO sprint_wake_outbox "
-                            "(sprint_id,participant_id,idempotency_key,available_at) "
-                            "VALUES (?,?,?,datetime('now', ?))",
+                            "(sprint_id,participant_id,receiver_shell_id,"
+                            "idempotency_key,available_at) "
+                            "VALUES (?,?,?,?,datetime('now', ?))",
                             (
                                 sprint_id,
                                 participant_id,
+                                _participant_shell_id(self.con, participant_id),
                                 recovery_key,
                                 f"+{backoff_seconds} seconds",
                             ),
@@ -1171,9 +1183,14 @@ class SprintLifecycleStore:
                     new_wake_id = int(
                         self.con.execute(
                             "INSERT INTO sprint_wake_outbox "
-                            "(sprint_id,participant_id,idempotency_key) "
-                            "VALUES (?,?,?)",
-                            (sprint_id, participant_id, recovery_key),
+                            "(sprint_id,participant_id,receiver_shell_id,"
+                            "idempotency_key) VALUES (?,?,?,?)",
+                            (
+                                sprint_id,
+                                participant_id,
+                                _participant_shell_id(self.con, participant_id),
+                                recovery_key,
+                            ),
                         ).lastrowid
                     )
             else:
@@ -1196,16 +1213,15 @@ class SprintLifecycleStore:
                     ),
                 )
             self.con.execute(
+                "UPDATE wake_message SET delivered_at=NULL WHERE message_id IN ("
+                "SELECT message_id FROM sprint_wake_messages "
+                "WHERE sprint_id=? AND wake_id=?)",
+                (sprint_id, old_wake_id),
+            )
+            self.con.execute(
                 "UPDATE sprint_wake_messages SET wake_id=? "
                 "WHERE sprint_id=? AND wake_id=?",
                 (new_wake_id, sprint_id, old_wake_id),
-            )
-            route = sprint_participant_chats.ensure_wake_conversation(
-                self.con,
-                participant_id,
-                idempotency_key=(
-                    f"sprint:{sprint_id}:wake:{new_wake_id}:conversation"
-                ),
             )
             self._event(
                 sprint_id,
@@ -1218,7 +1234,7 @@ class SprintLifecycleStore:
                     "prior_turn_state": turn,
                     "replacement_wake_id": new_wake_id,
                     "replacement_created": created,
-                    "replacement_conversation_id": route.conversation_id,
+                    "replacement_conversation_id": None,
                     **classification,
                     **(
                         {"failed_wake_id": old_wake_id}
@@ -1230,7 +1246,7 @@ class SprintLifecycleStore:
             replacements.append(new_wake_id)
 
         unwoken = self.con.execute(
-            "SELECT m.message_id,m.to_participant_id FROM sprint_messages m "
+            "SELECT m.message_id,m.to_participant_id FROM wake_message m "
             "WHERE m.sprint_id=? AND m.read_at IS NULL "
             "AND m.idempotency_key LIKE 'decline-result:%' "
             "AND m.to_participant_id IS NOT NULL AND NOT EXISTS ("
@@ -1253,12 +1269,16 @@ class SprintLifecycleStore:
                 new_wake_id = int(
                     self.con.execute(
                         "INSERT INTO sprint_wake_outbox "
-                        "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
+                        "(sprint_id,participant_id,receiver_shell_id,"
+                        "idempotency_key) VALUES (?,?,?,?)",
                         (
                             sprint_id,
                             participant_id,
-                            f"sprint-recovery:{sprint_id}:unwoken:"
-                            f"{int(message['message_id'])}",
+                            _participant_shell_id(self.con, participant_id),
+                            (
+                                f"sprint-recovery:{sprint_id}:unwoken:"
+                                f"{int(message['message_id'])}"
+                            ),
                         ),
                     ).lastrowid
                 )
@@ -1268,13 +1288,6 @@ class SprintLifecycleStore:
                 "INSERT INTO sprint_wake_messages "
                 "(sprint_id,wake_id,message_id) VALUES (?,?,?)",
                 (sprint_id, new_wake_id, int(message["message_id"])),
-            )
-            route = sprint_participant_chats.ensure_wake_conversation(
-                self.con,
-                participant_id,
-                idempotency_key=(
-                    f"sprint:{sprint_id}:wake:{new_wake_id}:conversation"
-                ),
             )
             self._event(
                 sprint_id,
@@ -1288,7 +1301,7 @@ class SprintLifecycleStore:
                     "message_id": int(message["message_id"]),
                     "replacement_wake_id": new_wake_id,
                     "replacement_created": created,
-                    "replacement_conversation_id": route.conversation_id,
+                    "replacement_conversation_id": None,
                 },
             )
             replacements.append(new_wake_id)
@@ -1399,7 +1412,7 @@ class SprintLifecycleStore:
     ) -> tuple[int, ...]:
         rows = self.con.execute(
             "SELECT e.message_id FROM sprint_liveness_expectations e "
-            "JOIN sprint_messages m ON m.message_id=e.message_id "
+            "JOIN wake_message m ON m.message_id=e.message_id "
             "WHERE m.work_unit_id=? AND m.message_kind='review_request' "
             "AND e.resolved_at IS NULL ORDER BY e.message_id",
             (work_unit_id,),
@@ -1438,21 +1451,11 @@ class SprintLifecycleStore:
             for row in self.con.execute(
                 "SELECT p.participant_id,p.role FROM sprint_participants p "
                 "JOIN shells sh USING (shell_id) WHERE p.sprint_id=? "
-                "AND (sh.is_deleted<>0 OR p.current_conversation_id IS NULL) "
+                "AND sh.is_deleted<>0 "
                 "ORDER BY p.participant_id",
                 (sprint_id,),
             )
         ]
-        anomalies.extend(
-            f"wake {row['wake_id']} targets a participant without a current conversation"
-            for row in self.con.execute(
-                "SELECT w.wake_id FROM sprint_wake_outbox w "
-                "JOIN sprint_participants p ON p.participant_id=w.participant_id "
-                "WHERE w.sprint_id=? AND w.state IN ('pending','delivering') "
-                "AND p.current_conversation_id IS NULL ORDER BY w.wake_id",
-                (sprint_id,),
-            )
-        )
         return tuple(anomalies)
 
     def _reconciliation_evidence(
@@ -1487,7 +1490,7 @@ class SprintLifecycleStore:
             "unread_message_ids": [
                 int(row[0])
                 for row in self.con.execute(
-                    "SELECT message_id FROM sprint_messages WHERE sprint_id=? "
+                    "SELECT message_id FROM wake_message WHERE sprint_id=? "
                     "AND read_at IS NULL ORDER BY message_id",
                     (sprint_id,),
                 )
@@ -1558,98 +1561,18 @@ class SprintLifecycleStore:
         idempotency_key: str,
     ) -> tuple[int, tuple[str, ...]]:
         participant_id = self._planner_participant_id(sprint_id)
-        participant = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE participant_id=?",
-            (participant_id,),
-        ).fetchone()
-        existing = self.con.execute(
-            "SELECT message_id FROM sprint_messages WHERE idempotency_key=?",
-            (idempotency_key,),
-        ).fetchone()
-        if existing is None:
-            message_id = int(
-                self.con.execute(
-                    "INSERT INTO sprint_messages "
-                    "(sprint_id,to_participant_id,message_kind,body,actionable,"
-                    "idempotency_key) VALUES (?,?,'notification',?,0,?)",
-                    (sprint_id, participant_id, body, idempotency_key),
-                ).lastrowid
-            )
-        else:
-            message_id = int(existing[0])
-        conversation_id = participant["current_conversation_id"]
-        if conversation_id is None:
-            return message_id, ()
-        conversation = self.con.execute(
-            "SELECT state FROM conversations WHERE conversation_id=?",
-            (conversation_id,),
-        ).fetchone()
-        if conversation is None or conversation["state"] == "closed":
-            return message_id, ()
-        prompt = sprint_participant_chats.wake_prompt(sprint_id, "planner")
-        prompt_key = f"{idempotency_key}:planner-conversation"
-        queued = self.con.execute(
-            "SELECT message_id FROM conversation_messages "
-            "WHERE conversation_id=? AND idempotency_key=?",
-            (conversation_id, prompt_key),
-        ).fetchone()
-        if queued is None:
-            conversation_message_id = int(
-                self.con.execute(
-                    "INSERT INTO conversation_messages "
-                    "(conversation_id,sender_kind,sender_ref,message_kind,body,"
-                    "idempotency_key,request_hash,state) "
-                    "VALUES (?,'engine','sprint-recovery','prompt',?,?,?,'queued')",
-                    (
-                        conversation_id,
-                        prompt,
-                        prompt_key,
-                        hashlib.sha256(prompt.encode()).hexdigest(),
-                    ),
-                ).lastrowid
-            )
-            self.con.execute(
-                "INSERT INTO conversation_outbox (conversation_id,message_id) "
-                "VALUES (?,?)",
-                (conversation_id, conversation_message_id),
-            )
-            sequence = int(
-                self.con.execute(
-                    "SELECT COALESCE(MAX(sequence),0)+1 "
-                    "FROM conversation_events WHERE conversation_id=?",
-                    (conversation_id,),
-                ).fetchone()[0]
-            )
-            self.con.execute(
-                "INSERT INTO conversation_events "
-                "(conversation_id,sequence,event_type,payload,message_id) "
-                "VALUES (?,?,'message.accepted',?,?)",
-                (
-                    conversation_id,
-                    sequence,
-                    json.dumps(
-                        {
-                            "message_id": conversation_message_id,
-                            "queue_state": "queued",
-                            "source": "sprint_recovery",
-                        },
-                        sort_keys=True,
-                    ),
-                    conversation_message_id,
-                ),
-            )
-            target_state = (
-                conversation["state"]
-                if conversation["state"] in {"queued", "running"}
-                else "queued"
-            )
-            self.con.execute(
-                "UPDATE conversations SET state=?,last_activity_at=datetime('now'),"
-                "version=version+1 WHERE conversation_id=?",
-                (target_state, conversation_id),
-            )
-        return message_id, (str(conversation_id),)
+        from sprint_message_delivery import SprintMessageStore
+
+        receipt = SprintMessageStore(self.con).send_in_transaction(
+            sprint_id,
+            to_participant_id=participant_id,
+            message_kind="notification",
+            body=body,
+            actionable=False,
+            declared_type="re-enter",
+            idempotency_key=idempotency_key,
+        )
+        return receipt.message_id, ()
 
     def _signal_interrupts_and_notifications(
         self, receipt: PauseReceipt | AbortReceipt
@@ -2297,52 +2220,23 @@ class SprintWorkUnitStore:
             raise SprintInvariantError("Sprint has no Planner participant")
         planner_id = int(planner["participant_id"])
         key = f"merge-grant-bypassed:{transition_key}:unit:{work_unit_id}"
-        existing = self.con.execute(
-            "SELECT message_id FROM sprint_messages WHERE idempotency_key=?",
-            (key,),
-        ).fetchone()
-        if existing is not None:
-            return int(existing["message_id"])
-        message_id = int(
-            self.con.execute(
-                "INSERT INTO sprint_messages "
-                "(sprint_id,to_participant_id,work_unit_id,message_kind,body,"
-                "actionable,idempotency_key) VALUES (?,?,?,'notification',?,0,?)",
-                (
-                    sprint_id,
-                    planner_id,
-                    work_unit_id,
-                    (
-                        f"Merged PR bypassed the Sprint merge grant for work unit "
-                        f"{work_unit_id} from {before}; the unit remains incomplete "
-                        "and requires Planner disposition."
-                    ),
-                    key,
-                ),
-            ).lastrowid
+        from sprint_message_delivery import SprintMessageStore
+
+        receipt = SprintMessageStore(self.con).send_in_transaction(
+            sprint_id,
+            to_participant_id=planner_id,
+            work_unit_id=work_unit_id,
+            message_kind="notification",
+            body=(
+                f"Merged PR bypassed the Sprint merge grant for work unit "
+                f"{work_unit_id} from {before}; the unit remains incomplete "
+                "and requires Planner disposition."
+            ),
+            actionable=False,
+            declared_type="re-enter",
+            idempotency_key=key,
         )
-        pending = self.con.execute(
-            "SELECT wake_id FROM sprint_wake_outbox WHERE sprint_id=? "
-            "AND participant_id=? AND state='pending'",
-            (sprint_id, planner_id),
-        ).fetchone()
-        wake_id = (
-            int(pending["wake_id"])
-            if pending is not None
-            else int(
-                self.con.execute(
-                    "INSERT INTO sprint_wake_outbox "
-                    "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
-                    (sprint_id, planner_id, f"wake:{key}"),
-                ).lastrowid
-            )
-        )
-        self.con.execute(
-            "INSERT INTO sprint_wake_messages "
-            "(sprint_id,wake_id,message_id) VALUES (?,?,?)",
-            (sprint_id, wake_id, message_id),
-        )
-        return message_id
+        return receipt.message_id
 
     def _dispatch_ready_locked(
         self,
@@ -2397,12 +2291,9 @@ class SprintWorkUnitStore:
         unit: sqlite3.Row,
     ) -> int:
         unit_id = int(unit["work_unit_id"])
-        sprint_participant_chats.select_work(
-            self.con, int(unit["participant_id"])
-        )
         generation = int(
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_messages "
+                "SELECT COUNT(*) FROM wake_message "
                 "WHERE work_unit_id=? AND message_kind='work_assignment'",
                 (unit_id,),
             ).fetchone()[0]
@@ -2410,44 +2301,25 @@ class SprintWorkUnitStore:
         key = (
             f"sprint:{sprint_id}:work-unit:{unit_id}:assignment:{generation}"
         )
-        message_id = int(
-            self.con.execute(
-                "INSERT INTO sprint_messages "
-                "(sprint_id,from_participant_id,to_participant_id,work_unit_id,"
-                "message_kind,body,actionable,disposition,idempotency_key) "
-                "VALUES (?,?,?,?,?,?,1,'pending',?)",
-                (
-                    sprint_id,
-                    planner_participant_id,
-                    unit["participant_id"],
-                    unit_id,
-                    "work_assignment",
-                    f"{unit['title']}\n\n{unit['expected_output']}",
-                    key,
-                ),
-            ).lastrowid
+        # Local import avoids a module cycle: the message store uses the domain
+        # lifecycle for durable failure evidence.
+        from sprint_message_delivery import SprintMessageStore
+
+        receipt = SprintMessageStore(self.con).send_in_transaction(
+            sprint_id,
+            from_participant_id=planner_participant_id,
+            to_participant_id=int(unit["participant_id"]),
+            work_unit_id=unit_id,
+            message_kind="work_assignment",
+            body=f"{unit['title']}\n\n{unit['expected_output']}",
+            actionable=True,
+            declared_type="new",
+            idempotency_key=key,
         )
-        pending = self.con.execute(
-            "SELECT wake_id FROM sprint_wake_outbox "
-            "WHERE sprint_id=? AND participant_id=? AND state='pending'",
-            (sprint_id, unit["participant_id"]),
-        ).fetchone()
-        wake_id = (
-            int(pending["wake_id"])
-            if pending is not None
-            else int(
-                self.con.execute(
-                    "INSERT INTO sprint_wake_outbox "
-                    "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
-                    (sprint_id, unit["participant_id"], f"wake:{key}"),
-                ).lastrowid
-            )
-        )
-        self.con.execute(
-            "INSERT INTO sprint_wake_messages "
-            "(sprint_id,wake_id,message_id) VALUES (?,?,?)",
-            (sprint_id, wake_id, message_id),
-        )
+        if receipt.wake_id is None:
+            raise SprintInvariantError("work assignment has no wake")
+        message_id = receipt.message_id
+        wake_id = receipt.wake_id
         self.con.execute(
             "UPDATE sprint_work_units SET disposition='ready',"
             "updated_at=datetime('now') WHERE work_unit_id=?",

--- a/.super-coder/scripts/sprint_liveness.py
+++ b/.super-coder/scripts/sprint_liveness.py
@@ -17,9 +17,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import db_driver
-import run as run_mod
 import shell_liveness
-import sprint_participant_chats
 from sprint_message_delivery import SprintMessageStore
 
 EVALUATION_INTERVAL = timedelta(minutes=5)
@@ -312,7 +310,7 @@ class SprintEvidenceCollector:
             )
 
         row = self.con.execute(
-            "SELECT message_id,message_kind,created_at FROM sprint_messages "
+            "SELECT message_id,message_kind,created_at FROM wake_message "
             "WHERE from_participant_id=? AND created_at>=? "
             "ORDER BY created_at DESC,message_id DESC LIMIT 1",
             (participant_id, threshold),
@@ -489,64 +487,16 @@ class PlannerEscalationRouter:
         reason: str,
     ) -> tuple[int, str]:
         planner = self.con.execute(
-            "SELECT p.participant_id,p.harness,p.model,p.effort,sh.flavor "
-            "FROM sprint_participants p JOIN shells sh ON sh.shell_id=p.shell_id "
-            "WHERE p.sprint_id=? AND p.role='planner'",
+            "SELECT participant_id FROM sprint_participants "
+            "WHERE sprint_id=? AND role='planner'",
             (sprint_id,),
         ).fetchone()
         if planner is None:
             raise RuntimeError("armed Sprint has no Planner participant")
-        participant_id = int(planner["participant_id"])
-        primary_provider = _provider(
-            run_mod.session_provider(planner["harness"], planner["model"])
-        )
-        primary = self.collector.quota_state(primary_provider, now)
-        if not primary.exhausted:
-            return participant_id, "primary"
-
-        incident_source = primary.key or primary.provider or "unknown"
-        incident = hashlib.sha256(incident_source.encode()).hexdigest()[:16]
-        fallback_key = f"sprint:{sprint_id}:liveness:planner-fallback:{incident}"
-        existing_id = sprint_participant_chats.linked_conversation_for_key(
-            self.con, participant_id, "fallback", fallback_key
-        )
-        if existing_id is not None:
-            existing = self.con.execute(
-                "SELECT conversation_id,harness FROM conversations "
-                "WHERE conversation_id=?",
-                (existing_id,),
-            ).fetchone()
-            self.con.execute(
-                "UPDATE sprint_participants SET current_conversation_id=? "
-                "WHERE participant_id=?",
-                (existing["conversation_id"], participant_id),
-            )
-            return participant_id, f"fallback:{existing['harness']}"
-
-        candidates = self.con.execute(
-            "SELECT harness,model FROM flavor_defaults WHERE flavor=? "
-            "AND harness<>? ORDER BY is_default DESC,harness",
-            (planner["flavor"], planner["harness"]),
-        ).fetchall()
-        for candidate in candidates:
-            candidate_provider = _provider(
-                run_mod.session_provider(candidate["harness"], candidate["model"])
-            )
-            if candidate_provider == primary.provider:
-                continue
-            if self.collector.quota_state(candidate_provider, now).exhausted:
-                continue
-            sprint_participant_chats.create_planner_fallback(
-                self.con,
-                participant_id=participant_id,
-                reason=reason,
-                harness=candidate["harness"],
-                model=candidate["model"],
-                effort=planner["effort"],
-                idempotency_key=fallback_key,
-            )
-            return participant_id, f"fallback:{candidate['harness']}"
-        return participant_id, "unavailable"
+        # Chat placement is no longer a producer concern.  The escalation
+        # commits through the unified wake-message store; the delivery worker
+        # resolves live-turn protection, Re-enter, or New afterward.
+        return int(planner["participant_id"]), "delivery-time"
 
 
 class SprintLivenessMonitor:
@@ -572,7 +522,7 @@ class SprintLivenessMonitor:
             return ()
         due = self.con.execute(
             "SELECT e.* FROM sprint_liveness_expectations e "
-            "JOIN sprint_messages m ON m.message_id=e.message_id "
+            "JOIN wake_message m ON m.message_id=e.message_id "
             "WHERE e.sprint_id=? AND e.resolved_at IS NULL "
             "AND e.next_evaluation_at IS NOT NULL "
             "AND e.next_evaluation_at<=? AND m.disposition='accepted' "
@@ -618,7 +568,7 @@ class SprintLivenessMonitor:
             raise ValueError("liveness expectation resolution is empty")
         rows = self.con.execute(
             "SELECT e.message_id FROM sprint_liveness_expectations e "
-            "JOIN sprint_messages m ON m.message_id=e.message_id "
+            "JOIN wake_message m ON m.message_id=e.message_id "
             "WHERE m.work_unit_id=? AND m.message_kind='review_request' "
             "AND e.resolved_at IS NULL ORDER BY e.message_id",
             (work_unit_id,),
@@ -709,7 +659,7 @@ class SprintLivenessMonitor:
                         f"liveness:{message_id}:episode:{episode}:nudge"
                     ),
                     actionable=False,
-                    active=True,
+                    declared_type="re-enter",
                 )
                 self._event(
                     int(row["sprint_id"]),
@@ -793,7 +743,7 @@ class SprintLivenessMonitor:
                 f"planner-escalation:{escalation_key}"
             ),
             actionable=False,
-            active=route != "unavailable",
+            declared_type="re-enter",
         )
         event_type = (
             "liveness.escalation_delivery_unavailable"

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -121,6 +121,31 @@ class SprintMessageStore:
         declared_type: str = "re-enter",
     ) -> MessageReceipt:
         """Send an engine-wide wake message with no Sprint scope."""
+        with db_driver.write_transaction(self.con, "wake.message.send"):
+            return self.send_to_shell_in_transaction(
+                receiver_shell_id,
+                message_kind=message_kind,
+                body=body,
+                idempotency_key=idempotency_key,
+                sender_shell_id=sender_shell_id,
+                declared_type=declared_type,
+            )
+
+    def send_to_shell_in_transaction(
+        self,
+        receiver_shell_id: int,
+        *,
+        message_kind: str,
+        body: str,
+        idempotency_key: str,
+        sender_shell_id: int | None = None,
+        declared_type: str = "re-enter",
+    ) -> MessageReceipt:
+        """Commit an engine-wide wake through a caller-owned transaction."""
+        if not self.con.in_transaction:
+            raise RuntimeError(
+                "send_to_shell_in_transaction requires an active transaction"
+            )
         body = body.strip()
         key = idempotency_key.strip()
         if not body:
@@ -129,66 +154,63 @@ class SprintMessageStore:
             raise ValueError("wake message idempotency key is empty")
         if declared_type not in {"new", "re-enter"}:
             raise ValueError("wake message type must be new or re-enter")
-        with db_driver.write_transaction(self.con, "wake.message.send"):
-            receiver = self.con.execute(
-                "SELECT 1 FROM shells WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
-                (receiver_shell_id,),
-            ).fetchone()
-            if receiver is None:
-                raise KeyError(f"unknown wake receiver shell: {receiver_shell_id}")
-            existing = self.con.execute(
-                "SELECT * FROM wake_message WHERE idempotency_key=?", (key,)
-            ).fetchone()
-            if existing is not None:
-                actual = (
-                    existing["sprint_id"],
-                    existing["sender_shell_id"],
-                    int(existing["receiver_shell_id"]),
-                    str(existing["message_kind"]),
-                    str(existing["body"]),
-                    str(existing["declared_type"]),
+        receiver = self.con.execute(
+            "SELECT 1 FROM shells WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+            (receiver_shell_id,),
+        ).fetchone()
+        if receiver is None:
+            raise KeyError(f"unknown wake receiver shell: {receiver_shell_id}")
+        existing = self.con.execute(
+            "SELECT * FROM wake_message WHERE idempotency_key=?", (key,)
+        ).fetchone()
+        if existing is not None:
+            actual = (
+                existing["sprint_id"],
+                existing["sender_shell_id"],
+                int(existing["receiver_shell_id"]),
+                str(existing["message_kind"]),
+                str(existing["body"]),
+                str(existing["declared_type"]),
+            )
+            expected = (
+                None,
+                sender_shell_id,
+                receiver_shell_id,
+                message_kind,
+                body,
+                declared_type,
+            )
+            if actual != expected:
+                raise SprintInvariantError(
+                    "wake message idempotency key was reused with different input"
                 )
-                expected = (
-                    None,
+            wake = self.con.execute(
+                "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
+                (existing["message_id"],),
+            ).fetchone()
+            if wake is None:
+                raise SprintInvariantError("wake message has no delivery intent")
+            return MessageReceipt(
+                int(existing["message_id"]), int(wake["wake_id"]), False
+            )
+        message_id = int(
+            self.con.execute(
+                "INSERT INTO wake_message "
+                "(sender_shell_id,receiver_shell_id,message_kind,body,"
+                "declared_type,actionable,idempotency_key) "
+                "VALUES (?,?,?,?,?,0,?)",
+                (
                     sender_shell_id,
                     receiver_shell_id,
                     message_kind,
                     body,
                     declared_type,
-                )
-                if actual != expected:
-                    raise SprintInvariantError(
-                        "wake message idempotency key was reused with different input"
-                    )
-                wake = self.con.execute(
-                    "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
-                    (existing["message_id"],),
-                ).fetchone()
-                if wake is None:
-                    raise SprintInvariantError("wake message has no delivery intent")
-                return MessageReceipt(
-                    int(existing["message_id"]), int(wake["wake_id"]), False
-                )
-            message_id = int(
-                self.con.execute(
-                    "INSERT INTO wake_message "
-                    "(sender_shell_id,receiver_shell_id,message_kind,body,"
-                    "declared_type,actionable,idempotency_key) "
-                    "VALUES (?,?,?,?,?,0,?)",
-                    (
-                        sender_shell_id,
-                        receiver_shell_id,
-                        message_kind,
-                        body,
-                        declared_type,
-                        key,
-                    ),
-                ).lastrowid
-            )
-            wake_id = self._coalesce_wake(
-                None, None, receiver_shell_id, message_id
-            )
-            return MessageReceipt(message_id, wake_id, True)
+                    key,
+                ),
+            ).lastrowid
+        )
+        wake_id = self._coalesce_wake(None, None, receiver_shell_id, message_id)
+        return MessageReceipt(message_id, wake_id, True)
 
     def relay(
         self,
@@ -688,15 +710,16 @@ class SprintWakeDeliveryService:
             row = self.con.execute(
                 "SELECT w.*,p.role "
                 "FROM sprint_wake_outbox w "
-                "LEFT JOIN sprints s ON s.sprint_id=w.sprint_id "
                 "LEFT JOIN sprint_participants p "
                 "ON p.sprint_id=w.sprint_id AND p.participant_id=w.participant_id "
                 "WHERE ((w.state='delivering' AND w.lease_expires_at<=?) "
                 "OR (w.state='pending' AND w.available_at<=?)) "
-                "AND (w.sprint_id IS NULL OR s.lifecycle='armed') "
                 "AND EXISTS (SELECT 1 FROM sprint_wake_messages wm "
                 "JOIN wake_message m USING (message_id) "
-                "WHERE wm.wake_id=w.wake_id AND m.delivered_at IS NULL) "
+                "LEFT JOIN sprints message_sprint "
+                "ON message_sprint.sprint_id=m.sprint_id "
+                "WHERE wm.wake_id=w.wake_id AND m.delivered_at IS NULL "
+                "AND (m.sprint_id IS NULL OR message_sprint.lifecycle='armed')) "
                 "ORDER BY w.wake_id LIMIT 1",
                 (now, now),
             ).fetchone()
@@ -789,37 +812,57 @@ class SprintWakeDeliveryService:
         if active is not None and not wants_new:
             return active.chat_id
 
+        shell_route = None
+        if lease.sprint_id is None or lease.participant_id is None:
+            shell_route = sprint_participant_chats.prepare_shell_wake_conversation(
+                self.con, lease.receiver_shell_id
+            )
+
         closed_id = None
         if active is not None:
-            with db_driver.write_transaction(self.con, "wake.route.close_active"):
-                closed = active_chat_registry.close_for_wake(
-                    self.con, lease.receiver_shell_id
-                )
-                if closed is not None:
-                    closed_id = closed.chat_id
-                    sprint_participant_chats._append_event(
-                        self.con,
-                        closed.chat_id,
-                        "conversation.closed",
-                        {
-                            "reason": "New wake_message delivery",
-                            "state": "closed",
-                            "wake_id": lease.wake_id,
-                        },
+            try:
+                with db_driver.write_transaction(self.con, "wake.route.close_active"):
+                    closed = active_chat_registry.close_for_wake(
+                        self.con, lease.receiver_shell_id
                     )
+                    if closed is not None:
+                        closed_id = closed.chat_id
+                        sprint_participant_chats._append_event(
+                            self.con,
+                            closed.chat_id,
+                            "conversation.closed",
+                            {
+                                "reason": "New wake_message delivery",
+                                "state": "closed",
+                                "wake_id": lease.wake_id,
+                            },
+                        )
+            except active_chat_registry.ActiveChatBusy:
+                raced = active_chat_registry.get(self.con, lease.receiver_shell_id)
+                if raced is not None:
+                    return raced.chat_id
+                raise
         if closed_id is not None:
             conversation_events.notify(closed_id)
-        if lease.sprint_id is None or lease.participant_id is None:
-            raise SprintInvariantError(
-                "New wake delivery without an active chat needs routing context"
-            )
-        with db_driver.write_transaction(self.con, "wake.route.create"):
-            return sprint_participant_chats.create_wake_conversation(
-                self.con,
-                wake_id=lease.wake_id,
-                sprint_id=lease.sprint_id,
-                participant_id=lease.participant_id,
-            )
+        try:
+            with db_driver.write_transaction(self.con, "wake.route.create"):
+                if shell_route is not None:
+                    return sprint_participant_chats.create_shell_wake_conversation(
+                        self.con,
+                        wake_id=lease.wake_id,
+                        route=shell_route,
+                    )
+                return sprint_participant_chats.create_wake_conversation(
+                    self.con,
+                    wake_id=lease.wake_id,
+                    sprint_id=lease.sprint_id,
+                    participant_id=lease.participant_id,
+                )
+        except sprint_participant_chats.WakeConversationBusy:
+            raced = active_chat_registry.get(self.con, lease.receiver_shell_id)
+            if raced is not None:
+                return raced.chat_id
+            raise
 
     def deliver_once(
         self,
@@ -838,8 +881,6 @@ class SprintWakeDeliveryService:
                 lease.idempotency_key,
             )
         except Exception as exc:  # external delivery faults become durable evidence
-            if lease.sprint_id is None:
-                raise
             attempt = self.lifecycle.record_wake_failure(
                 lease.wake_id,
                 str(exc) or exc.__class__.__name__,

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -708,10 +708,7 @@ class SprintWakeDeliveryService:
                 (now,),
             )
             row = self.con.execute(
-                "SELECT w.*,p.role "
-                "FROM sprint_wake_outbox w "
-                "LEFT JOIN sprint_participants p "
-                "ON p.sprint_id=w.sprint_id AND p.participant_id=w.participant_id "
+                "SELECT w.* FROM sprint_wake_outbox w "
                 "WHERE ((w.state='delivering' AND w.lease_expires_at<=?) "
                 "OR (w.state='pending' AND w.available_at<=?)) "
                 "AND EXISTS (SELECT 1 FROM sprint_wake_messages wm "
@@ -743,13 +740,61 @@ class SprintWakeDeliveryService:
                 return None
 
             messages = self.con.execute(
-                "SELECT message_id,sprint_id,declared_type,body "
-                "FROM wake_message WHERE receiver_shell_id=? "
-                "AND delivered_at IS NULL ORDER BY message_id",
+                "SELECT m.message_id,m.sprint_id,m.to_participant_id,"
+                "m.declared_type,m.body,s.lifecycle,p.role "
+                "FROM wake_message m LEFT JOIN sprints s "
+                "ON s.sprint_id=m.sprint_id LEFT JOIN sprint_participants p "
+                "ON p.sprint_id=m.sprint_id "
+                "AND p.participant_id=m.to_participant_id "
+                "WHERE m.receiver_shell_id=? AND m.delivered_at IS NULL "
+                "ORDER BY m.message_id",
                 (row["receiver_shell_id"],),
             ).fetchall()
             if not messages:
                 raise SprintInvariantError("claimed wake has no undelivered messages")
+            route = next(
+                (
+                    message
+                    for message in messages
+                    if message["sprint_id"] is not None
+                    and message["lifecycle"] == "armed"
+                ),
+                None,
+            )
+            if route is None:
+                route = next(
+                    (message for message in messages if message["sprint_id"] is None),
+                    None,
+                )
+            if route is None:
+                raise SprintInvariantError(
+                    "claimed wake has no message-scoped routing identity"
+                )
+            route_sprint_id = (
+                int(route["sprint_id"]) if route["sprint_id"] is not None else None
+            )
+            route_participant_id = (
+                int(route["to_participant_id"])
+                if route["to_participant_id"] is not None
+                else None
+            )
+            route_role = str(route["role"]) if route["role"] is not None else None
+            if route_sprint_id is not None and (
+                route_participant_id is None or route_role is None
+            ):
+                raise SprintInvariantError(
+                    "Sprint wake message has no participant routing identity"
+                )
+            self.con.execute(
+                "UPDATE sprint_wake_outbox SET sprint_id=?,participant_id=? "
+                "WHERE wake_id=? AND state='delivering' AND claim_owner=?",
+                (
+                    route_sprint_id,
+                    route_participant_id,
+                    row["wake_id"],
+                    owner,
+                ),
+            )
             message_ids = tuple(int(message["message_id"]) for message in messages)
             marks = ",".join("?" for _ in message_ids)
             self.con.execute(
@@ -767,30 +812,26 @@ class SprintWakeDeliveryService:
             )
             return WakeLease(
                 wake_id=int(row["wake_id"]),
-                sprint_id=(
-                    int(row["sprint_id"]) if row["sprint_id"] is not None else None
-                ),
-                participant_id=(
-                    int(row["participant_id"])
-                    if row["participant_id"] is not None
-                    else None
-                ),
-                participant_role=(str(row["role"]) if row["role"] else None),
+                sprint_id=route_sprint_id,
+                participant_id=route_participant_id,
+                participant_role=route_role,
                 receiver_shell_id=int(row["receiver_shell_id"]),
                 message_ids=message_ids,
                 declared_types=tuple(
                     str(message["declared_type"]) for message in messages
                 ),
-                prompt=self._delivery_prompt(row, messages),
+                prompt=self._delivery_prompt(route_sprint_id, route_role, messages),
                 idempotency_key=str(row["idempotency_key"]),
                 attempt_number=int(row["attempt_count"]) + 1,
                 claim_owner=owner,
             )
 
     @staticmethod
-    def _delivery_prompt(row: sqlite3.Row, messages: list[sqlite3.Row]) -> str:
-        sprint_id = row["sprint_id"]
-        role = row["role"]
+    def _delivery_prompt(
+        sprint_id: int | None,
+        role: str | None,
+        messages: list[sqlite3.Row],
+    ) -> str:
         if sprint_id is not None and role is not None:
             lead = wake_prompt(int(sprint_id), str(role))
         else:

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Dedicated Sprint v2 messages and retryable wake delivery.
+"""Engine-wide wake messages and retryable delivery.
 
-Sprint messages are durable collaboration facts.  An active message commits
-its wake intent in the same SQLite transaction; a later delivery worker claims
-that intent, resolves the participant's current conversation, and performs the
-external harness enqueue outside the database transaction.
+Every message commits its wake intent in the same SQLite transaction.  A later
+worker claims the coalesced receiver wake, resolves New versus Re-enter from the
+live registry, and performs the native enqueue outside database transactions.
 """
 from __future__ import annotations
 
@@ -14,6 +13,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
+import active_chat_registry
+import conversation_events
 import db_driver
 import sprint_participant_chats
 from sprint_domain import SprintInvariantError, SprintLifecycleStore
@@ -39,16 +40,19 @@ class ParticipantRelayReceipt:
     wake_id: int
     message_created: bool
     wake_state: str
-    conversation_id: str
+    conversation_id: str | None
 
 
 @dataclass(frozen=True)
 class WakeLease:
     wake_id: int
-    sprint_id: int
-    participant_id: int
-    participant_role: str
-    target_conversation_id: str | None
+    sprint_id: int | None
+    participant_id: int | None
+    participant_role: str | None
+    receiver_shell_id: int
+    message_ids: tuple[int, ...]
+    declared_types: tuple[str, ...]
+    prompt: str
     idempotency_key: str
     attempt_number: int
     claim_owner: str
@@ -66,7 +70,7 @@ def _stamp(value: datetime) -> str:
 
 
 class SprintMessageStore:
-    """Transactional inbox, acceptance, decline, and wake coalescing."""
+    """One transactional producer plus Sprint acceptance conveniences."""
 
     def __init__(self, con: sqlite3.Connection) -> None:
         self.con = con
@@ -83,7 +87,7 @@ class SprintMessageStore:
         from_participant_id: int | None = None,
         work_unit_id: int | None = None,
         actionable: bool = False,
-        active: bool = True,
+        declared_type: str = "re-enter",
     ) -> MessageReceipt:
         body = body.strip()
         key = idempotency_key.strip()
@@ -103,8 +107,88 @@ class SprintMessageStore:
                 from_participant_id=from_participant_id,
                 work_unit_id=work_unit_id,
                 actionable=actionable,
-                active=active,
+                declared_type=declared_type,
             )
+
+    def send_to_shell(
+        self,
+        receiver_shell_id: int,
+        *,
+        message_kind: str,
+        body: str,
+        idempotency_key: str,
+        sender_shell_id: int | None = None,
+        declared_type: str = "re-enter",
+    ) -> MessageReceipt:
+        """Send an engine-wide wake message with no Sprint scope."""
+        body = body.strip()
+        key = idempotency_key.strip()
+        if not body:
+            raise ValueError("wake message body is empty")
+        if not key:
+            raise ValueError("wake message idempotency key is empty")
+        if declared_type not in {"new", "re-enter"}:
+            raise ValueError("wake message type must be new or re-enter")
+        with db_driver.write_transaction(self.con, "wake.message.send"):
+            receiver = self.con.execute(
+                "SELECT 1 FROM shells WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+                (receiver_shell_id,),
+            ).fetchone()
+            if receiver is None:
+                raise KeyError(f"unknown wake receiver shell: {receiver_shell_id}")
+            existing = self.con.execute(
+                "SELECT * FROM wake_message WHERE idempotency_key=?", (key,)
+            ).fetchone()
+            if existing is not None:
+                actual = (
+                    existing["sprint_id"],
+                    existing["sender_shell_id"],
+                    int(existing["receiver_shell_id"]),
+                    str(existing["message_kind"]),
+                    str(existing["body"]),
+                    str(existing["declared_type"]),
+                )
+                expected = (
+                    None,
+                    sender_shell_id,
+                    receiver_shell_id,
+                    message_kind,
+                    body,
+                    declared_type,
+                )
+                if actual != expected:
+                    raise SprintInvariantError(
+                        "wake message idempotency key was reused with different input"
+                    )
+                wake = self.con.execute(
+                    "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
+                    (existing["message_id"],),
+                ).fetchone()
+                if wake is None:
+                    raise SprintInvariantError("wake message has no delivery intent")
+                return MessageReceipt(
+                    int(existing["message_id"]), int(wake["wake_id"]), False
+                )
+            message_id = int(
+                self.con.execute(
+                    "INSERT INTO wake_message "
+                    "(sender_shell_id,receiver_shell_id,message_kind,body,"
+                    "declared_type,actionable,idempotency_key) "
+                    "VALUES (?,?,?,?,?,0,?)",
+                    (
+                        sender_shell_id,
+                        receiver_shell_id,
+                        message_kind,
+                        body,
+                        declared_type,
+                        key,
+                    ),
+                ).lastrowid
+            )
+            wake_id = self._coalesce_wake(
+                None, None, receiver_shell_id, message_id
+            )
+            return MessageReceipt(message_id, wake_id, True)
 
     def relay(
         self,
@@ -161,25 +245,25 @@ class SprintMessageStore:
                 from_participant_id=int(sender["participant_id"]),
                 work_unit_id=None,
                 actionable=False,
-                active=True,
+                declared_type="re-enter",
             )
             wake = self.con.execute(
                 "SELECT state FROM sprint_wake_outbox WHERE wake_id=?",
                 (receipt.wake_id,),
             ).fetchone()
             route = self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=?",
+                "SELECT chat_id FROM active_shell_chats WHERE shell_id=("
+                "SELECT shell_id FROM sprint_participants WHERE participant_id=?)",
                 (recipient["participant_id"],),
             ).fetchone()
-            if wake is None or route is None or route["current_conversation_id"] is None:
+            if wake is None:
                 raise SprintInvariantError("Sprint relay did not produce a deliverable wake")
             return ParticipantRelayReceipt(
                 message_id=receipt.message_id,
                 wake_id=int(receipt.wake_id),
                 message_created=receipt.created,
                 wake_state=str(wake["state"]),
-                conversation_id=str(route["current_conversation_id"]),
+                conversation_id=(str(route["chat_id"]) if route is not None else None),
             )
 
     def send_in_transaction(
@@ -193,7 +277,7 @@ class SprintMessageStore:
         from_participant_id: int | None = None,
         work_unit_id: int | None = None,
         actionable: bool = False,
-        active: bool = True,
+        declared_type: str = "re-enter",
     ) -> MessageReceipt:
         """Commit through a caller-owned transaction.
 
@@ -220,15 +304,13 @@ class SprintMessageStore:
             from_participant_id=from_participant_id,
             work_unit_id=work_unit_id,
             actionable=actionable,
-            active=active,
+            declared_type=declared_type,
         )
 
     def inbox(self, sprint_id: int, shell_id: int) -> list[sqlite3.Row]:
         return self.con.execute(
-            "SELECT m.* FROM sprint_messages m "
-            "JOIN sprint_participants p "
-            "ON p.sprint_id=m.sprint_id AND p.participant_id=m.to_participant_id "
-            "WHERE m.sprint_id=? AND p.shell_id=? AND m.read_at IS NULL "
+            "SELECT m.* FROM wake_message m "
+            "WHERE m.sprint_id=? AND m.receiver_shell_id=? AND m.read_at IS NULL "
             "ORDER BY m.message_id",
             (sprint_id, shell_id),
         ).fetchall()
@@ -249,7 +331,7 @@ class SprintMessageStore:
                     return "declined"
                 if message["disposition"] == "pending":
                     self.con.execute(
-                        "UPDATE sprint_messages SET disposition='accepted',"
+                        "UPDATE wake_message SET disposition='accepted',"
                         "read_at=datetime('now') WHERE message_id=?",
                         (message_id,),
                     )
@@ -257,7 +339,7 @@ class SprintMessageStore:
                 disposition = "accepted"
             else:
                 self.con.execute(
-                    "UPDATE sprint_messages SET read_at=COALESCE(read_at,datetime('now')) "
+                    "UPDATE wake_message SET read_at=COALESCE(read_at,datetime('now')) "
                     "WHERE message_id=?",
                     (message_id,),
                 )
@@ -321,7 +403,7 @@ class SprintMessageStore:
                 raise SprintInvariantError("accepted Sprint messages cannot be declined")
             if message["disposition"] == "pending":
                 self.con.execute(
-                    "UPDATE sprint_messages SET disposition='declined',"
+                    "UPDATE wake_message SET disposition='declined',"
                     "read_at=datetime('now'),decline_reason=? WHERE message_id=?",
                     (reason, message_id),
                 )
@@ -346,10 +428,6 @@ class SprintMessageStore:
             ).fetchone()
             if planner is None:
                 raise SprintInvariantError("Sprint has no Planner participant")
-            lifecycle = self.con.execute(
-                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
-                (message["sprint_id"],),
-            ).fetchone()[0]
             routed = self._send(
                 int(message["sprint_id"]),
                 to_participant_id=int(planner["participant_id"]),
@@ -366,7 +444,7 @@ class SprintMessageStore:
                     else None
                 ),
                 actionable=False,
-                active=lifecycle == "armed",
+                declared_type="re-enter",
             )
             self._cancel_resolved_wakes(message_id)
             return routed.message_id
@@ -382,25 +460,36 @@ class SprintMessageStore:
         from_participant_id: int | None,
         work_unit_id: int | None,
         actionable: bool,
-        active: bool,
+        declared_type: str,
     ) -> MessageReceipt:
+        if declared_type not in {"new", "re-enter"}:
+            raise ValueError("wake message type must be new or re-enter")
         sprint = self.con.execute(
-            "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+            "SELECT sprint_id FROM sprints WHERE sprint_id=?", (sprint_id,)
         ).fetchone()
         if sprint is None:
             raise KeyError(f"unknown Sprint: {sprint_id}")
-        if active and sprint["lifecycle"] != "armed":
-            raise SprintInvariantError("active Sprint messages require an armed Sprint")
         recipient = self.con.execute(
-            "SELECT 1 FROM sprint_participants "
+            "SELECT shell_id FROM sprint_participants "
             "WHERE sprint_id=? AND participant_id=?",
             (sprint_id, to_participant_id),
         ).fetchone()
         if recipient is None:
             raise SprintInvariantError("recipient is not a Sprint participant")
+        sender_shell_id = None
+        if from_participant_id is not None:
+            sender = self.con.execute(
+                "SELECT shell_id FROM sprint_participants "
+                "WHERE sprint_id=? AND participant_id=?",
+                (sprint_id, from_participant_id),
+            ).fetchone()
+            if sender is None:
+                raise SprintInvariantError("sender is not a Sprint participant")
+            sender_shell_id = int(sender["shell_id"])
+        receiver_shell_id = int(recipient["shell_id"])
 
         existing = self.con.execute(
-            "SELECT * FROM sprint_messages WHERE idempotency_key=?",
+            "SELECT * FROM wake_message WHERE idempotency_key=?",
             (idempotency_key,),
         ).fetchone()
         if existing is not None:
@@ -412,6 +501,7 @@ class SprintMessageStore:
                 str(existing["message_kind"]),
                 str(existing["body"]),
                 bool(existing["actionable"]),
+                str(existing["declared_type"]),
             )
             expected = (
                 sprint_id,
@@ -421,12 +511,13 @@ class SprintMessageStore:
                 message_kind,
                 body,
                 actionable,
+                declared_type,
             )
             wake = self.con.execute(
                 "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
                 (existing["message_id"],),
             ).fetchone()
-            if actual != expected or (wake is not None) != active:
+            if actual != expected or wake is None:
                 raise SprintInvariantError(
                     "Sprint message idempotency key was reused with different input"
                 )
@@ -439,48 +530,58 @@ class SprintMessageStore:
         disposition = "pending" if actionable else None
         message_id = int(
             self.con.execute(
-                "INSERT INTO sprint_messages "
-                "(sprint_id,from_participant_id,to_participant_id,work_unit_id,"
-                "message_kind,body,actionable,disposition,idempotency_key) "
-                "VALUES (?,?,?,?,?,?,?,?,?)",
+                "INSERT INTO wake_message "
+                "(sprint_id,sender_shell_id,receiver_shell_id,from_participant_id,"
+                "to_participant_id,work_unit_id,message_kind,body,declared_type,"
+                "actionable,disposition,idempotency_key) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     sprint_id,
+                    sender_shell_id,
+                    receiver_shell_id,
                     from_participant_id,
                     to_participant_id,
                     work_unit_id,
                     message_kind,
                     body,
+                    declared_type,
                     1 if actionable else 0,
                     disposition,
                     idempotency_key,
                 ),
             ).lastrowid
         )
-        wake_id = (
-            self._coalesce_wake(sprint_id, to_participant_id, message_id)
-            if active
-            else None
+        wake_id = self._coalesce_wake(
+            sprint_id,
+            to_participant_id,
+            receiver_shell_id,
+            message_id,
         )
         return MessageReceipt(message_id, wake_id, True)
 
     def _coalesce_wake(
-        self, sprint_id: int, participant_id: int, message_id: int
+        self,
+        sprint_id: int | None,
+        participant_id: int | None,
+        receiver_shell_id: int,
+        message_id: int,
     ) -> int:
         wake = self.con.execute(
             "SELECT wake_id FROM sprint_wake_outbox "
-            "WHERE sprint_id=? AND participant_id=? AND state='pending'",
-            (sprint_id, participant_id),
+            "WHERE receiver_shell_id=? AND state='pending'",
+            (receiver_shell_id,),
         ).fetchone()
         if wake is None:
             wake_id = int(
                 self.con.execute(
                     "INSERT INTO sprint_wake_outbox "
-                    "(sprint_id,participant_id,idempotency_key) VALUES (?,?,?)",
+                    "(sprint_id,participant_id,receiver_shell_id,idempotency_key) "
+                    "VALUES (?,?,?,?)",
                     (
                         sprint_id,
                         participant_id,
-                        f"sprint:{sprint_id}:participant:{participant_id}:"
-                        f"wake-for-message:{message_id}",
+                        receiver_shell_id,
+                        f"receiver:{receiver_shell_id}:wake-for-message:{message_id}",
                     ),
                 ).lastrowid
             )
@@ -490,11 +591,6 @@ class SprintMessageStore:
             "INSERT INTO sprint_wake_messages (sprint_id,wake_id,message_id) "
             "VALUES (?,?,?)",
             (sprint_id, wake_id, message_id),
-        )
-        sprint_participant_chats.ensure_wake_conversation(
-            self.con,
-            participant_id,
-            idempotency_key=f"sprint:{sprint_id}:wake:{wake_id}:conversation",
         )
         return wake_id
 
@@ -511,10 +607,8 @@ class SprintMessageStore:
             else (message_id, shell_id)
         )
         row = self.con.execute(
-            "SELECT m.* FROM sprint_messages m "
-            "JOIN sprint_participants p "
-            "ON p.sprint_id=m.sprint_id AND p.participant_id=m.to_participant_id "
-            "WHERE m.message_id=? AND p.shell_id=?" + scope,
+            "SELECT m.* FROM wake_message m "
+            "WHERE m.message_id=? AND m.receiver_shell_id=?" + scope,
             params,
         ).fetchone()
         if row is None:
@@ -529,7 +623,7 @@ class SprintMessageStore:
         for wake in wake_ids:
             unresolved = self.con.execute(
                 "SELECT 1 FROM sprint_wake_messages wm "
-                "JOIN sprint_messages m USING (message_id) "
+                "JOIN wake_message m USING (message_id) "
                 "WHERE wm.wake_id=? AND m.read_at IS NULL LIMIT 1",
                 (wake["wake_id"],),
             ).fetchone()
@@ -543,7 +637,7 @@ class SprintMessageStore:
 
 
 class SprintWakeDeliveryService:
-    """Lease and deliver committed wake intents with a three-attempt budget."""
+    """Lease wake intents and resolve their chat placement at delivery time."""
 
     def __init__(
         self,
@@ -564,8 +658,8 @@ class SprintWakeDeliveryService:
                 "claimed_at=NULL,lease_expires_at=NULL "
                 "WHERE state='delivering' AND lease_expires_at<=? "
                 "AND NOT EXISTS (SELECT 1 FROM sprint_wake_outbox followup "
-                "WHERE followup.sprint_id=sprint_wake_outbox.sprint_id "
-                "AND followup.participant_id=sprint_wake_outbox.participant_id "
+                "WHERE followup.receiver_shell_id="
+                "sprint_wake_outbox.receiver_shell_id "
                 "AND followup.state='pending')",
                 (now,),
             )
@@ -586,23 +680,23 @@ class SprintWakeDeliveryService:
                 "claimed_at=NULL,lease_expires_at=NULL "
                 "WHERE state='delivering' AND lease_expires_at<=? "
                 "AND NOT EXISTS (SELECT 1 FROM sprint_wake_outbox followup "
-                "WHERE followup.sprint_id=sprint_wake_outbox.sprint_id "
-                "AND followup.participant_id=sprint_wake_outbox.participant_id "
+                "WHERE followup.receiver_shell_id="
+                "sprint_wake_outbox.receiver_shell_id "
                 "AND followup.state='pending')",
                 (now,),
             )
             row = self.con.execute(
-                "SELECT w.*,p.current_conversation_id,p.role "
+                "SELECT w.*,p.role "
                 "FROM sprint_wake_outbox w "
-                "JOIN sprints s USING (sprint_id) "
-                "JOIN sprint_participants p "
+                "LEFT JOIN sprints s ON s.sprint_id=w.sprint_id "
+                "LEFT JOIN sprint_participants p "
                 "ON p.sprint_id=w.sprint_id AND p.participant_id=w.participant_id "
                 "WHERE ((w.state='delivering' AND w.lease_expires_at<=?) "
                 "OR (w.state='pending' AND w.available_at<=?)) "
-                "AND s.lifecycle='armed' "
+                "AND (w.sprint_id IS NULL OR s.lifecycle='armed') "
                 "AND EXISTS (SELECT 1 FROM sprint_wake_messages wm "
-                "JOIN sprint_messages m USING (message_id) "
-                "WHERE wm.wake_id=w.wake_id AND m.read_at IS NULL) "
+                "JOIN wake_message m USING (message_id) "
+                "WHERE wm.wake_id=w.wake_id AND m.delivered_at IS NULL) "
                 "ORDER BY w.wake_id LIMIT 1",
                 (now, now),
             ).fetchone()
@@ -624,22 +718,107 @@ class SprintWakeDeliveryService:
                 )
             if result.rowcount != 1:
                 return None
-            route = sprint_participant_chats.ensure_wake_conversation(
-                self.con,
-                int(row["participant_id"]),
-                idempotency_key=(
-                    f"sprint:{row['sprint_id']}:wake:{row['wake_id']}:conversation"
-                ),
+
+            messages = self.con.execute(
+                "SELECT message_id,sprint_id,declared_type,body "
+                "FROM wake_message WHERE receiver_shell_id=? "
+                "AND delivered_at IS NULL ORDER BY message_id",
+                (row["receiver_shell_id"],),
+            ).fetchall()
+            if not messages:
+                raise SprintInvariantError("claimed wake has no undelivered messages")
+            message_ids = tuple(int(message["message_id"]) for message in messages)
+            marks = ",".join("?" for _ in message_ids)
+            self.con.execute(
+                "UPDATE sprint_wake_messages SET wake_id=? "
+                "WHERE message_id IN (" + marks + ")",
+                (row["wake_id"], *message_ids),
+            )
+            self.con.execute(
+                "UPDATE sprint_wake_outbox SET state='cancelled',claim_owner=NULL,"
+                "claimed_at=NULL,lease_expires_at=NULL "
+                "WHERE receiver_shell_id=? AND state='pending' AND wake_id<>? "
+                "AND NOT EXISTS (SELECT 1 FROM sprint_wake_messages joined "
+                "WHERE joined.wake_id=sprint_wake_outbox.wake_id)",
+                (row["receiver_shell_id"], row["wake_id"]),
             )
             return WakeLease(
                 wake_id=int(row["wake_id"]),
-                sprint_id=int(row["sprint_id"]),
-                participant_id=int(row["participant_id"]),
-                participant_role=str(row["role"]),
-                target_conversation_id=route.conversation_id,
+                sprint_id=(
+                    int(row["sprint_id"]) if row["sprint_id"] is not None else None
+                ),
+                participant_id=(
+                    int(row["participant_id"])
+                    if row["participant_id"] is not None
+                    else None
+                ),
+                participant_role=(str(row["role"]) if row["role"] else None),
+                receiver_shell_id=int(row["receiver_shell_id"]),
+                message_ids=message_ids,
+                declared_types=tuple(
+                    str(message["declared_type"]) for message in messages
+                ),
+                prompt=self._delivery_prompt(row, messages),
                 idempotency_key=str(row["idempotency_key"]),
                 attempt_number=int(row["attempt_count"]) + 1,
                 claim_owner=owner,
+            )
+
+    @staticmethod
+    def _delivery_prompt(row: sqlite3.Row, messages: list[sqlite3.Row]) -> str:
+        sprint_id = row["sprint_id"]
+        role = row["role"]
+        if sprint_id is not None and role is not None:
+            lead = wake_prompt(int(sprint_id), str(role))
+        else:
+            lead = "Wake-message delivery. Act on every message below."
+        rendered = []
+        for message in messages:
+            declared = str(message["declared_type"]).title()
+            rendered.append(
+                f"## wake_message #{int(message['message_id'])} "
+                f"(declared {declared})\n\n{message['body']}"
+            )
+        return lead + "\n\n" + "\n\n".join(rendered)
+
+    def _resolve_conversation(self, lease: WakeLease) -> str:
+        active = active_chat_registry.get(self.con, lease.receiver_shell_id)
+        if active is not None and active_chat_registry.has_live_process(active):
+            return active.chat_id
+        wants_new = "new" in lease.declared_types
+        if active is not None and not wants_new:
+            return active.chat_id
+
+        closed_id = None
+        if active is not None:
+            with db_driver.write_transaction(self.con, "wake.route.close_active"):
+                closed = active_chat_registry.close_for_wake(
+                    self.con, lease.receiver_shell_id
+                )
+                if closed is not None:
+                    closed_id = closed.chat_id
+                    sprint_participant_chats._append_event(
+                        self.con,
+                        closed.chat_id,
+                        "conversation.closed",
+                        {
+                            "reason": "New wake_message delivery",
+                            "state": "closed",
+                            "wake_id": lease.wake_id,
+                        },
+                    )
+        if closed_id is not None:
+            conversation_events.notify(closed_id)
+        if lease.sprint_id is None or lease.participant_id is None:
+            raise SprintInvariantError(
+                "New wake delivery without an active chat needs routing context"
+            )
+        with db_driver.write_transaction(self.con, "wake.route.create"):
+            return sprint_participant_chats.create_wake_conversation(
+                self.con,
+                wake_id=lease.wake_id,
+                sprint_id=lease.sprint_id,
+                participant_id=lease.participant_id,
             )
 
     def deliver_once(
@@ -650,19 +829,21 @@ class SprintWakeDeliveryService:
         lease = self.claim_next(owner)
         if lease is None:
             return None
+        target_conversation_id = None
         try:
-            if lease.target_conversation_id is None:
-                raise RuntimeError("participant has no current Sprint conversation")
+            target_conversation_id = self._resolve_conversation(lease)
             native_run_ref = deliver(
-                lease.target_conversation_id,
-                wake_prompt(lease.sprint_id, lease.participant_role),
+                target_conversation_id,
+                lease.prompt,
                 lease.idempotency_key,
             )
         except Exception as exc:  # external delivery faults become durable evidence
+            if lease.sprint_id is None:
+                raise
             attempt = self.lifecycle.record_wake_failure(
                 lease.wake_id,
                 str(exc) or exc.__class__.__name__,
-                target_conversation_id=lease.target_conversation_id,
+                target_conversation_id=target_conversation_id,
                 expected_claim_owner=owner,
             )
             state = "failed" if attempt == 3 else "pending"
@@ -686,9 +867,15 @@ class SprintWakeDeliveryService:
                 (
                     lease.wake_id,
                     attempt,
-                    lease.target_conversation_id,
+                    target_conversation_id,
                     native_run_ref,
                 ),
+            )
+            marks = ",".join("?" for _ in lease.message_ids)
+            self.con.execute(
+                "UPDATE wake_message SET delivered_at=COALESCE(delivered_at,"
+                "datetime('now')) WHERE message_id IN (" + marks + ")",
+                lease.message_ids,
             )
             self.con.execute(
                 "UPDATE sprint_wake_outbox SET state='delivered',attempt_count=?,"

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -687,6 +687,145 @@ def ensure_wake_conversation(
     return WakeConversationRoute(conversation_id, True)
 
 
+def create_wake_conversation(
+    con,
+    *,
+    wake_id: int,
+    sprint_id: int,
+    participant_id: int,
+) -> str:
+    """Create and register one wake chat after the prior chat is committed closed.
+
+    The caller owns this insertion transaction and must have resolved rotation
+    before entering it.  Unlike ``create_and_select``, this seam never closes a
+    chat, so close and replacement cannot roll back as one unit.
+    """
+    if not con.in_transaction:
+        raise RuntimeError("wake conversation creation requires a transaction")
+    row = con.execute(
+        "SELECT p.participant_id,p.sprint_id,p.shell_id,p.harness,p.model,p.effort,"
+        "p.persistent_conversation_id,p.current_conversation_id,"
+        "s.conversation_generation,sh.shortname,sh.flavor,owner.user_id "
+        "FROM sprint_participants p "
+        "JOIN sprints s ON s.sprint_id=p.sprint_id "
+        "JOIN shells sh ON sh.shell_id=p.shell_id "
+        "JOIN shells owner ON owner.shell_id=s.originating_planner_shell_id "
+        "WHERE p.participant_id=? AND p.sprint_id=?",
+        (participant_id, sprint_id),
+    ).fetchone()
+    if row is None:
+        raise SprintConversationError("wake recipient is not a Sprint participant")
+    if row["user_id"] is None:
+        raise SprintConversationError("originating Planner has no browser owner")
+    if active_chat_registry.get(con, int(row["shell_id"])) is not None:
+        raise SprintConversationError("another chat became active before wake creation")
+
+    generation = _nonblank(
+        row["conversation_generation"],
+        "Sprint conversation generation",
+        maximum=32,
+    )
+    key = f"generation:{generation}:wake:{wake_id}"
+    existing = con.execute(
+        "SELECT conversation_id,state FROM conversations "
+        "WHERE owner_user_id=? AND creation_idempotency_key=?",
+        (row["user_id"], key),
+    ).fetchone()
+    if existing is not None:
+        if existing["state"] == "closed":
+            raise SprintConversationError("idempotent wake chat is already closed")
+        conversation_id = str(existing["conversation_id"])
+        if not _linked_to_participant(con, participant_id, conversation_id):
+            raise SprintConversationError(
+                "idempotent wake chat belongs to another participant"
+            )
+        active_chat_registry.register(con, int(row["shell_id"]), conversation_id)
+        con.execute(
+            "UPDATE sprint_participants SET current_conversation_id=?,"
+            "updated_at=datetime('now') WHERE participant_id=?",
+            (conversation_id, participant_id),
+        )
+        return conversation_id
+
+    parent = con.execute(
+        "SELECT link.conversation_id FROM sprint_participant_conversations link "
+        "WHERE link.sprint_participant_id=? ORDER BY "
+        "(link.conversation_id=?) DESC,link.participant_conversation_id DESC LIMIT 1",
+        (participant_id, row["current_conversation_id"]),
+    ).fetchone()
+    parent_id = str(parent["conversation_id"]) if parent is not None else None
+    purpose = "fallback" if parent_id is not None else "work"
+    context_packet = (
+        {
+            "reason": "wake delivery selected a fresh chat",
+            "sprint_id": sprint_id,
+            "participant_id": participant_id,
+            "previous_conversation_id": parent_id,
+            "wake_id": wake_id,
+        }
+        if parent_id is not None
+        else None
+    )
+    worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
+    request = {
+        "effort": row["effort"],
+        "harness": row["harness"],
+        "model": row["model"],
+        "participant_id": participant_id,
+        "provider": run_mod.session_provider(row["harness"], row["model"]),
+        "sprint_id": sprint_id,
+        "wake_id": wake_id,
+        "worktree": str(worktree.resolve(strict=False)),
+    }
+    conversation_id = "cv_" + uuid.uuid4().hex
+    con.execute(
+        "INSERT INTO conversations "
+        "(conversation_id,shell_id,owner_user_id,harness,provider,model,effort,"
+        "worktree,title,creation_idempotency_key,creation_request_hash,"
+        "conversation_scope) VALUES (?,?,?,?,?,?,?,?,?,?,?,'sprint')",
+        (
+            conversation_id,
+            row["shell_id"],
+            row["user_id"],
+            row["harness"],
+            request["provider"],
+            row["model"],
+            row["effort"],
+            request["worktree"],
+            f"Sprint {sprint_id} · Wake {wake_id} · {row['shortname']}",
+            key,
+            _request_hash(request),
+        ),
+    )
+    _append_created_event(
+        con,
+        conversation_id=conversation_id,
+        participant_id=participant_id,
+        sprint_id=sprint_id,
+        purpose=purpose,
+    )
+    con.execute(
+        "INSERT INTO sprint_participant_conversations "
+        "(sprint_participant_id,conversation_id,purpose,parent_conversation_id,"
+        "context_packet) VALUES (?,?,?,?,?)",
+        (
+            participant_id,
+            conversation_id,
+            purpose,
+            parent_id,
+            _canonical_json(context_packet) if context_packet is not None else None,
+        ),
+    )
+    con.execute(
+        "UPDATE sprint_participants SET persistent_conversation_id="
+        "COALESCE(persistent_conversation_id,?),current_conversation_id=?,"
+        "updated_at=datetime('now') WHERE participant_id=?",
+        (conversation_id, conversation_id, participant_id),
+    )
+    active_chat_registry.register(con, int(row["shell_id"]), conversation_id)
+    return conversation_id
+
+
 def create_review_outcome(
     con,
     *,

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -32,10 +32,26 @@ class SprintConversationError(ValueError):
     """The requested Sprint conversation transition violates its contract."""
 
 
+class WakeConversationBusy(SprintConversationError):
+    """A wake replacement lost the boundary race to another active chat."""
+
+
 @dataclass(frozen=True)
 class WakeConversationRoute:
     conversation_id: str
     created: bool
+
+
+@dataclass(frozen=True)
+class PreparedShellWake:
+    shell_id: int
+    owner_user_id: int
+    shortname: str
+    harness: str
+    provider: str | None
+    model: str | None
+    effort: str | None
+    worktree: str
 
 
 def wake_prompt(sprint_id: int, role: str) -> str:
@@ -687,6 +703,127 @@ def ensure_wake_conversation(
     return WakeConversationRoute(conversation_id, True)
 
 
+def prepare_shell_wake_conversation(con, shell_id: int) -> PreparedShellWake:
+    """Resolve a non-Sprint shell route before any active chat is closed."""
+    shell = con.execute(
+        "SELECT shell_id,user_id,shortname,flavor FROM shells "
+        "WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+        (shell_id,),
+    ).fetchone()
+    if shell is None:
+        raise SprintConversationError("wake receiver shell does not exist")
+    if shell["user_id"] is None:
+        raise SprintConversationError("wake receiver shell has no browser owner")
+
+    prior = con.execute(
+        "SELECT harness,model,effort FROM conversations WHERE shell_id=? "
+        "ORDER BY created_at DESC,conversation_id DESC LIMIT 1",
+        (shell_id,),
+    ).fetchone()
+    defaults = run_mod.flavor_defaults(con).get(shell["flavor"], {})
+    harness = (
+        (str(prior["harness"]) if prior is not None else None)
+        or defaults.get("default_harness")
+        or run_mod._configured_harness()
+        or "claude"
+    )
+    model = (
+        str(prior["model"])
+        if prior is not None and prior["model"] is not None
+        else defaults.get("models", {}).get(harness)
+    )
+    adapter = run_mod.load_adapter(harness)
+    effort = (
+        str(prior["effort"])
+        if prior is not None and prior["effort"] is not None
+        else run_mod.default_headless_effort(adapter)
+    )
+    try:
+        run_mod.validate_headless_request(adapter, model, effort)
+    except ValueError as exc:
+        raise SprintConversationError(str(exc)) from exc
+    worktree = run_mod.shell_work_dir(shell["shortname"], shell["flavor"])
+    return PreparedShellWake(
+        shell_id=int(shell["shell_id"]),
+        owner_user_id=int(shell["user_id"]),
+        shortname=str(shell["shortname"]),
+        harness=harness,
+        provider=run_mod.session_provider(harness, model),
+        model=model,
+        effort=effort,
+        worktree=str(worktree.resolve(strict=False)),
+    )
+
+
+def create_shell_wake_conversation(
+    con,
+    *,
+    wake_id: int,
+    route: PreparedShellWake,
+) -> str:
+    """Create and register a prepared engine-wide wake chat."""
+    if not con.in_transaction:
+        raise RuntimeError("wake conversation creation requires a transaction")
+    if active_chat_registry.get(con, route.shell_id) is not None:
+        raise WakeConversationBusy("another chat became active before wake creation")
+
+    key = f"shell:{route.shell_id}:wake:{wake_id}"
+    request = {
+        "effort": route.effort,
+        "harness": route.harness,
+        "model": route.model,
+        "shell_id": route.shell_id,
+        "wake_id": wake_id,
+        "worktree": route.worktree,
+    }
+    existing = con.execute(
+        "SELECT conversation_id,shell_id,state,creation_request_hash "
+        "FROM conversations WHERE owner_user_id=? "
+        "AND creation_idempotency_key=?",
+        (route.owner_user_id, key),
+    ).fetchone()
+    request_hash = _request_hash(request)
+    if existing is not None:
+        if (
+            int(existing["shell_id"]) != route.shell_id
+            or existing["creation_request_hash"] != request_hash
+            or existing["state"] == "closed"
+        ):
+            raise SprintConversationError("idempotent wake chat is not reusable")
+        conversation_id = str(existing["conversation_id"])
+        active_chat_registry.register(con, route.shell_id, conversation_id)
+        return conversation_id
+
+    conversation_id = "cv_" + uuid.uuid4().hex
+    con.execute(
+        "INSERT INTO conversations "
+        "(conversation_id,shell_id,owner_user_id,harness,provider,model,effort,"
+        "worktree,title,creation_idempotency_key,creation_request_hash) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            conversation_id,
+            route.shell_id,
+            route.owner_user_id,
+            route.harness,
+            route.provider,
+            route.model,
+            route.effort,
+            route.worktree,
+            f"Wake {wake_id} · {route.shortname}",
+            key,
+            request_hash,
+        ),
+    )
+    _append_event(
+        con,
+        conversation_id,
+        "conversation.created",
+        {"scope": "normal", "shell_id": route.shell_id, "wake_id": wake_id},
+    )
+    active_chat_registry.register(con, route.shell_id, conversation_id)
+    return conversation_id
+
+
 def create_wake_conversation(
     con,
     *,
@@ -718,7 +855,7 @@ def create_wake_conversation(
     if row["user_id"] is None:
         raise SprintConversationError("originating Planner has no browser owner")
     if active_chat_registry.get(con, int(row["shell_id"])) is not None:
-        raise SprintConversationError("another chat became active before wake creation")
+        raise WakeConversationBusy("another chat became active before wake creation")
 
     generation = _nonblank(
         row["conversation_generation"],

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -506,31 +506,11 @@ class SprintPRWatcher:
                     "registered_pr.merged_grant_bypassed",
                 )
             )
-        recipients: dict[int, bool] = {
-            int(registered["owner_participant_id"]): state in {"red", "green"}
-        }
-        planner = self.con.execute(
-            "SELECT participant_id FROM sprint_participants "
-            "WHERE sprint_id=? AND role='planner'",
-            (sprint_id,),
-        ).fetchone()
-        if planner is None:
-            raise SprintInvariantError("registered PR has no Planner participant")
-        planner_id = int(planner["participant_id"])
-        recipients[planner_id] = recipients.get(planner_id, False) or state == "closed"
-        reviewer_shell_ids = {int(row["reviewer_shell_id"]) for row in unit_rows}
-        for shell_id in reviewer_shell_ids:
-            reviewer = self.con.execute(
-                "SELECT participant_id FROM sprint_participants "
-                "WHERE sprint_id=? AND shell_id=? AND role='reviewer'",
-                (sprint_id, shell_id),
-            ).fetchone()
-            if reviewer is None:
-                raise SprintInvariantError(
-                    "registered PR work unit has no Reviewer participant"
-                )
-            reviewer_id = int(reviewer["participant_id"])
-            recipients.setdefault(reviewer_id, False)
+        recipients = (
+            (int(registered["owner_participant_id"]),)
+            if state in {"red", "green", "closed"}
+            else ()
+        )
 
         head_changed = (
             previous_head_sha is not None

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -593,7 +593,7 @@ class SprintPRWatcher:
                     "review against the new head."
                 ),
                 actionable=True,
-                active=True,
+                declared_type="new",
                 idempotency_key=f"pr-head-change:{transition_key}:delta-review",
             )
             self.con.execute(
@@ -621,14 +621,14 @@ class SprintPRWatcher:
             f"GitHub observed {registered['repository']} PR "
             f"#{registered['pr_number']}: {state} at {head}."
         )
-        for participant_id, active in recipients.items():
+        for participant_id in recipients:
             self.messages.send_in_transaction(
                 sprint_id,
                 to_participant_id=participant_id,
                 work_unit_id=work_unit_id,
                 message_kind="notification",
                 body=body,
-                active=active,
+                declared_type="re-enter",
                 idempotency_key=(
                     f"pr-transition:{transition_key}:participant:{participant_id}"
                 ),
@@ -653,7 +653,7 @@ class SprintPRWatcher:
         if not isinstance(message_id, int):
             return None
         self.con.execute(
-            "UPDATE sprint_messages SET read_at=COALESCE(read_at,datetime('now')) "
+            "UPDATE wake_message SET read_at=COALESCE(read_at,datetime('now')) "
             "WHERE sprint_id=? AND message_id=?",
             (sprint_id, message_id),
         )
@@ -667,7 +667,7 @@ class SprintPRWatcher:
         ]
         for wake_id in wake_ids:
             unread = self.con.execute(
-                "SELECT 1 FROM sprint_wake_messages wm JOIN sprint_messages m "
+                "SELECT 1 FROM sprint_wake_messages wm JOIN wake_message m "
                 "ON m.sprint_id=wm.sprint_id AND m.message_id=wm.message_id "
                 "WHERE wm.sprint_id=? AND wm.wake_id=? AND m.read_at IS NULL LIMIT 1",
                 (sprint_id, wake_id),

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import db_driver
 import sprint_liveness
-import sprint_participant_chats
 from github_pull_requests import GitHubPullRequestReader, PullRequest
 from sprint_domain import (
     SprintAuthorityError,
@@ -31,7 +30,7 @@ class ReviewHandoffReceipt:
 @dataclass(frozen=True)
 class ReviewOutcomeReceipt:
     work_unit_id: int
-    conversation_id: str
+    conversation_id: str | None
     message_id: int
     wake_id: int
     disposition: str
@@ -94,7 +93,7 @@ class SprintReviewLoopStore:
                 message_kind="review_request",
                 body=readiness,
                 actionable=True,
-                active=True,
+                declared_type="new",
                 idempotency_key=idempotency_key,
             )
             if receipt.wake_id is None:
@@ -134,7 +133,7 @@ class SprintReviewLoopStore:
         body: str,
         idempotency_key: str,
     ) -> ReviewOutcomeReceipt:
-        """Route a Review verdict onto a fresh fix or merge conversation."""
+        """Record a Review verdict and enqueue its delivery-time wake."""
         if verdict not in {"changes_requested", "approved"}:
             raise ValueError("review verdict must be changes_requested or approved")
         body = self._required(body, "review body")
@@ -145,7 +144,6 @@ class SprintReviewLoopStore:
             if int(lane["reviewer_shell_id"]) != reviewer_shell_id:
                 raise SprintAuthorityError("only the assigned Reviewer owns the verdict")
             review_message_id, requested_head = self._accepted_review_request(lane)
-            purpose = "fix" if verdict == "changes_requested" else "merge"
             disposition = "fixing" if verdict == "changes_requested" else "merge_ready"
             notification = (
                 f"Review changes requested for PR #{lane['pr_number']}: {body}"
@@ -160,20 +158,14 @@ class SprintReviewLoopStore:
                 message_kind="notification",
                 body=notification,
                 actionable=verdict == "changes_requested",
-                active=True,
+                declared_type="re-enter",
                 idempotency_key=idempotency_key,
             )
             if receipt.wake_id is None:
                 raise SprintInvariantError("active review outcome has no wake")
-            conversation_key = f"{idempotency_key}:conversation"
             if not receipt.created:
-                conversation_id = self._conversation_for_key(
-                    int(lane["developer_participant_id"]),
-                    purpose,
-                    conversation_key,
-                )
                 outcome = self._outcome_receipt(
-                    lane, conversation_id, receipt, disposition
+                    lane, receipt, disposition
                 )
             else:
                 if lane["disposition"] != "in_review":
@@ -183,12 +175,6 @@ class SprintReviewLoopStore:
                 transition = self._latest_transition(registered_pr_id)
                 if transition["observed_head_sha"] != requested_head:
                     raise SprintInvariantError("review request is stale for the PR head")
-                conversation_id = sprint_participant_chats.create_review_outcome(
-                    self.con,
-                    participant_id=int(lane["developer_participant_id"]),
-                    purpose=purpose,
-                    idempotency_key=conversation_key,
-                )
                 self._record_judgment(
                     lane,
                     reviewer_shell_id,
@@ -205,7 +191,6 @@ class SprintReviewLoopStore:
                     f"review.{verdict}",
                     reviewer_shell_id,
                     {
-                        "conversation_id": conversation_id,
                         "head_sha": requested_head,
                         "message_id": receipt.message_id,
                         "registered_pr_id": registered_pr_id,
@@ -213,7 +198,7 @@ class SprintReviewLoopStore:
                     },
                 )
                 outcome = self._outcome_receipt(
-                    lane, conversation_id, receipt, disposition
+                    lane, receipt, disposition
                 )
             sprint_liveness.SprintLivenessMonitor(self.con).resolve_in_transaction(
                 review_message_id,
@@ -363,7 +348,7 @@ class SprintReviewLoopStore:
 
     def _accepted_review_request(self, lane: sqlite3.Row) -> tuple[int, str]:
         latest = self.con.execute(
-            "SELECT message_id,disposition FROM sprint_messages WHERE sprint_id=? "
+            "SELECT message_id,disposition FROM wake_message WHERE sprint_id=? "
             "AND work_unit_id=? AND to_participant_id=? "
             "AND message_kind='review_request' "
             "ORDER BY message_id DESC LIMIT 1",
@@ -423,16 +408,6 @@ class SprintReviewLoopStore:
         ).fetchone()
         return json.loads(row["payload"]).get("head_sha") if row is not None else None
 
-    def _conversation_for_key(
-        self, participant_id: int, purpose: str, key: str
-    ) -> str:
-        conversation_id = sprint_participant_chats.linked_conversation_for_key(
-            self.con, participant_id, purpose, key
-        )
-        if conversation_id is None:
-            raise SprintInvariantError("review outcome replay lost its conversation")
-        return conversation_id
-
     @staticmethod
     def _require_live_green(identity: sqlite3.Row, live: PullRequest) -> None:
         if live.number != int(identity["pr_number"]):
@@ -460,13 +435,12 @@ class SprintReviewLoopStore:
     @staticmethod
     def _outcome_receipt(
         lane: sqlite3.Row,
-        conversation_id: str,
         receipt: MessageReceipt,
         disposition: str,
     ) -> ReviewOutcomeReceipt:
         return ReviewOutcomeReceipt(
             int(lane["work_unit_id"]),
-            conversation_id,
+            None,
             receipt.message_id,
             int(receipt.wake_id),
             disposition,

--- a/.super-coder/scripts/sprint_runtime.py
+++ b/.super-coder/scripts/sprint_runtime.py
@@ -1,4 +1,4 @@
-"""Armed-only Sprint work dispatch and native wake-turn delivery."""
+"""Armed-only Sprint work dispatch plus engine-wide wake-turn delivery."""
 from __future__ import annotations
 
 import hashlib
@@ -19,8 +19,8 @@ from sprint_domain import (
     SprintLifecycleStore,
     SprintWorkUnitStore,
 )
-from sprint_message_delivery import SprintWakeDeliveryService
 from sprint_liveness import SprintLivenessMonitor
+from sprint_message_delivery import SprintWakeDeliveryService
 
 DEFAULT_PULSE_SECONDS = 5.0
 
@@ -185,14 +185,14 @@ class SprintRuntimeService(threading.Thread):
         con = db_driver.connect(self.db_path)
         try:
             switch = self._switch(con)
-            return switch.recover_on_startup() if startup else switch.tick()
+            serviced = switch.recover_on_startup() if startup else switch.tick()
+            return self._deliver_wakes(con) or serviced
         finally:
             con.close()
 
     def _switch(self, con: sqlite3.Connection) -> ArmedServiceSwitch:
         lifecycle = SprintLifecycleStore(con)
         units = SprintWorkUnitStore(con)
-        wakes = SprintWakeDeliveryService(con)
         liveness = SprintLivenessMonitor(con)
 
         def recover_pickup(sprint_id: int, trigger: str) -> None:
@@ -201,19 +201,25 @@ class SprintRuntimeService(threading.Thread):
         def dispatch(sprint_id: int, _trigger: str) -> None:
             units.dispatch_ready(sprint_id)
 
-        def deliver(_sprint_id: int, _trigger: str) -> None:
-            while not self._stop_event.is_set():
-                outcome = wakes.deliver_once(self.owner, self.deliver)
-                if outcome is None or outcome.state != "delivered":
-                    return
-
         def evaluate_liveness(sprint_id: int, _trigger: str) -> None:
             liveness.evaluate(sprint_id)
 
         return ArmedServiceSwitch(
             lifecycle,
-            (recover_pickup, dispatch, evaluate_liveness, deliver),
+            (recover_pickup, dispatch, evaluate_liveness),
         )
+
+    def _deliver_wakes(self, con: sqlite3.Connection) -> bool:
+        wakes = SprintWakeDeliveryService(con)
+        delivered = False
+        while not self._stop_event.is_set():
+            outcome = wakes.deliver_once(self.owner, self.deliver)
+            if outcome is None:
+                return delivered
+            if outcome.state != "delivered":
+                return True
+            delivered = True
+        return delivered
 
     def run(self) -> None:  # pragma: no cover - loop tested through pulse_once
         con = db_driver.connect(self.db_path)
@@ -221,12 +227,14 @@ class SprintRuntimeService(threading.Thread):
             switch = self._switch(con)
             try:
                 switch.recover_on_startup()
+                self._deliver_wakes(con)
             except Exception as exc:  # noqa: BLE001 - service faults stay visible
                 print(f"sprint-runtime: startup error ({exc})", flush=True)
             self._started_once.set()
             while not self._stop_event.wait(self.pulse_seconds):
                 try:
                     switch.tick()
+                    self._deliver_wakes(con)
                 except Exception as exc:  # noqa: BLE001 - keep inspection alive
                     print(f"sprint-runtime: pulse error ({exc})", flush=True)
         finally:

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -63,7 +63,8 @@
     ".super-coder/scripts/migration.py",
     "tests/test_migration_management.py",
     ".super-coder/migrations/0162_active_chat_registry.sql",
-    ".super-coder/migrations/0163_conversation_run_process_identity.sql"
+    ".super-coder/migrations/0163_conversation_run_process_identity.sql",
+    ".super-coder/migrations/0164_wake_message_delivery.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_sprint_board_api.py
+++ b/tests/test_sprint_board_api.py
@@ -233,10 +233,17 @@ class SprintBoardApiCase(unittest.TestCase):
             (pr_id,),
         )
         con.execute(
-            "INSERT INTO sprint_messages "
-            "(sprint_id,from_participant_id,to_participant_id,work_unit_id,message_kind,"
-            "body,actionable,idempotency_key) VALUES (?,?,?,?,'notification','audit note',0,'audit-1')",
-            (sprint_id, participant_ids["planner"], participant_ids["developer"], unit_ids[2]),
+            "INSERT INTO wake_message "
+            "(sprint_id,sender_shell_id,receiver_shell_id,from_participant_id,"
+            "to_participant_id,work_unit_id,message_kind,body,declared_type,"
+            "actionable,idempotency_key) VALUES (?,2,3,?,?,?,'notification',"
+            "'audit note','re-enter',0,'audit-1')",
+            (
+                sprint_id,
+                participant_ids["planner"],
+                participant_ids["developer"],
+                unit_ids[2],
+            ),
         )
         for event_type, payload in (
             ("work_unit.ready", {"work_unit_id": unit_ids[2], "message_id": 7, "token": "nope"}),

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -439,7 +439,7 @@ class SprintCliApiTest(unittest.TestCase):
             message = con.execute(
                 "SELECT from_participant_id,to_participant_id,"
                 "message_kind,body,actionable,work_unit_id,disposition "
-                "FROM sprint_messages WHERE message_id=?",
+                "FROM wake_message WHERE message_id=?",
                 (response["message_id"],),
             ).fetchone()
             self.assertEqual(
@@ -897,7 +897,7 @@ class SprintCliApiTest(unittest.TestCase):
                 ("prepared", "planned", 0),
                 con.execute(
                     "SELECT s.lifecycle,u.disposition,"
-                    "(SELECT COUNT(*) FROM sprint_messages WHERE sprint_id=s.sprint_id) "
+                    "(SELECT COUNT(*) FROM wake_message WHERE sprint_id=s.sprint_id) "
                     "FROM sprints s JOIN sprint_work_units u USING(sprint_id) "
                     "WHERE s.sprint_id=? AND u.work_unit_id=?",
                     (sprint_id, unit_id),
@@ -1075,7 +1075,7 @@ class SprintCliApiTest(unittest.TestCase):
                 dispatch["wake_ids"][0],
                 con.execute(
                     "SELECT wm.wake_id FROM sprint_wake_messages wm "
-                    "JOIN sprint_messages m USING(message_id) "
+                    "JOIN wake_message m USING(message_id) "
                     "WHERE m.work_unit_id=? ORDER BY m.message_id DESC LIMIT 1",
                     (self.dispatch_unit_id,),
                 ).fetchone()[0],

--- a/tests/test_sprint_close.py
+++ b/tests/test_sprint_close.py
@@ -712,8 +712,8 @@ class EvidenceCompilerTest(SprintCloseCase):
             f"/_sc/sprint/{self.sprint_id}/timeline",
             packet["full_history_links"]["timeline"],
         )
-        self.assertGreaterEqual(
-            len(packet["full_history_links"]["participant_conversations"]), 3
+        self.assertEqual(
+            [], packet["full_history_links"]["participant_conversations"]
         )
         self.assertGreater(packet["anomalies"]["events"]["truncated"], 0)
 

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -338,7 +338,7 @@ class SprintLiveProof(unittest.TestCase):
 
     def assignment_message(self, unit_id: int) -> int:
         row = self.con.execute(
-            "SELECT message_id FROM sprint_messages "
+            "SELECT message_id FROM wake_message "
             "WHERE work_unit_id=? AND message_kind='work_assignment' "
             "ORDER BY message_id DESC LIMIT 1",
             (unit_id,),
@@ -575,7 +575,7 @@ class SprintLiveProof(unittest.TestCase):
         self.assertEqual("lifecycle.completed", event_types[-1])
         self.assertEqual(2, packet["pr_outcomes"]["total"])
         self.assertEqual(
-            ["work"],
+            ["work", "fallback"],
             [
                 row[0]
                 for row in self.con.execute(
@@ -646,6 +646,7 @@ class SprintLiveProof(unittest.TestCase):
     def test_conversation_and_watcher_writes_share_wal_without_lock_loss(self) -> None:
         sprint_id, _document_id, units = self.prepare(((1, 2, ()),))
         sprint_domain.SprintLifecycleStore(self.con).arm(sprint_id, 3)
+        self.deliver_browser_turns()
         self.accept_assignment(units[0], 1)
         self.github.set(3001, "OPEN", checks="PENDING")
         watcher = self.watcher()
@@ -742,7 +743,7 @@ class SprintLiveProof(unittest.TestCase):
             str(assignment_id),
         )
 
-        planner_conversation = str(
+        self.assertIsNone(
             self.con.execute(
                 "SELECT current_conversation_id FROM sprint_participants "
                 "WHERE sprint_id=? AND shell_id=3",
@@ -765,13 +766,13 @@ class SprintLiveProof(unittest.TestCase):
         )
         self.assertTrue(question_receipt["message_created"])
         self.assertEqual("pending", question_receipt["wake_state"])
-        self.assertEqual(planner_conversation, question_receipt["conversation_id"])
+        self.assertIsNone(question_receipt["conversation_id"])
         self.assertEqual(
             (1, 3, 6000, question),
             tuple(
                 self.con.execute(
                     "SELECT sender.shell_id,recipient.shell_id,length(m.body),m.body "
-                    "FROM sprint_messages m "
+                    "FROM wake_message m "
                     "JOIN sprint_participants sender "
                     "ON sender.participant_id=m.from_participant_id "
                     "JOIN sprint_participants recipient "
@@ -782,6 +783,14 @@ class SprintLiveProof(unittest.TestCase):
             ),
         )
         self.deliver_browser_turns()
+        planner_conversation = str(
+            self.con.execute(
+                "SELECT current_conversation_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=3",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertNotEqual("None", planner_conversation)
         planner_inbox = self.run_cli(3, "inbox", "--sprint", str(sprint_id))
         self.assertIn(
             (question_receipt["message_id"], question),
@@ -790,15 +799,17 @@ class SprintLiveProof(unittest.TestCase):
                 for message in planner_inbox["messages"]
             ],
         )
-        self.assertEqual(
-            sprint_message_delivery.wake_prompt(sprint_id, "planner"),
-            self.con.execute(
+        delivered_prompt = self.con.execute(
                 "SELECT cm.body FROM sprint_wake_outbox w "
                 "JOIN conversation_messages cm "
                 "ON cm.idempotency_key=w.idempotency_key WHERE w.wake_id=?",
                 (question_receipt["wake_id"],),
-            ).fetchone()[0],
+            ).fetchone()[0]
+        self.assertIn(
+            sprint_message_delivery.wake_prompt(sprint_id, "planner"),
+            delivered_prompt,
         )
+        self.assertIn(question, delivered_prompt)
         self.run_cli(
             3,
             "accept",
@@ -850,19 +861,13 @@ class SprintLiveProof(unittest.TestCase):
             "--work-unit",
             str(units[0]),
         )
-        reviewer_old = str(
+        self.assertIsNone(
             self.con.execute(
                 "SELECT current_conversation_id FROM sprint_participants "
                 "WHERE sprint_id=? AND shell_id=2",
                 (sprint_id,),
             ).fetchone()[0]
         )
-        self.con.execute(
-            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
-            "WHERE conversation_id=?",
-            (reviewer_old,),
-        )
-        self.con.commit()
         review_request = self.run_cli(
             1,
             "request-review",
@@ -875,6 +880,14 @@ class SprintLiveProof(unittest.TestCase):
             "--key",
             "proof:68:dev-to-review",
         )
+        self.assertIsNone(
+            self.con.execute(
+                "SELECT current_conversation_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=2",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+        self.deliver_browser_turns()
         reviewer_new = str(
             self.con.execute(
                 "SELECT current_conversation_id FROM sprint_participants "
@@ -882,19 +895,7 @@ class SprintLiveProof(unittest.TestCase):
                 (sprint_id,),
             ).fetchone()[0]
         )
-        self.assertNotEqual(reviewer_old, reviewer_new)
-        self.assertEqual(
-            ("fallback", reviewer_old),
-            tuple(
-                self.con.execute(
-                    "SELECT purpose,parent_conversation_id "
-                    "FROM sprint_participant_conversations "
-                    "WHERE conversation_id=?",
-                    (reviewer_new,),
-                ).fetchone()
-            ),
-        )
-        self.deliver_browser_turns()
+        self.assertNotEqual("None", reviewer_new)
         reviewer_inbox = self.run_cli(2, "inbox", "--sprint", str(sprint_id))
         self.assertIn(
             review_request["message_id"],
@@ -954,13 +955,17 @@ class SprintLiveProof(unittest.TestCase):
             recovery_message["wake_id"]
         )
         self.assertEqual(recovery_message["conversation_id"], terminal_conversation)
-        self.assertEqual(
+        self.assertIn(
             sprint_message_delivery.wake_prompt(sprint_id, "developer"),
+            terminal_prompt,
+        )
+        self.assertIn(
+            "Preserve this separate delivered-unread recovery proof.",
             terminal_prompt,
         )
         self.assertIsNone(
             self.con.execute(
-                "SELECT read_at FROM sprint_messages WHERE message_id=?",
+                "SELECT read_at FROM wake_message WHERE message_id=?",
                 (recovery_message["message_id"],),
             ).fetchone()[0]
         )

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -152,6 +152,13 @@ class SprintLivenessCase(unittest.TestCase):
             ).fetchone()[0]
         )
         self.messages = sprint_message_delivery.SprintMessageStore(self.con)
+        delivered = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).deliver_once(
+            "liveness-setup",
+            lambda _conversation, _prompt, _key: "liveness-setup-run",
+        )
+        self.assertEqual(wake_id, delivered.wake_id)
         self.assertEqual(
             "accepted", self.messages.mark_read(self.assignment_message_id, 1)
         )
@@ -182,7 +189,7 @@ class SprintLivenessCase(unittest.TestCase):
 
     def message_rows(self, kind: str) -> list[sqlite3.Row]:
         return self.con.execute(
-            "SELECT * FROM sprint_messages WHERE message_kind=? ORDER BY message_id",
+            "SELECT * FROM wake_message WHERE message_kind=? ORDER BY message_id",
             (kind,),
         ).fetchall()
 
@@ -524,7 +531,7 @@ class FakeClockPolicyTest(SprintLivenessCase):
             message_kind="review_request",
             body="Please review",
             actionable=True,
-            active=True,
+            declared_type="new",
             idempotency_key="review-request:1",
         )
         self.assertEqual("accepted", self.messages.mark_read(review.message_id, 2))
@@ -547,7 +554,7 @@ class FakeClockPolicyTest(SprintLivenessCase):
 
 
 class DeliveryAndActivationTest(SprintLivenessCase):
-    def test_planner_quota_exhaustion_routes_escalation_to_fallback_only(self) -> None:
+    def test_planner_escalations_defer_chat_routing_and_coalesce(self) -> None:
         self.con.execute("DELETE FROM flavor_defaults WHERE flavor='planner'")
         self.con.executemany(
             "INSERT INTO flavor_defaults (flavor,harness,model,is_default) "
@@ -575,7 +582,7 @@ class DeliveryAndActivationTest(SprintLivenessCase):
             message_kind="review_request",
             body="Please review",
             actionable=True,
-            active=True,
+            declared_type="new",
             idempotency_key="review-request:fallback-dedup",
         )
         self.assertEqual("accepted", self.messages.mark_read(review.message_id, 2))
@@ -605,20 +612,18 @@ class DeliveryAndActivationTest(SprintLivenessCase):
             "FROM sprint_participants WHERE participant_id=?",
             (self.planner_id,),
         ).fetchone()
-        self.assertNotEqual(
-            planner["persistent_conversation_id"], planner["current_conversation_id"]
-        )
+        self.assertEqual((None, None), tuple(planner))
         fallbacks = self.con.execute(
             "SELECT link.purpose,c.harness FROM sprint_participant_conversations link "
             "JOIN conversations c ON c.conversation_id=link.conversation_id "
             "WHERE link.sprint_participant_id=? AND link.purpose='fallback'",
             (self.planner_id,),
         ).fetchall()
-        self.assertEqual([("fallback", "claude")], [tuple(row) for row in fallbacks])
+        self.assertEqual([], [tuple(row) for row in fallbacks])
         escalations = self.message_rows("escalation")
         self.assertEqual(2, len(escalations))
         self.assertEqual(
-            ["fallback:claude", "fallback:claude"],
+            ["delivery-time", "delivery-time"],
             [json.loads(row["body"])["planner_delivery_route"] for row in escalations],
         )
         wakes = self.con.execute(
@@ -631,6 +636,19 @@ class DeliveryAndActivationTest(SprintLivenessCase):
             [(self.planner_id, "pending"), (self.planner_id, "pending")],
             [tuple(row) for row in wakes],
         )
+        self.assertEqual(
+            1,
+            len(
+                {
+                    int(row["wake_id"])
+                    for row in self.con.execute(
+                        "SELECT wake_id FROM sprint_wake_messages "
+                        "WHERE message_id IN (?,?)",
+                        (escalations[0]["message_id"], escalations[1]["message_id"]),
+                    )
+                }
+            ),
+        )
         self.assertEqual([], self.message_rows("nudge"))
 
     def test_paused_sprint_does_no_evaluation_or_delivery_work(self) -> None:
@@ -642,11 +660,11 @@ class DeliveryAndActivationTest(SprintLivenessCase):
             reason="hold",
         )
         before = self.con.execute(
-            "SELECT COUNT(*) FROM sprint_messages"
+            "SELECT COUNT(*) FROM wake_message"
         ).fetchone()[0]
         self.assertEqual((), self.monitor().evaluate(self.sprint_id))
         after = self.con.execute(
-            "SELECT COUNT(*) FROM sprint_messages"
+            "SELECT COUNT(*) FROM wake_message"
         ).fetchone()[0]
         self.assertEqual(before, after)
         self.assertIsNone(self.expectation()["last_evaluated_at"])
@@ -685,7 +703,7 @@ class DeliveryAndActivationTest(SprintLivenessCase):
             message_kind="notification",
             body="Review changes requested",
             actionable=True,
-            active=False,
+            declared_type="re-enter",
             idempotency_key="changes-requested:former-developer",
         )
         self.assertEqual("accepted", self.messages.mark_read(notification.message_id, 1))
@@ -816,20 +834,25 @@ class MigrationGateTest(unittest.TestCase):
             (sprint_id, unit_id, task_id),
         )
         con.commit()
-        # Current runtime code reads the v2.1 active-chat authority even while
-        # this fixture isolates the older 0158 liveness migration.
-        con.executescript(
-            (MIGRATIONS / "0162_active_chat_registry.sql").read_text()
-        )
-        wake_id = sprint_domain.SprintLifecycleStore(con).arm(sprint_id, 3)[0]
         assignment_message_id = int(
             con.execute(
-                "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",
-                (wake_id,),
-            ).fetchone()[0]
+                "INSERT INTO sprint_messages "
+                "(sprint_id,from_participant_id,to_participant_id,work_unit_id,"
+                "message_kind,body,actionable,disposition,idempotency_key) "
+                "VALUES (?,(SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND role='planner'),"
+                "(SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND role='developer'),?,"
+                "'work_assignment','Ship it',1,'pending','legacy-assignment')",
+                (sprint_id, sprint_id, sprint_id, unit_id),
+            ).lastrowid
         )
-        messages = sprint_message_delivery.SprintMessageStore(con)
-        self.assertEqual("accepted", messages.mark_read(assignment_message_id, 1))
+        con.execute("UPDATE sprints SET lifecycle='armed' WHERE sprint_id=?", (sprint_id,))
+        con.execute(
+            "UPDATE sprint_messages SET disposition='accepted',"
+            "read_at='2026-08-02 00:00:00' WHERE message_id=?",
+            (assignment_message_id,),
+        )
         con.execute(
             "UPDATE sprint_work_units SET disposition='in_review',"
             "updated_at='2026-08-02 00:00:00' WHERE work_unit_id=?",

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Stage 3 gates for dedicated Sprint messages and wake delivery."""
+
 from __future__ import annotations
 
 import hashlib
@@ -9,6 +10,7 @@ import sys
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
@@ -87,8 +89,7 @@ class SprintMessageCase(unittest.TestCase):
         participants = {
             row["role"]: int(row["participant_id"])
             for row in self.con.execute(
-                "SELECT role,participant_id FROM sprint_participants "
-                "WHERE sprint_id=?",
+                "SELECT role,participant_id FROM sprint_participants WHERE sprint_id=?",
                 (self.sprint_id,),
             )
         }
@@ -237,15 +238,12 @@ class MessageTransactionTest(SprintMessageCase):
 
 class AcceptanceAndDeclineTest(SprintMessageCase):
     def test_actionable_read_accepts_but_informational_read_does_not(self) -> None:
-        task = self.send(
-            "accept-task", kind="review_request", actionable=True
-        )
+        task = self.send("accept-task", kind="review_request", actionable=True)
         with self.assertRaisesRegex(
             sqlite3.IntegrityError, "invalid wake message acceptance state"
         ):
             self.con.execute(
-                "UPDATE wake_message SET read_at=datetime('now') "
-                "WHERE message_id=?",
+                "UPDATE wake_message SET read_at=datetime('now') WHERE message_id=?",
                 (task.message_id,),
             )
         self.con.rollback()
@@ -437,7 +435,9 @@ class WakeDeliveryTest(SprintMessageCase):
                 (self.developer_conversation_id,),
             ).fetchone()[0],
         )
-        self.assertLess(prompt.index("body for mixed-reenter"), prompt.index("body for mixed-new"))
+        self.assertLess(
+            prompt.index("body for mixed-reenter"), prompt.index("body for mixed-new")
+        )
         self.assertEqual(
             [(first.message_id, 1), (second.message_id, 1)],
             [
@@ -496,6 +496,280 @@ class WakeDeliveryTest(SprintMessageCase):
         ).fetchone()
         self.assertEqual((None, None, 1, None, None, "re-enter"), tuple(row)[:6])
         self.assertIsNotNone(row["delivered_at"])
+
+    def test_armed_message_claims_foreign_paused_sprint_wake(self) -> None:
+        paused = self.messages.send(
+            self.sprint_id,
+            to_participant_id=self.planner_id,
+            message_kind="notification",
+            body="paused sprint backlog",
+            idempotency_key="paused-sprint-backlog",
+        )
+        self.con.execute(
+            "UPDATE sprints SET lifecycle='paused' WHERE sprint_id=?",
+            (self.sprint_id,),
+        )
+        feature_id = int(
+            self.con.execute(
+                "SELECT feature_id FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        armed_sprint_id = int(
+            self.con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "UPDATE sprints SET lifecycle='armed' WHERE sprint_id=?",
+            (armed_sprint_id,),
+        )
+        armed_planner_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_participants "
+                "(sprint_id,shell_id,role,harness) VALUES (?,3,'planner','codex')",
+                (armed_sprint_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+
+        armed = self.messages.send(
+            armed_sprint_id,
+            to_participant_id=armed_planner_id,
+            message_kind="notification",
+            body="armed sprint work",
+            idempotency_key="armed-sprint-work",
+        )
+        self.assertEqual(paused.wake_id, armed.wake_id)
+
+        lease = delivery.SprintWakeDeliveryService(self.con).claim_next(
+            "cross-sprint-worker"
+        )
+
+        self.assertIsNotNone(lease)
+        self.assertEqual(paused.wake_id, lease.wake_id)
+        self.assertEqual((paused.message_id, armed.message_id), lease.message_ids)
+        self.assertIn("paused sprint backlog", lease.prompt)
+        self.assertIn("armed sprint work", lease.prompt)
+
+    def test_engine_new_rotates_idle_chat_and_delivers(self) -> None:
+        sent = self.messages.send_to_shell(
+            1,
+            message_kind="system",
+            body="rotate engine chat",
+            idempotency_key="engine-new-idle",
+            declared_type="new",
+        )
+        observed: list[str] = []
+
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "engine-new-worker",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "engine-new-run"
+            ),
+        )
+
+        self.assertEqual(sent.wake_id, outcome.wake_id)
+        self.assertNotEqual(self.developer_conversation_id, observed[0])
+        self.assertEqual(
+            "closed",
+            self.con.execute(
+                "SELECT state FROM conversations WHERE conversation_id=?",
+                (self.developer_conversation_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            observed[0],
+            self.con.execute(
+                "SELECT chat_id FROM active_shell_chats WHERE shell_id=1"
+            ).fetchone()[0],
+        )
+
+    def test_engine_new_without_registry_creates_chat(self) -> None:
+        self.con.execute("DELETE FROM active_shell_chats WHERE shell_id=1")
+        self.con.commit()
+        sent = self.messages.send_to_shell(
+            1,
+            message_kind="system",
+            body="create engine chat",
+            idempotency_key="engine-new-no-registry",
+            declared_type="new",
+        )
+        observed: list[str] = []
+
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "engine-create-worker",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "engine-create-run"
+            ),
+        )
+
+        self.assertEqual(sent.wake_id, outcome.wake_id)
+        self.assertNotEqual(self.developer_conversation_id, observed[0])
+        created = self.con.execute(
+            "SELECT state,conversation_scope FROM conversations "
+            "WHERE conversation_id=?",
+            (observed[0],),
+        ).fetchone()
+        self.assertEqual(("idle", "normal"), tuple(created))
+
+    def test_engine_new_preflight_failure_preserves_active_chat(self) -> None:
+        self.con.execute("UPDATE shells SET user_id=NULL WHERE shell_id=1")
+        self.con.commit()
+        sent = self.messages.send_to_shell(
+            1,
+            message_kind="system",
+            body="invalid engine route",
+            idempotency_key="engine-new-invalid-route",
+            declared_type="new",
+        )
+
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "engine-invalid-worker",
+            lambda *_args: self.fail("invalid route must not enqueue"),
+        )
+
+        self.assertEqual(
+            (sent.wake_id, "pending", 1),
+            (outcome.wake_id, outcome.state, outcome.attempt_number),
+        )
+        self.assertEqual(
+            self.developer_conversation_id,
+            self.con.execute(
+                "SELECT chat_id FROM active_shell_chats WHERE shell_id=1"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            "idle",
+            self.con.execute(
+                "SELECT state FROM conversations WHERE conversation_id=?",
+                (self.developer_conversation_id,),
+            ).fetchone()[0],
+        )
+
+    def test_engine_delivery_failures_use_three_attempt_budget(self) -> None:
+        sent = self.messages.send_to_shell(
+            1,
+            message_kind="system",
+            body="bounded engine wake",
+            idempotency_key="engine-bounded-failure",
+        )
+        service = delivery.SprintWakeDeliveryService(self.con)
+
+        outcomes = [
+            service.deliver_once(
+                f"engine-failure-{attempt}",
+                lambda *_args: (_ for _ in ()).throw(RuntimeError("offline")),
+            )
+            for attempt in range(1, 4)
+        ]
+
+        self.assertEqual(
+            [
+                (sent.wake_id, "pending", 1),
+                (sent.wake_id, "pending", 2),
+                (sent.wake_id, "failed", 3),
+            ],
+            [
+                (outcome.wake_id, outcome.state, outcome.attempt_number)
+                for outcome in outcomes
+            ],
+        )
+        self.assertEqual(
+            [
+                (1, "failed", "offline"),
+                (2, "failed", "offline"),
+                (3, "failed", "offline"),
+            ],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT attempt_number,outcome,error_detail "
+                    "FROM sprint_wake_attempts WHERE wake_id=? "
+                    "ORDER BY attempt_number",
+                    (sent.wake_id,),
+                )
+            ],
+        )
+
+    def test_busy_close_race_reenters_without_failed_attempt(self) -> None:
+        sent = self.send("busy-close-race", declared_type="new")
+        service = delivery.SprintWakeDeliveryService(self.con)
+
+        with mock.patch.object(
+            active_chat_registry,
+            "close_for_wake",
+            side_effect=active_chat_registry.ActiveChatBusy("turn started"),
+        ):
+            outcome = service.deliver_once(
+                "busy-close-worker",
+                lambda conversation, _prompt, _key: conversation,
+            )
+
+        self.assertEqual(
+            (sent.wake_id, "delivered", 1),
+            (outcome.wake_id, outcome.state, outcome.attempt_number),
+        )
+        self.assertEqual(
+            [(1, "delivered")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT attempt_number,outcome FROM sprint_wake_attempts "
+                    "WHERE wake_id=?",
+                    (sent.wake_id,),
+                )
+            ],
+        )
+
+    def test_creation_race_reenters_winning_chat_without_failed_attempt(self) -> None:
+        self.con.execute("DELETE FROM active_shell_chats WHERE shell_id=1")
+        self.con.commit()
+        sent = self.messages.send_to_shell(
+            1,
+            message_kind="system",
+            body="creation race",
+            idempotency_key="engine-creation-race",
+            declared_type="new",
+        )
+
+        winner = active_chat_registry.ActiveChat(
+            1, self.developer_conversation_id, "idle", None, None
+        )
+        with (
+            mock.patch.object(
+                delivery.sprint_participant_chats,
+                "create_shell_wake_conversation",
+                side_effect=delivery.sprint_participant_chats.WakeConversationBusy(
+                    "another chat became active"
+                ),
+            ),
+            mock.patch.object(
+                active_chat_registry,
+                "get",
+                side_effect=(None, winner),
+            ),
+        ):
+            outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+                "creation-race-worker",
+                lambda conversation, _prompt, _key: conversation,
+            )
+
+        self.assertEqual(
+            (sent.wake_id, "delivered", 1),
+            (outcome.wake_id, outcome.state, outcome.attempt_number),
+        )
+        self.assertEqual(
+            self.developer_conversation_id,
+            self.con.execute(
+                "SELECT target_conversation_id FROM sprint_wake_attempts "
+                "WHERE wake_id=?",
+                (sent.wake_id,),
+            ).fetchone()[0],
+        )
 
     def test_claim_respects_available_at_backoff_boundary(self) -> None:
         sent = self.send("backoff-boundary")
@@ -648,7 +922,9 @@ class WakeDeliveryTest(SprintMessageCase):
             ],
         )
 
-    def test_expired_claim_retries_same_identity_without_logical_duplicate(self) -> None:
+    def test_expired_claim_retries_same_identity_without_logical_duplicate(
+        self,
+    ) -> None:
         sent = self.send("crash-retry")
         clock = [datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc)]
         service = delivery.SprintWakeDeliveryService(self.con, now=lambda: clock[0])
@@ -735,7 +1011,10 @@ class WakeDeliveryTest(SprintMessageCase):
             [(1, "pending"), (2, "pending"), (3, "failed")],
             [(item.attempt_number, item.state) for item in outcomes],
         )
-        self.assertIsNone(service.claim_next("worker-a"))
+        pause_notice = service.claim_next("worker-a")
+        self.assertIsNotNone(pause_notice)
+        self.assertIsNone(pause_notice.sprint_id)
+        self.assertIn("wake_delivery_exhausted", pause_notice.prompt)
         self.assertEqual(
             ("paused", "failed", 3, None),
             tuple(
@@ -905,9 +1184,10 @@ class ParticipantRelayTest(SprintMessageCase):
             "USING (conversation_id) WHERE c.conversation_id=?",
             (conversation_id,),
         ).fetchone()
-        self.assertEqual(before + 1, self.con.execute(
-            "SELECT COUNT(*) FROM conversations"
-        ).fetchone()[0])
+        self.assertEqual(
+            before + 1,
+            self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0],
+        )
         self.assertEqual(
             (3, "idle", "sprint", "work", None, None),
             tuple(route),

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -3,19 +3,19 @@
 from __future__ import annotations
 
 import hashlib
-import json
+import os
 import sqlite3
 import sys
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 MIGRATIONS = ENGINE / "migrations"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
+import active_chat_registry  # noqa: E402
 import sprint_domain  # noqa: E402
 import sprint_message_delivery as delivery  # noqa: E402
 
@@ -106,11 +106,14 @@ class SprintMessageCase(unittest.TestCase):
         self.con.commit()
         self.lifecycle = sprint_domain.SprintLifecycleStore(self.con)
         initial_wake = self.lifecycle.arm(self.sprint_id, 3)[0]
-        self.developer_conversation_id = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE participant_id=?",
-            (self.developer_id,),
-        ).fetchone()[0]
+        initial_delivery: list[str] = []
+        delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "setup-worker",
+            lambda conversation, _prompt, _key: (
+                initial_delivery.append(conversation) or "setup-native-run"
+            ),
+        )
+        self.developer_conversation_id = initial_delivery[0]
         initial_message = self.con.execute(
             "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",
             (initial_wake,),
@@ -125,7 +128,7 @@ class SprintMessageCase(unittest.TestCase):
         kind: str = "notification",
         actionable: bool = False,
         to_participant_id: int | None = None,
-        active: bool = True,
+        declared_type: str = "re-enter",
     ) -> delivery.MessageReceipt:
         return self.messages.send(
             self.sprint_id,
@@ -135,7 +138,7 @@ class SprintMessageCase(unittest.TestCase):
             message_kind=kind,
             body=f"body for {key}",
             actionable=actionable,
-            active=active,
+            declared_type=declared_type,
             idempotency_key=key,
         )
 
@@ -144,7 +147,7 @@ class MessageTransactionTest(SprintMessageCase):
     def test_message_and_active_wake_commit_or_roll_back_together(self) -> None:
         before = tuple(
             self.con.execute(
-                "SELECT (SELECT COUNT(*) FROM sprint_messages),"
+                "SELECT (SELECT COUNT(*) FROM wake_message),"
                 "(SELECT COUNT(*) FROM sprint_wake_outbox)"
             ).fetchone()
         )
@@ -160,7 +163,7 @@ class MessageTransactionTest(SprintMessageCase):
             before,
             tuple(
                 self.con.execute(
-                    "SELECT (SELECT COUNT(*) FROM sprint_messages),"
+                    "SELECT (SELECT COUNT(*) FROM wake_message),"
                     "(SELECT COUNT(*) FROM sprint_wake_outbox)"
                 ).fetchone()
             ),
@@ -182,19 +185,19 @@ class MessageTransactionTest(SprintMessageCase):
                 message_kind="notification",
                 body="different body",
                 idempotency_key="same-key",
-                active=True,
+                declared_type="re-enter",
             )
         self.assertEqual(
             1,
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_messages WHERE idempotency_key='same-key'"
+                "SELECT COUNT(*) FROM wake_message WHERE idempotency_key='same-key'"
             ).fetchone()[0],
         )
 
-    def test_only_participant_handoffs_are_actionable_and_passive_has_no_wake(
+    def test_only_participant_handoffs_are_actionable_and_every_message_wakes(
         self,
     ) -> None:
-        before = self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0]
+        before = self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0]
         with self.assertRaises(sprint_domain.SprintInvariantError) as direct:
             self.send("bad-action", kind="system", actionable=True)
         self.con.execute("BEGIN")
@@ -214,17 +217,21 @@ class MessageTransactionTest(SprintMessageCase):
         self.assertEqual(str(nested.exception), delivery.ACTIONABLE_KIND_ERROR)
         self.assertEqual(
             before,
-            self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0],
+            self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0],
         )
 
-        passive = self.send("passive", active=False)
-        self.assertIsNone(passive.wake_id)
+        passive = self.send("formerly-passive")
+        self.assertIsNotNone(passive.wake_id)
         self.assertEqual(
-            [],
-            self.con.execute(
-                "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
+            [(passive.wake_id, passive.message_id)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                "SELECT wake_id,message_id FROM sprint_wake_messages "
+                "WHERE message_id=?",
                 (passive.message_id,),
-            ).fetchall(),
+                )
+            ],
         )
 
 
@@ -234,17 +241,17 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
             "accept-task", kind="review_request", actionable=True
         )
         with self.assertRaisesRegex(
-            sqlite3.IntegrityError, "invalid Sprint message acceptance state"
+            sqlite3.IntegrityError, "invalid wake message acceptance state"
         ):
             self.con.execute(
-                "UPDATE sprint_messages SET read_at=datetime('now') "
+                "UPDATE wake_message SET read_at=datetime('now') "
                 "WHERE message_id=?",
                 (task.message_id,),
             )
         self.con.rollback()
         self.assertEqual("accepted", self.messages.mark_read(task.message_id, 1))
         task_row = self.con.execute(
-            "SELECT disposition,read_at,decline_reason FROM sprint_messages "
+            "SELECT disposition,read_at,decline_reason FROM wake_message "
             "WHERE message_id=?",
             (task.message_id,),
         ).fetchone()
@@ -255,7 +262,7 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
         info = self.send("read-info")
         self.assertIsNone(self.messages.mark_read(info.message_id, 1))
         info_row = self.con.execute(
-            "SELECT disposition,read_at FROM sprint_messages WHERE message_id=?",
+            "SELECT disposition,read_at FROM wake_message WHERE message_id=?",
             (info.message_id,),
         ).fetchone()
         self.assertIsNone(info_row["disposition"])
@@ -286,7 +293,7 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
             tuple(row)
             for row in self.con.execute(
                 "SELECT disposition,read_at IS NOT NULL,decline_reason "
-                "FROM sprint_messages WHERE message_id IN (?,?) ORDER BY message_id",
+                "FROM wake_message WHERE message_id IN (?,?) ORDER BY message_id",
                 (assignment.message_id, review.message_id),
             )
         ]
@@ -308,7 +315,7 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
         planner_results = [
             tuple(row)
             for row in self.con.execute(
-                "SELECT message_id,to_participant_id,body FROM sprint_messages "
+                "SELECT message_id,to_participant_id,body FROM wake_message "
                 "WHERE message_id IN (?,?) ORDER BY message_id",
                 (assignment_result, review_result),
             )
@@ -342,7 +349,7 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
             ],
         )
 
-    def test_decline_while_paused_records_passive_planner_result(self) -> None:
+    def test_decline_while_paused_still_records_planner_wake(self) -> None:
         assignment = self.send(
             "paused-decline", kind="work_assignment", actionable=True
         )
@@ -358,13 +365,13 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
         )
 
         result = self.con.execute(
-            "SELECT to_participant_id,body FROM sprint_messages WHERE message_id=?",
+            "SELECT to_participant_id,body FROM wake_message WHERE message_id=?",
             (result_id,),
         ).fetchone()
         self.assertEqual(self.planner_id, result["to_participant_id"])
         self.assertIn("cannot safely continue", result["body"])
         self.assertEqual(
-            0,
+            1,
             self.con.execute(
                 "SELECT COUNT(*) FROM sprint_wake_messages WHERE message_id=?",
                 (result_id,),
@@ -373,6 +380,123 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
 
 
 class WakeDeliveryTest(SprintMessageCase):
+    def test_live_verified_turn_forces_declared_new_to_reenter(self) -> None:
+        pid, start_ticks = active_chat_registry.process_identity(str(os.getpid()))
+        self.assertEqual(os.getpid(), pid)
+        self.con.execute(
+            "UPDATE active_shell_chats SET process_pid=?,process_start_ticks=? "
+            "WHERE shell_id=1",
+            (pid, start_ticks),
+        )
+        self.con.commit()
+        before = self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+        sent = self.send("busy-new", declared_type="new")
+        observed: list[str] = []
+
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "busy-worker",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "busy-run"
+            ),
+        )
+
+        self.assertEqual(sent.wake_id, outcome.wake_id)
+        self.assertEqual([self.developer_conversation_id], observed)
+        self.assertEqual(
+            before,
+            self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0],
+        )
+        self.assertEqual(
+            "idle",
+            self.con.execute(
+                "SELECT state FROM conversations WHERE conversation_id=?",
+                (self.developer_conversation_id,),
+            ).fetchone()[0],
+        )
+
+    def test_idle_mixed_types_rotate_once_and_drain_every_body(self) -> None:
+        first = self.send("mixed-reenter", declared_type="re-enter")
+        second = self.send("mixed-new", declared_type="new")
+        self.assertEqual(first.wake_id, second.wake_id)
+        observed: list[tuple[str, str]] = []
+
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "mixed-worker",
+            lambda conversation, prompt, _key: (
+                observed.append((conversation, prompt)) or "mixed-run"
+            ),
+        )
+
+        conversation_id, prompt = observed[0]
+        self.assertEqual(first.wake_id, outcome.wake_id)
+        self.assertNotEqual(self.developer_conversation_id, conversation_id)
+        self.assertEqual(
+            "closed",
+            self.con.execute(
+                "SELECT state FROM conversations WHERE conversation_id=?",
+                (self.developer_conversation_id,),
+            ).fetchone()[0],
+        )
+        self.assertLess(prompt.index("body for mixed-reenter"), prompt.index("body for mixed-new"))
+        self.assertEqual(
+            [(first.message_id, 1), (second.message_id, 1)],
+            [
+                (int(row["message_id"]), row["delivered_at"] is not None)
+                for row in self.con.execute(
+                    "SELECT message_id,delivered_at FROM wake_message "
+                    "WHERE message_id IN (?,?) ORDER BY message_id",
+                    (first.message_id, second.message_id),
+                )
+            ],
+        )
+
+    def test_stale_registry_pid_counts_as_idle_for_new(self) -> None:
+        self.con.execute(
+            "UPDATE active_shell_chats SET process_pid=2147483647,"
+            "process_start_ticks=1 WHERE shell_id=1"
+        )
+        self.con.commit()
+        sent = self.send("stale-new", declared_type="new")
+        observed: list[str] = []
+
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "stale-worker",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "stale-run"
+            ),
+        )
+
+        self.assertEqual(sent.wake_id, outcome.wake_id)
+        self.assertNotEqual(self.developer_conversation_id, observed[0])
+
+    def test_engine_wake_message_has_optional_sprint_scope(self) -> None:
+        sent = self.messages.send_to_shell(
+            1,
+            message_kind="system",
+            body="Engine-authored receiver-shell wake.",
+            idempotency_key="engine-wide-wake",
+        )
+        observed: list[tuple[str, str]] = []
+
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "engine-worker",
+            lambda conversation, prompt, _key: (
+                observed.append((conversation, prompt)) or "engine-run"
+            ),
+        )
+
+        self.assertEqual(sent.wake_id, outcome.wake_id)
+        self.assertEqual(self.developer_conversation_id, observed[0][0])
+        self.assertIn("Engine-authored receiver-shell wake.", observed[0][1])
+        row = self.con.execute(
+            "SELECT sprint_id,sender_shell_id,receiver_shell_id,"
+            "from_participant_id,to_participant_id,declared_type,delivered_at "
+            "FROM wake_message WHERE message_id=?",
+            (sent.message_id,),
+        ).fetchone()
+        self.assertEqual((None, None, 1, None, None, "re-enter"), tuple(row)[:6])
+        self.assertIsNotNone(row["delivered_at"])
+
     def test_claim_respects_available_at_backoff_boundary(self) -> None:
         sent = self.send("backoff-boundary")
         clock = [datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc)]
@@ -423,13 +547,17 @@ class WakeDeliveryTest(SprintMessageCase):
             [
                 (
                     self.developer_conversation_id,
-                    f"Sprint {self.sprint_id} handoff for your Developer role. "
-                    "Load `sprint_dev`. Run `sc sprint inbox --sprint "
-                    f"{self.sprint_id}` now and act on the Sprint message(s) using "
-                    "`sprint_dev`. Confirm every Sprint write succeeds before "
-                    "stopping. If the handoff is not complete, load `sprint_dev` "
-                    "again and run `sc sprint inbox --sprint "
-                    f"{self.sprint_id}` again.",
+                    (
+                        f"Sprint {self.sprint_id} handoff for your Developer role. "
+                        "Load `sprint_dev`. Run `sc sprint inbox --sprint "
+                        f"{self.sprint_id}` now and act on the Sprint message(s) using "
+                        "`sprint_dev`. Confirm every Sprint write succeeds before "
+                        "stopping. If the handoff is not complete, load `sprint_dev` "
+                        "again and run `sc sprint inbox --sprint "
+                        f"{self.sprint_id}` again.\n\n"
+                        f"## wake_message #{sent.message_id} "
+                        "(declared Re-Enter)\n\nbody for deliver"
+                    ),
                     self._wake_key(sent.wake_id),
                 )
             ],
@@ -462,7 +590,7 @@ class WakeDeliveryTest(SprintMessageCase):
         observed: dict[str, str] = {}
         service = delivery.SprintWakeDeliveryService(self.con)
         for role, (participant_id, label, skill) in expected.items():
-            self.messages.send(
+            sent = self.messages.send(
                 self.sprint_id,
                 to_participant_id=participant_id,
                 from_participant_id=(
@@ -486,12 +614,14 @@ class WakeDeliveryTest(SprintMessageCase):
                 f"now and act on the Sprint message(s) using `{skill}`. Confirm "
                 "every Sprint write succeeds before stopping. If the handoff is "
                 f"not complete, load `{skill}` again and run `sc sprint inbox "
-                f"--sprint {self.sprint_id}` again.",
+                f"--sprint {self.sprint_id}` again.\n\n"
+                f"## wake_message #{sent.message_id} (declared Re-Enter)\n\n"
+                "PR #321, message 987, work unit 654, sha deadbeef",
             )
-            self.assertNotIn("PR #321", observed[role])
-            self.assertNotIn("message 987", observed[role])
-            self.assertNotIn("work unit 654", observed[role])
-            self.assertNotIn("deadbeef", observed[role])
+            self.assertIn("PR #321", observed[role])
+            self.assertIn("message 987", observed[role])
+            self.assertIn("work unit 654", observed[role])
+            self.assertIn("deadbeef", observed[role])
 
     def test_messages_behind_delivering_wake_coalesce_once(self) -> None:
         first = self.send("first")
@@ -555,7 +685,7 @@ class WakeDeliveryTest(SprintMessageCase):
         first = self.send("expired-first")
         clock = [datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc)]
         service = delivery.SprintWakeDeliveryService(self.con, now=lambda: clock[0])
-        first_lease = service.claim_next("worker-a", lease_seconds=5)
+        service.claim_next("worker-a", lease_seconds=5)
         second = self.send("pending-second")
         clock[0] += timedelta(seconds=6)
 
@@ -565,7 +695,7 @@ class WakeDeliveryTest(SprintMessageCase):
         self.assertEqual(first.wake_id, reclaimed.wake_id)
         self.assertEqual(self._wake_key(first.wake_id), reclaimed.idempotency_key)
         self.assertEqual(
-            ("delivering", "pending"),
+            ("delivering", "cancelled"),
             tuple(
                 self.con.execute(
                     "SELECT "
@@ -574,6 +704,17 @@ class WakeDeliveryTest(SprintMessageCase):
                     (first.wake_id, second.wake_id),
                 ).fetchone()
             ),
+        )
+        self.assertEqual(
+            [(first.wake_id, first.message_id), (first.wake_id, second.message_id)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT wake_id,message_id FROM sprint_wake_messages "
+                    "WHERE message_id IN (?,?) ORDER BY message_id",
+                    (first.message_id, second.message_id),
+                )
+            ],
         )
 
     def test_third_delivery_failure_auto_pauses_and_stops_claiming(self) -> None:
@@ -647,7 +788,7 @@ class ParticipantRelayTest(SprintMessageCase):
         message = self.con.execute(
             "SELECT m.from_participant_id,m.to_participant_id,m.work_unit_id,"
             "m.message_kind,m.body,m.actionable,m.disposition,m.read_at "
-            "FROM sprint_messages m WHERE m.message_id=?",
+            "FROM wake_message m WHERE m.message_id=?",
             (receipt.message_id,),
         ).fetchone()
         self.assertEqual(
@@ -687,11 +828,22 @@ class ParticipantRelayTest(SprintMessageCase):
         self.assertEqual(before, after)
 
     def test_relay_reuses_a_usable_current_conversation(self) -> None:
-        current = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE participant_id=?",
-            (self.planner_id,),
-        ).fetchone()[0]
+        first = self.messages.relay(
+            self.sprint_id,
+            from_shell_id=1,
+            to_shortname="PLN1",
+            body="Create the Planner wake chat.",
+            idempotency_key="participant-send:create-chat",
+        )
+        observed: list[str] = []
+        service = delivery.SprintWakeDeliveryService(self.con)
+        service.deliver_once(
+            "create-route",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "create-run"
+            ),
+        )
+        current = observed[-1]
         before = int(
             self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
         )
@@ -703,25 +855,23 @@ class ParticipantRelayTest(SprintMessageCase):
             body="A durable answer is needed.",
             idempotency_key="participant-send:reuse-chat",
         )
+        outcome = service.deliver_once(
+            "reuse-route",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "reuse-run"
+            ),
+        )
 
         self.assertEqual(current, receipt.conversation_id)
+        self.assertEqual(receipt.wake_id, outcome.wake_id)
+        self.assertEqual(current, observed[-1])
+        self.assertNotEqual(first.message_id, receipt.message_id)
         self.assertEqual(
             before,
             int(self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]),
         )
 
-    def test_relay_creates_and_selects_a_linked_chat_when_current_is_closed(self) -> None:
-        old_conversation = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE participant_id=?",
-            (self.planner_id,),
-        ).fetchone()[0]
-        self.con.execute(
-            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
-            "WHERE conversation_id=?",
-            (old_conversation,),
-        )
-        self.con.commit()
+    def test_relay_defers_fresh_chat_creation_until_delivery(self) -> None:
         before = int(
             self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
         )
@@ -733,47 +883,60 @@ class ParticipantRelayTest(SprintMessageCase):
             body="Please answer from a fresh route.",
             idempotency_key="participant-send:new-chat",
         )
+        self.assertIsNone(receipt.conversation_id)
+        self.assertEqual(
+            before,
+            self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0],
+        )
+        observed: list[str] = []
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "fresh-route",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "fresh-run"
+            ),
+        )
+        self.assertEqual(receipt.wake_id, outcome.wake_id)
+        conversation_id = observed[0]
 
         route = self.con.execute(
             "SELECT c.shell_id,c.state,c.conversation_scope,pc.purpose,"
             "pc.parent_conversation_id,pc.context_packet "
             "FROM conversations c JOIN sprint_participant_conversations pc "
             "USING (conversation_id) WHERE c.conversation_id=?",
-            (receipt.conversation_id,),
+            (conversation_id,),
         ).fetchone()
-        self.assertNotEqual(old_conversation, receipt.conversation_id)
         self.assertEqual(before + 1, self.con.execute(
             "SELECT COUNT(*) FROM conversations"
         ).fetchone()[0])
         self.assertEqual(
-            (3, "idle", "sprint", "fallback", old_conversation),
-            tuple(route)[:5],
+            (3, "idle", "sprint", "work", None, None),
+            tuple(route),
         )
-        packet = json.loads(route["context_packet"])
-        self.assertEqual(self.sprint_id, packet["sprint_id"])
-        self.assertEqual(self.planner_id, packet["participant_id"])
-        self.assertEqual(old_conversation, packet["previous_conversation_id"])
         self.assertEqual(
-            receipt.conversation_id,
+            conversation_id,
             self.con.execute(
                 "SELECT current_conversation_id FROM sprint_participants "
                 "WHERE participant_id=?",
                 (self.planner_id,),
             ).fetchone()[0],
         )
+        self.assertEqual(
+            "generation:"
+            + str(
+                self.con.execute(
+                    "SELECT conversation_generation FROM sprints WHERE sprint_id=?",
+                    (self.sprint_id,),
+                ).fetchone()[0]
+            )
+            + f":wake:{receipt.wake_id}",
+            self.con.execute(
+                "SELECT creation_idempotency_key FROM conversations "
+                "WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0],
+        )
 
     def test_delivery_reroutes_when_the_created_wake_chat_closes(self) -> None:
-        old_conversation = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE participant_id=?",
-            (self.planner_id,),
-        ).fetchone()[0]
-        self.con.execute(
-            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
-            "WHERE conversation_id=?",
-            (old_conversation,),
-        )
-        self.con.commit()
         receipt = self.messages.relay(
             self.sprint_id,
             from_shell_id=1,
@@ -781,40 +944,37 @@ class ParticipantRelayTest(SprintMessageCase):
             body="Route this wake after a closed fallback.",
             idempotency_key="participant-send:closed-fallback-route",
         )
-        first_route = receipt.conversation_id
+        observed: list[str] = []
+        service = delivery.SprintWakeDeliveryService(self.con)
+        first = service.deliver_once(
+            "closed-route-first",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "first-run"
+            ),
+        )
+        self.assertEqual(receipt.wake_id, first.wake_id)
+        first_route = observed[-1]
         self.con.execute(
             "UPDATE conversations SET state='closed',closed_at=datetime('now') "
             "WHERE conversation_id=?",
             (first_route,),
         )
         self.con.commit()
-
-        lease = delivery.SprintWakeDeliveryService(self.con).claim_next(
-            "closed-route-retry"
+        second_receipt = self.messages.relay(
+            self.sprint_id,
+            from_shell_id=1,
+            to_shortname="PLN1",
+            body="Route the next wake after the first chat closed.",
+            idempotency_key="participant-send:closed-fallback-route:second",
         )
-
-        self.assertIsNotNone(lease)
-        self.assertEqual(receipt.wake_id, lease.wake_id)
-        self.assertNotEqual(first_route, lease.target_conversation_id)
-        self.assertEqual(
-            ("idle", "fallback", first_route),
-            tuple(
-                self.con.execute(
-                    "SELECT c.state,pc.purpose,pc.parent_conversation_id "
-                    "FROM conversations c JOIN sprint_participant_conversations pc "
-                    "USING (conversation_id) WHERE c.conversation_id=?",
-                    (lease.target_conversation_id,),
-                ).fetchone()
+        second = service.deliver_once(
+            "closed-route-second",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "second-run"
             ),
         )
-        self.assertEqual(
-            lease.target_conversation_id,
-            self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=?",
-                (self.planner_id,),
-            ).fetchone()[0],
-        )
+        self.assertEqual(second_receipt.wake_id, second.wake_id)
+        self.assertNotEqual(first_route, observed[-1])
 
     def test_relay_replay_returns_one_message_and_one_wake(self) -> None:
         first = self.messages.relay(
@@ -838,7 +998,7 @@ class ParticipantRelayTest(SprintMessageCase):
         self.assertEqual(
             1,
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_messages WHERE idempotency_key=?",
+                "SELECT COUNT(*) FROM wake_message WHERE idempotency_key=?",
                 ("participant-send:replay",),
             ).fetchone()[0],
         )
@@ -859,7 +1019,7 @@ class ParticipantRelayTest(SprintMessageCase):
         self.con.commit()
         before = tuple(
             self.con.execute(
-                "SELECT (SELECT COUNT(*) FROM sprint_messages),"
+                "SELECT (SELECT COUNT(*) FROM wake_message),"
                 "(SELECT COUNT(*) FROM sprint_wake_outbox),"
                 "(SELECT COUNT(*) FROM conversations)"
             ).fetchone()
@@ -881,7 +1041,7 @@ class ParticipantRelayTest(SprintMessageCase):
             before,
             tuple(
                 self.con.execute(
-                    "SELECT (SELECT COUNT(*) FROM sprint_messages),"
+                    "SELECT (SELECT COUNT(*) FROM wake_message),"
                     "(SELECT COUNT(*) FROM sprint_wake_outbox),"
                     "(SELECT COUNT(*) FROM conversations)"
                 ).fetchone()
@@ -895,7 +1055,7 @@ class ParticipantRelayTest(SprintMessageCase):
             "VALUES (4,'Outside','OUT1','dev','prompt',1)"
         )
         self.con.commit()
-        before = self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0]
+        before = self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0]
 
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError,
@@ -911,11 +1071,11 @@ class ParticipantRelayTest(SprintMessageCase):
 
         self.assertEqual(
             before,
-            self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0],
+            self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0],
         )
 
     def test_relay_rejects_oversize_body_with_actual_and_maximum_counts(self) -> None:
-        before = self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0]
+        before = self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0]
         with self.assertRaisesRegex(
             ValueError,
             "Sprint message body is 8001 characters; maximum is 8000",
@@ -929,7 +1089,7 @@ class ParticipantRelayTest(SprintMessageCase):
             )
         self.assertEqual(
             before,
-            self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0],
+            self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0],
         )
 
 

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -545,15 +545,186 @@ class WakeDeliveryTest(SprintMessageCase):
         )
         self.assertEqual(paused.wake_id, armed.wake_id)
 
-        lease = delivery.SprintWakeDeliveryService(self.con).claim_next(
-            "cross-sprint-worker"
-        )
+        service = delivery.SprintWakeDeliveryService(self.con)
+        lease = service.claim_next("cross-sprint-worker")
 
         self.assertIsNotNone(lease)
         self.assertEqual(paused.wake_id, lease.wake_id)
+        self.assertEqual(armed_sprint_id, lease.sprint_id)
+        self.assertEqual(armed_planner_id, lease.participant_id)
+        self.assertEqual("planner", lease.participant_role)
         self.assertEqual((paused.message_id, armed.message_id), lease.message_ids)
+        self.assertTrue(
+            lease.prompt.startswith(delivery.wake_prompt(armed_sprint_id, "planner"))
+        )
         self.assertIn("paused sprint backlog", lease.prompt)
         self.assertIn("armed sprint work", lease.prompt)
+        conversation_id = service._resolve_conversation(lease)
+        self.assertEqual(
+            armed_planner_id,
+            self.con.execute(
+                "SELECT sprint_participant_id "
+                "FROM sprint_participant_conversations WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0],
+        )
+
+    def test_mixed_scope_terminal_failure_pauses_armed_message_sprint(self) -> None:
+        engine = self.messages.send_to_shell(
+            3,
+            message_kind="system",
+            body="engine notice before armed work",
+            idempotency_key="mixed-failure-engine",
+        )
+        sprint = self.messages.send(
+            self.sprint_id,
+            to_participant_id=self.planner_id,
+            message_kind="notification",
+            body="armed sprint work on engine wake",
+            idempotency_key="mixed-failure-sprint",
+        )
+        self.assertEqual(engine.wake_id, sprint.wake_id)
+
+        def fail(_conversation: str, _prompt: str, _key: str) -> str:
+            raise RuntimeError("broker unavailable")
+
+        service = delivery.SprintWakeDeliveryService(self.con)
+        for attempt in range(1, 4):
+            outcome = service.deliver_once(
+                f"mixed-failure-{attempt}",
+                fail,
+            )
+            self.assertIsNotNone(outcome)
+            self.assertEqual(attempt, outcome.attempt_number)
+
+        self.assertEqual(
+            ("paused", "failed", 3),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,w.state,w.attempt_count FROM sprints s "
+                    "JOIN wake_message m ON m.sprint_id=s.sprint_id "
+                    "JOIN sprint_wake_messages wm USING (message_id) "
+                    "JOIN sprint_wake_outbox w USING (wake_id) "
+                    "WHERE s.sprint_id=? AND m.message_id=?",
+                    (self.sprint_id, sprint.message_id),
+                ).fetchone()
+            ),
+        )
+        pending = self.con.execute(
+            "SELECT w.wake_id,m.body FROM sprint_wake_outbox w "
+            "JOIN sprint_wake_messages wm USING (wake_id) "
+            "JOIN wake_message m USING (message_id) "
+            "WHERE w.receiver_shell_id=3 AND w.state='pending'"
+        ).fetchall()
+        self.assertEqual(1, len(pending))
+        self.assertIn("wake_delivery_exhausted", pending[0]["body"])
+
+    def test_resume_does_not_redeliver_paused_ride_along_message(self) -> None:
+        paused = self.messages.send(
+            self.sprint_id,
+            to_participant_id=self.planner_id,
+            message_kind="notification",
+            body="paused ride-along body",
+            idempotency_key="paused-ride-along",
+        )
+        self.con.execute(
+            "UPDATE sprints SET lifecycle='paused' WHERE sprint_id=?",
+            (self.sprint_id,),
+        )
+        feature_id = int(
+            self.con.execute(
+                "SELECT feature_id FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        armed_sprint_id = int(
+            self.con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+        )
+        armed_planner_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_participants "
+                "(sprint_id,shell_id,role,harness) VALUES (?,3,'planner','codex')",
+                (armed_sprint_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "UPDATE sprints SET lifecycle='armed' WHERE sprint_id=?",
+            (armed_sprint_id,),
+        )
+        self.con.commit()
+        armed = self.messages.send(
+            armed_sprint_id,
+            to_participant_id=armed_planner_id,
+            message_kind="notification",
+            body="armed delivery trigger",
+            idempotency_key="ride-along-trigger",
+        )
+        self.assertEqual(paused.wake_id, armed.wake_id)
+
+        def succeed(conversation: str, prompt: str, key: str) -> str:
+            message_id = int(
+                self.con.execute(
+                    "INSERT INTO conversation_messages "
+                    "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                    "idempotency_key,request_hash,state,completed_at) "
+                    "VALUES (?,'engine','test','prompt',?,?,?,'completed',"
+                    "datetime('now'))",
+                    (conversation, prompt, key, key),
+                ).lastrowid
+            )
+            run_id = int(
+                self.con.execute(
+                    "INSERT INTO conversation_runs "
+                    "(conversation_id,shell_id,trigger_message_id,state,"
+                    "lease_owner,lease_expires_at,started_at,ended_at,exit_code) "
+                    "VALUES (?,3,?,'succeeded','test','2999-01-01 00:00:00',"
+                    "datetime('now'),datetime('now'),0)",
+                    (conversation, message_id),
+                ).lastrowid
+            )
+            self.con.commit()
+            return f"conversation-run:{run_id}"
+
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "ride-along-worker",
+            succeed,
+        )
+        self.assertEqual("delivered", outcome.state)
+        delivered_at = self.con.execute(
+            "SELECT delivered_at FROM wake_message WHERE message_id=?",
+            (paused.message_id,),
+        ).fetchone()[0]
+        self.assertIsNotNone(delivered_at)
+        self.lifecycle.pause(
+            armed_sprint_id,
+            sprint_domain.LifecycleActor("fnb"),
+            reason="resume the ride-along sprint",
+        )
+
+        receipt = self.lifecycle.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("fnb"),
+            reason="body already delivered",
+        )
+
+        self.assertEqual((), receipt.requeued_wake_ids)
+        self.assertEqual(
+            (delivered_at, paused.wake_id, "delivered"),
+            tuple(
+                self.con.execute(
+                    "SELECT m.delivered_at,wm.wake_id,w.state "
+                    "FROM wake_message m JOIN sprint_wake_messages wm "
+                    "USING (message_id) JOIN sprint_wake_outbox w USING (wake_id) "
+                    "WHERE m.message_id=?",
+                    (paused.message_id,),
+                ).fetchone()
+            ),
+        )
 
     def test_engine_new_rotates_idle_chat_and_delivers(self) -> None:
         sent = self.messages.send_to_shell(

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -12,7 +12,6 @@ SCRIPTS = ROOT / ".super-coder" / "scripts"
 sys.path[:0] = [str(SCRIPTS), str(ROOT / "tests")]
 
 import sprint_domain
-import sprint_message_delivery
 import sprint_pr_watcher
 from github_pull_requests import GitHubReadError, PullRequest, normalize_pull_request
 from test_sprint_message_delivery import SprintMessageCase
@@ -248,11 +247,14 @@ class TransitionRoutingTest(SprintPRWatcherCase):
 
         self.assertEqual(["pending"], self._states())
         active_recipients = self.con.execute(
-            "SELECT m.to_participant_id FROM sprint_messages m "
+            "SELECT m.to_participant_id FROM wake_message m "
             "JOIN sprint_wake_messages wm USING (message_id) "
             "WHERE m.idempotency_key LIKE 'pr-transition:%'"
         ).fetchall()
-        self.assertEqual([], active_recipients)
+        self.assertEqual(
+            sorted([(self.developer_id,), (self.reviewer_id,), (self.planner_id,)]),
+            sorted(tuple(row) for row in active_recipients),
+        )
 
         raw["statusCheckRollup"][1] = {
             "name": "pytest",
@@ -264,16 +266,18 @@ class TransitionRoutingTest(SprintPRWatcherCase):
 
         self.assertEqual(["pending", "green"], self._states())
         active_recipients = self.con.execute(
-            "SELECT m.to_participant_id FROM sprint_messages m "
+            "SELECT m.to_participant_id FROM wake_message m "
             "JOIN sprint_wake_messages wm USING (message_id) "
             "WHERE m.idempotency_key LIKE 'pr-transition:%'"
         ).fetchall()
         self.assertEqual(
-            [(self.developer_id,)],
-            [tuple(row) for row in active_recipients],
+            sorted(
+                [(self.developer_id,), (self.reviewer_id,), (self.planner_id,)] * 2
+            ),
+            sorted(tuple(row) for row in active_recipients),
         )
 
-    def test_first_red_routes_one_active_owner_wake_and_passive_evidence(self):
+    def test_first_red_wakes_every_message_recipient(self):
         self.register()
 
         transition = self.con.execute(
@@ -283,7 +287,7 @@ class TransitionRoutingTest(SprintPRWatcherCase):
         self.assertEqual("red", transition["normalized_state"])
         self.assertEqual("registration", json.loads(transition["evidence"])["trigger"])
         routed = self.con.execute(
-            "SELECT message_id,to_participant_id,body FROM sprint_messages "
+            "SELECT message_id,to_participant_id,body FROM wake_message "
             "WHERE idempotency_key LIKE 'pr-transition:%' ORDER BY to_participant_id"
         ).fetchall()
         self.assertEqual(
@@ -296,20 +300,17 @@ class TransitionRoutingTest(SprintPRWatcherCase):
         )
         wakes = self.con.execute(
             "SELECT m.to_participant_id,w.wake_id,w.state "
-            "FROM sprint_messages m "
+            "FROM wake_message m "
             "JOIN sprint_wake_messages wm USING (message_id) "
             "JOIN sprint_wake_outbox w USING (wake_id) "
             "WHERE m.idempotency_key LIKE 'pr-transition:%'"
         ).fetchall()
         self.assertEqual(
-            [(self.developer_id, wakes[0]["wake_id"], "pending")],
-            [(int(row[0]), row[1], row[2]) for row in wakes],
+            sorted([self.developer_id, self.reviewer_id, self.planner_id]),
+            sorted(int(row[0]) for row in wakes),
         )
-        lease = sprint_message_delivery.SprintWakeDeliveryService(
-            self.con
-        ).claim_next("watch-test")
-        self.assertEqual(self.developer_id, lease.participant_id)
-        self.assertEqual(self.developer_conversation_id, lease.target_conversation_id)
+        self.assertEqual({"pending"}, {str(row["state"]) for row in wakes})
+        self.assertEqual(3, len({int(row["wake_id"]) for row in wakes}))
 
     def test_red_green_red_occurrences_wake_once_each_and_coalesce(self):
         self.register()
@@ -333,7 +334,7 @@ class TransitionRoutingTest(SprintPRWatcherCase):
             ],
         )
         owner_messages = self.con.execute(
-            "SELECT message_id FROM sprint_messages "
+            "SELECT message_id FROM wake_message "
             "WHERE to_participant_id=? AND idempotency_key LIKE 'pr-transition:%'",
             (self.developer_id,),
         ).fetchall()
@@ -342,14 +343,14 @@ class TransitionRoutingTest(SprintPRWatcherCase):
             1,
             self.con.execute(
                 "SELECT COUNT(DISTINCT wm.wake_id) FROM sprint_wake_messages wm "
-                "JOIN sprint_messages m USING (message_id) "
+                "JOIN wake_message m USING (message_id) "
                 "WHERE m.to_participant_id=? "
                 "AND m.idempotency_key LIKE 'pr-transition:%'",
                 (self.developer_id,),
             ).fetchone()[0],
         )
 
-    def test_closed_without_merge_actively_notifies_only_planner(self):
+    def test_closed_without_merge_wakes_every_message_recipient(self):
         self.reader.current = pull_request(
             state="CLOSED", checks=None, checks_failed=False
         )
@@ -358,18 +359,21 @@ class TransitionRoutingTest(SprintPRWatcherCase):
         active_recipients = [
             int(row[0])
             for row in self.con.execute(
-                "SELECT m.to_participant_id FROM sprint_messages m "
+                "SELECT m.to_participant_id FROM wake_message m "
                 "JOIN sprint_wake_messages wm USING (message_id) "
                 "WHERE m.idempotency_key LIKE 'pr-transition:%'"
             )
         ]
-        self.assertEqual([self.planner_id], active_recipients)
+        self.assertEqual(
+            sorted([self.developer_id, self.reviewer_id, self.planner_id]),
+            sorted(active_recipients),
+        )
         self.assertEqual(
             sorted([self.developer_id, self.reviewer_id, self.planner_id]),
             sorted(
                 int(row[0])
                 for row in self.con.execute(
-                    "SELECT to_participant_id FROM sprint_messages "
+                    "SELECT to_participant_id FROM wake_message "
                     "WHERE idempotency_key LIKE 'pr-transition:%'"
                 )
             ),
@@ -382,10 +386,10 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         before = tuple(
             self.con.execute(
                 "SELECT (SELECT COUNT(*) FROM sprint_pr_transitions),"
-                "(SELECT COUNT(*) FROM sprint_messages "
+                "(SELECT COUNT(*) FROM wake_message "
                 "WHERE idempotency_key LIKE 'pr-transition:%'),"
                 "(SELECT COUNT(*) FROM sprint_wake_messages wm "
-                "JOIN sprint_messages m USING (message_id) "
+                "JOIN wake_message m USING (message_id) "
                 "WHERE m.idempotency_key LIKE 'pr-transition:%')"
             ).fetchone()
         )
@@ -416,10 +420,10 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         after = tuple(
             self.con.execute(
                 "SELECT (SELECT COUNT(*) FROM sprint_pr_transitions),"
-                "(SELECT COUNT(*) FROM sprint_messages "
+                "(SELECT COUNT(*) FROM wake_message "
                 "WHERE idempotency_key LIKE 'pr-transition:%'),"
                 "(SELECT COUNT(*) FROM sprint_wake_messages wm "
-                "JOIN sprint_messages m USING (message_id) "
+                "JOIN wake_message m USING (message_id) "
                 "WHERE m.idempotency_key LIKE 'pr-transition:%')"
             ).fetchone()
         )
@@ -485,7 +489,7 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         self.assertEqual([42, 42], self.reader.get_calls)
         self.assertEqual(["green"], self._states())
         active_recipient = self.con.execute(
-            "SELECT m.to_participant_id FROM sprint_messages m "
+            "SELECT m.to_participant_id FROM wake_message m "
             "JOIN sprint_wake_messages wm USING (message_id) "
             "WHERE m.idempotency_key LIKE 'pr-transition:%'"
         ).fetchone()

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -1,4 +1,5 @@
 """Stage 5 gates for registered-PR observation and routed wakes."""
+
 from __future__ import annotations
 
 import json
@@ -163,15 +164,13 @@ class RegistrationTest(SprintPRWatcherCase):
         self.assertEqual([], self.reader.get_calls)
         self.assertEqual(
             0,
-            self.con.execute(
-                "SELECT COUNT(*) FROM sprint_registered_prs"
-            ).fetchone()[0],
+            self.con.execute("SELECT COUNT(*) FROM sprint_registered_prs").fetchone()[
+                0
+            ],
         )
         self.assertEqual(
             0,
-            self.con.execute(
-                "SELECT COUNT(*) FROM sprint_pr_work_units"
-            ).fetchone()[0],
+            self.con.execute("SELECT COUNT(*) FROM sprint_pr_work_units").fetchone()[0],
         )
 
     def test_registration_rejects_non_owner_work_and_non_armed_sprint(self):
@@ -213,9 +212,9 @@ class RegistrationTest(SprintPRWatcherCase):
             )
         self.assertEqual(
             0,
-            self.con.execute(
-                "SELECT COUNT(*) FROM sprint_registered_prs"
-            ).fetchone()[0],
+            self.con.execute("SELECT COUNT(*) FROM sprint_registered_prs").fetchone()[
+                0
+            ],
         )
 
 
@@ -251,10 +250,7 @@ class TransitionRoutingTest(SprintPRWatcherCase):
             "JOIN sprint_wake_messages wm USING (message_id) "
             "WHERE m.idempotency_key LIKE 'pr-transition:%'"
         ).fetchall()
-        self.assertEqual(
-            sorted([(self.developer_id,), (self.reviewer_id,), (self.planner_id,)]),
-            sorted(tuple(row) for row in active_recipients),
-        )
+        self.assertEqual([], active_recipients)
 
         raw["statusCheckRollup"][1] = {
             "name": "pytest",
@@ -271,18 +267,14 @@ class TransitionRoutingTest(SprintPRWatcherCase):
             "WHERE m.idempotency_key LIKE 'pr-transition:%'"
         ).fetchall()
         self.assertEqual(
-            sorted(
-                [(self.developer_id,), (self.reviewer_id,), (self.planner_id,)] * 2
-            ),
-            sorted(tuple(row) for row in active_recipients),
+            [(self.developer_id,)], [tuple(row) for row in active_recipients]
         )
 
-    def test_first_red_wakes_every_message_recipient(self):
+    def test_first_red_wakes_only_the_owning_developer(self):
         self.register()
 
         transition = self.con.execute(
-            "SELECT transition_id,normalized_state,evidence "
-            "FROM sprint_pr_transitions"
+            "SELECT transition_id,normalized_state,evidence FROM sprint_pr_transitions"
         ).fetchone()
         self.assertEqual("red", transition["normalized_state"])
         self.assertEqual("registration", json.loads(transition["evidence"])["trigger"])
@@ -291,7 +283,7 @@ class TransitionRoutingTest(SprintPRWatcherCase):
             "WHERE idempotency_key LIKE 'pr-transition:%' ORDER BY to_participant_id"
         ).fetchall()
         self.assertEqual(
-            sorted([self.developer_id, self.reviewer_id, self.planner_id]),
+            [self.developer_id],
             [int(row["to_participant_id"]) for row in routed],
         )
         self.assertEqual(
@@ -305,12 +297,9 @@ class TransitionRoutingTest(SprintPRWatcherCase):
             "JOIN sprint_wake_outbox w USING (wake_id) "
             "WHERE m.idempotency_key LIKE 'pr-transition:%'"
         ).fetchall()
-        self.assertEqual(
-            sorted([self.developer_id, self.reviewer_id, self.planner_id]),
-            sorted(int(row[0]) for row in wakes),
-        )
+        self.assertEqual([self.developer_id], [int(row[0]) for row in wakes])
         self.assertEqual({"pending"}, {str(row["state"]) for row in wakes})
-        self.assertEqual(3, len({int(row["wake_id"]) for row in wakes}))
+        self.assertEqual(1, len({int(row["wake_id"]) for row in wakes}))
 
     def test_red_green_red_occurrences_wake_once_each_and_coalesce(self):
         self.register()
@@ -350,7 +339,7 @@ class TransitionRoutingTest(SprintPRWatcherCase):
             ).fetchone()[0],
         )
 
-    def test_closed_without_merge_wakes_every_message_recipient(self):
+    def test_closed_without_merge_wakes_only_the_owning_developer(self):
         self.reader.current = pull_request(
             state="CLOSED", checks=None, checks_failed=False
         )
@@ -364,19 +353,16 @@ class TransitionRoutingTest(SprintPRWatcherCase):
                 "WHERE m.idempotency_key LIKE 'pr-transition:%'"
             )
         ]
+        self.assertEqual([self.developer_id], active_recipients)
         self.assertEqual(
-            sorted([self.developer_id, self.reviewer_id, self.planner_id]),
-            sorted(active_recipients),
-        )
-        self.assertEqual(
-            sorted([self.developer_id, self.reviewer_id, self.planner_id]),
-            sorted(
+            [self.developer_id],
+            [
                 int(row[0])
                 for row in self.con.execute(
                     "SELECT to_participant_id FROM wake_message "
                     "WHERE idempotency_key LIKE 'pr-transition:%'"
                 )
-            ),
+            ],
         )
 
 
@@ -494,6 +480,7 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
             "WHERE m.idempotency_key LIKE 'pr-transition:%'"
         ).fetchone()
         self.assertEqual(self.developer_id, int(active_recipient[0]))
+
 
 class BatchAndNormalizationTest(SprintPRWatcherCase):
     def test_multiple_registered_prs_share_one_repository_list_read(self):

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -149,13 +149,14 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             self.con.commit()
             return f"conversation-message:{message_id}"
 
-        outcome = sprint_message_delivery.SprintWakeDeliveryService(
-            self.con
-        ).deliver_once(f"delivery-{wake_id}", deliver)
-        self.assertIsNotNone(outcome)
-        self.assertEqual(wake_id, outcome.wake_id)
+        service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
+        while True:
+            outcome = service.deliver_once(f"delivery-{wake_id}", deliver)
+            self.assertIsNotNone(outcome)
+            if outcome.wake_id == wake_id:
+                break
         self.assertEqual("delivered", outcome.state)
-        return prompts[0], self.con.execute(
+        return prompts[-1], self.con.execute(
             "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
             (wake_id,),
         ).fetchone()[0]
@@ -203,11 +204,25 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             self.con.commit()
             return f"conversation-run:{run_id}"
 
-        outcome = sprint_message_delivery.SprintWakeDeliveryService(
-            self.con
-        ).deliver_once(f"failed-turn-{wake_id}", deliver)
-        self.assertIsNotNone(outcome)
-        self.assertEqual((wake_id, "delivered"), (outcome.wake_id, outcome.state))
+        service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
+        while True:
+            next_wake = int(
+                self.con.execute(
+                    "SELECT wake_id FROM sprint_wake_outbox "
+                    "WHERE state='pending' AND available_at<=datetime('now') "
+                    "ORDER BY wake_id LIMIT 1"
+                ).fetchone()[0]
+            )
+            callback = (
+                deliver
+                if next_wake == wake_id
+                else lambda _conversation, _prompt, _key: "drained-run"
+            )
+            outcome = service.deliver_once(f"failed-turn-{wake_id}", callback)
+            self.assertIsNotNone(outcome)
+            if outcome.wake_id == wake_id:
+                break
+        self.assertEqual("delivered", outcome.state)
 
     def test_participant_pause_atomically_persists_report_interrupt_and_notice(self):
         self.register()
@@ -264,26 +279,31 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             [
                 tuple(row)
                 for row in self.con.execute(
-                    "SELECT to_participant_id,actionable,body FROM sprint_messages "
+                    "SELECT to_participant_id,actionable,body FROM wake_message "
                     "WHERE idempotency_key LIKE 'sprint-pause:%'"
                 )
             ],
         )
         self.assertEqual(
-            [
-                (
-                    "engine",
-                    "sprint-recovery",
-                    "queued",
-                    sprint_message_delivery.wake_prompt(self.sprint_id, "planner"),
-                )
-            ],
+            [],
             [
                 tuple(row)
                 for row in self.con.execute(
                     "SELECT sender_kind,sender_ref,state,body "
                     "FROM conversation_messages "
                     "WHERE idempotency_key LIKE 'sprint-pause:%:planner-conversation'"
+                )
+            ],
+        )
+        self.assertEqual(
+            [(self.planner_id, "pending")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT w.participant_id,w.state FROM sprint_wake_outbox w "
+                    "JOIN sprint_wake_messages joined USING(wake_id) "
+                    "JOIN wake_message message USING(message_id) "
+                    "WHERE message.idempotency_key LIKE 'sprint-pause:%'"
                 )
             ],
         )
@@ -301,7 +321,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                     "SELECT (SELECT COUNT(*) FROM sprint_reports WHERE report_kind='pause'),"
                     "(SELECT COUNT(*) FROM conversation_events WHERE run_id=? "
                     "AND event_type='run.interrupt.requested'),"
-                    "(SELECT COUNT(*) FROM sprint_messages "
+                    "(SELECT COUNT(*) FROM wake_message "
                     "WHERE idempotency_key LIKE 'sprint-pause:%')",
                     (run_id,),
                 ).fetchone()
@@ -378,11 +398,16 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             replacement,
             [wake["wake_id"] for wake in evidence["pending_wakes"]],
         )
-        lease = sprint_message_delivery.SprintWakeDeliveryService(
-            self.con
-        ).claim_next("requeued-wake")
-        self.assertEqual(replacement, lease.wake_id)
-        self.assertEqual(1, lease.attempt_number)
+        service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
+        while True:
+            outcome = service.deliver_once(
+                "requeued-wake",
+                lambda conversation, _prompt, _key: conversation,
+            )
+            self.assertIsNotNone(outcome)
+            if outcome.wake_id == replacement:
+                break
+        self.assertEqual(1, outcome.attempt_number)
 
     def test_failed_recovery_wake_is_bounded_and_leaves_manual_evidence(self):
         message = self.send("bounded-recovery-wake")
@@ -418,7 +443,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             tuple(
                 self.con.execute(
                     "SELECT m.read_at,wm.wake_id,w.state,w.attempt_count "
-                    "FROM sprint_messages m JOIN sprint_wake_messages wm "
+                    "FROM wake_message m JOIN sprint_wake_messages wm "
                     "USING (message_id) JOIN sprint_wake_outbox w USING (wake_id) "
                     "WHERE m.message_id=?",
                     (message.message_id,),
@@ -525,7 +550,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                 trigger="attempt-5-exhausted",
             ),
         )
-        self.assertEqual(["notified"], notifications)
+        self.assertEqual([], notifications)
         self.assertEqual(
             ("paused", 5, "DEV1", "orphan"),
             tuple(
@@ -541,7 +566,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ),
         )
         notice = self.con.execute(
-            "SELECT body FROM sprint_messages WHERE sprint_id=? "
+            "SELECT body FROM wake_message WHERE sprint_id=? "
             "AND idempotency_key LIKE 'sprint-pause:%'",
             (self.sprint_id,),
         ).fetchone()[0]
@@ -632,7 +657,18 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             self.sprint_id,
             trigger="fresh-episode-attempt-2",
         )
-        self.assertEqual(1, len(fresh_retry))
+        busy_retry = [
+            wake_id
+            for wake_id in fresh_retry
+            if str(
+                self.con.execute(
+                    "SELECT idempotency_key FROM sprint_wake_outbox "
+                    "WHERE wake_id=?",
+                    (wake_id,),
+                ).fetchone()[0]
+            ).startswith(f"sprint-recovery:{self.sprint_id}:busy:{reset_wake}:")
+        ]
+        self.assertEqual(1, len(busy_retry))
         self.assertEqual(
             (
                 "armed",
@@ -647,7 +683,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                 self.con.execute(
                     "SELECT idempotency_key FROM sprint_wake_outbox "
                     "WHERE wake_id=?",
-                    (fresh_retry[0],),
+                    (busy_retry[0],),
                 ).fetchone()[0],
                 self.con.execute(
                     "SELECT COUNT(*) FROM sprint_wake_outbox "
@@ -833,7 +869,9 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         old_wake = int(assignment.wake_id)
         prompt, _ = self.deliver_wake_with_turn(old_wake, terminal=True)
         self.assertEqual(
-            sprint_message_delivery.wake_prompt(self.sprint_id, "developer"),
+            sprint_message_delivery.wake_prompt(self.sprint_id, "developer")
+            + f"\n\n## wake_message #{assignment.message_id} "
+            "(declared Re-Enter)\n\nbody for pickup-assignment",
             prompt,
         )
         self.lifecycle.pause(
@@ -924,14 +962,16 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             actual_prompt: list[str] = []
             outcome = delivery.deliver_once(
                 "relay-recovery",
-                lambda _conversation, prompt, _key: actual_prompt.append(prompt)
+                lambda _conversation, prompt, _key, sink=actual_prompt: sink.append(prompt)
                 or "native",
             )
             self.assertIsNotNone(outcome)
             captured.append((outcome.wake_id, actual_prompt[0]))
         self.assertEqual(replacement, outcome.wake_id)
         self.assertEqual(
-            sprint_message_delivery.wake_prompt(self.sprint_id, "developer"),
+            sprint_message_delivery.wake_prompt(self.sprint_id, "developer")
+            + f"\n\n## wake_message #{relay.message_id} "
+            "(declared Re-Enter)\n\nWhich compatibility fixture should I use?",
             captured[-1][1],
         )
         self.assertEqual(
@@ -980,7 +1020,8 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         self.deliver_wake_with_turn(int(terminal.wake_id), terminal=True)
         deliverable = self.send("pickup-already-pending")
         wake_count = self.con.execute(
-            "SELECT COUNT(*) FROM sprint_wake_outbox"
+            "SELECT COUNT(*) FROM sprint_wake_outbox WHERE participant_id=?",
+            (self.developer_id,),
         ).fetchone()[0]
         self.lifecycle.pause(
             self.sprint_id,
@@ -994,7 +1035,10 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         self.assertIn(deliverable.wake_id, second.requeued_wake_ids)
         self.assertEqual(
             wake_count,
-            self.con.execute("SELECT COUNT(*) FROM sprint_wake_outbox").fetchone()[0],
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_wake_outbox WHERE participant_id=?",
+                (self.developer_id,),
+            ).fetchone()[0],
             "resume reuses existing wakes instead of adding a pickup fallback",
         )
         self.assertEqual(
@@ -1048,7 +1092,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ),
         )
 
-    def test_resume_attaches_wakeless_unread_planner_notice_once(self):
+    def test_paused_decline_keeps_one_planner_wake_across_resume(self):
         assignment = self.send(
             "paused-decline-recovery",
             kind="work_assignment",
@@ -1080,7 +1124,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         )
         self.con.commit()
         self.assertEqual(
-            0,
+            1,
             self.con.execute(
                 "SELECT COUNT(*) FROM sprint_wake_messages WHERE message_id=?",
                 (result_id,),
@@ -1091,8 +1135,13 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             self.sprint_id,
             sprint_domain.LifecycleActor("planner", 3),
         )
-        self.assertEqual(1, len(first.requeued_wake_ids))
-        wake_id = first.requeued_wake_ids[0]
+        self.assertEqual((), first.requeued_wake_ids)
+        wake_id = int(
+            self.con.execute(
+                "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
+                (result_id,),
+            ).fetchone()[0]
+        )
         self.assertEqual(
             [(wake_id, result_id, "pending")],
             [
@@ -1213,7 +1262,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                 tuple(row)
                 for row in self.con.execute(
                     "SELECT work_unit_id,message_kind,disposition "
-                    "FROM sprint_messages WHERE work_unit_id=?",
+                    "FROM wake_message WHERE work_unit_id=?",
                     (downstream,),
                 )
             ],
@@ -1272,7 +1321,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             [
                 tuple(row)
                 for row in self.con.execute(
-                    "SELECT to_participant_id,actionable FROM sprint_messages "
+                    "SELECT to_participant_id,actionable FROM wake_message "
                     "WHERE idempotency_key LIKE 'sprint-resume:%'"
                 )
             ],
@@ -1314,7 +1363,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         self.assertEqual(
             1,
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_messages "
+                "SELECT COUNT(*) FROM wake_message "
                 "WHERE idempotency_key LIKE 'sprint-resume:%'",
             ).fetchone()[0],
         )
@@ -1386,17 +1435,49 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
             notify_commit=lambda: True,
         )
 
+    def ensure_wake_chat(self, sprint_id: int, shell_id: int) -> str:
+        conversation = self.con.execute(
+            "SELECT pc.conversation_id "
+            "FROM sprint_participant_conversations pc "
+            "JOIN sprint_participants participant "
+            "ON participant.participant_id=pc.sprint_participant_id "
+            "WHERE participant.sprint_id=? AND participant.shell_id=?",
+            (sprint_id, shell_id),
+        ).fetchone()
+        if conversation is None:
+            participant_id = int(
+                self.con.execute(
+                    "SELECT participant_id FROM sprint_participants "
+                    "WHERE sprint_id=? AND shell_id=?",
+                    (sprint_id, shell_id),
+                ).fetchone()[0]
+            )
+            receipt = sprint_message_delivery.SprintMessageStore(self.con).send(
+                sprint_id,
+                to_participant_id=participant_id,
+                message_kind="notification",
+                body="Create the fixture wake chat.",
+                declared_type="re-enter",
+                idempotency_key=f"fixture-live-run:{sprint_id}:{shell_id}",
+            )
+            service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
+            while True:
+                outcome = service.deliver_once(
+                    "fixture-live-run",
+                    lambda target, _prompt, _key: target,
+                )
+                self.assertIsNotNone(outcome)
+                if outcome.wake_id == receipt.wake_id:
+                    break
+            conversation = self.con.execute(
+                "SELECT current_conversation_id FROM sprint_participants "
+                "WHERE participant_id=?",
+                (participant_id,),
+            ).fetchone()
+        return str(conversation[0])
+
     def add_live_run(self, sprint_id: int, shell_id: int) -> tuple[str, int]:
-        conversation_id = str(
-            self.con.execute(
-                "SELECT pc.conversation_id "
-                "FROM sprint_participant_conversations pc "
-                "JOIN sprint_participants participant "
-                "ON participant.participant_id=pc.sprint_participant_id "
-                "WHERE participant.sprint_id=? AND participant.shell_id=?",
-                (sprint_id, shell_id),
-            ).fetchone()[0]
-        )
+        conversation_id = self.ensure_wake_chat(sprint_id, shell_id)
         token = int(
             self.con.execute("SELECT COUNT(*)+1 FROM conversation_runs").fetchone()[0]
         )
@@ -1607,7 +1688,7 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
             with closing(sqlite3.connect(db_path)) as observed:
                 observed.row_factory = sqlite3.Row
                 self.assertEqual(
-                    [("closed", 1)] * 3,
+                    [("closed", 1)] * 2,
                     [
                         tuple(row)
                         for row in observed.execute(
@@ -1730,6 +1811,8 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
         for target in ("completed", "aborted"):
             sprint_id, _ = self.create_sprint()
             self.store.arm(sprint_id, 3)
+            for shell_id in (1, 2, 3):
+                self.ensure_wake_chat(sprint_id, shell_id)
             conversation_ids = [
                 str(row[0])
                 for row in self.con.execute(
@@ -1846,7 +1929,7 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
             tuple(
                 self.con.execute(
                     "SELECT s.lifecycle,"
-                    "(SELECT COUNT(*) FROM sprint_messages WHERE sprint_id=s.sprint_id),"
+                    "(SELECT COUNT(*) FROM wake_message WHERE sprint_id=s.sprint_id),"
                     "(SELECT COUNT(*) FROM sprint_events WHERE sprint_id=s.sprint_id) "
                     "FROM sprints s WHERE s.sprint_id=?",
                     (sprint_id,),

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -1,4 +1,5 @@
 """Stage 8 gates for Sprint pause, resume, abort, and restart recovery."""
+
 from __future__ import annotations
 
 import json
@@ -61,9 +62,9 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             (self.sprint_id, shell_id),
         ).fetchone()
         conversation_id = str(participant[0])
-        token = self.con.execute(
-            "SELECT COUNT(*)+1 FROM conversation_runs"
-        ).fetchone()[0]
+        token = self.con.execute("SELECT COUNT(*)+1 FROM conversation_runs").fetchone()[
+            0
+        ]
         message_id = int(
             self.con.execute(
                 "INSERT INTO conversation_messages "
@@ -259,27 +260,31 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ).fetchone()[0]
         )
         self.assertEqual("GitHub state cannot be trusted", report["reason"])
+        self.assertEqual({"kind": "participant", "shell_id": 1}, report["actor"])
         self.assertEqual(
-            {"kind": "participant", "shell_id": 1}, report["actor"]
+            [run_id], [row["run_id"] for row in report["deterministic"]["active_turns"]]
         )
-        self.assertEqual([run_id], [row["run_id"] for row in report["deterministic"]["active_turns"]])
         self.assertEqual(
             [self.unit_id],
             [row["work_unit_id"] for row in report["deterministic"]["work_units"]],
         )
         self.assertEqual(
             ["red"],
-            [row["normalized_state"] for row in report["deterministic"]["registered_prs"]],
+            [
+                row["normalized_state"]
+                for row in report["deterministic"]["registered_prs"]
+            ],
         )
         self.assertEqual("", report["integrity_threat"])
         self.assertEqual("", report["judgment"])
         self.assertEqual("", report["recommendation"])
         self.assertEqual(
-            [(self.planner_id, 0, "Sprint 1 paused: GitHub state cannot be trusted")],
+            [(None, 3, None, 0, "Sprint 1 paused: GitHub state cannot be trusted")],
             [
                 tuple(row)
                 for row in self.con.execute(
-                    "SELECT to_participant_id,actionable,body FROM wake_message "
+                    "SELECT sprint_id,receiver_shell_id,to_participant_id,"
+                    "actionable,body FROM wake_message "
                     "WHERE idempotency_key LIKE 'sprint-pause:%'"
                 )
             ],
@@ -296,7 +301,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ],
         )
         self.assertEqual(
-            [(self.planner_id, "pending")],
+            [(None, "pending")],
             [
                 tuple(row)
                 for row in self.con.execute(
@@ -307,6 +312,22 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                 )
             ],
         )
+        pause_wake_id = int(
+            self.con.execute(
+                "SELECT w.wake_id FROM sprint_wake_outbox w "
+                "JOIN sprint_wake_messages joined USING(wake_id) "
+                "JOIN wake_message message USING(message_id) "
+                "WHERE message.idempotency_key LIKE 'sprint-pause:%'"
+            ).fetchone()[0]
+        )
+        pause_outcome = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).deliver_once(
+            "paused-notice-worker",
+            lambda conversation, _prompt, _key: conversation,
+        )
+        self.assertEqual(pause_wake_id, pause_outcome.wake_id)
+        self.assertEqual("delivered", pause_outcome.state)
 
         replay = coordinator.pause(
             self.sprint_id,
@@ -341,6 +362,25 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         self.assertEqual(2, store.record_wake_failure(wake_id, "two"))
         self.assertEqual(3, store.record_wake_failure(wake_id, "three"))
 
+        pause_outcome = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).deliver_once(
+            "auto-pause-notice-worker",
+            lambda conversation, _prompt, _key: conversation,
+        )
+        self.assertIsNotNone(pause_outcome)
+        self.assertEqual("delivered", pause_outcome.state)
+        self.assertEqual(
+            "wake_delivery_exhausted",
+            json.loads(
+                self.con.execute(
+                    "SELECT body FROM sprint_reports WHERE sprint_id=? "
+                    "AND report_kind='pause'",
+                    (self.sprint_id,),
+                ).fetchone()[0]
+            )["reason"],
+        )
+
         self.assertEqual([run_id], self.interrupts)
         report = json.loads(
             self.con.execute(
@@ -354,7 +394,9 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             {"attempts": 3, "last_error": "three", "wake_id": wake_id},
             report["detail"],
         )
-        self.assertEqual([run_id], [row["run_id"] for row in report["deterministic"]["active_turns"]])
+        self.assertEqual(
+            [run_id], [row["run_id"] for row in report["deterministic"]["active_turns"]]
+        )
 
         receipt = self.coordinator().resume(
             self.sprint_id,
@@ -408,6 +450,94 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             if outcome.wake_id == replacement:
                 break
         self.assertEqual(1, outcome.attempt_number)
+
+    def test_resume_requeue_coalesces_with_foreign_pending_receiver_wake(self):
+        original_message = self.send("cross-sprint-recovery")
+        original_wake_id = int(original_message.wake_id)
+        store = sprint_domain.SprintLifecycleStore(
+            self.con,
+            interrupt_run=lambda _run_id: True,
+            notify_commit=lambda: True,
+        )
+        for error in ("one", "two", "three"):
+            store.record_wake_failure(original_wake_id, error)
+        pause_notice = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).deliver_once(
+            "cross-sprint-pause-notice",
+            lambda conversation, _prompt, _key: conversation,
+        )
+        self.assertIsNotNone(pause_notice)
+        self.assertEqual("delivered", pause_notice.state)
+
+        feature_id = int(
+            self.con.execute(
+                "SELECT feature_id FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        foreign_sprint_id = int(
+            self.con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+        )
+        foreign_developer_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_participants "
+                "(sprint_id,shell_id,role,harness) "
+                "VALUES (?,1,'developer','codex')",
+                (foreign_sprint_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+        foreign_message = self.messages.send(
+            foreign_sprint_id,
+            to_participant_id=foreign_developer_id,
+            message_kind="notification",
+            body="foreign prepared sprint backlog",
+            idempotency_key="foreign-prepared-backlog",
+        )
+
+        receipt = self.coordinator().resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="reuse the receiver wake",
+        )
+
+        self.assertEqual((foreign_message.wake_id,), receipt.requeued_wake_ids)
+        self.assertEqual(
+            [(foreign_message.wake_id, foreign_sprint_id, "pending")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT wake_id,sprint_id,state FROM sprint_wake_outbox "
+                    "WHERE receiver_shell_id=1 AND state='pending'"
+                )
+            ],
+        )
+        self.assertEqual(
+            [original_message.message_id, foreign_message.message_id],
+            [
+                int(row[0])
+                for row in self.con.execute(
+                    "SELECT message_id FROM sprint_wake_messages "
+                    "WHERE wake_id=? ORDER BY message_id",
+                    (foreign_message.wake_id,),
+                )
+            ],
+        )
+        lease = sprint_message_delivery.SprintWakeDeliveryService(self.con).claim_next(
+            "foreign-recovery-worker"
+        )
+        self.assertIsNotNone(lease)
+        self.assertEqual(foreign_message.wake_id, lease.wake_id)
+        self.assertEqual(
+            (original_message.message_id, foreign_message.message_id),
+            lease.message_ids,
+        )
 
     def test_failed_recovery_wake_is_bounded_and_leaves_manual_evidence(self):
         message = self.send("bounded-recovery-wake")
@@ -566,9 +696,9 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ),
         )
         notice = self.con.execute(
-            "SELECT body FROM wake_message WHERE sprint_id=? "
-            "AND idempotency_key LIKE 'sprint-pause:%'",
-            (self.sprint_id,),
+            "SELECT body FROM wake_message WHERE sprint_id IS NULL "
+            "AND receiver_shell_id=3 "
+            "AND idempotency_key LIKE 'sprint-pause:%'"
         ).fetchone()[0]
         self.assertIn("shell DEV1", notice)
         self.assertIn("5 attempts", notice)
@@ -662,8 +792,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             for wake_id in fresh_retry
             if str(
                 self.con.execute(
-                    "SELECT idempotency_key FROM sprint_wake_outbox "
-                    "WHERE wake_id=?",
+                    "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
                     (wake_id,),
                 ).fetchone()[0]
             ).startswith(f"sprint-recovery:{self.sprint_id}:busy:{reset_wake}:")
@@ -681,8 +810,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                     (self.sprint_id,),
                 ).fetchone()[0],
                 self.con.execute(
-                    "SELECT idempotency_key FROM sprint_wake_outbox "
-                    "WHERE wake_id=?",
+                    "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
                     (busy_retry[0],),
                 ).fetchone()[0],
                 self.con.execute(
@@ -756,9 +884,9 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         self.con.commit()
 
         self.assertIsNone(
-            sprint_message_delivery.SprintWakeDeliveryService(
-                self.con
-            ).claim_next("read-message")
+            sprint_message_delivery.SprintWakeDeliveryService(self.con).claim_next(
+                "read-message"
+            )
         )
         self.assertEqual(
             (),
@@ -962,8 +1090,9 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             actual_prompt: list[str] = []
             outcome = delivery.deliver_once(
                 "relay-recovery",
-                lambda _conversation, prompt, _key, sink=actual_prompt: sink.append(prompt)
-                or "native",
+                lambda _conversation, prompt, _key, sink=actual_prompt: (
+                    sink.append(prompt) or "native"
+                ),
             )
             self.assertIsNotNone(outcome)
             captured.append((outcome.wake_id, actual_prompt[0]))
@@ -1001,8 +1130,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
 
         self.messages.mark_read(queued_turn.message_id, 1)
         self.con.execute(
-            "UPDATE conversation_messages SET state='running' "
-            "WHERE idempotency_key=?",
+            "UPDATE conversation_messages SET state='running' WHERE idempotency_key=?",
             (queued_key,),
         )
         self.con.execute(
@@ -1176,9 +1304,9 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ).fetchone()[0]
         )
         self.assertNotEqual(old_wake, replacement)
-        count = self.con.execute(
-            "SELECT COUNT(*) FROM sprint_wake_outbox"
-        ).fetchone()[0]
+        count = self.con.execute("SELECT COUNT(*) FROM sprint_wake_outbox").fetchone()[
+            0
+        ]
 
         self.assertEqual("armed", coordinator.recover_on_startup(self.sprint_id))
         self.assertEqual(
@@ -1317,11 +1445,12 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         self.assertEqual([str(document_id)], sorted(payload["spec_drift"]))
         self.assertEqual(list(receipt.anomalies), payload["anomalies"])
         self.assertEqual(
-            [(self.planner_id, 0)],
+            [(None, 3, 0)],
             [
                 tuple(row)
                 for row in self.con.execute(
-                    "SELECT to_participant_id,actionable FROM wake_message "
+                    "SELECT to_participant_id,receiver_shell_id,actionable "
+                    "FROM wake_message "
                     "WHERE idempotency_key LIKE 'sprint-resume:%'"
                 )
             ],
@@ -1532,8 +1661,7 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
             ("aborted", "discarded before arming"),
             tuple(
                 self.con.execute(
-                    "SELECT lifecycle,terminal_outcome FROM sprints "
-                    "WHERE sprint_id=?",
+                    "SELECT lifecycle,terminal_outcome FROM sprints WHERE sprint_id=?",
                     (sprint_id,),
                 ).fetchone()
             ),
@@ -1576,8 +1704,7 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
             ).lastrowid
         )
         self.con.execute(
-            "INSERT INTO conversation_outbox (conversation_id,message_id) "
-            "VALUES (?,?)",
+            "INSERT INTO conversation_outbox (conversation_id,message_id) VALUES (?,?)",
             (planner_conversation, queued_message_id),
         )
         self.con.commit()

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -1071,7 +1071,7 @@ class CarriedLowClosureTest(SprintReviewLoopCase):
             ).fetchone()[0],
         )
 
-    def test_paused_sprint_wake_cannot_be_claimed_for_delivery(self):
+    def test_paused_sprint_blocks_work_but_delivers_pause_notice(self):
         sent = self.messages.send(
             self.sprint_id,
             to_participant_id=self.developer_id,
@@ -1089,8 +1089,31 @@ class CarriedLowClosureTest(SprintReviewLoopCase):
             reason="integrity check",
         )
 
+        prompts: list[str] = []
         service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
-        self.assertIsNone(service.claim_next("paused-delivery"))
+        outcome = service.deliver_once(
+            "paused-delivery",
+            lambda conversation, prompt, _key: (
+                prompts.append(prompt) or conversation
+            ),
+        )
+
+        self.assertIsNotNone(outcome)
+        self.assertNotEqual(sent.wake_id, outcome.wake_id)
+        self.assertIn("Sprint 1 paused: integrity check", prompts[0])
+        self.assertEqual(
+            (None, "pending"),
+            tuple(
+                self.con.execute(
+                    "SELECT m.delivered_at,w.state FROM wake_message m "
+                    "JOIN sprint_wake_messages joined USING(message_id) "
+                    "JOIN sprint_wake_outbox w USING(wake_id) "
+                    "WHERE m.message_id=?",
+                    (sent.message_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertIsNone(service.claim_next("paused-work-stays-gated"))
         wake = self.con.execute(
             "SELECT state,attempt_count,claim_owner FROM sprint_wake_outbox "
             "WHERE wake_id=?",

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -26,7 +26,7 @@ class SprintReviewLoopCase(SprintPRWatcherCase):
         )
         self.registered_pr_id = self.register().registered_pr_id
         initial_green = self.con.execute(
-            "SELECT message_id FROM sprint_messages "
+            "SELECT message_id FROM wake_message "
             "WHERE to_participant_id=? "
             "AND idempotency_key LIKE 'pr-transition:%' "
             "ORDER BY message_id DESC LIMIT 1",
@@ -67,7 +67,7 @@ class SprintReviewLoopCase(SprintPRWatcherCase):
 class ReviewHandoffTest(SprintReviewLoopCase):
     def test_review_payloads_accept_8000_and_reject_8001_without_state_change(self):
         before_messages = self.con.execute(
-            "SELECT COUNT(*) FROM sprint_messages"
+            "SELECT COUNT(*) FROM wake_message"
         ).fetchone()[0]
         with self.assertRaisesRegex(
             ValueError,
@@ -84,7 +84,7 @@ class ReviewHandoffTest(SprintReviewLoopCase):
             ("active", before_messages),
             tuple(
                 self.con.execute(
-                    "SELECT u.disposition,(SELECT COUNT(*) FROM sprint_messages) "
+                    "SELECT u.disposition,(SELECT COUNT(*) FROM wake_message) "
                     "FROM sprint_work_units u WHERE u.work_unit_id=?",
                     (self.unit_id,),
                 ).fetchone()
@@ -136,7 +136,7 @@ class ReviewHandoffTest(SprintReviewLoopCase):
     def test_green_readiness_commits_judgment_and_active_reviewer_request(self):
         assignment_message_id = int(
             self.con.execute(
-                "SELECT message_id FROM sprint_messages WHERE work_unit_id=? "
+                "SELECT message_id FROM wake_message WHERE work_unit_id=? "
                 "AND message_kind='work_assignment'",
                 (self.unit_id,),
             ).fetchone()[0]
@@ -152,7 +152,7 @@ class ReviewHandoffTest(SprintReviewLoopCase):
         self.assertEqual("in_review", unit["disposition"])
         message = self.con.execute(
             "SELECT from_participant_id,to_participant_id,message_kind,body,"
-            "actionable,disposition FROM sprint_messages WHERE message_id=?",
+            "actionable,disposition FROM wake_message WHERE message_id=?",
             (handoff.message_id,),
         ).fetchone()
         self.assertEqual(
@@ -192,16 +192,28 @@ class ReviewHandoffTest(SprintReviewLoopCase):
                 assignment_expectation["next_evaluation_at"],
             ),
         )
-        lease = sprint_message_delivery.SprintWakeDeliveryService(
-            self.con
-        ).claim_next("stage6-review")
+        observed: list[tuple[int, str]] = []
+        service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
+        while True:
+            outcome = service.deliver_once(
+                "stage6-review",
+                lambda conversation, _prompt, _key: conversation,
+            )
+            self.assertIsNotNone(outcome)
+            attempt = self.con.execute(
+                "SELECT target_conversation_id FROM sprint_wake_attempts "
+                "WHERE wake_id=? AND outcome='delivered'",
+                (outcome.wake_id,),
+            ).fetchone()
+            observed.append((outcome.wake_id, str(attempt[0])))
+            if outcome.wake_id == handoff.wake_id:
+                break
         reviewer_chat = self.con.execute(
             "SELECT current_conversation_id FROM sprint_participants "
             "WHERE participant_id=?",
             (self.reviewer_id,),
         ).fetchone()[0]
-        self.assertEqual(self.reviewer_id, lease.participant_id)
-        self.assertEqual(reviewer_chat, lease.target_conversation_id)
+        self.assertEqual((handoff.wake_id, reviewer_chat), observed[-1])
         self.accept_review(handoff.message_id)
         review_expectation = self.con.execute(
             "SELECT resolved_at,resolution,next_evaluation_at "
@@ -214,7 +226,7 @@ class ReviewHandoffTest(SprintReviewLoopCase):
         self.assertEqual(
             0,
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_messages "
+                "SELECT COUNT(*) FROM wake_message "
                 "WHERE message_id=? AND to_participant_id=?",
                 (handoff.message_id, self.planner_id),
             ).fetchone()[0],
@@ -227,7 +239,7 @@ class ReviewHandoffTest(SprintReviewLoopCase):
         )
         self.watcher.poll_once()
         before = self.con.execute(
-            "SELECT COUNT(*) FROM sprint_messages"
+            "SELECT COUNT(*) FROM wake_message"
         ).fetchone()[0]
 
         with self.assertRaisesRegex(
@@ -247,7 +259,7 @@ class ReviewHandoffTest(SprintReviewLoopCase):
 
         self.assertEqual(
             before,
-            self.con.execute("SELECT COUNT(*) FROM sprint_messages").fetchone()[0],
+            self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0],
         )
         self.assertEqual(
             "active",
@@ -308,14 +320,14 @@ class ReviewHandoffTest(SprintReviewLoopCase):
             ),
         )
         self.assertEqual(
-            (2, 2, 1),
+            (2, 2, 0),
             tuple(
                 self.con.execute(
                     "SELECT COUNT(*),"
                     "(SELECT COUNT(*) FROM sprint_judgments WHERE work_unit_id=?),"
                     "(SELECT COUNT(*) FROM sprint_participant_conversations "
                     " WHERE purpose='merge') "
-                    "FROM sprint_messages WHERE idempotency_key IN (?,?)",
+                    "FROM wake_message WHERE idempotency_key IN (?,?)",
                     (
                         self.unit_id,
                         "idempotent-request",
@@ -378,14 +390,14 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             0,
             self.con.execute(
                 "SELECT COUNT(*) FROM sprint_liveness_expectations e "
-                "JOIN sprint_messages m USING(message_id) "
+                "JOIN wake_message m USING(message_id) "
                 "WHERE m.work_unit_id=? AND m.message_kind='review_request' "
                 "AND e.resolved_at IS NULL",
                 (self.unit_id,),
             ).fetchone()[0],
         )
 
-    def test_changes_and_approval_select_fresh_linked_conversations(self):
+    def test_changes_and_approval_route_only_when_the_wake_is_delivered(self):
         first = self.request_review()
         self.accept_review(first.message_id)
         changed = self.loop.record_review(
@@ -397,13 +409,14 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             idempotency_key="changes-1",
         )
         self.assertEqual("fixing", changed.disposition)
-        self.assertNotEqual(self.developer_conversation_id, changed.conversation_id)
-        fix_link = self.con.execute(
-            "SELECT purpose,parent_conversation_id FROM "
-            "sprint_participant_conversations WHERE conversation_id=?",
-            (changed.conversation_id,),
-        ).fetchone()
-        self.assertEqual(("fix", self.developer_conversation_id), tuple(fix_link))
+        self.assertIsNone(changed.conversation_id)
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_participant_conversations "
+                "WHERE purpose='fix'"
+            ).fetchone()[0],
+        )
         self.assertEqual("accepted", self.messages.mark_read(changed.message_id, 1))
         changed_expectation = self.con.execute(
             "SELECT resolved_at,resolution,next_evaluation_at "
@@ -415,7 +428,7 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         self.assertIsNotNone(changed_expectation["next_evaluation_at"])
         assignment_expectation = self.con.execute(
             "SELECT resolution FROM sprint_liveness_expectations expectation "
-            "JOIN sprint_messages message USING(message_id) "
+            "JOIN wake_message message USING(message_id) "
             "WHERE message.work_unit_id=? AND message.message_kind='work_assignment'",
             (self.unit_id,),
         ).fetchone()
@@ -430,20 +443,30 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
                 ).fetchone()
             ),
         )
+        service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
+        while service.deliver_once(
+            "stage6-before-red",
+            lambda conversation, _prompt, _key: conversation,
+        ) is not None:
+            pass
 
         self.reader.current = pull_request(
             checks="FAILURE", checks_failed=True, head_sha="b" * 40
         )
         self.watcher.poll_once()
-        red_lease = sprint_message_delivery.SprintWakeDeliveryService(
-            self.con
-        ).claim_next("stage6-fix-red")
-        self.assertEqual(changed.conversation_id, red_lease.target_conversation_id)
+        red_delivery: list[str] = []
+        red_outcome = service.deliver_once(
+            "stage6-fix-red",
+            lambda conversation, _prompt, _key: (
+                red_delivery.append(conversation) or "red-run"
+            ),
+        )
+        self.assertEqual(self.developer_conversation_id, red_delivery[0])
         red_messages = self.con.execute(
-            "SELECT m.message_id FROM sprint_messages m "
+            "SELECT m.message_id FROM wake_message m "
             "JOIN sprint_wake_messages wm USING(message_id) "
             "WHERE wm.wake_id=?",
-            (red_lease.wake_id,),
+            (red_outcome.wake_id,),
         ).fetchall()
         for message in red_messages:
             self.messages.mark_read(int(message["message_id"]), 1)
@@ -473,18 +496,16 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         )
 
         self.assertEqual("merge_ready", approved.disposition)
-        self.assertNotIn(
-            approved.conversation_id,
-            {self.developer_conversation_id, changed.conversation_id},
-        )
-        merge_link = self.con.execute(
-            "SELECT purpose,parent_conversation_id FROM "
-            "sprint_participant_conversations WHERE conversation_id=?",
-            (approved.conversation_id,),
-        ).fetchone()
-        self.assertEqual(("merge", changed.conversation_id), tuple(merge_link))
+        self.assertIsNone(approved.conversation_id)
         self.assertEqual(
-            approved.conversation_id,
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_participant_conversations "
+                "WHERE purpose='merge'"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            self.developer_conversation_id,
             self.con.execute(
                 "SELECT current_conversation_id FROM sprint_participants "
                 "WHERE participant_id=?",
@@ -548,7 +569,7 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             ).fetchone()[0],
         )
         self.assertEqual("pending", self.con.execute(
-            "SELECT disposition FROM sprint_messages WHERE message_id=?",
+            "SELECT disposition FROM wake_message WHERE message_id=?",
             (handoff.message_id,),
         ).fetchone()[0])
 
@@ -569,7 +590,7 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         )
         self.watcher.poll_once()
         red = self.con.execute(
-            "SELECT message_id FROM sprint_messages WHERE to_participant_id=? "
+            "SELECT message_id FROM wake_message WHERE to_participant_id=? "
             "AND idempotency_key LIKE 'pr-transition:%' "
             "ORDER BY message_id DESC LIMIT 1",
             (self.developer_id,),
@@ -596,7 +617,7 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         self.assertEqual(
             "pending",
             self.con.execute(
-                "SELECT disposition FROM sprint_messages WHERE message_id=?",
+                "SELECT disposition FROM wake_message WHERE message_id=?",
                 (pending.message_id,),
             ).fetchone()[0],
         )
@@ -631,7 +652,7 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         self.assertEqual(
             0,
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_messages "
+                "SELECT COUNT(*) FROM wake_message "
                 "WHERE idempotency_key='stale-review-head'"
             ).fetchone()[0],
         )
@@ -703,7 +724,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
         )
         delta = self.con.execute(
             "SELECT message_id,to_participant_id,actionable,disposition,body "
-            "FROM sprint_messages WHERE idempotency_key LIKE "
+            "FROM wake_message WHERE idempotency_key LIKE "
             "'pr-head-change:%:delta-review'"
         ).fetchone()
         self.assertEqual(
@@ -734,7 +755,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
         self.assertEqual(approved.message_id, invalidated["invalidated_message_id"])
         self.assertIsNotNone(
             self.con.execute(
-                "SELECT read_at FROM sprint_messages WHERE message_id=?",
+                "SELECT read_at FROM wake_message WHERE message_id=?",
                 (approved.message_id,),
             ).fetchone()[0]
         )
@@ -781,7 +802,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
                     "SELECT "
                     "(SELECT COUNT(*) FROM sprint_events "
                     "WHERE event_type='review.approval_invalidated'),"
-                    "(SELECT COUNT(*) FROM sprint_messages "
+                    "(SELECT COUNT(*) FROM wake_message "
                     "WHERE idempotency_key LIKE 'pr-head-change:%:delta-review'),"
                     "(SELECT COUNT(*) FROM sprint_events "
                     "WHERE event_type='merge.grant_bypassed')"
@@ -814,10 +835,10 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
                     "SELECT "
                     "(SELECT COUNT(*) FROM sprint_events "
                     "WHERE event_type='review.approval_invalidated'),"
-                    "(SELECT COUNT(*) FROM sprint_messages "
+                    "(SELECT COUNT(*) FROM wake_message "
                     "WHERE idempotency_key LIKE 'pr-head-change:%:delta-review'),"
                     "(SELECT COUNT(*) FROM sprint_liveness_expectations e "
-                    "JOIN sprint_messages m USING (message_id) "
+                    "JOIN wake_message m USING (message_id) "
                     "WHERE m.message_kind='review_request' "
                     "AND e.resolved_at IS NULL)"
                 ).fetchone()
@@ -852,7 +873,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
         )
         notice = self.con.execute(
             "SELECT m.to_participant_id,m.work_unit_id,m.body,w.state "
-            "FROM sprint_messages m JOIN sprint_wake_messages wm USING (message_id) "
+            "FROM wake_message m JOIN sprint_wake_messages wm USING (message_id) "
             "JOIN sprint_wake_outbox w USING (wake_id) "
             "WHERE m.idempotency_key LIKE 'merge-grant-bypassed:%'"
         ).fetchone()
@@ -879,7 +900,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
                     "SELECT "
                     "(SELECT COUNT(*) FROM sprint_events "
                     "WHERE event_type='merge.grant_bypassed'),"
-                    "(SELECT COUNT(*) FROM sprint_messages "
+                    "(SELECT COUNT(*) FROM wake_message "
                     "WHERE idempotency_key LIKE 'merge-grant-bypassed:%')"
                 ).fetchone()
             ),
@@ -971,17 +992,32 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
         self.assertEqual(self.developer_conversation_id, current[0])
         self.assertEqual(current[0], current[1])
         assignment = self.con.execute(
-            "SELECT message_id FROM sprint_messages WHERE work_unit_id=? "
+            "SELECT message_id FROM wake_message WHERE work_unit_id=? "
             "AND message_kind='work_assignment'",
             (next_unit,),
         ).fetchone()
         self.assertIsNotNone(assignment)
-        lease = sprint_message_delivery.SprintWakeDeliveryService(
-            self.con
-        ).claim_next("stage6-next")
+        assignment_wake_id = int(
+            self.con.execute(
+                "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
+                (assignment["message_id"],),
+            ).fetchone()[0]
+        )
+        delivered: list[str] = []
+        service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
+        while True:
+            outcome = service.deliver_once(
+                "stage6-next",
+                lambda conversation, _prompt, _key: (
+                    delivered.append(conversation) or "next-run"
+                ),
+            )
+            self.assertIsNotNone(outcome)
+            if outcome.wake_id == assignment_wake_id:
+                break
         self.assertNotEqual(
             self.developer_conversation_id,
-            lease.target_conversation_id,
+            delivered[-1],
         )
         active = self.con.execute(
             "SELECT chat_id,process_pid,process_start_ticks "
@@ -989,7 +1025,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
         ).fetchone()
         self.assertEqual(
             tuple(active),
-            (lease.target_conversation_id, None, None),
+            (delivered[-1], None, None),
         )
         self.assertEqual(
             ["work_unit.completed", "work_unit.ready", "pr.transition"],
@@ -1044,7 +1080,7 @@ class CarriedLowClosureTest(SprintReviewLoopCase):
             message_kind="notification",
             body="active before pause",
             idempotency_key="pause-race",
-            active=True,
+            declared_type="re-enter",
         )
         self.lifecycle.transition(
             self.sprint_id,

--- a/tests/test_sprint_snapshot_rebuild.py
+++ b/tests/test_sprint_snapshot_rebuild.py
@@ -194,16 +194,17 @@ def arm_with_representative_state(con: sqlite3.Connection) -> None:
         "updated_at='2026-08-01 21:01:00' WHERE work_unit_id=1"
     )
     con.execute(
-        "INSERT INTO sprint_messages "
-        "(message_id,sprint_id,from_participant_id,to_participant_id,work_unit_id,"
-        "message_kind,body,actionable,disposition,read_at,idempotency_key) "
-        "VALUES (1,1,1,2,1,'work_assignment','Implement now',1,'accepted',"
-        "'2026-08-01 21:01:00','assignment-1')"
+        "INSERT INTO wake_message "
+        "(message_id,sprint_id,sender_shell_id,receiver_shell_id,"
+        "from_participant_id,to_participant_id,work_unit_id,message_kind,body,"
+        "declared_type,actionable,disposition,read_at,delivered_at,idempotency_key) "
+        "VALUES (1,1,3,1,1,2,1,'work_assignment','Implement now','new',1,"
+        "'accepted','2026-08-01 21:01:00','2026-08-01 21:01:01','assignment-1')"
     )
     con.execute(
         "INSERT INTO sprint_wake_outbox "
-        "(wake_id,sprint_id,participant_id,state,attempt_count,idempotency_key,"
-        "delivered_at) VALUES (1,1,2,'delivered',1,'wake-1',"
+        "(wake_id,sprint_id,participant_id,receiver_shell_id,state,attempt_count,"
+        "idempotency_key,delivered_at) VALUES (1,1,2,1,'delivered',1,'wake-1',"
         "'2026-08-01 21:01:01')"
     )
     con.execute(
@@ -503,7 +504,7 @@ class SprintSnapshotRebuildTest(unittest.TestCase):
                 row[0]
                 for row in con.execute(
                     "SELECT name FROM sqlite_master WHERE type='table' "
-                    "AND (name='sprints' OR name LIKE 'sprint_%')"
+                    "AND (name IN ('sprints','wake_message') OR name LIKE 'sprint_%')"
                 )
             }
         finally:

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -431,7 +431,7 @@ class LifecycleTest(SprintDomainCase):
             ],
         )
 
-    def test_arm_atomically_provisions_every_participant_conversation(self) -> None:
+    def test_arm_defers_participant_conversations_until_delivery(self) -> None:
         sprint_id, _ = self.create_sprint()
 
         self.store.arm(sprint_id, 3)
@@ -445,32 +445,20 @@ class LifecycleTest(SprintDomainCase):
         self.assertEqual(3, len(participants))
         self.assertTrue(
             all(
-                row["persistent_conversation_id"] == row["current_conversation_id"]
+                row["persistent_conversation_id"] is None
+                and row["current_conversation_id"] is None
                 for row in participants
             )
         )
-        conversation_ids = {row["current_conversation_id"] for row in participants}
         self.assertEqual(
-            [("sprint", "idle", 3)],
-            [
-                tuple(row)
-                for row in self.con.execute(
-                    "SELECT conversation_scope,state,COUNT(*) "
-                    "FROM conversations WHERE conversation_id IN (?,?,?) "
-                    "GROUP BY conversation_scope,state",
-                    tuple(sorted(conversation_ids)),
-                )
-            ],
+            0,
+            self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0],
         )
         self.assertEqual(
-            [("work", 3)],
-            [
-                tuple(row)
-                for row in self.con.execute(
-                    "SELECT purpose,COUNT(*) FROM sprint_participant_conversations "
-                    "GROUP BY purpose"
-                )
-            ],
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_participant_conversations"
+            ).fetchone()[0],
         )
         self.assertEqual(
             0,
@@ -483,8 +471,8 @@ class LifecycleTest(SprintDomainCase):
             (sprint_id,),
         ).fetchone()
         self.assertEqual(
-            conversation_ids,
-            set(json.loads(event["payload"])["initial_conversation_ids"]),
+            1,
+            len(json.loads(event["payload"])["initial_wake_ids"]),
         )
 
         self.con.execute(
@@ -494,7 +482,7 @@ class LifecycleTest(SprintDomainCase):
             "VALUES (1,1,'codex','/normal','Normal chat','normal-1','hash')"
         )
         self.assertEqual(
-            [("normal", 1), ("sprint", 3)],
+            [("normal", 1)],
             [
                 tuple(row)
                 for row in self.con.execute(
@@ -512,10 +500,10 @@ class LifecycleTest(SprintDomainCase):
                 "'normal-2','hash')"
             )
 
-    def test_arm_rolls_back_conversations_when_initial_release_fails(self) -> None:
+    def test_arm_rolls_back_when_initial_release_fails(self) -> None:
         sprint_id, _ = self.create_sprint()
         self.con.execute(
-            "CREATE TRIGGER reject_initial_message BEFORE INSERT ON sprint_messages "
+            "CREATE TRIGGER reject_initial_message BEFORE INSERT ON wake_message "
             "BEGIN SELECT RAISE(ABORT,'release fault'); END"
         )
         self.con.commit()
@@ -593,6 +581,16 @@ class LifecycleTest(SprintDomainCase):
             "JOIN conversations c ON c.conversation_id=link.conversation_id "
             "ORDER BY link.sprint_participant_id"
         ).fetchall()
+        self.assertEqual(0, len(linked))
+        first_ids = sprint_domain.sprint_participant_chats.provision_at_arming(
+            self.con, sprint_id
+        )
+        linked = self.con.execute(
+            "SELECT c.conversation_id,c.creation_idempotency_key "
+            "FROM sprint_participant_conversations link "
+            "JOIN conversations c ON c.conversation_id=link.conversation_id "
+            "ORDER BY link.sprint_participant_id"
+        ).fetchall()
         self.assertEqual(3, len(linked))
         self.assertTrue(
             all(
@@ -604,7 +602,6 @@ class LifecycleTest(SprintDomainCase):
                 for row in linked
             )
         )
-        first_ids = [row["conversation_id"] for row in linked]
         replay_ids = sprint_domain.sprint_participant_chats.provision_at_arming(
             self.con, sprint_id
         )
@@ -678,7 +675,7 @@ class LifecycleTest(SprintDomainCase):
         )
         message = self.con.execute(
             "SELECT work_unit_id,message_kind,actionable,disposition,body "
-            "FROM sprint_messages WHERE sprint_id=?",
+            "FROM wake_message WHERE sprint_id=?",
             (sprint_id,),
         ).fetchone()
         self.assertEqual(first_unit, message["work_unit_id"])
@@ -695,7 +692,7 @@ class LifecycleTest(SprintDomainCase):
                 for row in self.con.execute(
                     "SELECT w.wake_id FROM sprint_wake_outbox w "
                     "JOIN sprint_wake_messages wm USING (wake_id) "
-                    "JOIN sprint_messages m USING (message_id) "
+                    "JOIN wake_message m USING (message_id) "
                     "WHERE w.sprint_id=? AND m.work_unit_id=?",
                     (sprint_id, first_unit),
                 )
@@ -726,7 +723,7 @@ class LifecycleTest(SprintDomainCase):
         self.assertEqual(
             0,
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_messages WHERE sprint_id=?", (second,)
+                "SELECT COUNT(*) FROM wake_message WHERE sprint_id=?", (second,)
             ).fetchone()[0],
         )
 
@@ -749,7 +746,7 @@ class LifecycleTest(SprintDomainCase):
                 tuple(row)
                 for row in self.con.execute(
                     "SELECT m.work_unit_id FROM sprint_wake_messages wm "
-                    "JOIN sprint_messages m USING (message_id) "
+                    "JOIN wake_message m USING (message_id) "
                     "WHERE wm.wake_id=? ORDER BY m.message_id",
                     (wake_ids[0],),
                 )
@@ -816,7 +813,7 @@ class LifecycleTest(SprintDomainCase):
                     (unit_id,),
                 ).fetchone()[0],
                 self.con.execute(
-                    "SELECT COUNT(*) FROM sprint_messages WHERE sprint_id=?",
+                    "SELECT COUNT(*) FROM wake_message WHERE sprint_id=?",
                     (sprint_id,),
                 ).fetchone()[0],
             ),

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -144,7 +144,7 @@ class SprintWorkDispatchCase(unittest.TestCase):
     def assignment_message(self, unit_id: int) -> int:
         return int(
             self.con.execute(
-                "SELECT message_id FROM sprint_messages "
+                "SELECT message_id FROM wake_message "
                 "WHERE work_unit_id=? AND message_kind='work_assignment' "
                 "ORDER BY message_id DESC LIMIT 1",
                 (unit_id,),
@@ -199,7 +199,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
             [
                 row[0]
                 for row in self.con.execute(
-                    "SELECT work_unit_id FROM sprint_messages "
+                    "SELECT work_unit_id FROM wake_message "
                     "WHERE message_kind='work_assignment' ORDER BY message_id"
                 )
             ],
@@ -242,7 +242,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
             [
                 row[0]
                 for row in self.con.execute(
-                    "SELECT work_unit_id FROM sprint_messages "
+                    "SELECT work_unit_id FROM wake_message "
                     "WHERE message_kind='work_assignment' AND work_unit_id<>? "
                     "ORDER BY message_id",
                     (first,),
@@ -418,7 +418,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
         self.lifecycle.arm(self.sprint_id, 3)
         first_message = self.assignment_message(unit)
         first_key = self.con.execute(
-            "SELECT idempotency_key FROM sprint_messages WHERE message_id=?",
+            "SELECT idempotency_key FROM wake_message WHERE message_id=?",
             (first_message,),
         ).fetchone()[0]
 
@@ -427,7 +427,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
 
         second_message = self.assignment_message(unit)
         second_key = self.con.execute(
-            "SELECT idempotency_key FROM sprint_messages WHERE message_id=?",
+            "SELECT idempotency_key FROM wake_message WHERE message_id=?",
             (second_message,),
         ).fetchone()[0]
         self.assertEqual(1, len(released))
@@ -438,7 +438,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
             [
                 tuple(row)
                 for row in self.con.execute(
-                    "SELECT disposition,decline_reason FROM sprint_messages "
+                    "SELECT disposition,decline_reason FROM wake_message "
                     "WHERE work_unit_id=? AND message_kind='work_assignment' "
                     "ORDER BY message_id",
                     (unit,),
@@ -625,7 +625,6 @@ class ProductionPulseTest(SprintWorkDispatchCase):
             "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
             (wake_id,),
         ).fetchone()[0]
-        conversation_id = self.conversation_for(1)
         runtime = sprint_runtime.SprintRuntimeService(
             self.db_path,
             owner="runtime-test",
@@ -633,6 +632,14 @@ class ProductionPulseTest(SprintWorkDispatchCase):
 
         self.assertTrue(runtime.pulse_once(startup=True))
         self.assertTrue(runtime.pulse_once())
+        conversation_id = self.conversation_for(1)
+        wake_message_id = int(
+            self.con.execute(
+                "SELECT message_id FROM wake_message WHERE work_unit_id=? "
+                "AND message_kind='work_assignment'",
+                (unit,),
+            ).fetchone()[0]
+        )
 
         wake = self.con.execute(
             "SELECT state,attempt_count FROM sprint_wake_outbox WHERE wake_id=?",
@@ -650,7 +657,9 @@ class ProductionPulseTest(SprintWorkDispatchCase):
             f"{self.sprint_id}` now and act on the Sprint message(s) using "
             "`sprint_dev`. Confirm every Sprint write succeeds before stopping. "
             "If the handoff is not complete, load `sprint_dev` again and run `sc "
-            f"sprint inbox --sprint {self.sprint_id}` again."
+            f"sprint inbox --sprint {self.sprint_id}` again.\n\n"
+            f"## wake_message #{wake_message_id} (declared New)\n\n"
+            "Unit 1\n\nOutput 1"
         )
         self.assertEqual(expected_prompt, native["body"])
         self.assertEqual(wake_key, native["idempotency_key"])
@@ -711,7 +720,7 @@ class ProductionPulseTest(SprintWorkDispatchCase):
             tuple(
                 self.con.execute(
                     "SELECT "
-                    "(SELECT COUNT(*) FROM sprint_messages),"
+                    "(SELECT COUNT(*) FROM wake_message),"
                     "(SELECT COUNT(*) FROM sprint_wake_outbox),"
                     "(SELECT COUNT(*) FROM conversation_outbox)"
                 ).fetchone()

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -727,6 +727,37 @@ class ProductionPulseTest(SprintWorkDispatchCase):
             ),
         )
 
+    def test_engine_wake_delivery_pulses_without_an_armed_sprint(self) -> None:
+        sent = self.messages.send_to_shell(
+            1,
+            message_kind="system",
+            body="armed-independent engine notice",
+            idempotency_key="engine-pulse-without-armed-sprint",
+        )
+        delivered: list[tuple[str, str]] = []
+        runtime = sprint_runtime.SprintRuntimeService(
+            self.db_path,
+            owner="engine-only-runtime-test",
+            deliver=lambda conversation, prompt, _key: (
+                delivered.append((conversation, prompt)) or "engine-only-run"
+            ),
+        )
+
+        self.assertTrue(runtime.pulse_once())
+
+        self.assertEqual(1, len(delivered))
+        self.assertIn("armed-independent engine notice", delivered[0][1])
+        self.assertEqual(
+            ("delivered", 1),
+            tuple(
+                self.con.execute(
+                    "SELECT state,attempt_count FROM sprint_wake_outbox "
+                    "WHERE wake_id=?",
+                    (sent.wake_id,),
+                ).fetchone()
+            ),
+        )
+
     def test_server_startup_wires_broker_before_sprint_runtime(self) -> None:
         order: list[str] = []
         preparer = object()


### PR DESCRIPTION
## Summary

- migrate Sprint messages to the engine-wide wake_message model with optional Sprint context and receiver-shell delivery keys
- route New versus Re-enter at delivery time, protect verified live turns, and drain every undelivered receiver message into one native turn
- remove eager arming/producer chat creation, active-message suppression, and the legacy review-outcome rotation transaction

Sprint 87 U2 · task #261.

## Verification

- 235 Sprint tests passed, with 132 subtests
- migration, conversation schema, schema guard, and Sprint domain gates passed: 74 tests, 295 subtests
- repository suite: 1,662 passed, 1 skipped; one unrelated supervision backup test fails identically on exact base 89e604e (tracked as flag #160)
- targeted changed-file lint checks passed; repository-wide lint/typecheck retain their existing baseline failures