### PR TITLE
feat(sprints): delay new wakes and order handoffs

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -346,7 +346,10 @@ def get_shells(con) -> list[dict]:
         "s.mandate, s.is_shared, "
         "(SELECT COUNT(*) FROM shell_messages m "
         " WHERE m.to_shell_id=s.shell_id AND m.read_at IS NULL "
-        " AND m.kind IN ('shell','task','result')) AS unread_message_count "
+        " AND m.kind IN ('shell','task','result')) AS unread_message_count, "
+        "(SELECT w.available_at FROM sprint_wake_outbox w "
+        " WHERE w.receiver_shell_id=s.shell_id AND w.state='pending' "
+        " AND w.available_at>datetime('now')) AS pending_wake_available_at "
         "FROM shells s WHERE COALESCE(s.is_deleted,0)=0 ORDER BY s.shell_id"))
     return sprint_participant_chats.attach_live_participations(con, shells)
 

--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -122,11 +122,15 @@ registered PR.
 
 ## Review handoff
 
-Put the readiness claim in a file, then use one stable retry key:
+Complete a review handoff in this exact order:
 
-Keep the readiness claim at about 6,000 characters or fewer; 8,000 is the hard
-maximum. Run `wc -m < <path>` and condense before the typed handoff. The handoff
-exists only after the command succeeds and confirms its durable write and wake.
+1. Finish the readiness claim and every local verification step.
+2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+3. Run `wc -m < <path>`; keep the claim near 6,000 characters and below the
+   8,000-character hard maximum.
+4. As the literal final action of the turn, send the typed handoff with one
+   stable retry key:
 
 ```text
 sc sprint request-review \
@@ -134,8 +138,10 @@ sc sprint request-review \
   --readiness-file <path> --key <stable-key>
 ```
 
-The assigned Reviewer receives an actionable request. After `request-review`
-succeeds, stop and await the native verdict wake. A changes-requested verdict
+5. When the command confirms the durable write and Reviewer wake, immediately
+   stop and await the native verdict wake. Run no trailing command.
+
+A changes-requested verdict
 returns as Re-enter to your registry chat. Apply every blocking finding,
 re-establish green, and hand back with a new stable review key. Record
 disagreements as judgment; the Reviewer owns scope/severity decisions and the
@@ -154,8 +160,30 @@ sc sprint authorize-merge \
 
 Merge only the exact repository, PR number, and head SHA returned. If the
 command refuses, do not work around it; wait for the watcher or return to the
-appropriate loop. After merge, clean the worktree, submit the unit result and
-judgments, and let automatic merge observation advance dependencies.
+appropriate loop.
+
+## Post-merge handoff
+
+After the exact authorized merge succeeds, complete close-out in this order:
+
+1. Clean the worktree and collect the merged PR identity, merge SHA, unit
+   result, verification evidence, and judgments in the handoff body file.
+2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+3. Run `wc -m < <path>`; keep the report near 6,000 characters and below the
+   8,000-character hard maximum.
+4. As the literal final action of the turn, send the merged-work handoff to the
+   Planner:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --key <stable-merged-handoff-key>
+```
+
+5. When the command confirms the durable write and Planner wake, stop
+   immediately. Run no trailing Git, Sprint, inbox, cleanup, or status command.
+   Automatic merge observation records the durable PR transition; the Planner
+   uses this handoff wake to release the next wave.
 
 ## Report and stop
 
@@ -166,7 +194,7 @@ the Reviewer decides whether to continue, re-plan, or pause and the Planner
 executes that decision.
 
 Stop when the unit is merged and reported, declined, awaiting Planner/FnB
-recovery, or returned to review. Before stopping, re-run `sc sprint inbox
---sprint <id>`, act on newly arrived messages, mark every handled informational
-message read with `accept`, and confirm the final typed handoff succeeded. Ask
-the Planner for later work only after the current editing lane is terminal.
+recovery, or returned to review. For normal review and merge handoffs, the
+ordered procedures above place inbox handling before the typed handoff and make
+that handoff the turn's last action. Ask the Planner for later work only after
+the current editing lane is terminal.

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -210,12 +210,32 @@ FnB override; it is terminal and deletes nothing.
 
 ## Handoffs and stop
 
-Assign ready work through the durable dispatcher. Planner → Developer
-assignments are declared New; Developer → Reviewer review requests are declared
-New; Developer/Reviewer → Planner results are Re-enter. These are idle-time
-guarantees under the live-turn boundary rule, not a parent/child chat topology.
-The Planner receives no PR-event wakes; Developer-owned subscriptions carry
-red, green, and externally closed facts directly to the owning Developer.
+Planner → Developer assignments are declared New; Developer → Reviewer review
+requests are declared New; Developer/Reviewer → Planner results are Re-enter.
+These are idle-time guarantees under the live-turn boundary rule, not a
+parent/child chat topology. The Planner receives no PR-event wakes;
+Developer-owned subscriptions carry red, green, and externally closed facts
+directly to the owning Developer.
+
+Never dispatch the next wave from a merge-observation turn. The Developer's
+merged-work handoff wake is the only normal next-wave dispatch trigger. On that
+wake, complete the turn in this exact order:
+
+1. Run `sc sprint inbox --sprint <id>` and inspect the durable merged-work
+   handoff plus current work-unit and dependency state.
+2. Act on every earlier informational item and mark each handled item read with
+   `accept`, including the Developer handoff.
+3. Finish all reconciliation, judgment recording, and other Planner
+   bookkeeping. No work remains after this step.
+4. As the literal final action of the turn, release dependency-ready lanes:
+
+```text
+sc sprint dispatch --sprint <id>
+```
+
+5. When the command confirms the durable assignment writes and New wakes, stop
+   immediately. Run no trailing command. Empty dispatch is still the final
+   action for that handoff turn; investigate only on a later durable wake.
 
 When all planned delivery work is terminal and merged or explicitly no-code,
 send the Reviewer the bound revisions, integrated main SHA, ratified judgments,

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -156,17 +156,25 @@ Findings must state:
 - a reproducible consequence; and
 - the fix boundary, without prescribing unnecessary architecture.
 
-Put the verdict body in a file and record it through the authenticated surface:
+Complete a unit verdict in this exact order:
 
-Keep the verdict at about 6,000 characters or fewer; 8,000 is the hard maximum.
-Run `wc -m < <path>` before submission. The typed review handoff exists only
-after the command succeeds and confirms its durable write and Developer wake.
+1. Finish the review, findings, and verdict body; no inspection remains after
+   this step.
+2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+3. Run `wc -m < <path>`; keep the verdict near 6,000 characters and below the
+   8,000-character hard maximum.
+4. As the literal final action of the turn, record the typed verdict through
+   the authenticated surface:
 
 ```text
 sc sprint record-review \
   --sprint <id> --registered-pr <registered-id> \
   --verdict changes_requested --body-file <path> --key <stable-key>
 ```
+
+5. When the command confirms the durable write and Developer wake, stop
+   immediately. Run no trailing command.
 
 Use `approved` only when no Critical/Major/Medium finding remains. The engine
 checks that the request was accepted and still binds to the reviewed head,
@@ -247,11 +255,24 @@ pause, re-plan, cancel, or abort decision instead.
 
 ## Stop
 
-For either mode, re-run `sc sprint inbox --sprint <id>` and act on newly arrived
-messages before stopping. For unit review, stop after the durable verdict is
-recorded and every handled informational message is marked read with `accept`.
-For conformance, also require the report and all findings to replay
-idempotently, then require successful delivery of the Reviewer-authored Sprint
-report and conclude decision to the Planner. The conformance receipt plus the
-durable decision handoff completes Reviewer work; stop until another native
-wake arrives.
+For unit review, follow the ordered verdict procedure above: inbox handling and
+all evidence work precede `record-review`; the durable verdict is the literal
+last action, then the Reviewer stops.
+
+For conformance, require the report and findings to replay idempotently, then
+complete this final handoff order:
+
+1. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+2. Confirm the Reviewer-authored Sprint report and conclude decision body are
+   final and below the 8,000-character hard maximum.
+3. As the literal final action of the turn, deliver that decision to the
+   Planner:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --key <stable-conclude-handoff-key>
+```
+
+4. When the command confirms the durable write and Planner wake, stop
+   immediately. Run no trailing command until another native wake arrives.

