### PR TITLE
feat(sprints): retire legacy chat machinery

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -73,7 +73,7 @@ import sprint_liveness  # noqa: E402  (Sprints v2 one-shot monitor surface)
 import sprint_message_delivery  # noqa: E402  (Sprints v2 inbox acceptance)
 import sprint_recovery  # noqa: E402  (Sprints v2 pause/resume reconciliation)
 import sprint_review_loop  # noqa: E402  (Sprints v2 Dev/Review command surface)
-import sprint_runtime  # noqa: E402  (armed-only Sprint dispatch + wake delivery)
+import sprint_runtime  # noqa: E402  (Sprint dispatch + engine wake delivery)
 import sprint_board  # noqa: E402  (read-only Sprints v2 FnB board projections)
 import skill_projection  # noqa: E402  (exact bounded grant mirrors)
 sys.path.insert(0, str(ENGINE / "api"))
@@ -83,8 +83,8 @@ import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import ports as ports_mod  # noqa: E402
 import shell_factory  # noqa: E402
 import snapshot as snapshot_mod  # noqa: E402  (engine_skill_names — origin rule)
-import sprint_participant_chats  # noqa: E402  (Sprints v2 participant chat topology)
-import sprint_pr_watcher  # noqa: E402  (Sprints v2 armed GitHub observation)
+import sprint_participant_chats  # noqa: E402  (registry-backed Sprint wake chats)
+import sprint_pr_watcher  # noqa: E402  (engine-wide PR subscription observation)
 import model_catalog  # noqa: E402  (live model-id suggestions, sibling module)
 import analytics  # noqa: E402  (token & session analytics sweep — doc #11)
 import token_parsers  # noqa: E402  (harness roster + per-parser data dirs)
@@ -4294,7 +4294,7 @@ def require_loopback_bind(bind: str) -> None:
 
 
 def start_runtime_services() -> None:
-    """Start commit-woken conversations and the armed Sprint services."""
+    """Start commit-woken conversations and Sprint/engine services."""
     broker = conversation_broker.start_service(
         DB_PATH,
         launch_preparer=conversation_launch.ConversationLaunchPreparer(DB_PATH),

--- a/.super-coder/assets/skills/sprint_close/SKILL.md
+++ b/.super-coder/assets/skills/sprint_close/SKILL.md
@@ -22,6 +22,14 @@ question, answer, blocker, or context message, run `accept` for that message.
 For informational messages it only marks the message read; it does not change
 Sprint or work-unit state.
 
+Planner-bound close/conformance messages are Re-enter wakes resolved through
+the active-chat registry. A verified live turn is never displaced; delivery
+waits for its natural boundary and drains every undelivered message. An idle
+Re-enter resumes the registry chat, while coordinate mode makes it an idle New
+ticket chat after FnB closes the Planner chat. Automatic pause preserves that
+mode; FnB pause/resume returns to supervise. The inactivity ceiling and reaper
+own silent or unlinked processes, not this skill.
+
 ## Questions, answers, blockers, and failures
 
 Put a concrete question, answer, blocker, or context request in a short body
@@ -50,18 +58,18 @@ successfully and confirms the durable write and wake where applicable.
 If a Sprint command is rejected or transport fails, the write or handoff is
 incomplete. Correct and retry when safe. If the relay itself fails, surface the
 attempted command and durable evidence to FnB; do not invent an alternate
-delivery protocol. This skill is Planner-owned: the Planner or FnB decides
-whether an integrity threat warrants pause. Send any needed participant context
-before pausing; an active relay is not available after the lifecycle becomes
-paused.
+delivery protocol. The Reviewer decides whether evidence warrants pause,
+re-plan, cancellation, or conclusion; the Planner executes that decision. FnB
+retains the board-level override from decision #46. Send any needed participant
+context before the Planner acts; an active relay is not available after the
+lifecycle becomes paused.
 
 Treat an exhausted recovery wake as bounded manual-recovery evidence for FnB;
 preserve the unread message and failed wake, and do not create recursive
 fallbacks.
 
-```text
-sc sprint pause --sprint <id> --reason <integrity-threat>
-```
+On a durable Reviewer pause decision (or live FnB override), the Planner runs
+`sc sprint pause --sprint <id> --reason <decision-reason>`.
 
 ## Delivery-complete gate
 
@@ -187,5 +195,6 @@ sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
 
 After `complete` succeeds, emit one bounded final response from its receipt:
 final report id, follow-up list, integrated SHA, and evidence links. Run no
-further Sprint command; close intent terminalizes the owning conversation and
-Sprint-scoped authority is over.
+further Sprint command. Terminal lifecycle removes Sprint authority and live
+pills but does not close the shell's registry chat; FnB close remains the one
+unconditional chat-displacement path.

--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -36,6 +36,14 @@ unit's scope, record the choice and rationale, and continue. Escalate changes to
 the unit boundary, interfaces another unit consumes, deliverable cuts, or scope
 growth to the Planner.
 
+The active-chat registry, not Sprint participant pointers, owns your current
+chat. Assignments are declared New, but a verified live turn is never displaced:
+delivery enters this chat at its natural boundary and drains every undelivered
+wake message. When idle, New rotates to a fresh chat; Re-enter resumes the
+registry chat; no registry row behaves as New. A generous inactivity ceiling
+unlinks a silent hung turn so the 60-second reaper can terminate its verified
+process identity.
+
 ## Questions, answers, blockers, and failures
 
 Write a concrete question, answer, blocker, or useful context to a short body
@@ -66,9 +74,9 @@ successfully and confirms the durable write and wake where applicable.
 If a Sprint command is rejected or transport fails, the write or handoff is
 incomplete. Correct and retry when safe. If the relay itself fails, surface the
 attempted command, evidence, impact, and recommendation to FnB; do not invent an
-alternate delivery protocol. A Developer does not pause the Sprint. The Planner
-decides whether the reported condition warrants continuing, re-planning, or
-pausing.
+alternate delivery protocol. A Developer does not pause the Sprint. The
+Reviewer decides whether the evidence warrants continuing, re-planning, or
+pausing; the Planner executes that decision.
 
 ## Build and verify
 
@@ -96,8 +104,11 @@ sc sprint complete-unit --sprint <id> --work-unit <id> \
 
 Register the PR through the authoritative Sprint surface and retain ownership
 until it is green. After `register-pr` succeeds, the native registered-PR
-watcher supplies red/green facts and their durable wakes. On red, diagnose and
-fix the PR. On green, judge readiness rather than forwarding mechanically.
+watcher creates an engine-wide subscription owned by your shell. It supplies
+self-describing red, green, and externally closed facts as Re-enter wakes even
+after chat rotation or outside an armed Sprint. On red, diagnose and fix the PR.
+On green, judge readiness rather than forwarding mechanically. Planner and
+Reviewer receive no PR-event wakes.
 
 ```text
 sc sprint register-pr --sprint <id> --repository <owner/name> \
@@ -125,10 +136,10 @@ sc sprint request-review \
 
 The assigned Reviewer receives an actionable request. After `request-review`
 succeeds, stop and await the native verdict wake. A changes-requested verdict
-opens a fresh linked fix conversation and makes it current. Apply every
-blocking finding, re-establish green, and hand back with a new stable review
-key. Record disagreements as judgment; the Planner resolves scope/severity
-disputes.
+returns as Re-enter to your registry chat. Apply every blocking finding,
+re-establish green, and hand back with a new stable review key. Record
+disagreements as judgment; the Reviewer owns scope/severity decisions and the
+Planner executes any resulting action.
 
 ## Merge boundary
 
@@ -151,7 +162,8 @@ judgments, and let automatic merge observation advance dependencies.
 Report broken bases, destructive ambiguity, unavailable GitHub, untrustworthy
 runners, provider exhaustion, or an unrecoverable environment to the Planner
 with evidence, impact, and a recommendation. Stop at the unsafe boundary while
-the Planner decides whether to continue, re-plan, or pause.
+the Reviewer decides whether to continue, re-plan, or pause and the Planner
+executes that decision.
 
 Stop when the unit is merged and reported, declined, awaiting Planner/FnB
 recovery, or returned to review. Before stopping, re-run `sc sprint inbox

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -24,6 +24,20 @@ decisions. The Reviewer owns pause, cancel, and conclude decisions plus the
 conformance and final Sprint reports. The Planner owns the corresponding state
 transitions.
 
+The active-chat registry is the only current-chat authority; zero or one chat
+per shell is legal. Every wake message creates delivery intent and a wake turn
+drains every undelivered message for the receiver. Planner-bound messages are
+declared Re-enter. If a verified turn is live, every declared type enters that
+chat at the natural boundary. When idle, Re-enter resumes the registry chat and
+New rotates it; no registry row behaves as New.
+
+FnB controls the Planner mode with the close button. Keeping the Planner chat
+open supervises one continuous thread. Closing it during an armed Sprint sets
+coordinate mode, so later idle Planner-bound Re-enters open fresh ticket chats;
+FnB pause/resume returns to supervise. Automatic pauses preserve that choice.
+Neither mode displaces a live turn. The inactivity ceiling closes a silent hung
+chat, and the registry reaper terminates its now-unlinked process.
+
 Read the Sprint inbox, lifecycle, bound spec revisions, work-unit graph,
 participant routes, active conversations, registered PRs, unresolved
 expectations, and recent anomalies. Viewing a participant conversation is
@@ -196,9 +210,12 @@ FnB override; it is terminal and deletes nothing.
 
 ## Handoffs and stop
 
-Assign ready work in the Developer's persistent Sprint conversation. Review
-outcomes move the Developer to fresh fix/merge conversations automatically;
-the next work assignment returns it to the persistent lane.
+Assign ready work through the durable dispatcher. Planner → Developer
+assignments are declared New; Developer → Reviewer review requests are declared
+New; Developer/Reviewer → Planner results are Re-enter. These are idle-time
+guarantees under the live-turn boundary rule, not a parent/child chat topology.
+The Planner receives no PR-event wakes; Developer-owned subscriptions carry
+red, green, and externally closed facts directly to the owning Developer.
 
 When all planned delivery work is terminal and merged or explicitly no-code,
 send the Reviewer the bound revisions, integrated main SHA, ratified judgments,

--- a/.super-coder/assets/skills/sprint_prep/SKILL.md
+++ b/.super-coder/assets/skills/sprint_prep/SKILL.md
@@ -19,13 +19,15 @@ Produce one editable prepared Sprint with:
 - work units made from existing spec tasks, each with one Developer and one
   assigned Reviewer;
 - dependency edges and planned waves;
-- one primary harness/model/effective effort per participant plus eligible
-  Planner fallback capacity;
+- one validated harness/model/effective effort selection per participant;
 - a committed Sprint merge grant; and
 - enough local/GitHub capacity to execute the plan.
 
-The arming transaction creates every participant conversation, the initial
-assignment messages and wake intents, and the armed transition together.
+The arming transaction validates every recorded selection (explicit null
+model/effort means the route default), records the armed transition, publishes
+the initial assignment messages, and declares a New wake to the overseeing
+Planner. Defaults satisfy the gate, but dispatch never precedes that validation.
+Participant chats are created or re-entered later by wake delivery.
 
 ## Eligibility pass
 
@@ -70,8 +72,7 @@ Prefer the smallest dependency graph that preserves correctness. Record the
 expected output in outcome language. Do not encode a shell's implementation
 steps into the durable plan when its role skill and judgment can decide them.
 
-For every participant, record role, route, model, effective effort, persistent
-conversation ownership, and fallback facts the plan actually depends on. Never
+For every participant, record role, route, model, and effective effort. Never
 pretend a native session can resume across harnesses.
 
 Declare the prepared envelope from a JSON array of participant objects, then
@@ -109,7 +110,9 @@ sc sprint arm --sprint <id>
 After `arm` succeeds, participant pickup belongs to native delivery. The armed
 runtime dispatches ready work and wake recovery reconciles unread pickup; the
 preparing Planner does not manually boot participants or create a second wake
-path.
+path. Every wake message creates delivery intent. An idle New rotates to a fresh
+registry chat, an idle Re-enter resumes the registry chat, and any type sent
+while a verified turn is live enters that same chat at its natural boundary.
 
 ## Handoff
 

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -44,6 +44,13 @@ question, answer, blocker, or context message, run `accept` for that message.
 For informational messages it only marks the message read; it does not change
 Sprint or work-unit state.
 
+Review requests are declared New, but wake type resolves at delivery. A verified
+live turn is never displaced: delivery enters the active registry chat at its
+natural boundary and drains every undelivered wake message. When idle, New
+rotates to a fresh chat; Re-enter resumes the registry chat; no registry row
+behaves as New. Reviewer verdicts to Developers and decisions to Planners are
+Re-enter. Reviewers never receive PR-event subscription wakes.
+
 ## Questions, answers, blockers, and failures
 
 Put a concrete question, answer, blocker, or useful context in a short body file
@@ -100,7 +107,7 @@ Reviewer → Planner route is Re-enter. The body must name:
 
 The Planner accepts the actionable message, verifies the assigned Reviewer,
 and executes exactly that transition. The Reviewer never runs the pause,
-cancel, resume, complete, or abort action. If the action is rejected, inspect
+replan, cancel, resume, complete, or abort action. If the action is rejected, inspect
 the returned durable state and issue a new decision only when the evidence
 supports one; never ask the Planner to improvise around a precondition.
 
@@ -163,7 +170,7 @@ sc sprint record-review \
 
 Use `approved` only when no Critical/Major/Medium finding remains. The engine
 checks that the request was accepted and still binds to the reviewed head,
-records judgment evidence, opens the correct fresh Developer conversation, and
+records judgment evidence, sends a Re-enter wake to the Developer, and
 resolves the review liveness expectation. Do not message around this surface;
 an unrecorded verdict cannot unlock merge.
 
@@ -171,7 +178,7 @@ an unrecorded verdict cannot unlock merge.
 
 Judge integrated `main` against every governing bound revision, plus the exact
 recorded mid-Sprint revision facts and ratified judgments. Review the integrated
-system, not unit diffs. Classify each requirement as:
+system, not unit diffs. Compile the bounded evidence packet first:
 
 ```text
 sc sprint compile-report --sprint <id> --limit 50 > evidence.json
@@ -179,6 +186,8 @@ sc sprint compile-report --sprint <id> --limit 50 > evidence.json
 
 Increase the bound only when truncation counters show the default omitted
 needed evidence; 200 is the maximum. The packet supplies facts, not judgment.
+
+Then classify each requirement as:
 
 - `as-specced`;
 - `deviated-intentionally` with its ratified judgment;

--- a/.super-coder/migrations/0168_retire_sprint_conversation_topology.sql
+++ b/.super-coder/migrations/0168_retire_sprint_conversation_topology.sql
@@ -1,0 +1,87 @@
+-- 0168 — retire Sprint conversation pointers and topology.
+--
+-- The active-chat registry is the only current-chat authority.  Sprint links
+-- remain as immutable history, but no longer classify work/fix/merge/fallback
+-- lanes or carry parent/context topology.  The one-open-chat invariant is now
+-- universal instead of exempting conversation_scope='sprint'.
+
+PRAGMA foreign_keys=OFF;
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_sprint_participant_conversation_pointers_insert;
+DROP TRIGGER IF EXISTS trg_sprint_participant_conversation_pointers_update;
+DROP TRIGGER IF EXISTS trg_sprint_participant_conversation_insert;
+DROP TRIGGER IF EXISTS trg_sprint_participant_conversations_immutable_update;
+DROP TRIGGER IF EXISTS trg_sprint_participant_conversations_immutable_delete;
+DROP INDEX IF EXISTS idx_sprint_participant_persistent_work;
+DROP INDEX IF EXISTS idx_sprint_participant_conversation_history;
+
+ALTER TABLE sprint_participants DROP COLUMN persistent_conversation_id;
+ALTER TABLE sprint_participants DROP COLUMN current_conversation_id;
+
+ALTER TABLE sprint_participant_conversations
+  RENAME TO _sprint_participant_conversations_topology;
+
+CREATE TABLE sprint_participant_conversations (
+    participant_conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_participant_id       INTEGER NOT NULL
+                                REFERENCES sprint_participants(participant_id),
+    conversation_id             TEXT NOT NULL UNIQUE
+                                REFERENCES conversations(conversation_id),
+    created_at                  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO sprint_participant_conversations (
+    participant_conversation_id,
+    sprint_participant_id,
+    conversation_id,
+    created_at
+)
+SELECT participant_conversation_id,
+       sprint_participant_id,
+       conversation_id,
+       created_at
+FROM _sprint_participant_conversations_topology;
+
+DROP TABLE _sprint_participant_conversations_topology;
+
+CREATE INDEX idx_sprint_participant_conversation_history
+    ON sprint_participant_conversations(
+      sprint_participant_id, created_at, participant_conversation_id
+    );
+
+CREATE TRIGGER trg_sprint_participant_conversation_insert
+BEFORE INSERT ON sprint_participant_conversations
+WHEN NOT EXISTS (
+    SELECT 1
+    FROM sprint_participants p
+    JOIN conversations c ON c.conversation_id=NEW.conversation_id
+    WHERE p.participant_id=NEW.sprint_participant_id
+      AND p.shell_id=c.shell_id
+      AND c.conversation_scope='sprint'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid Sprint participant conversation link');
+END;
+
+CREATE TRIGGER trg_sprint_participant_conversations_immutable_update
+BEFORE UPDATE ON sprint_participant_conversations
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint participant conversation links are immutable');
+END;
+
+CREATE TRIGGER trg_sprint_participant_conversations_immutable_delete
+BEFORE DELETE ON sprint_participant_conversations
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint participant conversation links are immutable');
+END;
+
+DROP INDEX IF EXISTS idx_conversations_live_normal_shell;
+CREATE UNIQUE INDEX idx_conversations_one_open_shell
+    ON conversations(shell_id)
+    WHERE state<>'closed';
+
+COMMIT;
+
+PRAGMA foreign_keys=ON;

--- a/.super-coder/migrations/0169_reseed_sprint_v21_guidance.sql
+++ b/.super-coder/migrations/0169_reseed_sprint_v21_guidance.sql
@@ -1,0 +1,1020 @@
+-- 0169 — reseed Sprints v2.1 role guidance.
+-- Full-body UPSERTs converge existing installations to the registry, delivery,
+-- reaper, coordinate, subscription, arming-gate, and authority-split contracts.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_prep',
+  'Prepare and arm a Sprints v2 run — bind reviewed spec revisions, shape work units and dependencies, assign routes and capacity, and refuse arming until the durable plan is eligible.',
+  'workflow',
+  NULL,
+  '0',
+  '# sprint_prep — declare the riverbed
+
+Use as the owning Planner while a Sprint is `prepared`. Preparation ends at one
+atomic arming decision; it does not launch participants piecemeal.
+
+## Outcome
+
+Produce one editable prepared Sprint with:
+
+- one roadmap feature;
+- exact governing spec revision hashes and their qualifying QAQC approvals;
+- work units made from existing spec tasks, each with one Developer and one
+  assigned Reviewer;
+- dependency edges and planned waves;
+- one validated harness/model/effective effort selection per participant;
+- a committed Sprint merge grant; and
+- enough local/GitHub capacity to execute the plan.
+
+The arming transaction validates every recorded selection (explicit null
+model/effort means the route default), records the armed transition, publishes
+the initial assignment messages, and declares a New wake to the overseeing
+Planner. Defaults satisfy the gate, but dispatch never precedes that validation.
+Participant chats are created or re-entered later by wake delivery.
+
+## Eligibility pass
+
+Read the feature, selected spec bodies, task ledgers, QAQC records, shell roster,
+model routes, quota state, repository access, and worktree availability. Record
+the exact revision hash you inspected; a title or document id is not a revision.
+
+The Review shell records its verdict against the current exact body through the
+authenticated Sprint surface:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> --verdict pass \
+  [--findings-document <document-id>]
+```
+
+Use `fail` until every blocking finding is resolved. A body edit changes the
+revision hash and therefore needs a fresh signed record.
+
+Refuse arming when any of these is true:
+
+- a selected current revision lacks Review-shell QAQC approval;
+- any Medium-or-higher QAQC finding is unresolved;
+- a selected task belongs to no work unit or more than one work unit;
+- a dependency cycle exists;
+- a work unit lacks an assigned Developer or Reviewer;
+- participant routes or required capacity are unavailable;
+- another Sprint is armed, or a selected shell already participates in an armed
+  Sprint; or
+- the merge grant was not committed as part of the final plan.
+
+Deficiencies remain editable in `prepared`. Do not weaken an invariant merely
+to get to `armed`; surface the missing fact or capacity to the FnB.
+
+## Shape work, do not script behavior
+
+A work unit is one coherent editing lane and may group related spec tasks. Use
+dependencies only for hard prerequisites. Waves express intent and later report
+comparison; they do not forbid safe out-of-order completion. Reviews are not
+editing lanes.
+
+Prefer the smallest dependency graph that preserves correctness. Record the
+expected output in outcome language. Do not encode a shell''s implementation
+steps into the durable plan when its role skill and judgment can decide them.
+
+For every participant, record role, route, model, and effective effort. Never
+pretend a native session can resume across harnesses.
+
+Declare the prepared envelope from a JSON array of participant objects, then
+add each editing lane from existing spec tasks:
+
+```text
+sc sprint declare --feature <feature-id> \
+  --spec-approval <approval-id> --participants-file <path> --merge-grant
+sc sprint plan-unit --sprint <id> \
+  --developer-shell <id> --reviewer-shell <id> --title <title> \
+  --expected-output-file <path> --task <task-id> \
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>] \
+  [--output-kind code|report-only|no-code]
+```
+
+The participant file contains `shell_id`, `role`, and `harness`, with optional
+`model`, `effort`, and `route`. FnB may add `--planner-shell <id>` when declaring
+for the originating Planner. Keep the Sprint prepared while shaping the plan.
+
+## Final arming check
+
+Immediately before arming, re-read the spec revision hashes, QAQC records,
+participant capacity, single-armed invariant, repository access, and merge
+grant. The final read and durable plan commit belong to the authoritative
+arming transaction; external harness and GitHub work occurs after it commits.
+
+Arming succeeds only when the first assignments and wake intents are durable.
+A process crash after commit is outbox recovery; a crash before commit exposes
+no partial Sprint.
+
+```text
+sc sprint arm --sprint <id>
+```
+
+After `arm` succeeds, participant pickup belongs to native delivery. The armed
+runtime dispatches ready work and wake recovery reconciles unread pickup; the
+preparing Planner does not manually boot participants or create a second wake
+path. Every wake message creates delivery intent. An idle New rotates to a fresh
+registry chat, an idle Re-enter resumes the registry chat, and any type sent
+while a verified turn is live enters that same chat at its natural boundary.
+
+## Handoff
+
+Once armed, hand control to `sprint_pln` and stop preparation work. Give the FnB
+a compact declaration:
+Sprint id, feature, exact spec revisions, participants/routes, work-unit graph,
+planned waves, merge-grant state, and known accepted risks.
+
+Stop when the Sprint is armed or when one concrete eligibility blocker has been
+surfaced. Do not dispatch from a partially prepared plan.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch ready lanes and execute Reviewer decisions through durable re-plan, pause, cancel, resume, and close protocols.',
+  'workflow',
+  NULL,
+  '0',
+  '# sprint_pln — govern the armed Sprint
+
+Use as the originating Planner after `sprint_prep` arms the Sprint. The system
+captures deterministic facts; the Reviewer decides and documents, and the
+Planner acts. Execute Reviewer decisions without taking over their judgment or
+report authorship. The FnB retains the board-level override established by
+decision #46.
+On every wake or re-entry, load `sprint_pln`, run the exact inbox command below,
+and inspect the durable message before deciding what to do.
+
+## Start from durable state
+
+The armed runtime owns scheduled dispatch, unread wake recovery, liveness
+evaluation, and registered-PR observation. React to its durable inbox and wake
+facts; use the Planner turn for dispatch and exact execution of durable Reviewer
+decisions. The Reviewer owns pause, cancel, and conclude decisions plus the
+conformance and final Sprint reports. The Planner owns the corresponding state
+transitions.
+
+The active-chat registry is the only current-chat authority; zero or one chat
+per shell is legal. Every wake message creates delivery intent and a wake turn
+drains every undelivered message for the receiver. Planner-bound messages are
+declared Re-enter. If a verified turn is live, every declared type enters that
+chat at the natural boundary. When idle, Re-enter resumes the registry chat and
+New rotates it; no registry row behaves as New.
+
+FnB controls the Planner mode with the close button. Keeping the Planner chat
+open supervises one continuous thread. Closing it during an armed Sprint sets
+coordinate mode, so later idle Planner-bound Re-enters open fresh ticket chats;
+FnB pause/resume returns to supervise. Automatic pauses preserve that choice.
+Neither mode displaces a live turn. The inactivity ceiling closes a silent hung
+chat, and the registry reaper terminates its now-unlinked process.
+
+Read the Sprint inbox, lifecycle, bound spec revisions, work-unit graph,
+participant routes, active conversations, registered PRs, unresolved
+expectations, and recent anomalies. Viewing a participant conversation is
+observation, not activity; never manufacture progress from browser presence.
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Release every dependency-ready lane through the production surface:
+
+```text
+sc sprint dispatch --sprint <id>
+```
+
+The returned ids are wake identities. Work-unit disposition and messages are
+the authoritative release facts. Dispatch is safe to repeat: occupied Developer
+lanes and stable assignment generations prevent double booking.
+
+Accept or decline only when the inbox item is actionable. After acting on an
+informational question, answer, blocker, or evidence message, run `accept` for
+that message. For informational messages it only marks the message read; it does
+not change Sprint or work-unit state.
+
+## Running loop
+
+- Keep dependencies as the only hard sequence. When reality requires a re-plan,
+  give the Reviewer the current projection and evidence, then execute the exact
+  decision it returns; never rewrite completed history.
+- Let Developers own their PRs through green, review, correction, and merge.
+  Let Reviewers own verdicts and Sprint decisions. Do not proxy routine
+  handoffs or substitute Planner judgment for a Reviewer decision.
+- Consume passive system facts without waking yourself into every transition.
+  Route a decision boundary to the Reviewer; act when its Re-enter decision
+  message arrives.
+- Record the Reviewer decision identity, the exact action taken, and the action
+  receipt. Do not rewrite its rationale as Planner-authored judgment evidence.
+- A mid-Sprint spec edit is allowed only by the owning Planner or FnB. Record
+  the prior and new exact revision hashes. When acting as Planner, require a
+  durable Reviewer decision before the edit. The running Sprint remains bound
+  to its approved revision unless that decision explicitly says otherwise.
+
+The armed runtime evaluates liveness on its five-second pulse. A one-shot
+diagnostic/evaluation is available when evidence requires it:
+
+```text
+sc sprint monitor --sprint <id>
+```
+
+Run `monitor` once for concrete evidence, then return control to native
+delivery. It evaluates only due accepted expectations and its
+nudge/escalation identities are durable. Use Sprint-native wakes for
+coordination. Do not start a recurring shell loop, scheduled job, manual
+participant boot, or external PR watcher to track Sprint state.
+
+## Questions, answers, blockers, and failures
+
+Put a concrete question, answer, decision, blocker, or useful context in a short
+body file and address the participant who owns the needed fact or action:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Answer incoming questions through `send` so the answer is durable and wakes the
+asker, confirm that write, then mark the handled question read with `accept`.
+For a cross-unit blocker, send evidence, impact, and the exact action needed to
+every directly affected participant. Continue safe independent governance, but
+stop at a decision boundary when an answer is required. Do not spam duplicates
+when no response is immediate; unread recovery owns re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the write or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command and durable evidence to FnB; do not invent an alternate
+delivery protocol. When a Developer reports an integrity concern, relay its
+evidence, impact, and recommendation to the Reviewer. When the Reviewer returns
+a decision, execute it through the protocol below. Send any needed participant
+context before pausing; an active relay is not available after the lifecycle
+becomes paused.
+
+## Reviewer decision actions
+
+Pause, cancel, and conclude are Reviewer decisions and Planner actions. A valid
+decision arrives as a durable Reviewer → Planner Re-enter message and names the
+decision, evidence, target ids, reason, and exact requested transition. Accept
+the actionable message, verify it came from the assigned Reviewer, and execute
+that transition without re-adjudicating the decision. Record the decision
+message id and action receipt together.
+
+The FnB board-level override from decision #46 is unaffected: a live FnB
+instruction may direct or supersede any action. Name that override in the
+evidence instead of attributing it to the Reviewer.
+
+If a requested action fails a lifecycle, authority, or disposition precondition,
+do not substitute a different action. Send the refusal and current durable state
+back to the Reviewer (or surface it directly to FnB for an FnB override), then
+stop at that decision boundary.
+
+### Pause or resume
+
+On a Reviewer pause decision, transition durably, stop external Sprint services,
+persist interrupt intent, preserve every partial artifact, and retain the
+Reviewer judgment and evidence for recovery:
+
+```text
+sc sprint pause --sprint <id> --reason <reviewer-decision-reason>
+```
+
+Resume only on a later Reviewer decision or an FnB override. Reconcile native
+runs, unread messages, pending wakes, work units, registered PRs, capacity, and
+spec drift, then act with the supplied reason:
+
+```text
+sc sprint resume --sprint <id> [--reason <reviewer-reconciliation-decision>]
+```
+
+An exhausted recovery wake is bounded manual-recovery evidence, not a retry
+loop. Preserve the unread message and failed wake, involve FnB, and do not create
+recursive fallbacks. Drift informs; it never silently blocks resume.
+
+### Cancel or re-plan
+
+A Reviewer cancel decision must name one unreleased work unit and its retained
+terminal reason. Execute exactly that cancellation:
+
+```text
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reviewer-decision-reason>
+```
+
+For a Reviewer re-plan decision, apply its complete projection; never infer
+omitted fields or alter a released or completed lane:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  --developer-shell <id> --reviewer-shell <id> --wave <n> \
+  [--depends-on <work-unit-id>] [--output-kind code|report-only|no-code]
+```
+
+If a Developer or Reviewer declines, preserve the reason and ask the Reviewer
+for the replacement routing decision before issuing a fresh assignment.
+
+### Conclude or abort
+
+The Reviewer decides when the Sprint is done, records conformance, authors the
+final Sprint report, and sends a conclude decision containing the conformance
+receipt, follow-up ids, exact reason/outcome, stable key, and full report body.
+Write that Reviewer-authored body to `<reviewer-report>` unchanged, then perform
+the close action:
+
+```text
+sc sprint complete --sprint <id> --reason <reviewer-decision-reason> \
+  --outcome <reviewer-decision-outcome> --report-file <reviewer-report> \
+  --key <reviewer-decision-key>
+```
+
+Do not run `compile-report`, synthesize the final report, or editorialize the
+Reviewer body. Abort is likewise an action taken only on a Reviewer decision or
+FnB override; it is terminal and deletes nothing.
+
+## Handoffs and stop
+
+Assign ready work through the durable dispatcher. Planner → Developer
+assignments are declared New; Developer → Reviewer review requests are declared
+New; Developer/Reviewer → Planner results are Re-enter. These are idle-time
+guarantees under the live-turn boundary rule, not a parent/child chat topology.
+The Planner receives no PR-event wakes; Developer-owned subscriptions carry
+red, green, and externally closed facts directly to the owning Developer.
+
+When all planned delivery work is terminal and merged or explicitly no-code,
+send the Reviewer the bound revisions, integrated main SHA, ratified judgments,
+and current close evidence, then stop and await its Re-enter conclude decision.
+The Reviewer writes the conformance and final Sprint reports; conformance
+findings become follow-ups rather than new editing lanes in this Sprint.
+
+On receipt, re-run `sc sprint inbox --sprint <id>`, accept the conclude message,
+execute its exact close action through the protocol above, and confirm the typed
+transition succeeded. After `complete` succeeds, emit its bounded receipt and
+run no further Sprint command. The Planner does not author a second report.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_dev',
+  'Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge only after live authorization, and record judgment without overlapping edits.',
+  'workflow',
+  NULL,
+  '0',
+  '# sprint_dev — own one editing lane
+
+Use for an actionable work-unit assignment in an armed Sprint. Marking that
+Sprint message read is acceptance and starts work immediately. If you cannot
+accept, decline with a concrete reason; never leave it unread and waking.
+On every wake or re-entry, load `sprint_dev`, run the exact inbox command below,
+and inspect the durable message before deciding what to do.
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Use `accept` or `decline` for actionable work. After acting on an informational
+question, answer, blocker, or context message, run `accept` for that message.
+For informational messages it only marks the message read; it does not change
+Sprint or work-unit state.
+
+## Orient and bound the lane
+
+Read the assignment, expected output, bound spec revision, dependencies,
+assigned Reviewer, repository/worktree, merge grant, and prior judgments. One
+Developer shell may own one active work unit in the Sprint. Do not start a
+second editing lane or edit another shell''s worktree.
+
+If the requirement is ambiguous, choose the shippable reading within your
+unit''s scope, record the choice and rationale, and continue. Escalate changes to
+the unit boundary, interfaces another unit consumes, deliverable cuts, or scope
+growth to the Planner.
+
+The active-chat registry, not Sprint participant pointers, owns your current
+chat. Assignments are declared New, but a verified live turn is never displaced:
+delivery enters this chat at its natural boundary and drains every undelivered
+wake message. When idle, New rotates to a fresh chat; Re-enter resumes the
+registry chat; no registry row behaves as New. A generous inactivity ceiling
+unlinks a silent hung turn so the 60-second reaper can terminate its verified
+process identity.
+
+## Questions, answers, blockers, and failures
+
+Write a concrete question, answer, blocker, or useful context to a short body
+file, then send it durably to the participant who can act:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Ask the Planner about scope, priority, or cross-unit decisions; ask the assigned
+Reviewer about review evidence. Answer an incoming question through `send` so it
+wakes the asker, confirm that write, then mark the handled question read with
+`accept`. For a blocker or integrity concern, send the Planner concise evidence,
+impact, the exact action needed, and your recommendation. Continue safe
+independent work, but stop at a decision boundary when the answer is required.
+No immediate response is not a reason to send duplicates: the durable message
+and recovery reconciler own re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the write or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command, evidence, impact, and recommendation to FnB; do not invent an
+alternate delivery protocol. A Developer does not pause the Sprint. The
+Reviewer decides whether the evidence warrants continuing, re-planning, or
+pausing; the Planner executes that decision.
+
+## Build and verify
+
+Sync the assigned repository, work on a feature branch, match the surrounding
+code, and implement the smallest complete change. Keep external calls outside
+database transactions. Preserve durable identities and append-only evidence.
+
+Verification must exercise the unit''s independent stage gate and realistic
+failure paths. A local exploratory number is not merge evidence. Record real CI
+failures, anomalous infrastructure failures, retries, review friction, and
+known departures for the final report.
+
+An explicitly planned report-only or no-code lane completes with its durable
+result instead of a PR. Code lanes cannot use this path; they complete only
+after merge authorization and observation.
+
+Keep the result at about 6,000 characters or fewer; 8,000 is the hard maximum.
+Run `wc -m < <path>` before submitting, then require a successful command and
+durable completion receipt.
+
+```text
+sc sprint complete-unit --sprint <id> --work-unit <id> \
+  --result-file <path>
+```
+
+Register the PR through the authoritative Sprint surface and retain ownership
+until it is green. After `register-pr` succeeds, the native registered-PR
+watcher creates an engine-wide subscription owned by your shell. It supplies
+self-describing red, green, and externally closed facts as Re-enter wakes even
+after chat rotation or outside an armed Sprint. On red, diagnose and fix the PR.
+On green, judge readiness rather than forwarding mechanically. Planner and
+Reviewer receive no PR-event wakes.
+
+```text
+sc sprint register-pr --sprint <id> --repository <owner/name> \
+  --pr <number> --work-unit <id>
+```
+
+When no local implementation action remains, stop and await the native PR-fact
+wake. Use Sprint-native wakes for coordination. Do not start a recurring shell
+loop, scheduled job, manual watcher daemon, or external PR watcher to track the
+registered PR.
+
+## Review handoff
+
+Put the readiness claim in a file, then use one stable retry key:
+
+Keep the readiness claim at about 6,000 characters or fewer; 8,000 is the hard
+maximum. Run `wc -m < <path>` and condense before the typed handoff. The handoff
+exists only after the command succeeds and confirms its durable write and wake.
+
+```text
+sc sprint request-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --readiness-file <path> --key <stable-key>
+```
+
+The assigned Reviewer receives an actionable request. After `request-review`
+succeeds, stop and await the native verdict wake. A changes-requested verdict
+returns as Re-enter to your registry chat. Apply every blocking finding,
+re-establish green, and hand back with a new stable review key. Record
+disagreements as judgment; the Reviewer owns scope/severity decisions and the
+Planner executes any resulting action.
+
+## Merge boundary
+
+Approval alone is stale evidence. Immediately before merge, ask the engine to
+re-read live GitHub state and revalidate the armed grant, ownership, work-unit
+state, approved head, and checks:
+
+```text
+sc sprint authorize-merge \
+  --sprint <id> --registered-pr <registered-id>
+```
+
+Merge only the exact repository, PR number, and head SHA returned. If the
+command refuses, do not work around it; wait for the watcher or return to the
+appropriate loop. After merge, clean the worktree, submit the unit result and
+judgments, and let automatic merge observation advance dependencies.
+
+## Report and stop
+
+Report broken bases, destructive ambiguity, unavailable GitHub, untrustworthy
+runners, provider exhaustion, or an unrecoverable environment to the Planner
+with evidence, impact, and a recommendation. Stop at the unsafe boundary while
+the Reviewer decides whether to continue, re-plan, or pause and the Planner
+executes that decision.
+
+Stop when the unit is merged and reported, declined, awaiting Planner/FnB
+recovery, or returned to review. Before stopping, re-run `sc sprint inbox
+--sprint <id>`, act on newly arrived messages, mark every handled informational
+message read with `accept`, and confirm the final typed handoff succeeded. Ask
+the Planner for later work only after the current editing lane is terminal.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_rev',
+  'Review Sprints v2 work and whole-Sprint conformance — own pause, cancel, and conclude decisions, author the conformance and Sprint reports, and direct Planner actions through durable messages.',
+  'workflow',
+  NULL,
+  '0',
+  '# sprint_rev — independent review and conformance
+
+Use in one of two modes: a work-unit PR review during the loop, or the final
+whole-Sprint conformance pass. Pre-declaration QAQC is a third entry condition,
+before a Sprint exists. The evidence differs; independence does not. The
+Reviewer decides and documents; the Planner acts. The FnB retains the
+board-level override established by decision #46.
+
+## Entry and durable state
+
+Pre-declaration QAQC begins from an explicit Planner or FnB request. Read the
+exact current spec document and sign that body directly; there is no Sprint id
+or Sprint inbox to inspect yet:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
+
+Once a Sprint is armed, every review or conformance entry arrives through its
+durable wake/inbox. On every wake or re-entry, load `sprint_rev`, inspect the
+message, and accept the actionable request before beginning:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+```
+
+Decline an actionable request you cannot take, with a concrete reason:
+
+```text
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Use `accept` or `decline` for actionable work. After acting on an informational
+question, answer, blocker, or context message, run `accept` for that message.
+For informational messages it only marks the message read; it does not change
+Sprint or work-unit state.
+
+Review requests are declared New, but wake type resolves at delivery. A verified
+live turn is never displaced: delivery enters the active registry chat at its
+natural boundary and drains every undelivered wake message. When idle, New
+rotates to a fresh chat; Re-enter resumes the registry chat; no registry row
+behaves as New. Reviewer verdicts to Developers and decisions to Planners are
+Re-enter. Reviewers never receive PR-event subscription wakes.
+
+## Questions, answers, blockers, and failures
+
+Put a concrete question, answer, blocker, or useful context in a short body file
+and send it to the participant who can act. Ask the Developer for missing PR
+evidence and the Planner for durable state or action-feasibility facts. Do not
+delegate Reviewer judgment to the Planner:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Answer incoming questions through `send` so the answer is durable and wakes the
+asker, confirm that write, then mark the handled question read with `accept`. A
+blocker or integrity concern is evidence for your decision. If action is needed,
+send the Planner the decision, impact, exact action, and recommendation through
+the protocol below. Continue independent safe review, but stop when missing
+facts prevent an honest decision at the decision boundary. Do not send duplicate
+reminders; unread recovery owns re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the verdict or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command, evidence, impact, and recommendation to FnB; do not invent an
+alternate delivery protocol. A Reviewer decides whether the condition warrants
+continuing, re-planning, pausing, cancellation, or conclusion, but does not
+invoke the lifecycle transition. Send the durable decision to the Planner, who
+executes it. A live FnB board-level override may supersede that decision and
+must be recorded as FnB authority, not Reviewer judgment.
+
+## Control and conclude decisions
+
+The Reviewer owns all pause, cancel, and conclude decisions and recommendations.
+The Planner owns all resulting actions. Base a decision on durable Sprint state,
+the exact bound revisions, current work/PR facts, liveness evidence, and any
+ratified judgment; ambiguous silence is not enough to corrupt a disposition.
+
+Send each decision to the Planner through the durable `send` surface above. The
+Reviewer → Planner route is Re-enter. The body must name:
+
+- `decision`: `pause`, `resume`, `replan`, `cancel`, `conclude`, or `abort`;
+- the evidence and rationale owned by the Reviewer;
+- exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
+- for conclude, the conformance report/follow-up ids, stable completion key,
+  and full Reviewer-authored final Sprint report body; and
+- any immediate safety impact that the FnB must see.
+
+The Planner accepts the actionable message, verifies the assigned Reviewer,
+and executes exactly that transition. The Reviewer never runs the pause,
+replan, cancel, resume, complete, or abort action. If the action is rejected, inspect
+the returned durable state and issue a new decision only when the evidence
+supports one; never ask the Planner to improvise around a precondition.
+
+The FnB board-level override from decision #46 is unaffected. A live FnB
+instruction can direct or supersede any decision; preserve it as a distinct
+authority record.
+
+## Severity rubric
+
+This skill owns severity. The governing spec intentionally does not.
+
+- **Critical** — active security/authority violation, destructive corruption,
+  or a condition that makes continued operation unsafe.
+- **Major** — wrong behavior, data loss, broken invariant, material spec
+  violation, or a loop/recovery path that can silently wedge delivery.
+- **Medium** — a concrete correctness or recovery gap likely to bite normal
+  use soon, including missing negative enforcement or an unreliable handoff.
+- **Low** — bounded cleanup, clarity, test depth, or resilience improvement that
+  does not make the delivered behavior wrong now.
+
+During a work-unit review, Critical/Major/Medium block approval; Low is a
+report note. During close-out conformance, every severity becomes a follow-up
+and none is fixed inside the Sprint.
+
+## Work-unit review
+
+Accept the actionable review request, then inspect the exact bound spec
+revision, readiness claim, PR head, diff, checks, tests, relevant runtime
+evidence, and prior judgment calls. Review code quality, edge cases/failure
+paths, and spec conformance. Trace the real path; do not trust names or PR prose.
+
+Read resolved closure evidence through the authenticated memory surface; no SQL
+or mutation is needed. Use the exact form for a cited flag and the scoped form
+to audit every resolved flag attached to the feature:
+
+```text
+sc mem get flags <flag-id>
+sc mem get flags --feature <feature-id> --resolved
+```
+
+Findings must state:
+
+- severity and concise title;
+- violated behavior or invariant;
+- exact code/evidence location;
+- a reproducible consequence; and
+- the fix boundary, without prescribing unnecessary architecture.
+
+Put the verdict body in a file and record it through the authenticated surface:
+
+Keep the verdict at about 6,000 characters or fewer; 8,000 is the hard maximum.
+Run `wc -m < <path>` before submission. The typed review handoff exists only
+after the command succeeds and confirms its durable write and Developer wake.
+
+```text
+sc sprint record-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --verdict changes_requested --body-file <path> --key <stable-key>
+```
+
+Use `approved` only when no Critical/Major/Medium finding remains. The engine
+checks that the request was accepted and still binds to the reviewed head,
+records judgment evidence, sends a Re-enter wake to the Developer, and
+resolves the review liveness expectation. Do not message around this surface;
+an unrecorded verdict cannot unlock merge.
+
+## Whole-Sprint conformance
+
+Judge integrated `main` against every governing bound revision, plus the exact
+recorded mid-Sprint revision facts and ratified judgments. Review the integrated
+system, not unit diffs. Compile the bounded evidence packet first:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 > evidence.json
+```
+
+Increase the bound only when truncation counters show the default omitted
+needed evidence; 200 is the maximum. The packet supplies facts, not judgment.
+
+Then classify each requirement as:
+
+- `as-specced`;
+- `deviated-intentionally` with its ratified judgment;
+- `deviated-silently`; or
+- `unimplemented`.
+
+The last two are findings. Include spec document id and work-unit id when known.
+Write the conformance report and a JSON findings array:
+
+```json
+[
+  {
+    "severity": "Major",
+    "title": "Integrated seam diverges",
+    "body": "Evidence and consequence.",
+    "spec_document_id": 46,
+    "work_unit_id": 9
+  }
+]
+```
+
+Then record both atomically:
+
+Keep the conformance report and each finding body at about 6,000 characters or
+fewer; 8,000 is the hard maximum for each. Run `wc -m < <report>` and length-check
+each finding body before submission. Require the successful report and
+follow-up receipt before stopping.
+
+```text
+sc sprint record-conformance \
+  --sprint <id> --body-file <report> --findings-file <json> \
+  --key <stable-pass-key>
+```
+
+This creates append-only conformance evidence and pending follow-ups for FnB
+disposition. It must not create a fix lane, reopen a completed work unit, or
+send findings to a Developer for in-Sprint repair — including Critical ones.
+Surface immediate safety risk to the FnB, but preserve the close-out rule.
+
+Then author the final Sprint report. Name the Reviewer as its author and answer:
+
+1. Which exact scope and revisions governed?
+2. What shipped, through which work units and PRs?
+3. Which Reviewer judgments and ratified deviations shaped the result?
+4. What failed, retried, paused, recovered, or remained anomalous?
+5. What did conformance conclude?
+6. Which follow-ups or unresolved items require FnB disposition?
+7. Where is the complete evidence?
+
+Keep the final report at about 6,000 characters or fewer and below the 8,000
+hard maximum; run `wc -m < <report>`. Do not smooth discrepancies into a
+success narrative. If the Sprint is done, send the Planner a `conclude`
+decision containing the full report body and the exact completion arguments
+defined in the control protocol. The Planner submits that body unchanged and
+owns only the close action. If the Sprint is not done, send the appropriate
+pause, re-plan, cancel, or abort decision instead.
+
+## Stop
+
+For either mode, re-run `sc sprint inbox --sprint <id>` and act on newly arrived
+messages before stopping. For unit review, stop after the durable verdict is
+recorded and every handled informational message is marked read with `accept`.
+For conformance, also require the report and all findings to replay
+idempotently, then require successful delivery of the Reviewer-authored Sprint
+report and conclude decision to the Planner. The conformance receipt plus the
+durable decision handoff completes Reviewer work; stop until another native
+wake arrives.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_close',
+  'Close or abort a Sprints v2 run — boot whole-Sprint conformance, compile the bounded evidence packet, synthesize the final report, preserve follow-ups, and transition terminally without deleting history.',
+  'workflow',
+  NULL,
+  '0',
+  '# sprint_close — synthesize and finish
+
+Use as the owning Planner when delivery work is terminal, or when abort has
+been chosen. Close-out supplies meaning; the compiler supplies facts.
+On entry or any wake, load `sprint_close`, run `sc sprint inbox --sprint <id>`,
+inspect the durable message, and accept or decline it only when actionable.
+
+```text
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Use `accept` or `decline` for actionable work. After acting on an informational
+question, answer, blocker, or context message, run `accept` for that message.
+For informational messages it only marks the message read; it does not change
+Sprint or work-unit state.
+
+Planner-bound close/conformance messages are Re-enter wakes resolved through
+the active-chat registry. A verified live turn is never displaced; delivery
+waits for its natural boundary and drains every undelivered message. An idle
+Re-enter resumes the registry chat, while coordinate mode makes it an idle New
+ticket chat after FnB closes the Planner chat. Automatic pause preserves that
+mode; FnB pause/resume returns to supervise. The inactivity ceiling and reaper
+own silent or unlinked processes, not this skill.
+
+## Questions, answers, blockers, and failures
+
+Put a concrete question, answer, blocker, or context request in a short body
+file, then send it to the conformance Reviewer or participant who owns the fact:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Answer incoming questions through `send`, confirm that write, then mark the
+handled question read with `accept`. For a blocker, relay the evidence, impact,
+and exact action needed to every directly affected Sprint participant, and
+surface the exceptional recovery need separately to FnB. Continue safe
+synthesis, but stop at a decision boundary when the answer is required. Do not
+send duplicate reminders; unread recovery owns re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the write or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command and durable evidence to FnB; do not invent an alternate
+delivery protocol. The Reviewer decides whether evidence warrants pause,
+re-plan, cancellation, or conclusion; the Planner executes that decision. FnB
+retains the board-level override from decision #46. Send any needed participant
+context before the Planner acts; an active relay is not available after the
+lifecycle becomes paused.
+
+Treat an exhausted recovery wake as bounded manual-recovery evidence for FnB;
+preserve the unread message and failed wake, and do not create recursive
+fallbacks.
+
+On a durable Reviewer pause decision (or live FnB override), the Planner runs
+`sc sprint pause --sprint <id> --reason <decision-reason>`.
+
+## Delivery-complete gate
+
+Before conformance, re-read work units, dependencies, registered PRs, checks,
+merge observations, task membership, pending actionable messages, and active
+native runs. Normally every planned unit is completed/cancelled with an
+explicit disposition, and code units have their real PR outcome. Close-out is
+advisory: the packet surfaces gaps but never prevents the owning Planner or FnB
+from making and reporting a completion judgment. Do not infer code completion
+from PR state alone.
+
+Request an independent Reviewer through the durable Sprint relay, using the
+`sc sprint send` command above with the bound spec revision hashes, integrated
+main SHA, ratified judgment list, and `sprint_rev` conformance mode. Confirm the
+write and wake receipt, then stop and await the native conformance-result wake.
+Give the Reviewer recorded judgments, not unit authors'' narrative; conformance
+judges artifacts.
+
+## Conformance boundary
+
+The Reviewer records its report and findings with `sc sprint
+record-conformance`. Every finding becomes a pending follow-up for FnB review.
+No conformance finding is fixed inside this Sprint at any severity. A safety
+finding may demand immediate operator action, but it still remains follow-up
+evidence rather than a silently reopened editing lane.
+
+Verify report id, follow-up ids, author identity, and idempotent replay before
+synthesis.
+
+FnB records one terminal disposition per follow-up. `accepted` acknowledges
+ship-as-is; `resolved` and `dismissed` require a resolution file.
+
+Keep a resolution at about 6,000 characters or fewer; 8,000 is the hard
+maximum. Run `wc -m < <path>` and require a successful durable disposition.
+
+```text
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition accepted
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition resolved --resolution-file <path>
+```
+
+## Compile bounded evidence
+
+Generate the packet through the authenticated production surface:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 > evidence.json
+```
+
+Increase the per-section bound only when the default truncation counters show
+that synthesis needs more detail; the maximum is 200. Follow the packet''s full
+timeline and participant-conversation links for raw history. Never paste the
+entire event stream into the final report.
+
+The packet supplies:
+
+- scope and lifecycle times;
+- exact bound spec revisions and recorded mid-Sprint edits;
+- planned versus actual work;
+- PR outcomes and links;
+- judgments and deviations;
+- pause, resume, recovery, interrupt, and drift evidence;
+- wake states, attempts, liveness aggregates, nudges, and escalations;
+- anomalies with bounded detail;
+- unresolved units, actionable messages, and follow-ups; and
+- links to the complete timeline and every participant conversation.
+
+The compiler does not decide whether a deviation was wise or an anomaly was
+acceptable. That is your synthesis.
+
+## Final report
+
+Write a concise report that answers:
+
+1. What scope and exact revisions governed the Sprint?
+2. What was planned, what actually shipped, and which PRs produced it?
+3. Which judgments and intentional deviations shaped the result?
+4. What failed, retried, paused, recovered, or remained anomalous?
+5. What did conformance conclude?
+6. Which unresolved items and follow-ups now require FnB disposition?
+7. Where can the complete evidence be inspected?
+
+Name discrepancies; do not smooth them into a success narrative. A recovered
+stall can be a successful Sprint when the failure stayed durable, visible, and
+contained.
+
+## Pause and abort reports
+
+When closing after a pause, include the integrity threat, deterministic state at
+pause, interrupt delivery, reconciliation, spec drift, judgment, and resume
+outcome. Keep this section behind the pause/recovery evidence seam; missing
+optional pause facts must not prevent compiling an otherwise valid packet.
+
+Abort is terminal and history-preserving. Its report names reason, completed
+work, partial artifacts, outstanding work, active interruption outcome, and
+recovery disposition. A prepared Sprint may abort with a stub report; delete
+nothing.
+
+## Terminal handoff
+
+Pass the final synthesis to `complete`; the surface commits the append-only
+`final` report before attempting the lifecycle transition. Omitting the report
+is permitted under advisory close-out, but the evidence packet records the gap.
+Abort only under Planner or FnB authority. Terminal state stops Sprint services
+and removes live pills while retaining conversations, messages, events, PR
+evidence, reports, and follow-ups.
+
+Immediately before `complete`, re-run `sc sprint inbox --sprint <id>` to drain
+newly arrived messages, mark every handled informational message read with
+`accept`, and confirm the final report file is the intended synthesis. This is
+the last pre-terminal evidence read.
+
+Keep the final report at about 6,000 characters or fewer; 8,000 is the hard
+maximum. Run `wc -m < <path>` before the typed terminal handoff, then require
+the successful report receipt and lifecycle transition.
+
+```text
+sc sprint complete --sprint <id> --reason <summary> --outcome <outcome> \
+  --report-file <path> --key <stable-key>
+sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
+```
+
+After `complete` succeeds, emit one bounded final response from its receipt:
+final report id, follow-up list, integrated SHA, and evidence links. Run no
+further Sprint command. Terminal lifecycle removes Sprint authority and live
+pills but does not close the shell''s registry chat; FnB close remains the one
+unconditional chat-displacement path.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -413,55 +413,6 @@ def dump_sprints(con) -> list[str]:
     return lines
 
 
-def dump_sprint_participants(con) -> list[str]:
-    """Insert participants before immutable links, with pointers deferred."""
-    table = "sprint_participants"
-    cols = _table_columns(con, table)
-    rows = con.execute(
-        f"SELECT {', '.join(cols)} FROM {table} ORDER BY rowid"
-    ).fetchall()
-    pointer_indexes = (
-        cols.index("persistent_conversation_id"),
-        cols.index("current_conversation_id"),
-    )
-    lines = [f"DELETE FROM {table};"]
-    for original in rows:
-        row = list(original)
-        for index in pointer_indexes:
-            row[index] = None
-        lines.append(_insert_line(table, cols, row))
-    lines.append("")
-    return lines
-
-
-def dump_sprint_participant_conversations(con) -> list[str]:
-    """Restore immutable links, then select the participants' exact pointers."""
-    lines = dump_dependency_ordered_table(
-        con,
-        "sprint_participant_conversations",
-        identity="conversation_id",
-        parent="parent_conversation_id",
-        scope=("sprint_participant_id",),
-    )
-    pointers = con.execute(
-        "SELECT participant_id,persistent_conversation_id,current_conversation_id "
-        "FROM sprint_participants "
-        "WHERE persistent_conversation_id IS NOT NULL "
-        "OR current_conversation_id IS NOT NULL ORDER BY participant_id"
-    ).fetchall()
-    if pointers:
-        lines.pop()  # keep pointer selection in the same readable table block
-    for participant_id, persistent, current in pointers:
-        lines.append(
-            "UPDATE sprint_participants SET persistent_conversation_id="
-            f"{quote(persistent)}, current_conversation_id={quote(current)} "
-            f"WHERE participant_id={quote(participant_id)};"
-        )
-    if pointers:
-        lines.append("")
-    return lines
-
-
 def dump_plain_table(con, table: str) -> list[str]:
     cols = _table_columns(con, table)
     cols = [c for c in cols if c not in SENSITIVE_COLUMNS.get(table, ())]
@@ -496,10 +447,6 @@ def dump_table(con, table: str) -> list[str]:
         )
     if table == "sprints":
         return dump_sprints(con)