--- a/.super-coder/migrations/0170_reseed_sprint_handoff_order.sql
+++ b/.super-coder/migrations/0170_reseed_sprint_handoff_order.sql
@@ -1,0 +1,751 @@
+-- 0170 — reseed ordered Sprint handoff guidance.
+-- Full-body UPSERTs converge existing installs to handoff-last-then-stop role contracts.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_dev',
+  'Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge only after live authorization, and record judgment without overlapping edits.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_dev — own one editing lane
+
+Use for an actionable work-unit assignment in an armed Sprint. Marking that
+Sprint message read is acceptance and starts work immediately. If you cannot
+accept, decline with a concrete reason; never leave it unread and waking.
+On every wake or re-entry, load `sprint_dev`, run the exact inbox command below,
+and inspect the durable message before deciding what to do.
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Use `accept` or `decline` for actionable work. After acting on an informational
+question, answer, blocker, or context message, run `accept` for that message.
+For informational messages it only marks the message read; it does not change
+Sprint or work-unit state.
+
+## Orient and bound the lane
+
+Read the assignment, expected output, bound spec revision, dependencies,
+assigned Reviewer, repository/worktree, merge grant, and prior judgments. One
+Developer shell may own one active work unit in the Sprint. Do not start a
+second editing lane or edit another shell''s worktree.
+
+If the requirement is ambiguous, choose the shippable reading within your
+unit''s scope, record the choice and rationale, and continue. Escalate changes to
+the unit boundary, interfaces another unit consumes, deliverable cuts, or scope
+growth to the Planner.
+
+The active-chat registry, not Sprint participant pointers, owns your current
+chat. Assignments are declared New, but a verified live turn is never displaced:
+delivery enters this chat at its natural boundary and drains every undelivered
+wake message. When idle, New rotates to a fresh chat; Re-enter resumes the
+registry chat; no registry row behaves as New. A generous inactivity ceiling
+unlinks a silent hung turn so the 60-second reaper can terminate its verified
+process identity.
+
+## Questions, answers, blockers, and failures
+
+Write a concrete question, answer, blocker, or useful context to a short body
+file, then send it durably to the participant who can act:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Ask the Planner about scope, priority, or cross-unit decisions; ask the assigned
+Reviewer about review evidence. Answer an incoming question through `send` so it
+wakes the asker, confirm that write, then mark the handled question read with
+`accept`. For a blocker or integrity concern, send the Planner concise evidence,
+impact, the exact action needed, and your recommendation. Continue safe
+independent work, but stop at a decision boundary when the answer is required.
+No immediate response is not a reason to send duplicates: the durable message
+and recovery reconciler own re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the write or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command, evidence, impact, and recommendation to FnB; do not invent an
+alternate delivery protocol. A Developer does not pause the Sprint. The
+Reviewer decides whether the evidence warrants continuing, re-planning, or
+pausing; the Planner executes that decision.
+
+## Build and verify
+
+Sync the assigned repository, work on a feature branch, match the surrounding
+code, and implement the smallest complete change. Keep external calls outside
+database transactions. Preserve durable identities and append-only evidence.
+
+Verification must exercise the unit''s independent stage gate and realistic
+failure paths. A local exploratory number is not merge evidence. Record real CI
+failures, anomalous infrastructure failures, retries, review friction, and
+known departures for the final report.
+
+An explicitly planned report-only or no-code lane completes with its durable
+result instead of a PR. Code lanes cannot use this path; they complete only
+after merge authorization and observation.
+
+Keep the result at about 6,000 characters or fewer; 8,000 is the hard maximum.
+Run `wc -m < <path>` before submitting, then require a successful command and
+durable completion receipt.
+
+```text
+sc sprint complete-unit --sprint <id> --work-unit <id> \
+  --result-file <path>
+```
+
+Register the PR through the authoritative Sprint surface and retain ownership
+until it is green. After `register-pr` succeeds, the native registered-PR
+watcher creates an engine-wide subscription owned by your shell. It supplies
+self-describing red, green, and externally closed facts as Re-enter wakes even
+after chat rotation or outside an armed Sprint. On red, diagnose and fix the PR.
+On green, judge readiness rather than forwarding mechanically. Planner and
+Reviewer receive no PR-event wakes.
+
+```text
+sc sprint register-pr --sprint <id> --repository <owner/name> \
+  --pr <number> --work-unit <id>
+```
+
+When no local implementation action remains, stop and await the native PR-fact
+wake. Use Sprint-native wakes for coordination. Do not start a recurring shell
+loop, scheduled job, manual watcher daemon, or external PR watcher to track the
+registered PR.
+
+## Review handoff
+
+Complete a review handoff in this exact order:
+
+1. Finish the readiness claim and every local verification step.
+2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+3. Run `wc -m < <path>`; keep the claim near 6,000 characters and below the
+   8,000-character hard maximum.
+4. As the literal final action of the turn, send the typed handoff with one
+   stable retry key:
+
+```text
+sc sprint request-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --readiness-file <path> --key <stable-key>
+```
+
+5. When the command confirms the durable write and Reviewer wake, immediately
+   stop and await the native verdict wake. Run no trailing command.
+
+A changes-requested verdict
+returns as Re-enter to your registry chat. Apply every blocking finding,
+re-establish green, and hand back with a new stable review key. Record
+disagreements as judgment; the Reviewer owns scope/severity decisions and the
+Planner executes any resulting action.
+
+## Merge boundary
+
+Approval alone is stale evidence. Immediately before merge, ask the engine to
+re-read live GitHub state and revalidate the armed grant, ownership, work-unit
+state, approved head, and checks:
+
+```text
+sc sprint authorize-merge \
+  --sprint <id> --registered-pr <registered-id>
+```
+
+Merge only the exact repository, PR number, and head SHA returned. If the
+command refuses, do not work around it; wait for the watcher or return to the
+appropriate loop.
+
+## Post-merge handoff
+
+After the exact authorized merge succeeds, complete close-out in this order:
+
+1. Clean the worktree and collect the merged PR identity, merge SHA, unit
+   result, verification evidence, and judgments in the handoff body file.
+2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+3. Run `wc -m < <path>`; keep the report near 6,000 characters and below the
+   8,000-character hard maximum.
+4. As the literal final action of the turn, send the merged-work handoff to the
+   Planner:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --key <stable-merged-handoff-key>
+```
+
+5. When the command confirms the durable write and Planner wake, stop
+   immediately. Run no trailing Git, Sprint, inbox, cleanup, or status command.
+   Automatic merge observation records the durable PR transition; the Planner
+   uses this handoff wake to release the next wave.
+
+## Report and stop
+
+Report broken bases, destructive ambiguity, unavailable GitHub, untrustworthy
+runners, provider exhaustion, or an unrecoverable environment to the Planner
+with evidence, impact, and a recommendation. Stop at the unsafe boundary while
+the Reviewer decides whether to continue, re-plan, or pause and the Planner
+executes that decision.
+
+Stop when the unit is merged and reported, declined, awaiting Planner/FnB
+recovery, or returned to review. For normal review and merge handoffs, the
+ordered procedures above place inbox handling before the typed handoff and make
+that handoff the turn''s last action. Ask the Planner for later work only after
+the current editing lane is terminal.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_rev',
+  'Review Sprints v2 work and whole-Sprint conformance — own pause, cancel, and conclude decisions, author the conformance and Sprint reports, and direct Planner actions through durable messages.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_rev — independent review and conformance
+
+Use in one of two modes: a work-unit PR review during the loop, or the final
+whole-Sprint conformance pass. Pre-declaration QAQC is a third entry condition,
+before a Sprint exists. The evidence differs; independence does not. The
+Reviewer decides and documents; the Planner acts. The FnB retains the
+board-level override established by decision #46.
+
+## Entry and durable state
+
+Pre-declaration QAQC begins from an explicit Planner or FnB request. Read the
+exact current spec document and sign that body directly; there is no Sprint id
+or Sprint inbox to inspect yet:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
+
+Once a Sprint is armed, every review or conformance entry arrives through its
+durable wake/inbox. On every wake or re-entry, load `sprint_rev`, inspect the
+message, and accept the actionable request before beginning:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+```
+
+Decline an actionable request you cannot take, with a concrete reason:
+
+```text
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Use `accept` or `decline` for actionable work. After acting on an informational
+question, answer, blocker, or context message, run `accept` for that message.
+For informational messages it only marks the message read; it does not change
+Sprint or work-unit state.
+
+Review requests are declared New, but wake type resolves at delivery. A verified
+live turn is never displaced: delivery enters the active registry chat at its
+natural boundary and drains every undelivered wake message. When idle, New
+rotates to a fresh chat; Re-enter resumes the registry chat; no registry row
+behaves as New. Reviewer verdicts to Developers and decisions to Planners are
+Re-enter. Reviewers never receive PR-event subscription wakes.
+
+## Questions, answers, blockers, and failures
+
+Put a concrete question, answer, blocker, or useful context in a short body file
+and send it to the participant who can act. Ask the Developer for missing PR
+evidence and the Planner for durable state or action-feasibility facts. Do not
+delegate Reviewer judgment to the Planner:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Answer incoming questions through `send` so the answer is durable and wakes the
+asker, confirm that write, then mark the handled question read with `accept`. A
+blocker or integrity concern is evidence for your decision. If action is needed,
+send the Planner the decision, impact, exact action, and recommendation through
+the protocol below. Continue independent safe review, but stop when missing
+facts prevent an honest decision at the decision boundary. Do not send duplicate
+reminders; unread recovery owns re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the verdict or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command, evidence, impact, and recommendation to FnB; do not invent an
+alternate delivery protocol. A Reviewer decides whether the condition warrants
+continuing, re-planning, pausing, cancellation, or conclusion, but does not
+invoke the lifecycle transition. Send the durable decision to the Planner, who
+executes it. A live FnB board-level override may supersede that decision and
+must be recorded as FnB authority, not Reviewer judgment.
+
+## Control and conclude decisions
+
+The Reviewer owns all pause, cancel, and conclude decisions and recommendations.
+The Planner owns all resulting actions. Base a decision on durable Sprint state,
+the exact bound revisions, current work/PR facts, liveness evidence, and any
+ratified judgment; ambiguous silence is not enough to corrupt a disposition.
+
+Send each decision to the Planner through the durable `send` surface above. The
+Reviewer → Planner route is Re-enter. The body must name:
+
+- `decision`: `pause`, `resume`, `replan`, `cancel`, `conclude`, or `abort`;
+- the evidence and rationale owned by the Reviewer;
+- exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
+- for conclude, the conformance report/follow-up ids, stable completion key,
+  and full Reviewer-authored final Sprint report body; and
+- any immediate safety impact that the FnB must see.
+
+The Planner accepts the actionable message, verifies the assigned Reviewer,
+and executes exactly that transition. The Reviewer never runs the pause,
+replan, cancel, resume, complete, or abort action. If the action is rejected, inspect
+the returned durable state and issue a new decision only when the evidence
+supports one; never ask the Planner to improvise around a precondition.
+
+The FnB board-level override from decision #46 is unaffected. A live FnB
+instruction can direct or supersede any decision; preserve it as a distinct
+authority record.
+
+## Severity rubric
+
+This skill owns severity. The governing spec intentionally does not.
+
+- **Critical** — active security/authority violation, destructive corruption,
+  or a condition that makes continued operation unsafe.
+- **Major** — wrong behavior, data loss, broken invariant, material spec
+  violation, or a loop/recovery path that can silently wedge delivery.
+- **Medium** — a concrete correctness or recovery gap likely to bite normal
+  use soon, including missing negative enforcement or an unreliable handoff.
+- **Low** — bounded cleanup, clarity, test depth, or resilience improvement that
+  does not make the delivered behavior wrong now.
+
+During a work-unit review, Critical/Major/Medium block approval; Low is a
+report note. During close-out conformance, every severity becomes a follow-up
+and none is fixed inside the Sprint.
+
+## Work-unit review
+
+Accept the actionable review request, then inspect the exact bound spec
+revision, readiness claim, PR head, diff, checks, tests, relevant runtime
+evidence, and prior judgment calls. Review code quality, edge cases/failure
+paths, and spec conformance. Trace the real path; do not trust names or PR prose.
+
+Read resolved closure evidence through the authenticated memory surface; no SQL
+or mutation is needed. Use the exact form for a cited flag and the scoped form
+to audit every resolved flag attached to the feature:
+
+```text
+sc mem get flags <flag-id>
+sc mem get flags --feature <feature-id> --resolved
+```
+
+Findings must state:
+
+- severity and concise title;
+- violated behavior or invariant;
+- exact code/evidence location;
+- a reproducible consequence; and
+- the fix boundary, without prescribing unnecessary architecture.
+
+Complete a unit verdict in this exact order:
+
+1. Finish the review, findings, and verdict body; no inspection remains after
+   this step.
+2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+3. Run `wc -m < <path>`; keep the verdict near 6,000 characters and below the
+   8,000-character hard maximum.
+4. As the literal final action of the turn, record the typed verdict through
+   the authenticated surface:
+
+```text
+sc sprint record-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --verdict changes_requested --body-file <path> --key <stable-key>
+```
+
+5. When the command confirms the durable write and Developer wake, stop
+   immediately. Run no trailing command.
+
+Use `approved` only when no Critical/Major/Medium finding remains. The engine
+checks that the request was accepted and still binds to the reviewed head,
+records judgment evidence, sends a Re-enter wake to the Developer, and
+resolves the review liveness expectation. Do not message around this surface;
+an unrecorded verdict cannot unlock merge.
+
+## Whole-Sprint conformance
+
+Judge integrated `main` against every governing bound revision, plus the exact
+recorded mid-Sprint revision facts and ratified judgments. Review the integrated
+system, not unit diffs. Compile the bounded evidence packet first:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 > evidence.json
+```
+
+Increase the bound only when truncation counters show the default omitted
+needed evidence; 200 is the maximum. The packet supplies facts, not judgment.
+
+Then classify each requirement as:
+
+- `as-specced`;
+- `deviated-intentionally` with its ratified judgment;
+- `deviated-silently`; or
+- `unimplemented`.
+
+The last two are findings. Include spec document id and work-unit id when known.
+Write the conformance report and a JSON findings array:
+
+```json
+[
+  {
+    "severity": "Major",
+    "title": "Integrated seam diverges",
+    "body": "Evidence and consequence.",
+    "spec_document_id": 46,
+    "work_unit_id": 9
+  }
+]
+```
+
+Then record both atomically:
+
+Keep the conformance report and each finding body at about 6,000 characters or
+fewer; 8,000 is the hard maximum for each. Run `wc -m < <report>` and length-check
+each finding body before submission. Require the successful report and
+follow-up receipt before stopping.
+
+```text
+sc sprint record-conformance \
+  --sprint <id> --body-file <report> --findings-file <json> \
+  --key <stable-pass-key>
+```
+
+This creates append-only conformance evidence and pending follow-ups for FnB
+disposition. It must not create a fix lane, reopen a completed work unit, or
+send findings to a Developer for in-Sprint repair — including Critical ones.
+Surface immediate safety risk to the FnB, but preserve the close-out rule.
+
+Then author the final Sprint report. Name the Reviewer as its author and answer:
+
+1. Which exact scope and revisions governed?
+2. What shipped, through which work units and PRs?
+3. Which Reviewer judgments and ratified deviations shaped the result?
+4. What failed, retried, paused, recovered, or remained anomalous?
+5. What did conformance conclude?
+6. Which follow-ups or unresolved items require FnB disposition?
+7. Where is the complete evidence?
+
+Keep the final report at about 6,000 characters or fewer and below the 8,000
+hard maximum; run `wc -m < <report>`. Do not smooth discrepancies into a
+success narrative. If the Sprint is done, send the Planner a `conclude`
+decision containing the full report body and the exact completion arguments
+defined in the control protocol. The Planner submits that body unchanged and
+owns only the close action. If the Sprint is not done, send the appropriate
+pause, re-plan, cancel, or abort decision instead.
+
+## Stop
+
+For unit review, follow the ordered verdict procedure above: inbox handling and
+all evidence work precede `record-review`; the durable verdict is the literal
+last action, then the Reviewer stops.
+
+For conformance, require the report and findings to replay idempotently, then
+complete this final handoff order:
+
+1. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+2. Confirm the Reviewer-authored Sprint report and conclude decision body are
+   final and below the 8,000-character hard maximum.
+3. As the literal final action of the turn, deliver that decision to the
+   Planner:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --key <stable-conclude-handoff-key>
+```
+
+4. When the command confirms the durable write and Planner wake, stop
+   immediately. Run no trailing command until another native wake arrives.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch ready lanes and execute Reviewer decisions through durable re-plan, pause, cancel, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
+
+Use as the originating Planner after `sprint_prep` arms the Sprint. The system
+captures deterministic facts; the Reviewer decides and documents, and the
+Planner acts. Execute Reviewer decisions without taking over their judgment or
+report authorship. The FnB retains the board-level override established by
+decision #46.
+On every wake or re-entry, load `sprint_pln`, run the exact inbox command below,
+and inspect the durable message before deciding what to do.
+
+## Start from durable state
+
+The armed runtime owns scheduled dispatch, unread wake recovery, liveness
+evaluation, and registered-PR observation. React to its durable inbox and wake
+facts; use the Planner turn for dispatch and exact execution of durable Reviewer
+decisions. The Reviewer owns pause, cancel, and conclude decisions plus the
+conformance and final Sprint reports. The Planner owns the corresponding state
+transitions.
+
+The active-chat registry is the only current-chat authority; zero or one chat
+per shell is legal. Every wake message creates delivery intent and a wake turn
+drains every undelivered message for the receiver. Planner-bound messages are
+declared Re-enter. If a verified turn is live, every declared type enters that
+chat at the natural boundary. When idle, Re-enter resumes the registry chat and
+New rotates it; no registry row behaves as New.
+
+FnB controls the Planner mode with the close button. Keeping the Planner chat
+open supervises one continuous thread. Closing it during an armed Sprint sets
+coordinate mode, so later idle Planner-bound Re-enters open fresh ticket chats;
+FnB pause/resume returns to supervise. Automatic pauses preserve that choice.
+Neither mode displaces a live turn. The inactivity ceiling closes a silent hung
+chat, and the registry reaper terminates its now-unlinked process.
+
+Read the Sprint inbox, lifecycle, bound spec revisions, work-unit graph,
+participant routes, active conversations, registered PRs, unresolved
+expectations, and recent anomalies. Viewing a participant conversation is
+observation, not activity; never manufacture progress from browser presence.
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Release every dependency-ready lane through the production surface:
+
+```text
+sc sprint dispatch --sprint <id>
+```
+
+The returned ids are wake identities. Work-unit disposition and messages are
+the authoritative release facts. Dispatch is safe to repeat: occupied Developer
+lanes and stable assignment generations prevent double booking.
+
+Accept or decline only when the inbox item is actionable. After acting on an
+informational question, answer, blocker, or evidence message, run `accept` for
+that message. For informational messages it only marks the message read; it does
+not change Sprint or work-unit state.
+
+## Running loop
+
+- Keep dependencies as the only hard sequence. When reality requires a re-plan,
+  give the Reviewer the current projection and evidence, then execute the exact
+  decision it returns; never rewrite completed history.
+- Let Developers own their PRs through green, review, correction, and merge.
+  Let Reviewers own verdicts and Sprint decisions. Do not proxy routine
+  handoffs or substitute Planner judgment for a Reviewer decision.
+- Consume passive system facts without waking yourself into every transition.
+  Route a decision boundary to the Reviewer; act when its Re-enter decision
+  message arrives.
+- Record the Reviewer decision identity, the exact action taken, and the action
+  receipt. Do not rewrite its rationale as Planner-authored judgment evidence.
+- A mid-Sprint spec edit is allowed only by the owning Planner or FnB. Record
+  the prior and new exact revision hashes. When acting as Planner, require a
+  durable Reviewer decision before the edit. The running Sprint remains bound
+  to its approved revision unless that decision explicitly says otherwise.
+
+The armed runtime evaluates liveness on its five-second pulse. A one-shot
+diagnostic/evaluation is available when evidence requires it:
+
+```text
+sc sprint monitor --sprint <id>
+```
+
+Run `monitor` once for concrete evidence, then return control to native
+delivery. It evaluates only due accepted expectations and its
+nudge/escalation identities are durable. Use Sprint-native wakes for
+coordination. Do not start a recurring shell loop, scheduled job, manual
+participant boot, or external PR watcher to track Sprint state.
+
+## Questions, answers, blockers, and failures
+
+Put a concrete question, answer, decision, blocker, or useful context in a short
+body file and address the participant who owns the needed fact or action:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Answer incoming questions through `send` so the answer is durable and wakes the
+asker, confirm that write, then mark the handled question read with `accept`.
+For a cross-unit blocker, send evidence, impact, and the exact action needed to
+every directly affected participant. Continue safe independent governance, but
+stop at a decision boundary when an answer is required. Do not spam duplicates
+when no response is immediate; unread recovery owns re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the write or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command and durable evidence to FnB; do not invent an alternate
+delivery protocol. When a Developer reports an integrity concern, relay its
+evidence, impact, and recommendation to the Reviewer. When the Reviewer returns
+a decision, execute it through the protocol below. Send any needed participant
+context before pausing; an active relay is not available after the lifecycle
+becomes paused.
+
+## Reviewer decision actions
+
+Pause, cancel, and conclude are Reviewer decisions and Planner actions. A valid
+decision arrives as a durable Reviewer → Planner Re-enter message and names the
+decision, evidence, target ids, reason, and exact requested transition. Accept
+the actionable message, verify it came from the assigned Reviewer, and execute
+that transition without re-adjudicating the decision. Record the decision
+message id and action receipt together.
+
+The FnB board-level override from decision #46 is unaffected: a live FnB
+instruction may direct or supersede any action. Name that override in the
+evidence instead of attributing it to the Reviewer.
+
+If a requested action fails a lifecycle, authority, or disposition precondition,
+do not substitute a different action. Send the refusal and current durable state
+back to the Reviewer (or surface it directly to FnB for an FnB override), then
+stop at that decision boundary.
+
+### Pause or resume
+
+On a Reviewer pause decision, transition durably, stop external Sprint services,
+persist interrupt intent, preserve every partial artifact, and retain the
+Reviewer judgment and evidence for recovery:
+
+```text
+sc sprint pause --sprint <id> --reason <reviewer-decision-reason>
+```
+
+Resume only on a later Reviewer decision or an FnB override. Reconcile native
+runs, unread messages, pending wakes, work units, registered PRs, capacity, and
+spec drift, then act with the supplied reason:
+
+```text
+sc sprint resume --sprint <id> [--reason <reviewer-reconciliation-decision>]
+```
+
+An exhausted recovery wake is bounded manual-recovery evidence, not a retry
+loop. Preserve the unread message and failed wake, involve FnB, and do not create
+recursive fallbacks. Drift informs; it never silently blocks resume.
+
+### Cancel or re-plan
+
+A Reviewer cancel decision must name one unreleased work unit and its retained
+terminal reason. Execute exactly that cancellation:
+
+```text
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reviewer-decision-reason>
+```
+
+For a Reviewer re-plan decision, apply its complete projection; never infer
+omitted fields or alter a released or completed lane:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  --developer-shell <id> --reviewer-shell <id> --wave <n> \
+  [--depends-on <work-unit-id>] [--output-kind code|report-only|no-code]
+```
+
+If a Developer or Reviewer declines, preserve the reason and ask the Reviewer
+for the replacement routing decision before issuing a fresh assignment.
+
+### Conclude or abort
+
+The Reviewer decides when the Sprint is done, records conformance, authors the
+final Sprint report, and sends a conclude decision containing the conformance
+receipt, follow-up ids, exact reason/outcome, stable key, and full report body.
+Write that Reviewer-authored body to `<reviewer-report>` unchanged, then perform
+the close action:
+
+```text
+sc sprint complete --sprint <id> --reason <reviewer-decision-reason> \
+  --outcome <reviewer-decision-outcome> --report-file <reviewer-report> \
+  --key <reviewer-decision-key>
+```
+
+Do not run `compile-report`, synthesize the final report, or editorialize the
+Reviewer body. Abort is likewise an action taken only on a Reviewer decision or
+FnB override; it is terminal and deletes nothing.
+
+## Handoffs and stop
+
+Planner → Developer assignments are declared New; Developer → Reviewer review
+requests are declared New; Developer/Reviewer → Planner results are Re-enter.
+These are idle-time guarantees under the live-turn boundary rule, not a
+parent/child chat topology. The Planner receives no PR-event wakes;
+Developer-owned subscriptions carry red, green, and externally closed facts
+directly to the owning Developer.
+
+Never dispatch the next wave from a merge-observation turn. The Developer''s
+merged-work handoff wake is the only normal next-wave dispatch trigger. On that
+wake, complete the turn in this exact order:
+
+1. Run `sc sprint inbox --sprint <id>` and inspect the durable merged-work
+   handoff plus current work-unit and dependency state.
+2. Act on every earlier informational item and mark each handled item read with
+   `accept`, including the Developer handoff.
+3. Finish all reconciliation, judgment recording, and other Planner
+   bookkeeping. No work remains after this step.
+4. As the literal final action of the turn, release dependency-ready lanes:
+
+```text
+sc sprint dispatch --sprint <id>
+```
+
+5. When the command confirms the durable assignment writes and New wakes, stop
+   immediately. Run no trailing command. Empty dispatch is still the final
+   action for that handoff turn; investigate only on a later durable wake.
+
+When all planned delivery work is terminal and merged or explicitly no-code,
+send the Reviewer the bound revisions, integrated main SHA, ratified judgments,
+and current close evidence, then stop and await its Re-enter conclude decision.
+The Reviewer writes the conformance and final Sprint reports; conformance
+findings become follow-ups rather than new editing lanes in this Sprint.
+
+On receipt, re-run `sc sprint inbox --sprint <id>`, accept the conclude message,
+execute its exact close action through the protocol above, and confirm the typed
+transition succeeded. After `complete` succeeds, emit its bounded receipt and
+run no further Sprint command. The Planner does not author a second report.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -8,6 +8,7 @@ live registry, and performs the native enqueue outside database transactions.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -72,9 +73,24 @@ def _stamp(value: datetime) -> str:
 class SprintMessageStore:
     """One transactional producer plus Sprint acceptance conveniences."""
 