-    if table == "sprint_participants":
-        return dump_sprint_participants(con)
-    if table == "sprint_participant_conversations":
-        return dump_sprint_participant_conversations(con)
     return dump_plain_table(con, table)
 
 

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -373,8 +373,11 @@ class SprintBoardProjection:
             for row in self.con.execute(
                 "SELECT p.participant_id,p.shell_id,sh.shortname,sh.display_name,"
                 "p.role,p.harness,p.model,p.effort,p.disposition,"
-                "p.current_conversation_id FROM sprint_participants p "
-                "JOIN shells sh ON sh.shell_id=p.shell_id WHERE p.sprint_id=? "
+                "active.chat_id AS current_conversation_id "
+                "FROM sprint_participants p "
+                "JOIN shells sh ON sh.shell_id=p.shell_id "
+                "LEFT JOIN active_shell_chats active ON active.shell_id=p.shell_id "
+                "WHERE p.sprint_id=? "
                 "ORDER BY p.participant_id",
                 (sprint_id,),
             )

--- a/.super-coder/scripts/sprint_close.py
+++ b/.super-coder/scripts/sprint_close.py
@@ -512,7 +512,7 @@ class SprintCloseStore:
     def _history_links(self, sprint_id: int) -> dict[str, Any]:
         conversations = self._rows(
             "SELECT c.conversation_id,link.sprint_participant_id,p.shell_id,p.role,"
-            "link.purpose,link.parent_conversation_id,c.conversation_scope,c.state "
+            "c.conversation_scope,c.state "
             "FROM sprint_participant_conversations link "
             "JOIN sprint_participants p "
             "ON p.participant_id=link.sprint_participant_id "

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -305,8 +305,6 @@ class SprintLifecycleStore:
                 reason=reason or terminal_outcome or "aborted",
                 terminal_outcome=terminal_outcome,
             ).changed
-        cleanup_run_ids: tuple[int, ...] = ()
-        cleanup_conversations: tuple[str, ...] = ()
         with db_driver.write_transaction(self.con, "sprint.transition"):
             sprint = self._sprint(sprint_id)
             current = str(sprint["lifecycle"])
@@ -334,24 +332,12 @@ class SprintLifecycleStore:
                     actor,
                     reason="Sprint closed by FnB",
                 )
-            if target == "completed":
-                cleanup_run_ids, cleanup_conversations = (
-                    sprint_participant_chats.close_for_terminal_lifecycle(
-                        self.con,
-                        sprint_id,
-                        lifecycle=target,
-                    )
-                )
             self._event(
                 sprint_id,
                 f"lifecycle.{target}",
                 actor,
                 {"from": current, "reason": reason},
             )
-        self._signal_terminal_conversation_cleanup(
-            cleanup_run_ids,
-            cleanup_conversations,
-        )
         return True
 
     def pause(
@@ -651,17 +637,6 @@ class SprintLifecycleStore:
                     "interrupt_run_ids": list(run_ids),
                 },
             )
-            cleanup_run_ids, cleanup_conversations = (
-                sprint_participant_chats.close_for_terminal_lifecycle(
-                    self.con,
-                    sprint_id,
-                    lifecycle="aborted",
-                )
-            )
-            if set(cleanup_run_ids) != set(run_ids):
-                raise SprintInvariantError(
-                    "terminal conversation cleanup found an untracked active run"
-                )
             receipt = AbortReceipt(
                 True,
                 report_id,
@@ -670,7 +645,6 @@ class SprintLifecycleStore:
                     sorted(
                         set(run_conversations)
                         | set(notice_conversations)
-                        | set(cleanup_conversations)
                     )
                 ),
             )
@@ -1660,9 +1634,10 @@ class SprintLifecycleStore:
                 dict(row)
                 for row in self.con.execute(
                     "SELECT p.participant_id,p.shell_id,p.role,p.disposition,"
-                    "CASE WHEN sh.is_deleted=0 AND p.current_conversation_id IS NOT NULL "
+                    "CASE WHEN sh.is_deleted=0 AND active.chat_id IS NOT NULL "
                     "THEN 1 ELSE 0 END available "
                     "FROM sprint_participants p JOIN shells sh USING (shell_id) "
+                    "LEFT JOIN active_shell_chats active ON active.shell_id=p.shell_id "
                     "WHERE p.sprint_id=? ORDER BY p.participant_id",
                     (sprint_id,),
                 )
@@ -1735,18 +1710,6 @@ class SprintLifecycleStore:
             conversation_events.notify(conversation_id)
         if tuple(conversation_ids):
             self.notify_commit()
-
-    def _signal_terminal_conversation_cleanup(
-        self,
-        run_ids: Iterable[int],
-        conversation_ids: Iterable[str],
-    ) -> None:
-        self._signal_notifications(conversation_ids)
-        for run_id in run_ids:
-            try:
-                self.interrupt_run(run_id)
-            except Exception:  # noqa: BLE001 - durable intent is already committed
-                self.notify_commit()
 
     @staticmethod
     def _required_text(value: str, label: str, limit: int) -> str:

--- a/.super-coder/scripts/sprint_liveness.py
+++ b/.super-coder/scripts/sprint_liveness.py
@@ -191,7 +191,8 @@ class SprintEvidenceCollector:
     ) -> QuotaState:
         row = self.con.execute(
             "SELECT c.provider FROM sprint_participants p "
-            "LEFT JOIN conversations c ON c.conversation_id=p.current_conversation_id "
+            "LEFT JOIN active_shell_chats active ON active.shell_id=p.shell_id "
+            "LEFT JOIN conversations c ON c.conversation_id=active.chat_id "
             "WHERE p.participant_id=?",
             (participant_id,),
         ).fetchone()

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -1,10 +1,9 @@
-"""Sprint participant reuse of durable browser conversations.
+"""Sprint wake-chat creation backed by the active-chat registry.
 