-    def __init__(self, con: sqlite3.Connection) -> None:
+    def __init__(
+        self,
+        con: sqlite3.Connection,
+        *,
+        now: Callable[[], datetime] | None = None,
+        new_wake_delay_seconds: int | None = None,
+    ) -> None:
         self.con = con
         self.con.row_factory = sqlite3.Row
+        self.now = now or (lambda: datetime.now(timezone.utc))
+        delay = (
+            int(os.environ.get("SC_WAKE_NEW_DELAY_SECONDS", "15"))
+            if new_wake_delay_seconds is None
+            else new_wake_delay_seconds
+        )
+        if delay < 0:
+            raise ValueError("SC_WAKE_NEW_DELAY_SECONDS must be non-negative")
+        self.new_wake_delay_seconds = delay
 
     def send(
         self,
@@ -209,7 +225,13 @@ class SprintMessageStore:
                 ),
             ).lastrowid
         )
-        wake_id = self._coalesce_wake(None, None, receiver_shell_id, message_id)
+        wake_id = self._coalesce_wake(
+            None,
+            None,
+            receiver_shell_id,
+            message_id,
+            declared_type,
+        )
         return MessageReceipt(message_id, wake_id, True)
 
     def relay(
@@ -578,6 +600,7 @@ class SprintMessageStore:
             to_participant_id,
             receiver_shell_id,
             message_id,
+            declared_type,
         )
         return MessageReceipt(message_id, wake_id, True)
 