-This module owns no transaction boundary.  Arming and later Sprint transition
-services call it inside their existing write transaction so conversation
-creation, Sprint linkage, and the participant's current pointer commit (or
-roll back) together.  Creating a conversation is deliberately DB-only: it
-does not launch a harness or enqueue a wake.
+Sprint participants keep durable conversation history, but current-chat state
+belongs exclusively to ``active_shell_chats``.  Callers own transaction
+boundaries; New delivery closes the previous registry chat in a committed
+transaction before calling ``create_wake_conversation``.
 """
 
 from __future__ import annotations
@@ -16,11 +15,8 @@ from dataclasses import dataclass
 from typing import Any
 
 import active_chat_registry
-import conversation_broker
 import run as run_mod
 
-_PURPOSES = {"work", "fix", "merge", "fallback"}
-_USABLE_WAKE_STATES = {"idle", "queued", "running", "waiting"}
 _WAKE_ROLES = {
     "developer": ("Developer", "sprint_dev"),
     "reviewer": ("Reviewer", "sprint_rev"),
@@ -34,12 +30,6 @@ class SprintConversationError(ValueError):
 
 class WakeConversationBusy(SprintConversationError):
     """A wake replacement lost the boundary race to another active chat."""
-
-
-@dataclass(frozen=True)
-class WakeConversationRoute:
-    conversation_id: str
-    created: bool
 
 
 @dataclass(frozen=True)
@@ -87,83 +77,6 @@ def _nonblank(value: str | None, field: str, *, maximum: int) -> str:
     return value
 
 
-def _participant(con, participant_id: int):
-    row = con.execute(
-        "SELECT p.participant_id,p.sprint_id,p.shell_id,"
-        "p.persistent_conversation_id,p.current_conversation_id,"
-        "s.conversation_generation,sh.shortname,sh.flavor "
-        "FROM sprint_participants p "
-        "JOIN sprints s ON s.sprint_id=p.sprint_id "
-        "JOIN shells sh ON sh.shell_id=p.shell_id "
-        "WHERE p.participant_id=?",
-        (participant_id,),
-    ).fetchone()
-    if row is None:
-        raise SprintConversationError("Sprint participant does not exist")
-    return row
-
-
-def _scoped_idempotency_key(participant, purpose: str, operation_key: str) -> str:
-    generation = _nonblank(
-        participant["conversation_generation"],
-        "Sprint conversation generation",
-        maximum=32,
-    )
-    digest = hashlib.sha256(operation_key.encode()).hexdigest()
-    return (
-        f"sprint-generation:{generation}:participant:"
-        f"{participant['participant_id']}:{purpose}:{digest}"
-    )
-
-
-def _reroute_operation_key(operation_key: str, index: int) -> str:
-    if index == 0:
-        return operation_key
-    digest = hashlib.sha256(operation_key.encode()).hexdigest()
-    return f"reroute:{index}:{digest}"
-
-
-def conversation_idempotency_key(
-    con,
-    participant_id: int,
-    purpose: str,
-    operation_key: str,
-) -> str:
-    """Return the generation-stable global key for one participant operation."""
-    if purpose not in _PURPOSES:
-        raise SprintConversationError(f"unsupported conversation purpose: {purpose}")
-    operation_key = _nonblank(
-        operation_key, "idempotency_key", maximum=255
-    )
-    return _scoped_idempotency_key(
-        _participant(con, participant_id), purpose, operation_key
-    )
-
-
-def linked_conversation_for_key(
-    con,
-    participant_id: int,
-    purpose: str,
-    operation_key: str,
-) -> str | None:
-    """Find a new scoped key or one legacy raw key linked to this participant."""
-    operation_key = _nonblank(
-        operation_key, "idempotency_key", maximum=255
-    )
-    scoped_key = conversation_idempotency_key(
-        con, participant_id, purpose, operation_key
-    )
-    row = con.execute(
-        "SELECT c.conversation_id FROM sprint_participant_conversations link "
-        "JOIN conversations c ON c.conversation_id=link.conversation_id "
-        "WHERE link.sprint_participant_id=? AND link.purpose=? "
-        "AND c.creation_idempotency_key IN (?,?) "
-        "ORDER BY c.creation_idempotency_key=? DESC LIMIT 1",
-        (participant_id, purpose, scoped_key, operation_key, scoped_key),
-    ).fetchone()
-    return None if row is None else str(row["conversation_id"])
-
-
 def _linked_to_participant(con, participant_id: int, conversation_id: str) -> bool:
     return (
         con.execute(
@@ -181,7 +94,7 @@ def _append_created_event(
     conversation_id: str,
     participant_id: int,
     sprint_id: int,
-    purpose: str,
+    wake_id: int,
 ) -> None:
     con.execute(
         "INSERT INTO conversation_events "
@@ -194,7 +107,7 @@ def _append_created_event(
                     "scope": "sprint",
                     "sprint_id": sprint_id,
                     "participant_id": participant_id,
-                    "purpose": purpose,
+                    "wake_id": wake_id,
                 }
             ),
         ),
@@ -227,480 +140,6 @@ def _append_event(
             run_id,
         ),
     )
-
-
-def _cancel_queued_turns(con, conversation_id: str) -> int:
-    message_ids = [
-        int(row[0])
-        for row in con.execute(
-            "SELECT DISTINCT message_id FROM conversation_outbox "
-            "WHERE conversation_id=? AND state IN ('pending','claimed')",
-            (conversation_id,),
-        )
-    ]
-    if not message_ids:
-        return 0
-    marks = ",".join("?" for _ in message_ids)
-    cancelled = con.execute(
-        "UPDATE conversation_messages SET state='cancelled',"
-        "completed_at=datetime('now') "
-        f"WHERE message_id IN ({marks}) "
-        "AND state IN ('accepted','queued','running')",
-        message_ids,
-    ).rowcount
-    con.execute(
-        "UPDATE conversation_outbox SET state='cancelled',claim_owner=NULL,"
-        "claimed_at=NULL,lease_expires_at=NULL "
-        f"WHERE message_id IN ({marks}) AND state IN ('pending','claimed')",
-        message_ids,
-    )
-    return int(cancelled)
-
-
-def close_for_terminal_lifecycle(
-    con,
-    sprint_id: int,
-    *,
-    lifecycle: str,
-) -> tuple[tuple[int, ...], tuple[str, ...]]:
-    """Close linked conversations or persist close intent for live runs."""
-    if not con.in_transaction:
-        raise RuntimeError("Sprint conversation cleanup requires a transaction")
-    if lifecycle not in {"completed", "aborted"}:
-        raise ValueError("Sprint conversation cleanup requires a terminal lifecycle")
-    owning_planner_shell_id = int(
-        con.execute(
-            "SELECT originating_planner_shell_id FROM sprints WHERE sprint_id=?",
-            (sprint_id,),
-        ).fetchone()[0]
-    )
-    rows = con.execute(
-        "SELECT DISTINCT c.conversation_id,c.state "
-        "FROM sprint_participant_conversations pc "
-        "JOIN sprint_participants p "
-        "ON p.participant_id=pc.sprint_participant_id "
-        "JOIN conversations c ON c.conversation_id=pc.conversation_id "
-        "WHERE p.sprint_id=? ORDER BY c.conversation_id",
-        (sprint_id,),
-    ).fetchall()
-    run_ids: list[int] = []
-    conversation_ids: list[str] = []
-    now = str(con.execute("SELECT datetime('now')").fetchone()[0])
-    for row in rows:
-        conversation_id = str(row["conversation_id"])
-        if row["state"] == "closed":
-            continue
-        conversation_ids.append(conversation_id)
-        cancelled = _cancel_queued_turns(con, conversation_id)
-        active = con.execute(
-            "SELECT run_id,shell_id FROM conversation_runs WHERE conversation_id=? "
-            "AND state IN ('leased','starting','running') "
-            "ORDER BY run_id DESC LIMIT 1",
-            (conversation_id,),
-        ).fetchone()
-        if active is not None:
-            run_id = int(active["run_id"])
-            close_requested = con.execute(
-                "SELECT 1 FROM conversation_events WHERE conversation_id=? "
-                "AND event_type='conversation.close.requested' LIMIT 1",
-                (conversation_id,),
-            ).fetchone()
-            if close_requested is None:
-                _append_event(
-                    con,
-                    conversation_id,
-                    "conversation.close.requested",
-                    {
-                        "cancelled_queued_turns": cancelled,
-                        "reason": f"sprint.lifecycle.{lifecycle}",
-                        "sprint_id": sprint_id,
-                    },
-                    run_id=run_id,
-                )
-            # Completion defers the owning Planner even when FnB called complete.
-            if (
-                lifecycle == "completed"
-                and int(active["shell_id"]) == owning_planner_shell_id
-            ):
-                continue
-            run_ids.append(run_id)
-            conversation_broker.BrokerStore.request_interrupt_in_transaction(
-                con,
-                run_id,
-                requested_at=now,
-            )
-            continue
-        if row["state"] == "queued":
-            con.execute(
-                "UPDATE conversations SET state='idle' WHERE conversation_id=?",
-                (conversation_id,),
-            )
-        elif row["state"] == "running":
-            con.execute(
-                "UPDATE conversations SET state='error' WHERE conversation_id=?",
-                (conversation_id,),
-            )
-        con.execute(
-            "UPDATE conversations SET state='closed',closed_at=?,"
-            "last_activity_at=?,version=version+1 WHERE conversation_id=?",
-            (now, now, conversation_id),
-        )
-        _append_event(
-            con,
-            conversation_id,
-            "conversation.closed",
-            {
-                "cancelled_queued_turns": cancelled,
-                "reason": f"sprint.lifecycle.{lifecycle}",
-                "sprint_id": sprint_id,
-                "state": "closed",
-            },
-        )
-    return tuple(run_ids), tuple(conversation_ids)
-
-
-def create_and_select(
-    con,
-    *,
-    participant_id: int,
-    owner_user_id: int,
-    purpose: str,
-    harness: str,
-    provider: str | None,
-    model: str | None,
-    effort: str | None,
-    worktree: str,
-    title: str,
-    idempotency_key: str,
-    parent_conversation_id: str | None = None,
-    context_packet: dict[str, Any] | None = None,
-) -> str:
-    """Create and select one Sprint conversation inside the caller's txn.
-
-    ``work`` is the participant's persistent lane. ``fix`` and ``merge`` are
-    fresh linked outcome conversations. ``fallback`` is a linked replacement
-    route and must retain the generated context packet that made the native
-    harness change intelligible.
-    """
-    if purpose not in _PURPOSES:
-        raise SprintConversationError(f"unsupported conversation purpose: {purpose}")
-    if purpose == "work" and parent_conversation_id is not None:
-        raise SprintConversationError("the persistent work conversation has no parent")
-    if purpose != "work" and not parent_conversation_id:
-        raise SprintConversationError(f"{purpose} conversations require a parent")
-    if purpose == "fallback" and not context_packet:
-        raise SprintConversationError("fallback conversations require a context packet")
-    if purpose != "fallback" and context_packet is not None:
-        raise SprintConversationError(
-            "only fallback conversations store a context packet"
-        )
-
-    harness = _nonblank(harness, "harness", maximum=64)
-    worktree = _nonblank(worktree, "worktree", maximum=4096)
-    title = _nonblank(title, "title", maximum=200)
-    operation_key = _nonblank(idempotency_key, "idempotency_key", maximum=255)
-    participant = _participant(con, participant_id)
-    idempotency_key = _scoped_idempotency_key(
-        participant, purpose, operation_key
-    )
-
-    if parent_conversation_id and not _linked_to_participant(
-        con, participant_id, parent_conversation_id
-    ):
-        raise SprintConversationError(
-            "parent conversation does not belong to the Sprint participant"
-        )
-    if purpose == "work":
-        existing_work = con.execute(
-            "SELECT conversation_id FROM sprint_participant_conversations "
-            "WHERE sprint_participant_id=? AND purpose='work'",
-            (participant_id,),
-        ).fetchone()
-        if existing_work is not None:
-            existing = con.execute(
-                "SELECT creation_idempotency_key FROM conversations "
-                "WHERE conversation_id=?",
-                (existing_work["conversation_id"],),
-            ).fetchone()
-            if existing["creation_idempotency_key"] not in {
-                idempotency_key,
-                operation_key,
-            }:
-                raise SprintConversationError(
-                    "the participant already has a persistent work conversation"
-                )
-
-    packet_json = (
-        _canonical_json(context_packet) if context_packet is not None else None
-    )
-    request = {
-        "participant_id": participant_id,
-        "purpose": purpose,
-        "harness": harness,
-        "provider": provider,
-        "model": model,
-        "effort": effort,
-        "worktree": worktree,
-        "title": title,
-        "parent_conversation_id": parent_conversation_id,
-        "context_packet": context_packet,
-    }
-    request_hash = _request_hash(request)
-    existing = con.execute(
-        "SELECT conversation_id,creation_request_hash FROM conversations "
-        "WHERE owner_user_id=? AND creation_idempotency_key=?",
-        (owner_user_id, idempotency_key),
-    ).fetchone()
-    if existing is None:
-        legacy = con.execute(
-            "SELECT conversation_id,creation_request_hash FROM conversations "
-            "WHERE owner_user_id=? AND creation_idempotency_key=?",
-            (owner_user_id, operation_key),
-        ).fetchone()
-        if legacy is not None and _linked_to_participant(
-            con, participant_id, legacy["conversation_id"]
-        ):
-            existing = legacy
-    if existing is not None:
-        if existing["creation_request_hash"] != request_hash:
-            raise SprintConversationError(
-                "idempotency key was reused with a different request"
-            )
-        conversation_id = existing["conversation_id"]
-        if not _linked_to_participant(con, participant_id, conversation_id):
-            raise SprintConversationError(
-                "idempotent conversation is linked to another participant"
-            )
-        con.execute(
-            "UPDATE sprint_participants SET current_conversation_id=? "
-            "WHERE participant_id=?",
-            (conversation_id, participant_id),
-        )
-        return conversation_id
-
-    try:
-        closed = active_chat_registry.close_active(
-            con,
-            int(participant["shell_id"]),
-        )
-    except active_chat_registry.ActiveChatBusy as exc:
-        active = active_chat_registry.get(con, int(participant["shell_id"]))
-        if active is not None and _linked_to_participant(
-            con,
-            participant_id,
-            active.chat_id,
-        ):
-            # Delivery-time resolution protects a live turn: a declared New
-            # re-enters the linked active chat instead of displacing it.
-            con.execute(
-                "UPDATE sprint_participants SET current_conversation_id=?,"
-                "updated_at=datetime('now') WHERE participant_id=?",
-                (active.chat_id, participant_id),
-            )
-            return active.chat_id
-        raise SprintConversationError(str(exc)) from exc
-    if closed is not None:
-        _append_event(
-            con,
-            closed.chat_id,
-            "conversation.closed",
-            {
-                "state": "closed",
-                "reason": "another chat opened",
-                "sprint_id": int(participant["sprint_id"]),
-            },
-        )
-
-    conversation_id = "cv_" + uuid.uuid4().hex
-    con.execute(
-        "INSERT INTO conversations "
-        "(conversation_id,shell_id,owner_user_id,harness,provider,model,effort,"
-        "worktree,title,creation_idempotency_key,creation_request_hash,"
-        "conversation_scope) VALUES (?,?,?,?,?,?,?,?,?,?,?,'sprint')",
-        (
-            conversation_id,
-            participant["shell_id"],
-            owner_user_id,
-            harness,
-            provider,
-            model,
-            effort,
-            worktree,
-            title,
-            idempotency_key,
-            request_hash,
-        ),
-    )
-    _append_created_event(
-        con,
-        conversation_id=conversation_id,
-        participant_id=participant_id,
-        sprint_id=participant["sprint_id"],
-        purpose=purpose,
-    )
-    con.execute(
-        "INSERT INTO sprint_participant_conversations "
-        "(sprint_participant_id,conversation_id,purpose,"
-        "parent_conversation_id,context_packet) VALUES (?,?,?,?,?)",
-        (
-            participant_id,
-            conversation_id,
-            purpose,
-            parent_conversation_id,
-            packet_json,
-        ),
-    )
-    if purpose == "work":
-        updated = con.execute(
-            "UPDATE sprint_participants SET persistent_conversation_id=?,"
-            "current_conversation_id=?,updated_at=datetime('now') "
-            "WHERE participant_id=?",
-            (conversation_id, conversation_id, participant_id),
-        ).rowcount
-    else:
-        updated = con.execute(
-            "UPDATE sprint_participants SET current_conversation_id=?,"
-            "updated_at=datetime('now') WHERE participant_id=?",
-            (conversation_id, participant_id),
-        ).rowcount
-    if updated != 1:
-        raise SprintConversationError("Sprint participant disappeared during creation")
-    active_chat_registry.register(
-        con,
-        int(participant["shell_id"]),
-        conversation_id,
-    )
-    return conversation_id
-
-
-def select_work(con, participant_id: int) -> str:
-    """Return the participant pointer to its persistent work conversation."""
-    participant = _participant(con, participant_id)
-    conversation_id = participant["persistent_conversation_id"]
-    if conversation_id is None or not _linked_to_participant(
-        con, participant_id, conversation_id
-    ):
-        raise SprintConversationError(
-            "Sprint participant has no persistent work conversation"
-        )
-    con.execute(
-        "UPDATE sprint_participants SET current_conversation_id=?,"
-        "updated_at=datetime('now') WHERE participant_id=?",
-        (conversation_id, participant_id),
-    )
-    return conversation_id
-
-
-def ensure_wake_conversation(
-    con,
-    participant_id: int,
-    *,
-    idempotency_key: str,
-) -> WakeConversationRoute:
-    """Return a usable current chat, creating one linked route when absent."""
-    row = con.execute(
-        "SELECT p.participant_id,p.sprint_id,p.harness,p.model,p.effort,"
-        "p.persistent_conversation_id,p.current_conversation_id,"
-        "sh.shortname,sh.flavor,owner.user_id,c.state AS current_state "
-        "FROM sprint_participants p "
-        "JOIN sprints s ON s.sprint_id=p.sprint_id "
-        "JOIN shells sh ON sh.shell_id=p.shell_id "
-        "JOIN shells owner ON owner.shell_id=s.originating_planner_shell_id "
-        "LEFT JOIN conversations c "
-        "ON c.conversation_id=p.current_conversation_id "
-        "WHERE p.participant_id=?",
-        (participant_id,),
-    ).fetchone()
-    if row is None:
-        raise SprintConversationError("Sprint participant does not exist")
-    current_id = row["current_conversation_id"]
-    if (
-        current_id is not None
-        and row["current_state"] in _USABLE_WAKE_STATES
-        and _linked_to_participant(con, participant_id, current_id)
-    ):
-        return WakeConversationRoute(str(current_id), False)
-    if row["user_id"] is None:
-        raise SprintConversationError("originating Planner has no browser owner")
-
-    parent_id = None
-    for candidate in (current_id, row["persistent_conversation_id"]):
-        if candidate is not None and _linked_to_participant(
-            con, participant_id, candidate
-        ):
-            parent_id = str(candidate)
-            break
-    purpose = "fallback" if parent_id is not None else "work"
-    linked_routes = con.execute(
-        "SELECT c.conversation_id,c.state,c.creation_idempotency_key "
-        "FROM sprint_participant_conversations link "
-        "JOIN conversations c ON c.conversation_id=link.conversation_id "
-        "WHERE link.sprint_participant_id=? AND link.purpose=? "
-        "AND c.owner_user_id=? ORDER BY c.rowid",
-        (participant_id, purpose, row["user_id"]),
-    ).fetchall()
-    routes_by_key = {
-        str(route["creation_idempotency_key"]): route for route in linked_routes
-    }
-    prior_routes = []
-    route_indices = []
-    for index in range(len(linked_routes) + 2):
-        operation_key = _reroute_operation_key(idempotency_key, index)
-        scoped_key = conversation_idempotency_key(
-            con, participant_id, purpose, operation_key
-        )
-        legacy_key = (
-            idempotency_key
-            if index == 0
-            else f"{idempotency_key}:reroute:{index}"
-        )
-        prior = routes_by_key.get(scoped_key) or routes_by_key.get(legacy_key)
-        if prior is not None:
-            prior_routes.append(prior)
-            route_indices.append(index)
-    for prior in reversed(prior_routes):
-        if (
-            prior["state"] in _USABLE_WAKE_STATES
-            and _linked_to_participant(con, participant_id, prior["conversation_id"])
-        ):
-            con.execute(
-                "UPDATE sprint_participants SET current_conversation_id=?,"
-                "updated_at=datetime('now') WHERE participant_id=?",
-                (prior["conversation_id"], participant_id),
-            )
-            return WakeConversationRoute(str(prior["conversation_id"]), False)
-    route_key = _reroute_operation_key(
-        idempotency_key,
-        0 if not route_indices else max(route_indices) + 1,
-    )
-    worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
-    conversation_id = create_and_select(
-        con,
-        participant_id=participant_id,
-        owner_user_id=int(row["user_id"]),
-        purpose=purpose,
-        harness=row["harness"],
-        provider=run_mod.session_provider(row["harness"], row["model"]),
-        model=row["model"],
-        effort=row["effort"],
-        worktree=str(worktree.resolve(strict=False)),
-        title=(
-            f"Sprint {row['sprint_id']} · Wake route · {row['shortname']}"
-        ),
-        idempotency_key=route_key,
-        parent_conversation_id=parent_id,
-        context_packet=(
-            {
-                "reason": "sprint wake requires a usable current conversation",
-                "sprint_id": int(row["sprint_id"]),
-                "participant_id": participant_id,
-                "previous_conversation_id": parent_id,
-            }
-            if parent_id is not None
-            else None
-        ),
-    )
-    return WakeConversationRoute(conversation_id, True)
 
 
 def prepare_shell_wake_conversation(con, shell_id: int) -> PreparedShellWake:
@@ -831,17 +270,11 @@ def create_wake_conversation(
     sprint_id: int,
     participant_id: int,
 ) -> str:
-    """Create and register one wake chat after the prior chat is committed closed.
-
-    The caller owns this insertion transaction and must have resolved rotation
-    before entering it.  Unlike ``create_and_select``, this seam never closes a
-    chat, so close and replacement cannot roll back as one unit.
-    """
+    """Create and register one Sprint wake chat after close commits."""
     if not con.in_transaction:
         raise RuntimeError("wake conversation creation requires a transaction")
     row = con.execute(
         "SELECT p.participant_id,p.sprint_id,p.shell_id,p.harness,p.model,p.effort,"
-        "p.persistent_conversation_id,p.current_conversation_id,"
         "s.conversation_generation,sh.shortname,sh.flavor,owner.user_id "
         "FROM sprint_participants p "
         "JOIN sprints s ON s.sprint_id=p.sprint_id "
@@ -877,32 +310,8 @@ def create_wake_conversation(
                 "idempotent wake chat belongs to another participant"
             )
         active_chat_registry.register(con, int(row["shell_id"]), conversation_id)
-        con.execute(
-            "UPDATE sprint_participants SET current_conversation_id=?,"
-            "updated_at=datetime('now') WHERE participant_id=?",
-            (conversation_id, participant_id),
-        )
         return conversation_id
 
-    parent = con.execute(
-        "SELECT link.conversation_id FROM sprint_participant_conversations link "
-        "WHERE link.sprint_participant_id=? ORDER BY "
-        "(link.conversation_id=?) DESC,link.participant_conversation_id DESC LIMIT 1",
-        (participant_id, row["current_conversation_id"]),
-    ).fetchone()
-    parent_id = str(parent["conversation_id"]) if parent is not None else None
-    purpose = "fallback" if parent_id is not None else "work"
-    context_packet = (
-        {
-            "reason": "wake delivery selected a fresh chat",
-            "sprint_id": sprint_id,
-            "participant_id": participant_id,
-            "previous_conversation_id": parent_id,
-            "wake_id": wake_id,
-        }
-        if parent_id is not None
-        else None
-    )
     worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
     request = {
         "effort": row["effort"],
@@ -939,130 +348,25 @@ def create_wake_conversation(
         conversation_id=conversation_id,
         participant_id=participant_id,
         sprint_id=sprint_id,
-        purpose=purpose,
+        wake_id=wake_id,
     )
     con.execute(
         "INSERT INTO sprint_participant_conversations "
-        "(sprint_participant_id,conversation_id,purpose,parent_conversation_id,"
-        "context_packet) VALUES (?,?,?,?,?)",
-        (
-            participant_id,
-            conversation_id,
-            purpose,
-            parent_id,
-            _canonical_json(context_packet) if context_packet is not None else None,
-        ),
-    )
-    con.execute(
-        "UPDATE sprint_participants SET persistent_conversation_id="
-        "COALESCE(persistent_conversation_id,?),current_conversation_id=?,"
-        "updated_at=datetime('now') WHERE participant_id=?",
-        (conversation_id, conversation_id, participant_id),
+        "(sprint_participant_id,conversation_id) VALUES (?,?)",
+        (participant_id, conversation_id),
     )
     active_chat_registry.register(con, int(row["shell_id"]), conversation_id)
     return conversation_id
 
 
-def create_review_outcome(
-    con,
-    *,
-    participant_id: int,
-    purpose: str,
-    idempotency_key: str,
-) -> str:
-    """Create and select a fresh Developer fix or merge conversation."""
-    if purpose not in {"fix", "merge"}:
-        raise SprintConversationError("review outcomes create fix or merge chats")
-    row = con.execute(
-        "SELECT p.sprint_id,p.role,p.harness,p.model,p.effort,"
-        "p.current_conversation_id,sh.shortname,sh.flavor,owner.user_id "
-        "FROM sprint_participants p "
-        "JOIN sprints s ON s.sprint_id=p.sprint_id "
-        "JOIN shells sh ON sh.shell_id=p.shell_id "
-        "JOIN shells owner ON owner.shell_id=s.originating_planner_shell_id "
-        "WHERE p.participant_id=?",
-        (participant_id,),
-    ).fetchone()
-    if row is None:
-        raise SprintConversationError("Sprint participant does not exist")
-    if row["role"] != "developer":
-        raise SprintConversationError("review outcomes target a Developer")
-    if row["current_conversation_id"] is None:
-        raise SprintConversationError("Developer has no current Sprint conversation")
-    if row["user_id"] is None:
-        raise SprintConversationError("originating Planner has no browser owner")
-    worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
-    return create_and_select(
-        con,
-        participant_id=participant_id,
-        owner_user_id=int(row["user_id"]),
-        purpose=purpose,
-        harness=row["harness"],
-        provider=run_mod.session_provider(row["harness"], row["model"]),
-        model=row["model"],
-        effort=row["effort"],
-        worktree=str(worktree.resolve(strict=False)),
-        title=(
-            f"Sprint {row['sprint_id']} · {purpose.title()} · {row['shortname']}"
-        ),
-        idempotency_key=idempotency_key,
-        parent_conversation_id=row["current_conversation_id"],
-    )
-
-
-def provision_at_arming(con, sprint_id: int) -> list[str]:
-    """Create every participant's persistent conversation during arming.
-
-    The caller's arming transaction owns the commit.  This function performs
-    no harness or Git operation and emits no wake, so even later-wave
-    participants can receive durable placeholders without consuming usage.
-    """
-    rows = con.execute(
-        "SELECT p.participant_id,p.role,p.harness,p.model,p.effort,"
-        "s.originating_planner_shell_id,sh.shortname,sh.flavor,owner.user_id "
-        "FROM sprint_participants p "
-        "JOIN sprints s ON s.sprint_id=p.sprint_id "
-        "JOIN shells sh ON sh.shell_id=p.shell_id "
-        "JOIN shells owner ON owner.shell_id=s.originating_planner_shell_id "
-        "WHERE p.sprint_id=? ORDER BY p.participant_id",
-        (sprint_id,),
-    ).fetchall()
-    if not rows:
-        raise SprintConversationError("arming requires Sprint participants")
-    conversation_ids = []
-    for row in rows:
-        if row["user_id"] is None:
-            raise SprintConversationError(
-                "originating Planner has no browser operator owner"
-            )
-        worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
-        conversation_ids.append(
-            create_and_select(
-                con,
-                participant_id=int(row["participant_id"]),
-                owner_user_id=int(row["user_id"]),
-                purpose="work",
-                harness=row["harness"],
-                provider=run_mod.session_provider(row["harness"], row["model"]),
-                model=row["model"],
-                effort=row["effort"],
-                worktree=str(worktree.resolve(strict=False)),
-                title=f"Sprint {sprint_id} · {row['role']} · {row['shortname']}",
-                idempotency_key=(
-                    f"sprint:{sprint_id}:participant:{row['participant_id']}:work"
-                ),
-            )
-        )
-    return conversation_ids
-
-
 def attach_live_participations(con, shells: list[dict]) -> list[dict]:
-    """Attach the one live/paused Sprint pill projection to shell rows."""
+    """Attach the live/paused Sprint projection using registry state."""
     rows = con.execute(
-        "SELECT p.shell_id,p.role,p.disposition,p.current_conversation_id,"
+        "SELECT p.shell_id,p.role,p.disposition,a.chat_id AS current_conversation_id,"
         "s.sprint_id,s.lifecycle "
         "FROM sprint_participants p "
         "JOIN sprints s ON s.sprint_id=p.sprint_id "
+        "LEFT JOIN active_shell_chats a ON a.shell_id=p.shell_id "
         "WHERE s.lifecycle IN ('armed','paused') "
         "ORDER BY s.lifecycle='armed' DESC,s.paused_at DESC,s.sprint_id DESC"
     ).fetchall()
@@ -1071,10 +375,6 @@ def attach_live_participations(con, shells: list[dict]) -> list[dict]:
         shell_id = int(row["shell_id"])
         if shell_id in by_shell:
             continue
-        if row["current_conversation_id"] is None:
-            raise SprintConversationError(
-                "live Sprint participant has no current conversation"
-            )
         by_shell[shell_id] = {
             "sprint_id": int(row["sprint_id"]),
             "lifecycle": row["lifecycle"],
@@ -1085,116 +385,3 @@ def attach_live_participations(con, shells: list[dict]) -> list[dict]:
     for shell in shells:
         shell["sprint"] = by_shell.get(int(shell["shell_id"]))
     return shells
-
-
-def planner_fallback_packet(con, participant_id: int, *, reason: str) -> dict[str, Any]:
-    """Build a bounded durable packet for one linked Planner replacement."""
-    reason = _nonblank(reason, "reason", maximum=2000)
-    row = con.execute(
-        "SELECT p.participant_id,p.sprint_id,p.role,p.disposition,"
-        "p.harness,p.model,p.effort,p.current_conversation_id,"
-        "sh.shell_id,sh.shortname,s.lifecycle,s.feature_id,r.title "
-        "FROM sprint_participants p "
-        "JOIN shells sh ON sh.shell_id=p.shell_id "
-        "JOIN sprints s ON s.sprint_id=p.sprint_id "
-        "JOIN roadmap r ON r.feature_id=s.feature_id "
-        "WHERE p.participant_id=?",
-        (participant_id,),
-    ).fetchone()
-    if row is None:
-        raise SprintConversationError("Sprint participant does not exist")
-    if row["role"] != "planner":
-        raise SprintConversationError("fallback route replacement is Planner-only")
-    if row["current_conversation_id"] is None:
-        raise SprintConversationError("Planner has no current Sprint conversation")
-    specs = [
-        {
-            "document_id": int(spec["document_id"]),
-            "revision_sha256": spec["bound_revision_sha256"],
-        }
-        for spec in con.execute(
-            "SELECT document_id,bound_revision_sha256 FROM sprint_specs "
-            "WHERE sprint_id=? ORDER BY document_id",
-            (row["sprint_id"],),
-        )
-    ]
-    units = [
-        {
-            "work_unit_id": int(unit["work_unit_id"]),
-            "title": unit["title"],
-            "disposition": unit["disposition"],
-        }
-        for unit in con.execute(
-            "SELECT work_unit_id,title,disposition FROM sprint_work_units "
-            "WHERE sprint_id=? AND disposition NOT IN ('completed','cancelled') "
-            "ORDER BY planned_wave,work_unit_id",
-            (row["sprint_id"],),
-        )
-    ]
-    return {
-        "packet_version": 1,
-        "reason": reason,
-        "sprint": {
-            "sprint_id": int(row["sprint_id"]),
-            "feature_id": int(row["feature_id"]),
-            "feature_title": row["title"],
-            "lifecycle": row["lifecycle"],
-        },
-        "participant": {
-            "participant_id": int(row["participant_id"]),
-            "shell_id": int(row["shell_id"]),
-            "shortname": row["shortname"],
-            "role": row["role"],
-            "disposition": row["disposition"],
-            "previous_route": {
-                "harness": row["harness"],
-                "model": row["model"],
-                "effort": row["effort"],
-            },
-            "previous_conversation_id": row["current_conversation_id"],
-        },
-        "bound_specs": specs,
-        "open_work_units": units,
-    }
-
-
-def create_planner_fallback(
-    con,
-    *,
-    participant_id: int,
-    reason: str,
-    harness: str,
-    model: str | None,
-    effort: str | None,
-    idempotency_key: str,
-) -> str:
-    """Create and select a linked fallback route inside the caller's txn."""
-    packet = planner_fallback_packet(con, participant_id, reason=reason)
-    participant = _participant(con, participant_id)
-    owner = con.execute(
-        "SELECT planner.user_id FROM sprints s "
-        "JOIN shells planner ON planner.shell_id=s.originating_planner_shell_id "
-        "WHERE s.sprint_id=?",
-        (participant["sprint_id"],),
-    ).fetchone()
-    if owner is None or owner["user_id"] is None:
-        raise SprintConversationError("originating Planner has no browser owner")
-    worktree = run_mod.shell_work_dir(participant["shortname"], participant["flavor"])
-    return create_and_select(
-        con,
-        participant_id=participant_id,
-        owner_user_id=int(owner["user_id"]),
-        purpose="fallback",
-        harness=harness,
-        provider=run_mod.session_provider(harness, model),
-        model=model,
-        effort=effort,
-        worktree=str(worktree.resolve(strict=False)),
-        title=(
-            f"Sprint {participant['sprint_id']} · Planner fallback · "
-            f"{participant['shortname']}"
-        ),
-        idempotency_key=idempotency_key,
-        parent_conversation_id=packet["participant"]["previous_conversation_id"],
-        context_packet=packet,
-    )

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -180,14 +180,10 @@ class SprintPRRegistrationStore:
 
         with db_driver.write_transaction(self.con, "sprint.pr.register"):
             sprint = self.con.execute(
-                "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
+                "SELECT sprint_id FROM sprints WHERE sprint_id=?", (sprint_id,)
             ).fetchone()
             if sprint is None:
                 raise KeyError(f"unknown Sprint: {sprint_id}")