@@ -587,28 +610,48 @@ class SprintMessageStore:
         participant_id: int | None,
         receiver_shell_id: int,
         message_id: int,
+        declared_type: str,
     ) -> int:
+        available_at = None
+        if declared_type == "new" and self.new_wake_delay_seconds:
+            available_at = _stamp(
+                self.now() + timedelta(seconds=self.new_wake_delay_seconds)
+            )
         wake = self.con.execute(
             "SELECT wake_id FROM sprint_wake_outbox "
             "WHERE receiver_shell_id=? AND state='pending'",
             (receiver_shell_id,),
         ).fetchone()
         if wake is None:
+            columns = (
+                "sprint_id,participant_id,receiver_shell_id,idempotency_key"
+            )
+            values: tuple[object, ...] = (
+                sprint_id,
+                participant_id,
+                receiver_shell_id,
+                f"receiver:{receiver_shell_id}:wake-for-message:{message_id}",
+            )
+            placeholders = "?,?,?,?"
+            if available_at is not None:
+                columns += ",available_at"
+                values += (available_at,)
+                placeholders += ",?"
             wake_id = int(
                 self.con.execute(
-                    "INSERT INTO sprint_wake_outbox "
-                    "(sprint_id,participant_id,receiver_shell_id,idempotency_key) "
-                    "VALUES (?,?,?,?)",
-                    (
-                        sprint_id,
-                        participant_id,
-                        receiver_shell_id,
-                        f"receiver:{receiver_shell_id}:wake-for-message:{message_id}",
-                    ),
+                    f"INSERT INTO sprint_wake_outbox ({columns}) "
+                    f"VALUES ({placeholders})",
+                    values,
                 ).lastrowid
             )
         else:
             wake_id = int(wake["wake_id"])