-            if sprint["lifecycle"] != "armed":
-                raise SprintInvariantError(
-                    "pull requests may be registered only for an armed Sprint"
-                )
             owner = self.con.execute(
                 "SELECT participant_id FROM sprint_participants "
                 "WHERE sprint_id=? AND shell_id=? AND role='developer'",

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -140,6 +140,37 @@ shell, `--message send <shortname> <body>`; mark an item read with
 
 ---
 
+## ACTIVE CHAT DELIVERY
+
+The engine tracks at most one active chat per shell in the active-chat registry;
+zero is legal. The registry is the sole current-chat authority and carries the
+verified pid/start-ticks identity only while a turn runs. Closing or rotating a
+chat unlinks its process. A 60-second reaper verifies process identity before
+interrupt/TERM/KILL escalation, and a generous inactivity ceiling closes silent
+hung turns so they become reapable.
+
+Every `wake_message` creates durable delivery intent. Pending wakes coalesce per
+receiver, and one wake turn drains every undelivered message for that shell.
+Acceptance is still an explicit shell act. Wake type resolves at delivery:
+
+| Registry state | Delivery |
+|---|---|
+| verified live turn | every declared type Re-enters the active chat at its natural boundary |
+| idle registry chat | any coalesced New rotates; all-Re-enter resumes the chat |
+| no registry row | create a chat and deliver as New |
+
+Sprint routing uses those literals: Planner→Developer and Developer→Reviewer
+are New; Developer/Reviewer→Planner and Reviewer→Developer are Re-enter. FnB can
+close the Planner chat during an armed Sprint to set coordinate mode (idle
+Planner Re-enters become fresh ticket chats); FnB pause/resume returns to
+supervise, while automatic pauses preserve the dial. Developer-owned PR
+subscriptions emit self-describing red/green/closed Re-enter wakes even outside
+an armed Sprint; Planner and Reviewer receive no PR-event wakes. Arming validates
+all recorded role harness/model/effort selections before publishing work;
+defaults satisfy the gate.
+
+---
+
 ## CURATION
 
 On boot, if the `## STATUS` `L&S:` line says **curation due**, run the `curate`

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -69,7 +69,10 @@
     ".super-coder/migrations/0164_wake_message_delivery.sql",
     ".super-coder/migrations/0165_pr_subscriptions.sql",
     ".super-coder/migrations/0166_sprint_coordinate_mode.sql",
-    ".super-coder/migrations/0167_reseed_sprint_authority_split.sql"
+    ".super-coder/migrations/0167_reseed_sprint_authority_split.sql",
+    ".super-coder/migrations/0168_retire_sprint_conversation_topology.sql",
+    ".super-coder/migrations/0169_reseed_sprint_v21_guidance.sql",
+    ".super-coder/templates/boot.md"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -94,6 +94,47 @@ class AssemblerSmokeTest(unittest.TestCase):
     def tearDown(self) -> None:
         self.con.close()
 
+    def create_sprint_chat(
+        self,
+        participant_id: int,
+        *,
+        conversation_id: str,
+        harness: str,
+        key: str,
+    ) -> str:
+        shell_id = int(
+            self.con.execute(
+                "SELECT shell_id FROM sprint_participants WHERE participant_id=?",
+                (participant_id,),
+            ).fetchone()[0]
+        )
+        active = self.con.execute(
+            "SELECT chat_id FROM active_shell_chats WHERE shell_id=?", (shell_id,)
+        ).fetchone()
+        if active is not None:
+            self.con.execute(
+                "UPDATE conversations SET state='closed',closed_at=datetime('now') "
+                "WHERE conversation_id=?",
+                (active[0],),
+            )
+        self.con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,owner_user_id,harness,worktree,title,"
+            "creation_idempotency_key,creation_request_hash,conversation_scope) "
+            "VALUES (?,?,1,?,'/fixture','Sprint fixture',?,?,'sprint')",
+            (conversation_id, shell_id, harness, key, f"hash:{key}"),
+        )
+        self.con.execute(
+            "INSERT INTO sprint_participant_conversations "
+            "(sprint_participant_id,conversation_id) VALUES (?,?)",
+            (participant_id, conversation_id),
+        )
+        self.con.execute(
+            "INSERT INTO active_shell_chats (shell_id,chat_id) VALUES (?,?)",
+            (shell_id, conversation_id),
+        )
+        return conversation_id
+
     def test_get_shells(self) -> None:
         out = server.get_shells(self.con)
         self.assertTrue(any(s["shell_id"] == self.ids["shell_id"] for s in out))
@@ -146,18 +187,11 @@ class AssemblerSmokeTest(unittest.TestCase):
             "VALUES (?,?,'developer','codex','active')",
             (sprint_id, shell_id),
         ).lastrowid
-        conversation_id = server.sprint_participant_chats.create_and_select(
-            self.con,
-            participant_id=int(participant_id),
-            owner_user_id=1,
-            purpose="work",
+        conversation_id = self.create_sprint_chat(
+            int(participant_id),
+            conversation_id="cv_fixture_live",
             harness="codex",
-            provider="openai",
-            model=None,
-            effort="high",
-            worktree="/fixture/dev",
-            title="Sprint participant",
-            idempotency_key="fixture:sprint:participant:work",
+            key="fixture:sprint:participant:wake",
         )
         self.con.commit()
 
@@ -203,18 +237,11 @@ class AssemblerSmokeTest(unittest.TestCase):
             "VALUES (?,?,'developer','codex','active')",
             (paused_id, shell_id),
         ).lastrowid
-        paused_conversation_id = server.sprint_participant_chats.create_and_select(
-            self.con,
-            participant_id=int(paused_participant_id),
-            owner_user_id=1,
-            purpose="work",
+        self.create_sprint_chat(
+            int(paused_participant_id),
+            conversation_id="cv_fixture_paused",
             harness="codex",
-            provider="openai",
-            model=None,
-            effort="high",
-            worktree="/fixture/paused",
-            title="Paused Sprint participant",
-            idempotency_key="fixture:sprint:paused:participant:work",
+            key="fixture:sprint:paused:participant:wake",
         )
         self.con.execute(
             "UPDATE sprints SET lifecycle='armed',armed_at='2026-07-31 08:00:00' "
@@ -239,18 +266,11 @@ class AssemblerSmokeTest(unittest.TestCase):
             "VALUES (?,?,'reviewer','kimi','idle')",
             (armed_id, shell_id),
         ).lastrowid
-        armed_conversation_id = server.sprint_participant_chats.create_and_select(
-            self.con,
-            participant_id=int(armed_participant_id),
-            owner_user_id=1,
-            purpose="work",
+        armed_conversation_id = self.create_sprint_chat(
+            int(armed_participant_id),
+            conversation_id="cv_fixture_armed",
             harness="kimi",
-            provider="kimi",
-            model=None,
-            effort="high",
-            worktree="/fixture/armed",
-            title="Armed Sprint participant",
-            idempotency_key="fixture:sprint:armed:participant:work",
+            key="fixture:sprint:armed:participant:wake",
         )
         self.con.execute(
             "UPDATE sprints SET lifecycle='armed',armed_at='2026-07-31 11:00:00' "
@@ -284,7 +304,7 @@ class AssemblerSmokeTest(unittest.TestCase):
                 "lifecycle": "paused",
                 "role": "developer",
                 "disposition": "active",
-                "current_conversation_id": paused_conversation_id,
+                "current_conversation_id": armed_conversation_id,
             },
             by_id[shell_id]["sprint"],
         )

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -163,18 +163,11 @@ class ConversationApiCase(unittest.TestCase):
                 "(sprint_id,shell_id,role,harness,model,effort,disposition) "
                 "VALUES (7,1,'planner','codex','gpt-test','high','active')"
             ).lastrowid
-            return sprint_participant_chats.create_and_select(
+            return sprint_participant_chats.create_wake_conversation(
                 con,
+                wake_id=1,
+                sprint_id=7,
                 participant_id=int(participant_id),
-                owner_user_id=1,
-                purpose="work",
-                harness="codex",
-                provider="openai",
-                model="gpt-test",
-                effort="high",
-                worktree=str(self.root / ".sc-worktrees" / "dev"),
-                title="Sprint 7 developer",
-                idempotency_key="sprint:7:participant:1:work",
             )
 
     def seed_conversation(

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -313,7 +313,7 @@ class ConversationBrokerCase(unittest.TestCase):
     def allow_legacy_duplicate_open_chats(self) -> None:
         """Exercise the broker's independent lock against pre-migration data."""
         con = self.connect()
-        con.execute("DROP INDEX idx_conversations_live_normal_shell")
+        con.execute("DROP INDEX idx_conversations_one_open_shell")
         con.commit()
         con.close()
 

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -18,6 +18,7 @@ FOUNDATION = MIGRATIONS / "0132_conversation_foundation.sql"
 GIT_TARGETS = MIGRATIONS / "0142_conversation_git_targets.sql"
 ACTIVE_REGISTRY = MIGRATIONS / "0162_active_chat_registry.sql"
 REAPER_IDENTITY = MIGRATIONS / "0163_conversation_run_process_identity.sql"
+TOPOLOGY_RETIREMENT = MIGRATIONS / "0168_retire_sprint_conversation_topology.sql"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import conversation_state  # noqa: E402
@@ -549,6 +550,106 @@ class MigrationAndShapeTest(ConversationDbCase):
                 0,
             )
 
+    def test_topology_retirement_converges_dirty_links_and_universal_fence(self):
+        with closing(sqlite3.connect(":memory:")) as con:
+            con.row_factory = sqlite3.Row
+            apply_schema(con, through="0167_reseed_sprint_authority_split.sql")
+            con.execute("INSERT INTO users (user_id,username) VALUES (9,'legacy')")
+            con.execute(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (9,'Legacy','legacy','dev','prompt',9)"
+            )
+            feature_id = int(
+                con.execute(
+                    "INSERT INTO roadmap (title) VALUES ('Legacy Sprint')"
+                ).lastrowid
+            )
+            sprint_id = int(
+                con.execute(
+                    "INSERT INTO sprints "
+                    "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                    "VALUES (?,9,1)",
+                    (feature_id,),
+                ).lastrowid
+            )
+            participant_id = int(
+                con.execute(
+                    "INSERT INTO sprint_participants "
+                    "(sprint_id,shell_id,role,harness) "
+                    "VALUES (?,9,'developer','codex')",
+                    (sprint_id,),
+                ).lastrowid
+            )
+            con.execute(
+                "INSERT INTO conversations "
+                "(conversation_id,shell_id,owner_user_id,harness,worktree,"
+                "creation_idempotency_key,creation_request_hash,conversation_scope) "
+                "VALUES ('cv_legacy_sprint',9,9,'codex','/tmp/legacy',"
+                "'legacy-sprint','legacy-hash','sprint')"
+            )
+            link_id = int(
+                con.execute(
+                    "INSERT INTO sprint_participant_conversations "
+                    "(sprint_participant_id,conversation_id,purpose) "
+                    "VALUES (?,'cv_legacy_sprint','work')",
+                    (participant_id,),
+                ).lastrowid
+            )
+            con.execute(
+                "UPDATE sprint_participants SET persistent_conversation_id="
+                "'cv_legacy_sprint',current_conversation_id='cv_legacy_sprint' "
+                "WHERE participant_id=?",
+                (participant_id,),
+            )
+            con.execute(
+                "INSERT INTO active_shell_chats (shell_id,chat_id) "
+                "VALUES (9,'cv_legacy_sprint')"
+            )
+
+            con.executescript(TOPOLOGY_RETIREMENT.read_text())
+
+            self.assertEqual(
+                set(),
+                {"persistent_conversation_id", "current_conversation_id"}
+                & {
+                    row[1]
+                    for row in con.execute("PRAGMA table_info(sprint_participants)")
+                },
+            )
+            self.assertEqual(
+                set(),
+                {"purpose", "parent_conversation_id", "context_packet"}
+                & {
+                    row[1]
+                    for row in con.execute(
+                        "PRAGMA table_info(sprint_participant_conversations)"
+                    )
+                },
+            )
+            self.assertEqual(
+                (link_id, participant_id, "cv_legacy_sprint"),
+                tuple(
+                    con.execute(
+                        "SELECT participant_conversation_id,"
+                        "sprint_participant_id,conversation_id "
+                        "FROM sprint_participant_conversations"
+                    ).fetchone()
+                ),
+            )
+            self.assertEqual(
+                [], [tuple(row) for row in con.execute("PRAGMA foreign_key_check")]
+            )
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute(
+                    "INSERT INTO conversations "
+                    "(conversation_id,shell_id,owner_user_id,harness,worktree,"
+                    "creation_idempotency_key,creation_request_hash,"
+                    "conversation_scope) VALUES "
+                    "('cv_second_sprint',9,9,'codex','/tmp/legacy',"
+                    "'second-sprint','second-hash','sprint')"
+                )
+
     def test_conversation_requires_direct_user_owner(self) -> None:
         with self.assertRaises(sqlite3.IntegrityError):
             self.con.execute(
@@ -866,7 +967,7 @@ class TransitionMatrixTest(ConversationDbCase):
 
 class FenceAndEventTest(ConversationDbCase):
     def test_open_chat_migration_closes_older_legacy_rows(self) -> None:
-        self.con.execute("DROP INDEX idx_conversations_live_normal_shell")
+        self.con.execute("DROP INDEX idx_conversations_one_open_shell")
         older = self.add_conversation(shell_id=1)
         self.con.execute(
             "UPDATE conversations SET last_activity_at='2026-01-01 00:00:00' "

--- a/tests/test_local_skill_persistence.py
+++ b/tests/test_local_skill_persistence.py
@@ -44,7 +44,12 @@ GRANTS_DDL = (
     "CREATE TABLE shell_skills (shell_skill_id INTEGER PRIMARY KEY, "
     "shell_id INTEGER NOT NULL, skill_id INTEGER NOT NULL, UNIQUE(shell_id, skill_id));"
     "CREATE TABLE flavor_skills (flavor TEXT NOT NULL, skill_id INTEGER NOT NULL, "
-    "UNIQUE(flavor, skill_id))")
+    "UNIQUE(flavor, skill_id));"
+    "CREATE VIEW resolved_shell_skills AS "
+    "SELECT sh.shell_id, fs.skill_id FROM shells sh "
+    "JOIN flavor_skills fs ON fs.flavor=sh.flavor WHERE sh.flavor IS NOT NULL "
+    "UNION ALL SELECT ss.shell_id, ss.skill_id FROM shell_skills ss "
+    "JOIN shells sh ON sh.shell_id=ss.shell_id WHERE sh.flavor IS NULL")
 
 
 def write_asset(root: Path, name: str, body: str) -> None:

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -502,8 +502,10 @@ class SprintCliApiTest(unittest.TestCase):
                 wake,
             )
             current = con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=1",
+                "SELECT active.chat_id FROM sprint_participants participant "
+                "LEFT JOIN active_shell_chats active "
+                "ON active.shell_id=participant.shell_id "
+                "WHERE participant.participant_id=1",
             ).fetchone()
             self.assertEqual((response["conversation_id"],), current)
 

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -575,18 +575,14 @@ class SprintLiveProof(unittest.TestCase):
         self.assertEqual("lifecycle.completed", event_types[-1])
         self.assertEqual(2, packet["pr_outcomes"]["total"])
         self.assertEqual(
-            ["work", "fallback"],
-            [
-                row[0]
-                for row in self.con.execute(
-                    "SELECT link.purpose FROM sprint_participant_conversations link "
-                    "JOIN sprint_participants p "
-                    "ON p.participant_id=link.sprint_participant_id "
-                    "WHERE p.sprint_id=? AND p.shell_id=1 "
-                    "ORDER BY link.participant_conversation_id",
-                    (sprint_id,),
-                )
-            ],
+            2,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_participant_conversations link "
+                "JOIN sprint_participants p "
+                "ON p.participant_id=link.sprint_participant_id "
+                "WHERE p.sprint_id=? AND p.shell_id=1",
+                (sprint_id,),
+            ).fetchone()[0],
         )
 
     def test_parallel_sprint_completes_out_of_order_without_lane_overlap(self) -> None:
@@ -660,8 +656,10 @@ class SprintLiveProof(unittest.TestCase):
         self.github.set(3001, "OPEN")
         conversation_id = str(
             self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE sprint_id=? AND shell_id=1",
+                "SELECT active.chat_id FROM sprint_participants participant "
+                "JOIN active_shell_chats active "
+                "ON active.shell_id=participant.shell_id "
+                "WHERE participant.sprint_id=? AND participant.shell_id=1",
                 (sprint_id,),
             ).fetchone()[0]
         )
@@ -744,8 +742,9 @@ class SprintLiveProof(unittest.TestCase):
         )
 
         arming_planner_conversation = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE sprint_id=? AND shell_id=3",
+            "SELECT active.chat_id FROM sprint_participants participant "
+            "JOIN active_shell_chats active ON active.shell_id=participant.shell_id "
+            "WHERE participant.sprint_id=? AND participant.shell_id=3",
             (sprint_id,),
         ).fetchone()[0]
         self.assertIsNotNone(
@@ -791,8 +790,10 @@ class SprintLiveProof(unittest.TestCase):
         self.deliver_browser_turns()
         planner_conversation = str(
             self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE sprint_id=? AND shell_id=3",
+                "SELECT active.chat_id FROM sprint_participants participant "
+                "JOIN active_shell_chats active "
+                "ON active.shell_id=participant.shell_id "
+                "WHERE participant.sprint_id=? AND participant.shell_id=3",
                 (sprint_id,),
             ).fetchone()[0]
         )
@@ -869,8 +870,10 @@ class SprintLiveProof(unittest.TestCase):
         )
         self.assertIsNone(
             self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE sprint_id=? AND shell_id=2",
+                "SELECT (SELECT chat_id FROM active_shell_chats "
+                "WHERE shell_id=participant.shell_id) "
+                "FROM sprint_participants participant "
+                "WHERE participant.sprint_id=? AND participant.shell_id=2",
                 (sprint_id,),
             ).fetchone()[0]
         )
@@ -888,16 +891,20 @@ class SprintLiveProof(unittest.TestCase):
         )
         self.assertIsNone(
             self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE sprint_id=? AND shell_id=2",
+                "SELECT (SELECT chat_id FROM active_shell_chats "
+                "WHERE shell_id=participant.shell_id) "
+                "FROM sprint_participants participant "
+                "WHERE participant.sprint_id=? AND participant.shell_id=2",
                 (sprint_id,),
             ).fetchone()[0]
         )
         self.deliver_browser_turns()
         reviewer_new = str(
             self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE sprint_id=? AND shell_id=2",
+                "SELECT active.chat_id FROM sprint_participants participant "
+                "JOIN active_shell_chats active "
+                "ON active.shell_id=participant.shell_id "
+                "WHERE participant.sprint_id=? AND participant.shell_id=2",
                 (sprint_id,),
             ).fetchone()[0]
         )

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -208,8 +208,9 @@ class SprintLivenessCase(unittest.TestCase):
 
     def add_native_event(self, event_type: str, minutes: int) -> int:
         conversation_id = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE participant_id=?",
+            "SELECT active.chat_id FROM sprint_participants participant "
+            "JOIN active_shell_chats active ON active.shell_id=participant.shell_id "
+            "WHERE participant.participant_id=?",
             (self.developer_id,),
         ).fetchone()[0]
         sequence = int(
@@ -239,8 +240,9 @@ class SprintLivenessCase(unittest.TestCase):
         self, state: str, minutes: int, error_code: str | None = None
     ) -> int:
         conversation_id = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE participant_id=?",
+            "SELECT active.chat_id FROM sprint_participants participant "
+            "JOIN active_shell_chats active ON active.shell_id=participant.shell_id "
+            "WHERE participant.participant_id=?",
             (self.developer_id,),
         ).fetchone()[0]
         token = self.con.execute(
@@ -439,8 +441,9 @@ class FakeClockPolicyTest(SprintLivenessCase):
         run_id = self.add_terminal_run("failed", 1, "BROKER_RUN_ERROR")
         self.add_native_event("run.failed", 2)
         conversation_id = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE participant_id=?",
+            "SELECT active.chat_id FROM sprint_participants participant "
+            "JOIN active_shell_chats active ON active.shell_id=participant.shell_id "
+            "WHERE participant.participant_id=?",
             (self.developer_id,),
         ).fetchone()[0]
         head = "a" * 40
@@ -621,19 +624,23 @@ class DeliveryAndActivationTest(SprintLivenessCase):
             ["escalated", "escalated"], [outcome.action for outcome in outcomes]
         )
         planner = self.con.execute(
-            "SELECT persistent_conversation_id,current_conversation_id "
-            "FROM sprint_participants WHERE participant_id=?",
+            "SELECT active.chat_id FROM sprint_participants participant "
+            "LEFT JOIN active_shell_chats active "
+            "ON active.shell_id=participant.shell_id "
+            "WHERE participant.participant_id=?",
             (self.planner_id,),
         ).fetchone()
         self.assertIsNotNone(planner[0])
-        self.assertEqual(planner[0], planner[1])
-        fallbacks = self.con.execute(
-            "SELECT link.purpose,c.harness FROM sprint_participant_conversations link "
-            "JOIN conversations c ON c.conversation_id=link.conversation_id "
-            "WHERE link.sprint_participant_id=? AND link.purpose='fallback'",
-            (self.planner_id,),
-        ).fetchall()
-        self.assertEqual([], [tuple(row) for row in fallbacks])
+        self.assertEqual(
+            set(),
+            {"purpose", "parent_conversation_id", "context_packet"}
+            & {
+                row[1]
+                for row in self.con.execute(
+                    "PRAGMA table_info(sprint_participant_conversations)"
+                )
+            },
+        )
         escalations = self.message_rows("escalation")
         self.assertEqual(2, len(escalations))
         self.assertEqual(

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -788,7 +788,11 @@ class WakeDeliveryTest(SprintMessageCase):
         )
 
     def test_engine_new_without_registry_creates_chat(self) -> None:
-        self.con.execute("DELETE FROM active_shell_chats WHERE shell_id=1")
+        self.con.execute(
+            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
+            "WHERE conversation_id=?",
+            (self.developer_conversation_id,),
+        )
         self.con.commit()
         sent = self.messages.send_to_shell(
             1,
@@ -1394,8 +1398,8 @@ class ParticipantRelayTest(SprintMessageCase):
         conversation_id = observed[0]
 
         route = self.con.execute(
-            "SELECT c.shell_id,c.state,c.conversation_scope,pc.purpose,"
-            "pc.parent_conversation_id,pc.context_packet "
+            "SELECT c.shell_id,c.state,c.conversation_scope,"
+            "pc.sprint_participant_id "
             "FROM conversations c JOIN sprint_participant_conversations pc "
             "USING (conversation_id) WHERE c.conversation_id=?",
             (conversation_id,),
@@ -1406,14 +1410,16 @@ class ParticipantRelayTest(SprintMessageCase):
         )
         self.assertEqual(active_before, conversation_id)
         self.assertEqual(
-            (3, "idle", "sprint", "work", None, None),
+            (3, "idle", "sprint", self.planner_id),
             tuple(route),
         )
         self.assertEqual(
             conversation_id,
             self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=?",
+                "SELECT active.chat_id FROM sprint_participants participant "
+                "JOIN active_shell_chats active "
+                "ON active.shell_id=participant.shell_id "
+                "WHERE participant.participant_id=?",
                 (self.planner_id,),
             ).fetchone()[0],
         )

--- a/tests/test_sprint_participant_chats.py
+++ b/tests/test_sprint_participant_chats.py
@@ -1,4 +1,4 @@
-"""Stage 2 Sprint participant-conversation transaction contracts."""
+"""Active-registry Sprint wake-chat contracts after topology retirement."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
 
+import active_chat_registry
 import sprint_participant_chats
 
 
@@ -23,19 +24,14 @@ def substrate():
     con.executescript(
         """
         PRAGMA foreign_keys=ON;
-        CREATE TABLE users (
-          user_id INTEGER PRIMARY KEY
-        );
+        CREATE TABLE users (user_id INTEGER PRIMARY KEY);
         CREATE TABLE shells (
           shell_id INTEGER PRIMARY KEY,
           shortname TEXT NOT NULL,
           flavor TEXT,
           user_id INTEGER REFERENCES users(user_id)
         );
-        CREATE TABLE roadmap (
-          feature_id INTEGER PRIMARY KEY,
-          title TEXT NOT NULL
-        );
+        CREATE TABLE roadmap (feature_id INTEGER PRIMARY KEY, title TEXT NOT NULL);
         CREATE TABLE sprints (
           sprint_id INTEGER PRIMARY KEY,
           feature_id INTEGER NOT NULL REFERENCES roadmap(feature_id),
@@ -43,12 +39,6 @@ def substrate():
           conversation_generation TEXT NOT NULL,
           lifecycle TEXT NOT NULL,
           paused_at TEXT
-        );
-        CREATE TABLE sprint_specs (
-          sprint_id INTEGER NOT NULL REFERENCES sprints(sprint_id),
-          document_id INTEGER NOT NULL,
-          bound_revision_sha256 TEXT NOT NULL,
-          PRIMARY KEY(sprint_id,document_id)
         );
         CREATE TABLE conversations (
           conversation_id TEXT PRIMARY KEY,
@@ -69,6 +59,8 @@ def substrate():
           version INTEGER NOT NULL DEFAULT 1,
           UNIQUE(owner_user_id, creation_idempotency_key)
         );