+            if available_at is not None:
+                self.con.execute(
+                    "UPDATE sprint_wake_outbox "
+                    "SET available_at=MAX(available_at,?) WHERE wake_id=?",
+                    (available_at, wake_id),
+                )
         self.con.execute(
             "INSERT INTO sprint_wake_messages (sprint_id,wake_id,message_id) "
             "VALUES (?,?,?)",

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2617,6 +2617,36 @@ function chatUnreadBadge(shell) {
   }, "📩");
 }
 
+function chatWakePendingIndicator(shell, now = Date.now()) {
+  const raw = String(shell.pending_wake_available_at || "");
+  if (!raw) return null;
+  const timestamp = /(?:Z|[+-]\d\d:\d\d)$/.test(raw)
+    ? raw
+    : `${raw.replace(" ", "T")}Z`;
+  const available = new Date(timestamp);
+  const seconds = Math.ceil((available.getTime() - now) / 1000);
+  if (!Number.isFinite(seconds) || seconds < 1) return null;
+  const label = `wake message pending — delivering in ~${seconds}s`;
+  return el("span", {
+    className: "chat-shell-wake",
+    title: label,
+    ariaLabel: label,
+  }, "◷");
+}
+
+function chatPaintShellStatus(status, ...items) {
+  const visible = items.filter(Boolean);
+  status.replaceChildren();
+  visible.forEach((item, index) => {
+    if (index) status.append(el("span", {
+      className: "chat-shell-status-separator",
+      ariaHidden: "true",
+    }, "|"));
+    status.append(item);
+  });
+  status.hidden = visible.length === 0;
+}
+
 function chatHeaderLabel(conversation) {
   return [
     conversation.shell?.shortname,
@@ -3746,7 +3776,9 @@ function chatFlushTranscript(
   onPosition();
 }
 
-async function chatRenderOpen(host, initialConversation, initialSnapshot) {
+async function chatRenderOpen(
+  host, initialConversation, initialSnapshot, onWakeDelivered = null,
+) {
   const generation = chatRenderGeneration;
   let conversation = initialConversation;
   let transcriptState = chatCreateTranscriptState(initialSnapshot);
@@ -4282,6 +4314,7 @@ async function chatRenderOpen(host, initialConversation, initialSnapshot) {
       conversation.active_run_id = event.run_id;
       if (event.run_id != null)
         transcriptState.assistantAnchors.set(event.run_id, 0);
+      if (onWakeDelivered) onWakeDelivered(conversation.shell.shell_id);
     }
     if (type === "conversation.updated" || type === "conversation.renamed")
       Object.assign(conversation, event.payload || {});
@@ -4420,6 +4453,7 @@ async function renderInterface(root) {
   const orderedShells = orderedFlavors.flatMap((flavor) =>
     shells.filter((item) => (item.flavor || "bespoke") === flavor));
   const shellItems = new Map();
+  const shellStatusItems = new Map();
   const openByShell = new Map();
   for (const conversation of openPage.items) {
     if (conversation.state !== "closed")
@@ -4442,6 +4476,7 @@ async function renderInterface(root) {
       el("span", { className: "chat-shell-identity-separator", ariaHidden: "true" }, "|"));
     identity.append(el("span", { className: "chat-shell-name" }, item.display_name));
     const mail = chatUnreadBadge(item);
+    const wake = chatWakePendingIndicator(item);
     const button = el("button", {
       className: "chat-shell"
         + (item.shell_id === shell.shell_id ? " selected" : ""),
@@ -4456,7 +4491,8 @@ async function renderInterface(root) {
     const shellRow = el("div", {
       className: "chat-shell-row"
         + (sprint ? " has-assignment" : "")
-        + (mail ? " has-mail" : ""),
+        + (mail ? " has-mail" : "")
+        + (wake ? " has-wake" : ""),
     }, button);
     let badge = null;
     if (sprint) {
@@ -4473,16 +4509,28 @@ async function renderInterface(root) {
         );
       };
     }
-    if (badge || mail) {
-      const status = el("span", { className: "chat-shell-status" });
-      if (badge) status.append(badge);
-      if (badge && mail) status.append(
-        el("span", { className: "chat-shell-status-separator", ariaHidden: "true" }, "|"));
-      if (mail) status.append(mail);
-      shellRow.append(status);
-    }
+    const status = el("span", { className: "chat-shell-status" });
+    chatPaintShellStatus(status, badge, mail, wake);
+    shellStatusItems.set(item.shell_id, { row: shellRow, status, badge, mail });
+    shellRow.append(status);
     rail.append(shellRow);
   }
+
+  const paintWakeIndicators = (nextShells) => {
+    for (const next of nextShells) {
+      const target = shellStatusItems.get(next.shell_id);
+      if (!target) continue;
+      const wake = chatWakePendingIndicator(next);
+      target.row.classList.toggle("has-wake", Boolean(wake));
+      chatPaintShellStatus(target.status, target.badge, target.mail, wake);
+    }
+  };
+  const refreshWakeIndicators = async () => {
+    try {
+      const { shells: nextShells } = await api("/shells");
+      if (generation === chatRenderGeneration) paintWakeIndicators(nextShells);
+    } catch { /* The next shell refresh or SSE event retries. */ }
+  };
 
   const side = el("aside", { className: "chat-history" });
   const adminCliOnly = chatAdminCliOnly(shell);
@@ -4751,6 +4799,8 @@ async function renderInterface(root) {
     if (document.hidden || historyPollInFlight) return;
     historyPollInFlight = true;
     try {
+      const shellProjectionRequest = api("/shells")
+        .catch(() => ({ shells: [] }));
       let cursor = null;
       let selectedSeen = false;
       const nextOpenByShell = new Map();
@@ -4790,9 +4840,11 @@ async function renderInterface(root) {
         if (item) chatPaintHistoryItem(item, accepted);
         selectedConversation = accepted;
       }
+      const { shells: nextShells } = await shellProjectionRequest;
       if (generation !== chatRenderGeneration || !chatHistoryPollTimer) return;
       for (const [shellId, button] of shellItems)
         chatPaintShellState(button, nextOpenByShell.get(shellId));
+      paintWakeIndicators(nextShells);
     } catch { /* The next poll retries without disrupting the open chat. */ }
     finally { historyPollInFlight = false; }
   };
@@ -4858,7 +4910,12 @@ async function renderInterface(root) {
       const snapshot = await chatApi(
         `/conversations/${selectedId}/transcript`);
       if (generation !== chatRenderGeneration) return;
-      await chatRenderOpen(pane, conversation, snapshot);
+      await chatRenderOpen(
+        pane,
+        conversation,
+        snapshot,
+        refreshWakeIndicators,
+      );
     } catch (error) {
       if (generation !== chatRenderGeneration) return;
       const retry = el("button", {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -188,8 +188,12 @@ body.interface-view main {
   gap: .25rem; margin-bottom: .18rem;
 }
 .chat-shell-row.has-mail .chat-shell { padding-right: 2.2rem; }
+.chat-shell-row.has-wake .chat-shell { padding-right: 2.2rem; }
+.chat-shell-row.has-mail.has-wake .chat-shell { padding-right: 3.85rem; }
 .chat-shell-row.has-assignment .chat-shell { padding-right: 4.35rem; }
 .chat-shell-row.has-mail.has-assignment .chat-shell { padding-right: 6rem; }
+.chat-shell-row.has-wake.has-assignment .chat-shell { padding-right: 6rem; }
+.chat-shell-row.has-mail.has-wake.has-assignment .chat-shell { padding-right: 7.65rem; }
 .chat-shell-identity {
   min-width: 0; width: 100%; display: flex; align-items: center; gap: .35rem;
 }
@@ -225,6 +229,9 @@ body.interface-view main {
 .chat-shell-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
 .chat-shell-mail {
   color: var(--accent); flex: none; font: .8rem/1 ui-sans-serif, sans-serif;
+}
+.chat-shell-wake {
+  color: #ef545f; flex: none; font: 1rem/1 ui-sans-serif, sans-serif;
 }
 .chat-shell-shortname {
   color: rgba(255,255,255,.46); font: .68rem ui-monospace, monospace;
@@ -757,8 +764,13 @@ body.interface-view main {
   .chat-history { display: none; }
   .chat-shell { justify-content: center; }
   .chat-shell-row.has-mail .chat-shell,
+  .chat-shell-row.has-wake .chat-shell,
   .chat-shell-row.has-assignment .chat-shell,
-  .chat-shell-row.has-mail.has-assignment .chat-shell { padding-right: .55rem; }
+  .chat-shell-row.has-mail.has-assignment .chat-shell,
+  .chat-shell-row.has-wake.has-assignment .chat-shell,
+  .chat-shell-row.has-mail.has-wake.has-assignment .chat-shell {
+    padding-right: .55rem;
+  }
   .chat-shell-status {
     grid-column: 1; grid-row: 2; justify-self: center; margin-right: 0;
   }

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -72,6 +72,7 @@
     ".super-coder/migrations/0167_reseed_sprint_authority_split.sql",
     ".super-coder/migrations/0168_retire_sprint_conversation_topology.sql",
     ".super-coder/migrations/0169_reseed_sprint_v21_guidance.sql",
+    ".super-coder/migrations/0170_reseed_sprint_handoff_order.sql",
     ".super-coder/templates/boot.md"
   ],
   "baseline_migration_ledger": {

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -164,6 +164,39 @@ class AssemblerSmokeTest(unittest.TestCase):
         self.assertEqual(2, by_id[target]["unread_message_count"])
         self.assertEqual(0, by_id[sender]["unread_message_count"])
 
+    def test_get_shells_projects_only_future_pending_wake_availability(self) -> None:
+        target = self.ids["shell_id"]
+        other = self.ids["bespoke_shell_id"]
+        future_wake = self.con.execute(
+            "INSERT INTO sprint_wake_outbox "
+            "(receiver_shell_id,idempotency_key,available_at) "
+            "VALUES (?,?,'2099-07-31 12:00:15')",
+            (target, "future-pending-wake"),
+        ).lastrowid
+        self.con.execute(
+            "INSERT INTO sprint_wake_outbox "
+            "(receiver_shell_id,idempotency_key,available_at) "
+            "VALUES (?,?,'2000-07-31 12:00:15')",
+            (other, "past-pending-wake"),
+        )
+        self.con.commit()
+
+        by_id = {row["shell_id"]: row for row in server.get_shells(self.con)}
+        self.assertEqual(
+            "2099-07-31 12:00:15",
+            by_id[target]["pending_wake_available_at"],
+        )
+        self.assertIsNone(by_id[other]["pending_wake_available_at"])
+
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET state='delivered',"
+            "delivered_at=datetime('now') WHERE wake_id=?",
+            (future_wake,),
+        )
+        self.con.commit()
+        by_id = {row["shell_id"]: row for row in server.get_shells(self.con)}
+        self.assertIsNone(by_id[target]["pending_wake_available_at"])
+
     def test_get_shells_projects_only_live_current_sprint_conversation(self) -> None:
         shell_id = self.ids["shell_id"]
         self.con.execute(

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -19,6 +19,10 @@ POLL_BLOCK = APP[
         "  chatHistoryPollTimer = setInterval(pollHistory, CHAT_HISTORY_POLL_MS);"
     ) + len("  chatHistoryPollTimer = setInterval(pollHistory, CHAT_HISTORY_POLL_MS);")
 ]
+WAKE_INDICATOR = APP[
+    APP.index("function chatWakePendingIndicator"):
+    APP.index("function chatPaintShellStatus")
+]
 
 
 def run_js(script: str) -> dict:
@@ -67,7 +71,7 @@ def test_sprint_badge_enters_the_current_conversation_without_a_wake():
     interface = APP[APP.index("async function renderInterface"):
                     APP.index("// ── Tabs + boot")]
     badge = interface[interface.index('className: "chat-sprint-badge"'):
-                      interface.index("if (badge || mail)")]
+                      interface.index('const status = el("span"')]
     assert "sprint.current_conversation_id" in badge
     assert "location.hash = chatHash(" in badge
     assert "chatApi(" not in badge
@@ -94,18 +98,62 @@ def test_shell_card_orders_left_identity_and_right_status_cluster():
         'className: "chat-shell-identity-separator"'
     ) < identity.index('className: "chat-shell-name"')
 
-    status = interface[interface.index("if (badge || mail)"):
+    status = interface[interface.index('const status = el("span"'):
                        interface.index("rail.append(shellRow)")]
     assert 'className: "chat-shell-status"' in status
-    assert status.index("status.append(badge)") < status.index("status.append(mail)")
-    assert "if (badge && mail)" in status
-    assert 'className: "chat-shell-status-separator"' in status
+    assert "chatPaintShellStatus(status, badge, mail, wake)" in status
+    assert "shellStatusItems.set" in status
 
     status_style = STYLE[STYLE.index(".chat-shell-status {"):
                          STYLE.index(".chat-sprint-badge {")]
     assert "grid-column: 2" in status_style
     assert "justify-self: end" in status_style
     assert "pointer-events: none" in status_style
+
+
+def test_future_pending_wake_renders_a_red_clock_with_approximate_tooltip():
+    script = r"""
+function el(tag, props = {}, ...children) {
+  return { tag, ...props, text: children.join("") };
+}
+""" + WAKE_INDICATOR + r"""
+const now = Date.parse("2099-07-31T12:00:00Z");
+const future = chatWakePendingIndicator(
+  { pending_wake_available_at: "2099-07-31 12:00:15" }, now);
+const expired = chatWakePendingIndicator(
+  { pending_wake_available_at: "2099-07-31 11:59:59" }, now);
+const malformed = chatWakePendingIndicator(
+  { pending_wake_available_at: "not-a-date" }, now);
+console.log(JSON.stringify({ future, expired, malformed }));
+"""
+    result = run_js(script)
+    assert result == {
+        "future": {
+            "tag": "span",
+            "className": "chat-shell-wake",
+            "title": "wake message pending — delivering in ~15s",
+            "ariaLabel": "wake message pending — delivering in ~15s",
+            "text": "◷",
+        },
+        "expired": None,
+        "malformed": None,
+    }
+    wake_style = STYLE[
+        STYLE.index(".chat-shell-wake {"):
+        STYLE.index("}", STYLE.index(".chat-shell-wake {")) + 1
+    ]
+    assert "color: #ef545f" in wake_style
+
+
+def test_pending_wake_indicator_refreshes_without_a_new_polling_loop():
+    interface = APP[APP.index("async function renderInterface"):
+                    APP.index("// ── Tabs + boot")]
+    assert 'const shellProjectionRequest = api("/shells")' in POLL_BLOCK
+    assert "const { shells: nextShells } = await shellProjectionRequest" in POLL_BLOCK
+    assert "paintWakeIndicators(nextShells)" in POLL_BLOCK
+    assert "refreshWakeIndicators" in interface
+    assert "onWakeDelivered(conversation.shell.shell_id)" in APP
+    assert APP.count("setInterval(pollHistory, CHAT_HISTORY_POLL_MS)") == 1
 
 
 def test_sprint_conversations_are_not_closed_by_normal_chat_controls():
@@ -567,6 +615,7 @@ globalThis.document = {hidden: false};
 let scheduled = null;
 globalThis.setInterval = (callback) => { scheduled = callback; return 1; };
 const calls = [];
+const shellCalls = [];
 const painted = [];
 let openPoll = 0;
 async function chatApi(path) {
@@ -583,6 +632,11 @@ async function chatApi(path) {
       shell: {shell_id: 7}};
   throw new Error(`unexpected request: ${path}`);
 }
+async function api(path) {
+  shellCalls.push(path);
+  if (path === "/shells") return {shells: []};
+  throw new Error(`unexpected API request: ${path}`);
+}
 const historyItems = new Map([["cv1", {id: "selected"}]]);
 const shellItems = new Map([[7, {}]]);
 const acceptSummary = (conversation) => conversation;
@@ -590,6 +644,7 @@ const chatPaintHistoryItem = (item, conversation) => {
   painted.push([item.id, conversation.state, conversation.version]);
 };
 const chatPaintShellState = () => {};
+const paintWakeIndicators = () => {};
 let selectedConversation = {
   conversation_id: "cv1", state: "idle", version: 1, shell: {shell_id: 7},
 };
@@ -602,7 +657,9 @@ const CHAT_HISTORY_POLL_MS = 2000;
   await scheduled();
   await scheduled();
   await scheduled();
-  console.log(JSON.stringify({calls, painted, selected: selectedConversation}));
+  console.log(JSON.stringify({
+    calls, shellCalls, painted, selected: selectedConversation,
+  }));
 })().catch((error) => {
   console.error(error.stack || error);
   process.exit(1);
@@ -615,6 +672,7 @@ const CHAT_HISTORY_POLL_MS = 2000;
         "/conversations/cv1",
         "/conversations?open=true&limit=100",
     ]
+    assert result["shellCalls"] == ["/shells", "/shells", "/shells"]
     assert result["painted"] == [
         ["selected", "running", 2],
         ["selected", "closed", 3],

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -104,6 +104,11 @@ class SprintLiveProof(unittest.TestCase):
         cls.httpd.server_close()
 
     def setUp(self) -> None:
+        delay_env = mock.patch.dict(
+            "os.environ", {"SC_WAKE_NEW_DELAY_SECONDS": "0"}
+        )
+        delay_env.start()
+        self.addCleanup(delay_env.stop)
         self.temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp_dir.cleanup)
         self.db_path = Path(self.temp_dir.name) / "sprint-live-proof.db"

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -9,6 +9,7 @@ import unittest
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
@@ -48,6 +49,11 @@ class FakeClock:
 
 class SprintLivenessCase(unittest.TestCase):
     def setUp(self) -> None:
+        delay_env = mock.patch.dict(
+            "os.environ", {"SC_WAKE_NEW_DELAY_SECONDS": "0"}
+        )
+        delay_env.start()
+        self.addCleanup(delay_env.stop)
         self.con = sqlite3.connect(":memory:")
         self.addCleanup(self.con.close)
         self.con.row_factory = sqlite3.Row

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -31,6 +31,11 @@ def apply_schema(con: sqlite3.Connection) -> None:
 
 class SprintMessageCase(unittest.TestCase):
     def setUp(self) -> None:
+        delay_env = mock.patch.dict(
+            os.environ, {"SC_WAKE_NEW_DELAY_SECONDS": "0"}
+        )
+        delay_env.start()
+        self.addCleanup(delay_env.stop)
         self.con = sqlite3.connect(":memory:")
         self.addCleanup(self.con.close)
         self.con.row_factory = sqlite3.Row
@@ -396,6 +401,159 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
                 "SELECT COUNT(*) FROM sprint_wake_messages WHERE message_id=?",
                 (result_id,),
             ).fetchone()[0],
+        )
+
+
+class WakeDelayTest(SprintMessageCase):
+    def test_declared_new_uses_constructor_time_env_delay_and_claim_boundary(
+        self,
+    ) -> None:
+        clock = [datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc)]
+        with mock.patch.dict(os.environ, {"SC_WAKE_NEW_DELAY_SECONDS": "15"}):
+            messages = delivery.SprintMessageStore(
+                self.con,
+                now=lambda: clock[0],
+            )
+
+        sent = messages.send(
+            self.sprint_id,
+            to_participant_id=self.developer_id,
+            from_participant_id=self.planner_id,
+            work_unit_id=self.unit_id,
+            message_kind="notification",
+            body="delayed new wake",
+            declared_type="new",
+            idempotency_key="delayed-new",
+        )
+
+        row = self.con.execute(
+            "SELECT created_at,available_at FROM sprint_wake_outbox WHERE wake_id=?",
+            (sent.wake_id,),
+        ).fetchone()
+        self.assertEqual("2099-07-31 12:00:15", row["available_at"])
+        self.assertNotEqual(row["created_at"], row["available_at"])
+        service = delivery.SprintWakeDeliveryService(
+            self.con,
+            now=lambda: clock[0],
+        )
+        self.assertIsNone(service.claim_next("before-new-delay"))
+        clock[0] += timedelta(seconds=15)
+        lease = service.claim_next("at-new-delay")
+        self.assertIsNotNone(lease)
+        self.assertEqual(sent.wake_id, lease.wake_id)
+
+    def test_reenter_wake_keeps_immediate_database_availability(self) -> None:
+        messages = delivery.SprintMessageStore(
+            self.con,
+            now=lambda: datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc),
+            new_wake_delay_seconds=15,
+        )
+
+        sent = messages.send(
+            self.sprint_id,
+            to_participant_id=self.developer_id,
+            from_participant_id=self.planner_id,
+            work_unit_id=self.unit_id,
+            message_kind="notification",
+            body="immediate reenter wake",
+            declared_type="re-enter",
+            idempotency_key="immediate-reenter",
+        )
+
+        row = self.con.execute(
+            "SELECT created_at,available_at FROM sprint_wake_outbox WHERE wake_id=?",
+            (sent.wake_id,),
+        ).fetchone()
+        self.assertEqual(row["created_at"], row["available_at"])
+        self.assertNotEqual("2099-07-31 12:00:15", row["available_at"])
+
+    def test_zero_delay_disables_hold_for_declared_new(self) -> None:
+        messages = delivery.SprintMessageStore(
+            self.con,
+            now=lambda: datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc),
+            new_wake_delay_seconds=0,
+        )
+
+        sent = messages.send(
+            self.sprint_id,
+            to_participant_id=self.developer_id,
+            from_participant_id=self.planner_id,
+            work_unit_id=self.unit_id,
+            message_kind="notification",
+            body="disabled new wake hold",
+            declared_type="new",
+            idempotency_key="zero-delay-new",
+        )
+
+        row = self.con.execute(
+            "SELECT created_at,available_at FROM sprint_wake_outbox WHERE wake_id=?",
+            (sent.wake_id,),
+        ).fetchone()
+        self.assertEqual(row["created_at"], row["available_at"])
+        self.assertNotEqual("2099-07-31 12:00:00", row["available_at"])
+
+    def test_new_message_extends_a_pending_reenter_wake(self) -> None:
+        first = self.send("pending-reenter", declared_type="re-enter")
+        messages = delivery.SprintMessageStore(
+            self.con,
+            now=lambda: datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc),
+            new_wake_delay_seconds=15,
+        )
+
+        second = messages.send(
+            self.sprint_id,
+            to_participant_id=self.developer_id,
+            from_participant_id=self.planner_id,
+            work_unit_id=self.unit_id,
+            message_kind="notification",
+            body="coalesced new wake",
+            declared_type="new",
+            idempotency_key="coalesced-new",
+        )
+
+        self.assertEqual(first.wake_id, second.wake_id)
+        self.assertEqual(
+            "2099-07-31 12:00:15",
+            self.con.execute(
+                "SELECT available_at FROM sprint_wake_outbox WHERE wake_id=?",
+                (first.wake_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            [first.message_id, second.message_id],
+            [
+                int(row[0])
+                for row in self.con.execute(
+                    "SELECT message_id FROM sprint_wake_messages "
+                    "WHERE wake_id=? ORDER BY message_id",
+                    (first.wake_id,),
+                )
+            ],
+        )
+
+    def test_shell_scoped_new_wake_uses_the_same_delay(self) -> None:
+        messages = delivery.SprintMessageStore(
+            self.con,
+            now=lambda: datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc),
+            new_wake_delay_seconds=8,
+        )
+
+        sent = messages.send_to_shell(
+            2,
+            message_kind="system",
+            body="delayed shell-scoped wake",
+            idempotency_key="shell-scoped-new-delay",
+            declared_type="new",
+        )
+
+        row = self.con.execute(
+            "SELECT sprint_id,participant_id,receiver_shell_id,available_at "
+            "FROM sprint_wake_outbox WHERE wake_id=?",
+            (sent.wake_id,),
+        ).fetchone()
+        self.assertEqual(
+            (None, None, 2, "2099-07-31 12:00:08"),
+            tuple(row),
         )
 
 

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".super-coder" / "scripts"
@@ -1561,6 +1562,14 @@ class ClosedReviewRecoveryTest(SprintReviewLoopCase):
 
 
 class LifecycleExitAndRestartTest(SprintDomainCase):
+    def setUp(self) -> None:
+        delay_env = mock.patch.dict(
+            "os.environ", {"SC_WAKE_NEW_DELAY_SECONDS": "0"}
+        )
+        delay_env.start()
+        self.addCleanup(delay_env.stop)
+        super().setUp()
+
     def coordinator(self) -> sprint_recovery.SprintRecoveryCoordinator:
         def no_reader(_repository: str):
             raise AssertionError("non-armed restart performed GitHub egress")

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -25,6 +25,7 @@ SKILLS = {
 RESEEDED_SKILLS = set(SKILLS) | {"db_map"}
 AUTHORITY_SPLIT_SKILLS = {"sprint_pln", "sprint_rev"}
 V21_ROLE_SKILLS = set(SKILLS)
+HANDOFF_ROLE_SKILLS = {"sprint_dev", "sprint_rev", "sprint_pln"}
 
 
 class SprintSkillTest(unittest.TestCase):
@@ -176,28 +177,28 @@ class SprintSkillTest(unittest.TestCase):
         finally:
             con.close()
 
-    def test_v21_reseed_converges_dirty_rows_and_replays_idempotently(self):
+    def test_terminal_handoff_reseed_converges_dirty_rows_and_replays_idempotently(self):
         con = sqlite3.connect(":memory:")
         try:
             con.executescript((ENGINE / "schema.sql").read_text())
             for migration in sorted((ENGINE / "migrations").glob("*.sql")):
-                if migration.name >= "0169_reseed_sprint_v21_guidance.sql":
+                if migration.name >= "0170_reseed_sprint_handoff_order.sql":
                     break
                 con.executescript(migration.read_text())
-            placeholders = ",".join("?" for _ in V21_ROLE_SKILLS)
+            placeholders = ",".join("?" for _ in HANDOFF_ROLE_SKILLS)
             con.execute(
-                f"UPDATE skills SET content='stale pre-0169 guidance' "
+                f"UPDATE skills SET content='stale pre-0170 guidance' "
                 f"WHERE name IN ({placeholders})",
-                tuple(sorted(V21_ROLE_SKILLS)),
+                tuple(sorted(HANDOFF_ROLE_SKILLS)),
             )
 
             migration = (
-                ENGINE / "migrations" / "0169_reseed_sprint_v21_guidance.sql"
+                ENGINE / "migrations" / "0170_reseed_sprint_handoff_order.sql"
             ).read_text()
             con.executescript(migration)
             con.executescript(migration)
 
-            for name in sorted(V21_ROLE_SKILLS):
+            for name in sorted(HANDOFF_ROLE_SKILLS):
                 with self.subTest(name=name):
                     expected = seed_skills.parse_skill(
                         ASSETS / name / "SKILL.md"
@@ -504,6 +505,57 @@ class SprintSkillTest(unittest.TestCase):
             "sc job start",
         ):
             self.assertNotIn(shell_owned_loop, combined)
+
+    def test_role_handoffs_are_explicitly_ordered_and_message_last(self):
+        developer = (ASSETS / "sprint_dev" / "SKILL.md").read_text()
+        post_merge = developer[
+            developer.index("## Post-merge handoff"):
+            developer.index("## Report and stop")
+        ]
+        self.assertLess(
+            post_merge.index("Clean the worktree"),
+            post_merge.index("Re-run `sc sprint inbox"),
+        )
+        self.assertLess(
+            post_merge.index("Re-run `sc sprint inbox"),
+            post_merge.index("sc sprint send --sprint <id>"),
+        )
+        self.assertLess(
+            post_merge.index("sc sprint send --sprint <id>"),
+            post_merge.index("Run no trailing Git"),
+        )
+
+        reviewer = (ASSETS / "sprint_rev" / "SKILL.md").read_text()
+        unit_verdict = reviewer[
+            reviewer.index("Complete a unit verdict in this exact order"):
+            reviewer.index("## Whole-Sprint conformance")
+        ]
+        self.assertLess(
+            unit_verdict.index("Re-run `sc sprint inbox"),
+            unit_verdict.index("sc sprint record-review"),
+        )
+        self.assertLess(
+            unit_verdict.index("sc sprint record-review"),
+            unit_verdict.index("Run no trailing command"),
+        )
+
+        planner = (ASSETS / "sprint_pln" / "SKILL.md").read_text()
+        wave_handoff = planner[
+            planner.index("Never dispatch the next wave"):
+            planner.index("When all planned delivery work is terminal")
+        ]
+        self.assertIn(
+            "merged-work handoff wake is the only normal next-wave dispatch trigger",
+            wave_handoff,
+        )
+        self.assertLess(
+            wave_handoff.index("Run `sc sprint inbox"),
+            wave_handoff.index("sc sprint dispatch --sprint <id>"),
+        )
+        self.assertLess(
+            wave_handoff.index("sc sprint dispatch --sprint <id>"),
+            wave_handoff.index("Run no trailing command"),
+        )
 
     def test_reviewer_entry_separates_predeclaration_qaqc_from_armed_inbox(self):
         reviewer = (ASSETS / "sprint_rev" / "SKILL.md").read_text()

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -33,6 +33,11 @@ def apply_schema(con: sqlite3.Connection) -> None:
 
 class SprintWorkDispatchCase(unittest.TestCase):
     def setUp(self) -> None:
+        delay_env = mock.patch.dict(
+            "os.environ", {"SC_WAKE_NEW_DELAY_SECONDS": "0"}
+        )
+        delay_env.start()
+        self.addCleanup(delay_env.stop)
         self.temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp_dir.cleanup)
         self.db_path = Path(self.temp_dir.name) / "sprint.db"


### PR DESCRIPTION
## Summary
- hold `new`-declared wake intents for `SC_WAKE_NEW_DELAY_SECONDS` (default 15, 0 disables) and extend coalesced pending intents
- project future pending wakes into the shell rail with a red countdown clock refreshed by existing chat refresh/SSE paths
- make Developer, Reviewer, and Planner handoffs explicitly ordered, handoff-last-then-stop, with trailing reseed migration 0170

## Verification
- `1724 passed, 1 skipped, 876 subtests passed`
- focused gate: `152 passed, 27 subtests passed`
- core Ruff rules (`E4/E7/E9/F`, excluding existing E402 path-injection pattern): clean
- hermetic schema + 119-migration rebuild, local flat render, and render-check: clean
- `tests/test_skills_freshness.py`: clean

## Implementation note
The spec/task called for a tracked `skills_sc` mirror, but current main policy from #726 makes generated mirrors local-only and untracked. This PR follows the current repository contract: source assets + terminal reseed migration are tracked, while the ignored local mirror was regenerated from render-check’s throwaway DB path and matched byte-for-byte. No live DB was used.

Trade-off: the UI folds `/api/shells` into the existing two-second chat refresh and also repaints on `run.started`; it adds no endpoint or polling loop.