+        CREATE UNIQUE INDEX one_open_chat_per_shell
+          ON conversations(shell_id) WHERE state<>'closed';
         CREATE TABLE active_shell_chats (
           shell_id INTEGER PRIMARY KEY REFERENCES shells(shell_id),
           chat_id TEXT NOT NULL UNIQUE REFERENCES conversations(conversation_id),
@@ -105,8 +97,6 @@ def substrate():
           model TEXT,
           effort TEXT,
           disposition TEXT NOT NULL,
-          persistent_conversation_id TEXT REFERENCES conversations(conversation_id),
-          current_conversation_id TEXT REFERENCES conversations(conversation_id),
           updated_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
         CREATE TABLE sprint_participant_conversations (
@@ -115,38 +105,36 @@ def substrate():
             REFERENCES sprint_participants(participant_id),
           conversation_id TEXT NOT NULL UNIQUE
             REFERENCES conversations(conversation_id),
-          purpose TEXT NOT NULL,
-          parent_conversation_id TEXT REFERENCES conversations(conversation_id),
-          context_packet TEXT,
           created_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
-        CREATE UNIQUE INDEX one_work_conversation
-          ON sprint_participant_conversations(sprint_participant_id)
-          WHERE purpose='work';
-        CREATE TABLE sprint_work_units (
-          work_unit_id INTEGER PRIMARY KEY,
-          sprint_id INTEGER NOT NULL REFERENCES sprints(sprint_id),
-          title TEXT NOT NULL,
-          disposition TEXT NOT NULL,
-          planned_wave INTEGER NOT NULL
-        );
+        CREATE TRIGGER validate_sprint_conversation_link
+        BEFORE INSERT ON sprint_participant_conversations
+        WHEN NOT EXISTS (
+          SELECT 1 FROM sprint_participants p
+          JOIN conversations c ON c.conversation_id=NEW.conversation_id
+          WHERE p.participant_id=NEW.sprint_participant_id
+            AND p.shell_id=c.shell_id
+            AND c.conversation_scope='sprint'
+        )
+        BEGIN
+          SELECT RAISE(ABORT,'invalid Sprint participant conversation link');
+        END;
+        CREATE TRIGGER immutable_sprint_conversation_link
+        BEFORE UPDATE ON sprint_participant_conversations
+        BEGIN
+          SELECT RAISE(ABORT,'Sprint participant conversation links are immutable');
+        END;
         INSERT INTO users VALUES (1);
         INSERT INTO roadmap VALUES (31,'Collaborative orchestration');
         INSERT INTO shells VALUES
           (10,'DEV1','dev',1),(20,'REV1','reviewer',1),(30,'PLN1','planner',1);
-        INSERT INTO sprints
-          (sprint_id,feature_id,originating_planner_shell_id,
-           conversation_generation,lifecycle)
-          VALUES (7,31,30,'0123456789abcdef0123456789abcdef','armed');
-        INSERT INTO sprint_specs VALUES (7,46,'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+        INSERT INTO sprints VALUES
+          (7,31,30,'0123456789abcdef0123456789abcdef','armed',NULL);
         INSERT INTO sprint_participants
           (participant_id,sprint_id,shell_id,role,harness,model,effort,disposition)
           VALUES (101,7,10,'developer','codex','gpt-test','high','active'),
                  (102,7,20,'reviewer','kimi','kimi-test','high','idle'),
                  (103,7,30,'planner','codex','planner-test','high','active');
-        INSERT INTO sprint_work_units VALUES
-          (700,7,'Participant chats','active',1),
-          (701,7,'Already shipped','completed',0);
         """
     )
     try:
@@ -155,446 +143,147 @@ def substrate():
         con.close()
 
 
-def create(
+def create_wake(
     con: sqlite3.Connection,
-    participant_id: int,
-    purpose: str,
-    key: str,
-    **changes,
+    *,
+    wake_id: int,
+    participant_id: int = 101,
 ) -> str:
-    values = {
-        "participant_id": participant_id,
-        "owner_user_id": 1,
-        "purpose": purpose,
-        "harness": "codex",
-        "provider": "openai",
-        "model": "gpt-test",
-        "effort": "high",
-        "worktree": f"/worktrees/{participant_id}",
-        "title": f"Sprint 7 {purpose}",
-        "idempotency_key": key,
-    }
-    values.update(changes)
-    return sprint_participant_chats.create_and_select(con, **values)
+    con.execute("BEGIN")
+    try:
+        conversation_id = sprint_participant_chats.create_wake_conversation(
+            con,
+            wake_id=wake_id,
+            sprint_id=7,
+            participant_id=participant_id,
+        )
+    except Exception:
+        con.rollback()
+        raise
+    con.commit()
+    return conversation_id
 
 
-def test_arming_provisions_every_participant_without_a_wake() -> None:
+def test_wake_creation_registers_one_chat_and_flat_history() -> None:
     with substrate() as con:
-        provisioned = sprint_participant_chats.provision_at_arming(con, 7)
-        assert len(provisioned) == 3
+        conversation_id = create_wake(con, wake_id=41)
 
-        conversations = con.execute(
-            "SELECT shell_id,conversation_scope,state "
-            "FROM conversations ORDER BY shell_id"
-        ).fetchall()
-        assert [tuple(row) for row in conversations] == [
-            (10, "sprint", "idle"),
-            (20, "sprint", "idle"),
-            (30, "sprint", "idle"),
-        ]
-        pointers = con.execute(
-            "SELECT participant_id,persistent_conversation_id,"
-            "current_conversation_id "
-            "FROM sprint_participants ORDER BY participant_id"
-        ).fetchall()
-        assert [row["participant_id"] for row in pointers] == [101, 102, 103]
-        assert all(
-            row["persistent_conversation_id"] == row["current_conversation_id"]
-            for row in pointers
+        conversation = con.execute(
+            "SELECT shell_id,state,conversation_scope,creation_idempotency_key "
+            "FROM conversations WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()
+        assert tuple(conversation) == (
+            10,
+            "idle",
+            "sprint",
+            "generation:0123456789abcdef0123456789abcdef:wake:41",
         )
-        assert {row["current_conversation_id"] for row in pointers} == set(provisioned)
-        events = con.execute(
-            "SELECT conversation_id,event_type,payload "
-            "FROM conversation_events ORDER BY conversation_id"
-        ).fetchall()
-        assert len(events) == 3
-        assert {json.loads(row["payload"])["purpose"] for row in events} == {"work"}
-        assert all(row["event_type"] == "conversation.created" for row in events)
-
-
-def test_replay_is_idempotent_and_conflicting_reuse_changes_nothing() -> None:
-    with substrate() as con:
-        work = create(con, 101, "work", "s7:p101:work")
-        replay = create(con, 101, "work", "s7:p101:work")
-        assert replay == work
-        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 1
-        assert (
-            con.execute(
-                "SELECT COUNT(*) FROM sprint_participant_conversations"
-            ).fetchone()[0]
-            == 1
-        )
-
-        with pytest.raises(
-            sprint_participant_chats.SprintConversationError,
-            match="different request",
-        ):
-            create(
-                con,
-                101,
-                "work",
-                "s7:p101:work",
-                title="Changed after retry",
-            )
-        assert (
-            con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=101"
-            ).fetchone()[0]
-            == work
-        )
-        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 1
-
-
-def test_every_purpose_ignores_orphan_legacy_keys_and_replays_scoped_key() -> None:
-    operations = {
-        "work": "s7:p101:work",
-        "fix": "review:55:fix:conversation",
-        "merge": "review:56:merge:conversation",
-        "fallback": "s7:p101:fallback:quota-1",
-    }
-    with substrate() as con:
-        con.executemany(
-            "INSERT INTO conversations "
-            "(conversation_id,shell_id,owner_user_id,harness,worktree,state,title,"
-            "creation_idempotency_key,creation_request_hash,conversation_scope) "
-            "VALUES (?,?,1,'codex','/historical','closed','Orphan',?,"
-            "'historical-request','sprint')",
-            (
-                (f"cv_orphan_{purpose}", 10, key)
-                for purpose, key in operations.items()
-            ),
-        )
-        work = create(con, 101, "work", operations["work"])
-        created = {"work": work}
-        for purpose in ("fix", "merge", "fallback"):
-            changes = {"parent_conversation_id": work}
-            if purpose == "fallback":
-                changes["context_packet"] = {"reason": "route exhausted"}
-            created[purpose] = create(
-                con, 101, purpose, operations[purpose], **changes
-            )
-            assert (
-                create(con, 101, purpose, operations[purpose], **changes)
-                == created[purpose]
-            )
-
-        assert len(set(created.values())) == 4
-        keys = {
-            row["purpose"]: row["creation_idempotency_key"]
+        assert [
+            tuple(row)
             for row in con.execute(
-                "SELECT link.purpose,c.creation_idempotency_key "
-                "FROM sprint_participant_conversations link "
-                "JOIN conversations c ON c.conversation_id=link.conversation_id"
+                "SELECT shell_id,chat_id FROM active_shell_chats"
             )
+        ] == [(10, conversation_id)]
+        assert [
+            tuple(row)
+            for row in con.execute(
+                "SELECT sprint_participant_id,conversation_id "
+                "FROM sprint_participant_conversations"
+            )
+        ] == [(101, conversation_id)]
+
+        payload = json.loads(
+            con.execute(
+                "SELECT payload FROM conversation_events WHERE conversation_id=?",
+                (conversation_id,),
+            ).fetchone()[0]
+        )
+        assert payload == {
+            "participant_id": 101,
+            "scope": "sprint",
+            "sprint_id": 7,
+            "wake_id": 41,
         }
-        for purpose, operation_key in operations.items():
-            assert keys[purpose] == sprint_participant_chats.conversation_idempotency_key(
-                con, 101, purpose, operation_key
-            )
-            assert keys[purpose] != operation_key
-            assert len(keys[purpose]) <= 255
-        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 8
 
 
-def test_wake_reroutes_use_bounded_scoped_keys_and_replay_latest_route() -> None:
+def test_replay_restores_registry_without_duplicating_history() -> None:
     with substrate() as con:
-        work = create(con, 101, "work", "s7:p101:work")
-        con.execute(
-            "UPDATE conversations SET state='closed' WHERE conversation_id=?",
-            (work,),
-        )
-        maximum_key = "k" * 255
-        first = sprint_participant_chats.ensure_wake_conversation(
-            con, 101, idempotency_key=maximum_key
-        )
-        assert first.created
-        con.execute(
-            "UPDATE conversations SET state='closed' WHERE conversation_id=?",
-            (first.conversation_id,),
-        )
-        second = sprint_participant_chats.ensure_wake_conversation(
-            con, 101, idempotency_key=maximum_key
-        )
-        assert second.created
-        assert second.conversation_id != first.conversation_id
-
-        replay = sprint_participant_chats.ensure_wake_conversation(
-            con, 101, idempotency_key=maximum_key
-        )
-        assert replay == sprint_participant_chats.WakeConversationRoute(
-            second.conversation_id, False
-        )
-        keys = [
-            row[0]
-            for row in con.execute(
-                "SELECT c.creation_idempotency_key "
-                "FROM sprint_participant_conversations link "
-                "JOIN conversations c ON c.conversation_id=link.conversation_id "
-                "WHERE link.sprint_participant_id=101 AND link.purpose='fallback' "
-                "ORDER BY link.participant_conversation_id"
-            )
-        ]
-        assert len(keys) == 2
-        assert len(set(keys)) == 2
-        assert all(key.startswith("sprint-generation:") for key in keys)
-        assert all(len(key) <= 255 for key in keys)
-
-
-def test_caller_transaction_rolls_back_every_row_when_pointer_selection_fails() -> None:
-    with substrate() as con:
-        con.execute(
-            "CREATE TRIGGER reject_pointer BEFORE UPDATE OF current_conversation_id "
-            "ON sprint_participants BEGIN SELECT RAISE(ABORT,'pointer fault'); END"
-        )
+        conversation_id = create_wake(con, wake_id=42)
+        con.execute("DELETE FROM active_shell_chats WHERE shell_id=10")
         con.commit()
 
-        with pytest.raises(sqlite3.IntegrityError, match="pointer fault"), con:
-            create(con, 101, "work", "s7:p101:work")
+        replayed = create_wake(con, wake_id=42)
 
-        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 0
-        assert (
-            con.execute("SELECT COUNT(*) FROM conversation_events").fetchone()[0] == 0
-        )
-        assert (
-            con.execute(
-                "SELECT COUNT(*) FROM sprint_participant_conversations"
-            ).fetchone()[0]
-            == 0
-        )
+        assert replayed == conversation_id
+        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 1
+        assert con.execute(
+            "SELECT COUNT(*) FROM sprint_participant_conversations"
+        ).fetchone()[0] == 1
+        assert con.execute(
+            "SELECT chat_id FROM active_shell_chats WHERE shell_id=10"
+        ).fetchone()[0] == conversation_id
 
 
-def test_fix_conversation_closes_and_replaces_persistent_work() -> None:
+def test_new_wake_requires_committed_close_then_preserves_history() -> None:
     with substrate() as con:
-        work = create(con, 101, "work", "s7:p101:work")
-        fix = create(
-            con,
-            101,
-            "fix",
-            "s7:p101:review:55:fix",
-            parent_conversation_id=work,
-        )
-
-        rows = con.execute(
-            "SELECT c.conversation_id,c.state,l.purpose,l.parent_conversation_id "
-            "FROM conversations c JOIN sprint_participant_conversations l "
-            "ON l.conversation_id=c.conversation_id ORDER BY l.purpose"
-        ).fetchall()
-        assert [tuple(row) for row in rows] == [
-            (fix, "idle", "fix", work),
-            (work, "closed", "work", None),
-        ]
-        assert tuple(
-            con.execute(
-                "SELECT shell_id,chat_id FROM active_shell_chats"
-            ).fetchone()
-        ) == (10, fix)
-        assert (
-            con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=101"
-            ).fetchone()[0]
-            == fix
-        )
-
-        selected = sprint_participant_chats.select_work(con, 101)
-        assert selected == work
-        assert (
-            con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=101"
-            ).fetchone()[0]
-            == work
-        )
-
-
-def test_cross_participant_parent_is_rejected_without_partial_rows() -> None:
-    with substrate() as con:
-        developer = create(con, 101, "work", "s7:p101:work")
-        reviewer = create(con, 102, "work", "s7:p102:work")
+        first = create_wake(con, wake_id=43)
 
         with pytest.raises(
-            sprint_participant_chats.SprintConversationError,
-            match="does not belong",
+            sprint_participant_chats.WakeConversationBusy,
+            match="another chat became active",
         ):
-            create(
-                con,
-                101,
-                "merge",
-                "s7:p101:review:9:merge",
-                parent_conversation_id=reviewer,
+            create_wake(con, wake_id=44)
+        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 1
+
+        con.execute("BEGIN")
+        closed = active_chat_registry.close_for_wake(con, 10)
+        con.commit()
+        assert closed is not None and closed.chat_id == first
+
+        second = create_wake(con, wake_id=44)
+        assert second != first
+        assert [
+            tuple(row)
+            for row in con.execute(
+                "SELECT conversation_id,state FROM conversations ORDER BY rowid"
             )
-
-        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 2
-        assert (
-            con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=101"
-            ).fetchone()[0]
-            == developer
-        )
-        assert (
-            con.execute(
-                "SELECT COUNT(*) FROM sprint_participant_conversations "
-                "WHERE purpose='merge'"
-            ).fetchone()[0]
-            == 0
-        )
+        ] == [(first, "closed"), (second, "idle")]
+        assert [
+            tuple(row)
+            for row in con.execute(
+                "SELECT conversation_id FROM sprint_participant_conversations "
+                "ORDER BY participant_conversation_id"
+            )
+        ] == [(first,), (second,)]
 
 
-def test_fallback_replacement_retains_packet_route_and_history() -> None:
-    packet = {
-        "sprint_id": 7,
-        "reason": "planner route exhausted",
-        "pending": ["review unit 2"],
-    }
+def test_flat_link_rejects_cross_shell_and_is_immutable() -> None:
     with substrate() as con:
-        work = create(con, 101, "work", "s7:p101:work")
-        fallback = create(
-            con,
-            101,
-            "fallback",
-            "s7:p101:fallback:1",
-            parent_conversation_id=work,
-            context_packet=packet,
-            harness="kimi",
-            provider="moonshot",
-            model="kimi-test",
-        )
-
-        replacement = con.execute(
-            "SELECT c.harness,c.provider,c.model,c.state,l.parent_conversation_id,"
-            "l.context_packet FROM conversations c "
-            "JOIN sprint_participant_conversations l "
-            "ON l.conversation_id=c.conversation_id "
-            "WHERE c.conversation_id=?",
-            (fallback,),
-        ).fetchone()
-        assert tuple(replacement) == (
-            "kimi",
-            "moonshot",
-            "kimi-test",
-            "idle",
-            work,
-            json.dumps(packet, separators=(",", ":"), sort_keys=True),
-        )
-        assert (
-            con.execute(
-                "SELECT state FROM conversations WHERE conversation_id=?", (work,)
-            ).fetchone()[0]
-            == "closed"
-        )
-        assert tuple(
-            con.execute(
-                "SELECT shell_id,chat_id FROM active_shell_chats"
-            ).fetchone()
-        ) == (10, fallback)
-        assert (
-            con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=101"
-            ).fetchone()[0]
-            == fallback
-        )
-
-
-def test_planner_fallback_generates_bounded_context_and_rejects_developer() -> None:
-    with substrate() as con:
-        provisioned = sprint_participant_chats.provision_at_arming(con, 7)
-
-        fallback = sprint_participant_chats.create_planner_fallback(
-            con,
-            participant_id=103,
-            reason="primary route quota exhausted",
-            harness="kimi",
-            model="kimi-fallback",
-            effort="high",
-            idempotency_key="s7:p103:fallback:quota-1",
-        )
-
-        row = con.execute(
-            "SELECT c.harness,c.provider,l.parent_conversation_id,l.context_packet "
-            "FROM conversations c JOIN sprint_participant_conversations l "
-            "ON l.conversation_id=c.conversation_id WHERE c.conversation_id=?",
-            (fallback,),
-        ).fetchone()
-        packet = json.loads(row["context_packet"])
-        assert tuple(row)[:3] == ("kimi", "kimi", provisioned[2])
-        assert packet == {
-            "packet_version": 1,
-            "reason": "primary route quota exhausted",
-            "sprint": {
-                "sprint_id": 7,
-                "feature_id": 31,
-                "feature_title": "Collaborative orchestration",
-                "lifecycle": "armed",
-            },
-            "participant": {
-                "participant_id": 103,
-                "shell_id": 30,
-                "shortname": "PLN1",
-                "role": "planner",
-                "disposition": "active",
-                "previous_route": {
-                    "harness": "codex",
-                    "model": "planner-test",
-                    "effort": "high",
-                },
-                "previous_conversation_id": provisioned[2],
-            },
-            "bound_specs": [
-                {
-                    "document_id": 46,
-                    "revision_sha256": "a" * 64,
-                }
-            ],
-            "open_work_units": [
-                {
-                    "work_unit_id": 700,
-                    "title": "Participant chats",
-                    "disposition": "active",
-                }
-            ],
-        }
-        assert (
-            con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=103"
-            ).fetchone()[0]
-            == fallback
-        )
-
-        before = con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+        conversation_id = create_wake(con, wake_id=45)
         with pytest.raises(
-            sprint_participant_chats.SprintConversationError,
-            match="Planner-only",
+            sqlite3.IntegrityError,
+            match="invalid Sprint participant conversation link",
         ):
-            sprint_participant_chats.create_planner_fallback(
-                con,
-                participant_id=101,
-                reason="not a planner",
-                harness="kimi",
-                model="kimi-fallback",
-                effort="high",
-                idempotency_key="s7:p101:fallback:invalid",
+            con.execute(
+                "INSERT INTO sprint_participant_conversations "
+                "(sprint_participant_id,conversation_id) VALUES (?,?)",
+                (102, conversation_id),
             )
-        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == before
+        with pytest.raises(
+            sqlite3.IntegrityError,
+            match="Sprint participant conversation links are immutable",
+        ):
+            con.execute(
+                "UPDATE sprint_participant_conversations "
+                "SET sprint_participant_id=102 WHERE conversation_id=?",
+                (conversation_id,),
+            )
 
 
-def test_live_pill_projection_follows_current_pointer_until_terminal() -> None:
+def test_live_projection_reads_registry_and_allows_zero_chat() -> None:
     with substrate() as con:
-        provisioned = sprint_participant_chats.provision_at_arming(con, 7)
-        work = con.execute(
-            "SELECT persistent_conversation_id FROM sprint_participants "
-            "WHERE participant_id=101"
-        ).fetchone()[0]
-        fix = create(
-            con,
-            101,
-            "fix",
-            "s7:p101:review:55:fix",
-            parent_conversation_id=work,
-        )
+        developer_chat = create_wake(con, wake_id=46)
         shells = [{"shell_id": 10}, {"shell_id": 20}, {"shell_id": 30}]
 
         projected = sprint_participant_chats.attach_live_participations(con, shells)
@@ -604,21 +293,16 @@ def test_live_pill_projection_follows_current_pointer_until_terminal() -> None:
             "lifecycle": "armed",
             "role": "developer",
             "disposition": "active",
-            "current_conversation_id": fix,
+            "current_conversation_id": developer_chat,
         }
-        assert projected[1]["sprint"] == {
-            "sprint_id": 7,
-            "lifecycle": "armed",
-            "role": "reviewer",
-            "disposition": "idle",
-            "current_conversation_id": provisioned[1],
-        }
+        assert projected[1]["sprint"]["current_conversation_id"] is None
+        assert projected[2]["sprint"]["current_conversation_id"] is None
 
         con.execute("UPDATE sprints SET lifecycle='completed' WHERE sprint_id=7")
         terminal = sprint_participant_chats.attach_live_participations(
-            con, [{"shell_id": 10}, {"shell_id": 20}]
+            con, [{"shell_id": 10}]
         )
-        assert terminal == [
-            {"shell_id": 10, "sprint": None},
-            {"shell_id": 20, "sprint": None},
-        ]
+        assert terminal == [{"shell_id": 10, "sprint": None}]
+        assert con.execute(
+            "SELECT chat_id FROM active_shell_chats WHERE shell_id=10"
+        ).fetchone()[0] == developer_chat

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -183,7 +183,7 @@ class RegistrationTest(SprintPRWatcherCase):
             self.con.execute("SELECT COUNT(*) FROM sprint_pr_work_units").fetchone()[0],
         )
 
-    def test_registration_rejects_non_owner_work_and_non_armed_sprint(self):
+    def test_registration_rejects_non_owner_work_and_allows_paused_sprint(self):
         other_unit = int(
             self.con.execute(
                 "INSERT INTO sprint_work_units "
@@ -210,20 +210,28 @@ class RegistrationTest(SprintPRWatcherCase):
             sprint_domain.LifecycleActor("participant", 1),
             reason="test",
         )
-        with self.assertRaisesRegex(
-            sprint_domain.SprintInvariantError, "only for an armed Sprint"
-        ):
-            self.watcher.registration.register(
-                self.sprint_id,
-                owner_shell_id=1,
-                repository="acme/repo",
-                pr_number=41,
-                work_unit_ids=(self.unit_id,),
-            )
+        receipt = self.watcher.registration.register(
+            self.sprint_id,
+            owner_shell_id=1,
+            repository="acme/repo",
+            pr_number=41,
+            work_unit_ids=(self.unit_id,),
+        )
+        self.assertTrue(receipt.created)
         self.assertEqual(
-            0,
+            1,
             self.con.execute("SELECT COUNT(*) FROM sprint_registered_prs").fetchone()[
                 0
+            ],
+        )
+        self.assertEqual(
+            [(1, "acme/repo", 41)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT owner_shell_id,repository,pr_number "
+                    "FROM pr_subscriptions"
+                )
             ],
         )
 

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import json
-import sqlite3
 import sys
-import tempfile
-from contextlib import closing
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".super-coder" / "scripts"
 sys.path[:0] = [str(SCRIPTS), str(ROOT / "tests")]
 
-import conversation_broker
 import sprint_domain
 import sprint_message_delivery
 import sprint_participant_chats
@@ -57,8 +53,9 @@ class SprintRecoveryCase(SprintPRWatcherCase):
 
     def add_live_run(self, shell_id: int = 1) -> int:
         participant = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE sprint_id=? AND shell_id=?",
+            "SELECT active.chat_id FROM sprint_participants participant "
+            "JOIN active_shell_chats active ON active.shell_id=participant.shell_id "
+            "WHERE participant.sprint_id=? AND participant.shell_id=?",
             (self.sprint_id, shell_id),
         ).fetchone()
         conversation_id = str(participant[0])
@@ -1611,8 +1608,10 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
                 if outcome.wake_id == receipt.wake_id:
                     break
             conversation = self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=?",
+                "SELECT active.chat_id FROM sprint_participants participant "
+                "JOIN active_shell_chats active "
+                "ON active.shell_id=participant.shell_id "
+                "WHERE participant.participant_id=?",
                 (participant_id,),
             ).fetchone()
         return str(conversation[0])
@@ -1700,26 +1699,11 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
             ).fetchone()[0],
         )
 
-    def test_completed_defers_only_owning_planner_run_until_broker_finish(self):
+    def test_completion_does_not_close_or_interrupt_registry_chats(self):
         sprint_id, _ = self.create_sprint()
         self.store.arm(sprint_id, 3)
         planner_conversation, planner_run = self.add_live_run(sprint_id, 3)
-        _, developer_run = self.add_live_run(sprint_id, 1)
-        queued_message_id = int(
-            self.con.execute(
-                "INSERT INTO conversation_messages "
-                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
-                "idempotency_key,request_hash,state) "
-                "VALUES (?,'engine','test','prompt','queued follow-up',"
-                "'terminal-follow-up','terminal-follow-up','queued')",
-                (planner_conversation,),
-            ).lastrowid
-        )
-        self.con.execute(
-            "INSERT INTO conversation_outbox (conversation_id,message_id) VALUES (?,?)",
-            (planner_conversation, queued_message_id),
-        )
-        self.con.commit()
+        developer_conversation, developer_run = self.add_live_run(sprint_id, 1)
         interrupts: list[int] = []
         lifecycle = sprint_domain.SprintLifecycleStore(
             self.con,
@@ -1732,185 +1716,46 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
                 sprint_id,
                 "completed",
                 sprint_domain.LifecycleActor("planner", 3),
-                reason="final response follows",
+                reason="finish without displacement",
                 terminal_outcome="accepted",
             )
         )
 
-        self.assertEqual([developer_run], interrupts)
+        self.assertEqual([], interrupts)
         self.assertEqual(
-            [(developer_run,)],
+            [(planner_run, "running"), (developer_run, "running")],
             [
                 tuple(row)
                 for row in self.con.execute(
-                    "SELECT run_id FROM conversation_events "
-                    "WHERE event_type='run.interrupt.requested' ORDER BY run_id"
+                    "SELECT run_id,state FROM conversation_runs "
+                    "WHERE run_id IN (?,?) ORDER BY run_id",
+                    (planner_run, developer_run),
                 )
             ],
         )
         self.assertEqual(
-            [(planner_run,), (developer_run,)],
+            [(1, developer_conversation), (3, planner_conversation)],
             [
                 tuple(row)
                 for row in self.con.execute(
-                    "SELECT run_id FROM conversation_events "
-                    "WHERE event_type='conversation.close.requested' ORDER BY run_id"
+                    "SELECT shell_id,chat_id FROM active_shell_chats "
+                    "WHERE shell_id IN (1,3) ORDER BY shell_id"
                 )
             ],
         )
         self.assertEqual(
-            ("cancelled", "cancelled"),
-            tuple(
-                self.con.execute(
-                    "SELECT message.state,outbox.state "
-                    "FROM conversation_messages message "
-                    "JOIN conversation_outbox outbox USING(message_id) "
-                    "WHERE message.message_id=?",
-                    (queued_message_id,),
-                ).fetchone()
-            ),
-        )
-        terminal_fact_counts = tuple(
+            0,
             self.con.execute(
-                "SELECT "
-                "(SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
-                " AND event_type='lifecycle.completed'),"
-                "(SELECT COUNT(*) FROM conversation_events "
-                " WHERE event_type='conversation.close.requested')",
-                (sprint_id,),
-            ).fetchone()
-        )
-        self.assertFalse(
-            lifecycle.transition(
-                sprint_id,
-                "completed",
-                sprint_domain.LifecycleActor("planner", 3),
-                reason="retry",
-                terminal_outcome="accepted",
-            )
+                "SELECT COUNT(*) FROM conversation_events "
+                "WHERE event_type='conversation.close.requested'"
+            ).fetchone()[0],
         )
         self.assertEqual(
-            terminal_fact_counts,
-            tuple(
-                self.con.execute(
-                    "SELECT "
-                    "(SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
-                    " AND event_type='lifecycle.completed'),"
-                    "(SELECT COUNT(*) FROM conversation_events "
-                    " WHERE event_type='conversation.close.requested')",
-                    (sprint_id,),
-                ).fetchone()
+            [{"shell_id": 1, "sprint": None}, {"shell_id": 3, "sprint": None}],
+            sprint_participant_chats.attach_live_participations(
+                self.con,
+                [{"shell_id": 1}, {"shell_id": 3}],
             ),
-        )
-
-        with tempfile.TemporaryDirectory() as directory:
-            db_path = Path(directory) / "terminal.db"
-            with closing(sqlite3.connect(db_path)) as target:
-                self.con.backup(target)
-            broker = conversation_broker.BrokerStore(db_path)
-            self.assertTrue(
-                broker.finish_run(
-                    planner_run,
-                    "succeeded",
-                    event_type="run.completed",
-                    payload={"final_output": "Sprint completed successfully."},
-                )
-            )
-            self.assertTrue(
-                broker.finish_run(
-                    developer_run,
-                    "cancelled",
-                    event_type="run.interrupted",
-                    payload={"interrupt_evidence": "sprint completion"},
-                )
-            )
-            with closing(sqlite3.connect(db_path)) as observed:
-                observed.row_factory = sqlite3.Row
-                self.assertEqual(
-                    [("closed", 1)] * 2,
-                    [
-                        tuple(row)
-                        for row in observed.execute(
-                            "SELECT conversation.state,"
-                            "conversation.closed_at IS NOT NULL "
-                            "FROM conversations conversation "
-                            "JOIN sprint_participant_conversations linked "
-                            "ON linked.conversation_id=conversation.conversation_id "
-                            "JOIN sprint_participants participant "
-                            "ON participant.participant_id=linked.sprint_participant_id "
-                            "WHERE participant.sprint_id=? "
-                            "ORDER BY conversation.conversation_id",
-                            (sprint_id,),
-                        )
-                    ],
-                )
-                planner_terminal = observed.execute(
-                    "SELECT event_type,payload FROM conversation_events "
-                    "WHERE conversation_id=? AND run_id=? "
-                    "AND event_type='run.completed'",
-                    (planner_conversation, planner_run),
-                ).fetchone()
-                self.assertEqual("run.completed", planner_terminal["event_type"])
-                self.assertEqual(
-                    "Sprint completed successfully.",
-                    json.loads(planner_terminal["payload"])["final_output"],
-                )
-                self.assertEqual(
-                    "cancelled",
-                    observed.execute(
-                        "SELECT state FROM conversation_runs WHERE run_id=?",
-                        (developer_run,),
-                    ).fetchone()[0],
-                )
-
-    def test_fnb_completion_still_defers_owning_planner_run(self):
-        sprint_id, _ = self.create_sprint()
-        self.store.arm(sprint_id, 3)
-        self.con.execute(
-            "INSERT INTO shells "
-            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
-            "VALUES (5,'FnB','FNB','admin','prompt',1)"
-        )
-        self.con.commit()
-        _, planner_run = self.add_live_run(sprint_id, 3)
-        _, developer_run = self.add_live_run(sprint_id, 1)
-        interrupts: list[int] = []
-        lifecycle = sprint_domain.SprintLifecycleStore(
-            self.con,
-            interrupt_run=lambda run_id: interrupts.append(run_id) or True,
-            notify_commit=lambda: True,
-        )
-
-        self.assertTrue(
-            lifecycle.transition(
-                sprint_id,
-                "completed",
-                sprint_domain.LifecycleActor("fnb", 5),
-                reason="FnB accepts the completed Sprint",
-                terminal_outcome="accepted",
-            )
-        )
-
-        self.assertEqual([developer_run], interrupts)
-        self.assertEqual(
-            [(developer_run,)],
-            [
-                tuple(row)
-                for row in self.con.execute(
-                    "SELECT run_id FROM conversation_events "
-                    "WHERE event_type='run.interrupt.requested' ORDER BY run_id"
-                )
-            ],
-        )
-        self.assertEqual(
-            [(planner_run,), (developer_run,)],
-            [
-                tuple(row)
-                for row in self.con.execute(
-                    "SELECT run_id FROM conversation_events "
-                    "WHERE event_type='conversation.close.requested' ORDER BY run_id"
-                )
-            ],
         )
 
     def test_abort_interrupts_owning_planner_and_other_active_participants(self):
@@ -1944,58 +1789,56 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
                 )
             ],
         )
+        self.assertEqual(
+            2,
+            self.con.execute(
+                "SELECT COUNT(*) FROM active_shell_chats WHERE shell_id IN (1,3)"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM conversation_events "
+                "WHERE event_type='conversation.close.requested'"
+            ).fetchone()[0],
+        )
 
-    def test_terminal_lifecycle_closes_every_sprint_conversation(self):
-        terminal_sprints = []
-        for target in ("completed", "aborted"):
-            sprint_id, _ = self.create_sprint()
-            self.store.arm(sprint_id, 3)
-            for shell_id in (1, 2, 3):
-                self.ensure_wake_chat(sprint_id, shell_id)
-            conversation_ids = [
-                str(row[0])
+    def test_completed_sprint_keeps_idle_registry_chats_open(self):
+        sprint_id, _ = self.create_sprint()
+        self.store.arm(sprint_id, 3)
+        conversation_ids = [
+            self.ensure_wake_chat(sprint_id, shell_id)
+            for shell_id in (1, 2, 3)
+        ]
+
+        self.store.transition(
+            sprint_id,
+            "completed",
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="finish without chat displacement",
+            terminal_outcome="completed",
+        )
+
+        marks = ",".join("?" for _ in conversation_ids)
+        self.assertEqual(
+            [("idle", 0)] * 3,
+            [
+                tuple(row)
                 for row in self.con.execute(
-                    "SELECT pc.conversation_id "
-                    "FROM sprint_participant_conversations pc "
-                    "JOIN sprint_participants p "
-                    "ON p.participant_id=pc.sprint_participant_id "
-                    "WHERE p.sprint_id=? ORDER BY pc.conversation_id",
-                    (sprint_id,),
-                )
-            ]
-            self.assertEqual(3, len(conversation_ids))
-
-            self.store.transition(
-                sprint_id,
-                target,
-                sprint_domain.LifecycleActor("planner", 3),
-                reason=f"finish as {target}",
-                terminal_outcome=f"terminal {target}",
-            )
-
-            marks = ",".join("?" for _ in conversation_ids)
-            self.assertEqual(
-                [("closed", 1)] * 3,
-                [
-                    tuple(row)
-                    for row in self.con.execute(
-                        "SELECT state,closed_at IS NOT NULL FROM conversations "
-                        f"WHERE conversation_id IN ({marks}) ORDER BY conversation_id",
-                        conversation_ids,
-                    )
-                ],
-            )
-            self.assertEqual(
-                3,
-                self.con.execute(
-                    "SELECT COUNT(*) FROM conversation_events "
-                    f"WHERE conversation_id IN ({marks}) "
-                    "AND event_type='conversation.closed'",
+                    "SELECT state,closed_at IS NOT NULL FROM conversations "
+                    f"WHERE conversation_id IN ({marks}) ORDER BY conversation_id",
                     conversation_ids,
-                ).fetchone()[0],
-            )
-            terminal_sprints.append(sprint_id)
-
+                )
+            ],
+        )
+        self.assertEqual(
+            3,
+            self.con.execute(
+                "SELECT COUNT(*) FROM active_shell_chats "
+                f"WHERE chat_id IN ({marks})",
+                conversation_ids,
+            ).fetchone()[0],
+        )
         self.assertEqual(
             [{"shell_id": 1, "sprint": None}, {"shell_id": 2, "sprint": None}],
             sprint_participant_chats.attach_live_participations(
@@ -2003,17 +1846,6 @@ class LifecycleExitAndRestartTest(SprintDomainCase):
                 [{"shell_id": 1}, {"shell_id": 2}],
             ),
         )
-        self.assertEqual(
-            ["completed", "aborted"],
-            [
-                self.con.execute(
-                    "SELECT lifecycle FROM sprints WHERE sprint_id=?",
-                    (sprint_id,),
-                ).fetchone()[0]
-                for sprint_id in terminal_sprints
-            ],
-        )
-
     def test_restart_recovers_prepared_armed_and_paused_without_state_drift(self):
         sprint_id, _ = self.create_sprint()
         coordinator = self.coordinator()

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -211,8 +211,9 @@ class ReviewHandoffTest(SprintReviewLoopCase):
             if outcome.wake_id == handoff.wake_id:
                 break
         reviewer_chat = self.con.execute(
-            "SELECT current_conversation_id FROM sprint_participants "
-            "WHERE participant_id=?",
+            "SELECT active.chat_id FROM sprint_participants participant "
+            "JOIN active_shell_chats active ON active.shell_id=participant.shell_id "
+            "WHERE participant.participant_id=?",
             (self.reviewer_id,),
         ).fetchone()[0]
         self.assertEqual((handoff.wake_id, reviewer_chat), observed[-1])
@@ -327,8 +328,9 @@ class ReviewHandoffTest(SprintReviewLoopCase):
                 self.con.execute(
                     "SELECT COUNT(*),"
                     "(SELECT COUNT(*) FROM sprint_judgments WHERE work_unit_id=?),"
-                    "(SELECT COUNT(*) FROM sprint_participant_conversations "
-                    " WHERE purpose='merge') "
+                    "(SELECT COUNT(*) FROM pragma_table_info("
+                    "'sprint_participant_conversations') "
+                    "WHERE name IN ('purpose','parent_conversation_id')) "
                     "FROM wake_message WHERE idempotency_key IN (?,?)",
                     (
                         self.unit_id,
@@ -422,8 +424,9 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         self.assertEqual(
             0,
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_participant_conversations "
-                "WHERE purpose='fix'"
+                "SELECT COUNT(*) FROM pragma_table_info("
+                "'sprint_participant_conversations') "
+                "WHERE name IN ('purpose','parent_conversation_id')"
             ).fetchone()[0],
         )
         self.assertEqual("accepted", self.messages.mark_read(changed.message_id, 1))
@@ -509,15 +512,18 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         self.assertEqual(
             0,
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_participant_conversations "
-                "WHERE purpose='merge'"
+                "SELECT COUNT(*) FROM pragma_table_info("
+                "'sprint_participant_conversations') "
+                "WHERE name IN ('purpose','parent_conversation_id')"
             ).fetchone()[0],
         )
         self.assertEqual(
             self.developer_conversation_id,
             self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=?",
+                "SELECT active.chat_id FROM sprint_participants participant "
+                "JOIN active_shell_chats active "
+                "ON active.shell_id=participant.shell_id "
+                "WHERE participant.participant_id=?",
                 (self.developer_id,),
             ).fetchone()[0],
         )
@@ -668,8 +674,10 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         self.assertEqual(
             self.developer_conversation_id,
             self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE participant_id=?",
+                "SELECT active.chat_id FROM sprint_participants participant "
+                "JOIN active_shell_chats active "
+                "ON active.shell_id=participant.shell_id "
+                "WHERE participant.participant_id=?",
                 (self.developer_id,),
             ).fetchone()[0],
         )
@@ -988,12 +996,12 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             ],
         )
         current = self.con.execute(
-            "SELECT persistent_conversation_id,current_conversation_id "
-            "FROM sprint_participants WHERE participant_id=?",
+            "SELECT active.chat_id FROM sprint_participants participant "
+            "JOIN active_shell_chats active ON active.shell_id=participant.shell_id "
+            "WHERE participant.participant_id=?",
             (self.developer_id,),
         ).fetchone()
         self.assertEqual(self.developer_conversation_id, current[0])
-        self.assertEqual(current[0], current[1])
         assignment = self.con.execute(
             "SELECT message_id FROM wake_message WHERE work_unit_id=? "
             "AND message_kind='work_assignment'",

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -24,6 +24,7 @@ SKILLS = {
 }
 RESEEDED_SKILLS = set(SKILLS) | {"db_map"}
 AUTHORITY_SPLIT_SKILLS = {"sprint_pln", "sprint_rev"}
+V21_ROLE_SKILLS = set(SKILLS)
 
 
 class SprintSkillTest(unittest.TestCase):
@@ -162,6 +163,41 @@ class SprintSkillTest(unittest.TestCase):
             con.executescript(migration)
 
             for name in sorted(AUTHORITY_SPLIT_SKILLS):
+                with self.subTest(name=name):
+                    rows = con.execute(
+                        "SELECT description,category,command,common,content,is_deleted "
+                        "FROM skills WHERE name=?",
+                        (name,),
+                    ).fetchall()
+                    self.assertEqual(len(rows), 1)
+                    self.assertEqual(0, rows[0][5])
+                    self.assertIn("Reviewer decides", rows[0][4])
+                    self.assertIn("Planner", rows[0][4])
+        finally:
+            con.close()
+
+    def test_v21_reseed_converges_dirty_rows_and_replays_idempotently(self):
+        con = sqlite3.connect(":memory:")
+        try:
+            con.executescript((ENGINE / "schema.sql").read_text())
+            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name >= "0169_reseed_sprint_v21_guidance.sql":
+                    break
+                con.executescript(migration.read_text())
+            placeholders = ",".join("?" for _ in V21_ROLE_SKILLS)
+            con.execute(
+                f"UPDATE skills SET content='stale pre-0169 guidance' "
+                f"WHERE name IN ({placeholders})",
+                tuple(sorted(V21_ROLE_SKILLS)),
+            )
+
+            migration = (
+                ENGINE / "migrations" / "0169_reseed_sprint_v21_guidance.sql"
+            ).read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+
+            for name in sorted(V21_ROLE_SKILLS):
                 with self.subTest(name=name):
                     expected = seed_skills.parse_skill(
                         ASSETS / name / "SKILL.md"
@@ -363,13 +399,47 @@ class SprintSkillTest(unittest.TestCase):
         self.assertIn("does not pause the sprint", normalized)
         self.assertIn("relay itself fails", normalized)
 
-    def test_legacy_close_skill_keeps_planner_transition_safety_until_retirement(self):
+    def test_close_skill_routes_decisions_without_owning_judgment(self):
         close = (ASSETS / "sprint_close" / "SKILL.md").read_text()
         normalized = " ".join(close.lower().split())
         self.assertIn("sc sprint pause --sprint <id>", close)
-        self.assertIn("active relay is not available after", normalized)
+        self.assertIn("the reviewer decides", normalized)
+        self.assertIn("the planner executes", normalized)
+        self.assertIn("decision #46", normalized)
         self.assertIn("exhausted recovery wake", normalized)
         self.assertIn("do not create recursive", normalized)
+
+    def test_v21_delivery_contract_is_folded_into_roles_and_boot(self):
+        bodies = {
+            name: (ASSETS / name / "SKILL.md").read_text()
+            for name in SKILLS
+        }
+        combined = "\n".join(bodies.values())
+        for phrase in (
+            "active-chat registry",
+            "natural boundary",
+            "inactivity ceiling",
+            "reaper",
+            "coordinate mode",
+            "PR-event wakes",
+            "Defaults satisfy the gate",
+        ):
+            self.assertIn(phrase, combined)
+
+        developer = bodies["sprint_dev"]
+        reviewer = bodies["sprint_rev"]
+        planner = bodies["sprint_pln"]
+        self.assertIn("outside an armed Sprint", developer)
+        self.assertIn("Reviewer decides", developer)
+        self.assertIn("replan, cancel", reviewer)
+        self.assertIn("Compile the bounded evidence packet first", reviewer)
+        self.assertIn("Developer-owned subscriptions", planner)
+
+        boot = (ENGINE / "templates" / "boot.md").read_text()
+        self.assertIn("## ACTIVE CHAT DELIVERY", boot)
+        self.assertIn("Every `wake_message` creates durable delivery intent", boot)
+        self.assertIn("verified live turn", boot)
+        self.assertIn("defaults satisfy the gate", boot)
 
     def test_every_affected_file_argument_names_the_hard_ceiling(self):
         parser = sprint_cli.build_parser()

--- a/tests/test_sprint_snapshot_rebuild.py
+++ b/tests/test_sprint_snapshot_rebuild.py
@@ -172,18 +172,21 @@ def arm_with_representative_state(con: sqlite3.Connection) -> None:
     )
     con.executemany(
         "INSERT INTO sprint_participant_conversations "
-        "(sprint_participant_id,conversation_id,purpose) VALUES (?,?,'work')",
+        "(sprint_participant_id,conversation_id) VALUES (?,?)",
         ((1, "cv_plan"), (2, "cv_dev"), (3, "cv_rev")),
     )
     con.executemany(
-        "UPDATE sprint_participants SET persistent_conversation_id=?,"
-        "current_conversation_id=?,disposition=?,updated_at=? "
+        "UPDATE sprint_participants SET disposition=?,updated_at=? "
         "WHERE participant_id=?",
         (
-            ("cv_plan", "cv_plan", "active", "2026-08-01 21:00:00", 1),
-            ("cv_dev", "cv_dev", "active", "2026-08-01 21:00:01", 2),
-            ("cv_rev", "cv_rev", "idle", "2026-08-01 21:00:02", 3),
+            ("active", "2026-08-01 21:00:00", 1),
+            ("active", "2026-08-01 21:00:01", 2),
+            ("idle", "2026-08-01 21:00:02", 3),
         ),
+    )
+    con.executemany(
+        "INSERT INTO active_shell_chats (shell_id,chat_id) VALUES (?,?)",
+        ((3, "cv_plan"), (1, "cv_dev"), (2, "cv_rev")),
     )
     con.execute(
         "UPDATE sprints SET lifecycle='armed',armed_at='2026-08-01 21:00:00',"
@@ -395,9 +398,7 @@ class SprintSnapshotRebuildTest(unittest.TestCase):
 
         self.assertEqual(before, rows_by_table(self.db, compared))
 
-    def test_participant_link_parent_with_higher_id_restores_before_pointers(
-        self,
-    ) -> None:
+    def test_flat_participant_links_restore_out_of_id_order(self) -> None:
         con = sqlite3.connect(self.db)
         try:
             seed_prepared(con)
@@ -405,29 +406,33 @@ class SprintSnapshotRebuildTest(unittest.TestCase):
                 "INSERT INTO conversations "
                 "(conversation_id,shell_id,owner_user_id,harness,provider,model,"
                 "effort,worktree,title,creation_idempotency_key,"
-                "creation_request_hash,conversation_scope) VALUES "
+                "creation_request_hash,conversation_scope,state,closed_at) VALUES "
                 "(?,1,1,'codex','test','model','high','/worktree','Sprint link',"
-                "?,?,'sprint')",
+                "?,?,'sprint',?,?)",
                 (
-                    ("cv_parent", "link-parent", "link-parent-hash"),
-                    ("cv_child", "link-child", "link-child-hash"),
+                    (
+                        "cv_parent",
+                        "link-parent",
+                        "link-parent-hash",
+                        "closed",
+                        "2026-08-01 20:00:00",
+                    ),
+                    ("cv_child", "link-child", "link-child-hash", "idle", None),
                 ),
             )
             con.execute(
                 "INSERT INTO sprint_participant_conversations "
                 "(participant_conversation_id,sprint_participant_id,"
-                "conversation_id,purpose) VALUES (100,2,'cv_parent','work')"
+                "conversation_id) VALUES (100,2,'cv_parent')"
             )
             con.execute(
                 "INSERT INTO sprint_participant_conversations "
                 "(participant_conversation_id,sprint_participant_id,"
-                "conversation_id,purpose,parent_conversation_id) "
-                "VALUES (1,2,'cv_child','fix','cv_parent')"
+                "conversation_id) VALUES (1,2,'cv_child')"
             )
             con.execute(
-                "UPDATE sprint_participants SET persistent_conversation_id="
-                "'cv_parent', current_conversation_id='cv_child' "
-                "WHERE participant_id=2"
+                "INSERT INTO active_shell_chats (shell_id,chat_id) "
+                "VALUES (1,'cv_child')"
             )
             con.commit()
         finally:

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -437,18 +437,20 @@ class LifecycleTest(SprintDomainCase):
         self.store.arm(sprint_id, 3)
 
         participants = self.con.execute(
-            "SELECT participant_id,persistent_conversation_id,"
-            "current_conversation_id FROM sprint_participants "
+            "SELECT participant_id FROM sprint_participants "
             "WHERE sprint_id=? ORDER BY participant_id",
             (sprint_id,),
         ).fetchall()
         self.assertEqual(3, len(participants))
-        self.assertTrue(
-            all(
-                row["persistent_conversation_id"] is None
-                and row["current_conversation_id"] is None
-                for row in participants
-            )
+        self.assertEqual(
+            set(),
+            {"persistent_conversation_id", "current_conversation_id"}
+            & {
+                row[1]
+                for row in self.con.execute(
+                    "PRAGMA table_info(sprint_participants)"
+                )
+            },
         )
         self.assertEqual(
             0,
@@ -528,16 +530,11 @@ class LifecycleTest(SprintDomainCase):
             ).fetchone()[0],
         )
         self.assertEqual(
-            [(None, None), (None, None), (None, None)],
-            [
-                tuple(row)
-                for row in self.con.execute(
-                    "SELECT persistent_conversation_id,current_conversation_id "
-                    "FROM sprint_participants WHERE sprint_id=? "
-                    "ORDER BY participant_id",
-                    (sprint_id,),
-                )
-            ],
+            3,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_participants WHERE sprint_id=?",
+                (sprint_id,),
+            ).fetchone()[0],
         )
 
     def test_arm_ignores_orphan_conversation_keys_from_reused_numeric_ids(self) -> None:
@@ -582,33 +579,13 @@ class LifecycleTest(SprintDomainCase):
             "ORDER BY link.sprint_participant_id"
         ).fetchall()
         self.assertEqual(0, len(linked))
-        first_ids = sprint_domain.sprint_participant_chats.provision_at_arming(
-            self.con, sprint_id
-        )
-        linked = self.con.execute(
-            "SELECT c.conversation_id,c.creation_idempotency_key "
-            "FROM sprint_participant_conversations link "
-            "JOIN conversations c ON c.conversation_id=link.conversation_id "
-            "ORDER BY link.sprint_participant_id"
-        ).fetchall()
-        self.assertEqual(3, len(linked))
-        self.assertTrue(
-            all(
-                row["conversation_id"] not in {item[0] for item in historical}
-                and row["creation_idempotency_key"].startswith(
-                    "sprint-generation:"
-                )
-                and len(row["creation_idempotency_key"]) <= 255
-                for row in linked
-            )
-        )
-        replay_ids = sprint_domain.sprint_participant_chats.provision_at_arming(
-            self.con, sprint_id
-        )
-        self.assertEqual(first_ids, replay_ids)
         self.assertEqual(
-            6,
+            3,
             self.con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute("SELECT COUNT(*) FROM active_shell_chats").fetchone()[0],
         )
 
     def test_armed_sprint_merge_grant_is_immutable(self) -> None:

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -164,9 +164,8 @@ class SprintWorkDispatchCase(unittest.TestCase):
     def conversation_for(self, shell_id: int) -> str:
         return str(
             self.con.execute(
-                "SELECT current_conversation_id FROM sprint_participants "
-                "WHERE sprint_id=? AND shell_id=?",
-                (self.sprint_id, shell_id),
+                "SELECT chat_id FROM active_shell_chats WHERE shell_id=?",
+                (shell_id,),
             ).fetchone()[0]
         )
 

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -78,6 +78,7 @@ class SupervisionFixture:
                 "NO_COLOR": "1",
             }
         )
+        self.env.pop("SC_DB_BACKUP_DIR", None)
         self._sockets: list[socket.socket] = []
 
     def close(self) -> None:


### PR DESCRIPTION
## Summary

- retire participant chat pointers, purpose/parent topology, reroute helpers, terminal lifecycle chat closure, and the Sprint-armed PR-subscription gate
- make active_shell_chats the sole current-chat authority, retain flat immutable Sprint history links, and enforce one open chat per shell universally
- fold Sprints v2.1 authority and delivery guidance into five skills plus boot, with convergent reseed migration 0169
- make full-suite skill and supervision fixtures hermetic

Fresh writer inventory at base d1b0aa7: 9 pointer-writing SQL sites. Remaining after this change: 0.

Trade-off: the API still exposes current_conversation_id as a derived registry projection for UI compatibility, while all mutable participant pointer/topology state is deleted.

## Verification

- ./sc test — 1717 passed
- migration/reseed slice — 80 passed, 199 subtests passed
- ./sc render-check
- ./sc verify
- git diff --check

Sprint 87 U9 · task #268. Never merge without the FnB gate.