### PR TITLE
feat(sprints): delivery-terminal reviewer wake + compile authority

### DIFF
--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -33,6 +33,9 @@ _EVENT_FIELDS = {
     "sprint.declared": frozenset(
         {"feature_id", "spec_approval_ids", "participant_shell_ids"}
     ),
+    "sprint.delivery_terminal": frozenset(
+        {"terminal_count", "completed_count", "cancelled_count"}
+    ),
     "lifecycle.armed": frozenset(
         {
             "from",

--- a/.super-coder/scripts/sprint_close.py
+++ b/.super-coder/scripts/sprint_close.py
@@ -251,7 +251,9 @@ class SprintCloseStore:
             raise ValueError(
                 f"section limit must be between 1 and {MAX_SECTION_LIMIT}"
             )
-        sprint = self._require_close_authority(sprint_id, caller_shell_id)
+        sprint = self._require_close_authority(
+            sprint_id, caller_shell_id, allow_reviewer=True
+        )
         events = self._events(sprint_id)
         specs = self._spec_revisions(sprint_id)
         units = self._planned_vs_actual(sprint_id)
@@ -541,7 +543,11 @@ class SprintCloseStore:
         return events
 
     def _require_close_authority(
-        self, sprint_id: int, caller_shell_id: int
+        self,
+        sprint_id: int,
+        caller_shell_id: int,
+        *,
+        allow_reviewer: bool = False,
     ) -> sqlite3.Row:
         row = self.con.execute(
             "SELECT sp.*,r.title AS feature_title,s.flavor AS caller_flavor "
@@ -555,6 +561,10 @@ class SprintCloseStore:
             int(row["originating_planner_shell_id"]) != caller_shell_id
             and row["caller_flavor"] != "admin"
         ):
+            if not allow_reviewer:
+                raise SprintAuthorityError(
+                    "only the owning Planner or FnB may record the final report"
+                )
             try:
                 self._require_reviewer(sprint_id, caller_shell_id)
             except SprintAuthorityError:

--- a/.super-coder/scripts/sprint_close.py
+++ b/.super-coder/scripts/sprint_close.py
@@ -555,7 +555,13 @@ class SprintCloseStore:
             int(row["originating_planner_shell_id"]) != caller_shell_id
             and row["caller_flavor"] != "admin"
         ):
-            raise SprintAuthorityError("only the owning Planner or FnB may compile")
+            try:
+                self._require_reviewer(sprint_id, caller_shell_id)
+            except SprintAuthorityError:
+                raise SprintAuthorityError(
+                    "only the owning Planner, FnB, or a participating Reviewer "
+                    "may compile"
+                ) from None
         return row
 
     def _require_participant_or_admin(

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -467,6 +467,7 @@ class SprintLifecycleStore:
                 )
             dispatched: tuple[int, ...] = ()
             if pause_receipt is None:
+                SprintWorkUnitStore(self.con)._queue_delivery_terminal(sprint_id)
                 planner = self._planner_participant_id(sprint_id)
                 dispatched = tuple(
                     SprintWorkUnitStore(self.con)._dispatch_ready_locked(
@@ -2225,6 +2226,7 @@ class SprintWorkUnitStore:
                 "WHERE sprint_id=?",
                 (sprint_id,),
             ).fetchone()
+            self._queue_delivery_terminal(sprint_id)
             if sprint["lifecycle"] != "armed":
                 return []
             planner = self._require_participant(
@@ -2277,6 +2279,7 @@ class SprintWorkUnitStore:
                 planner_shell_id,
                 {"work_unit_id": work_unit_id, "reason": reason},
             )
+            self._queue_delivery_terminal(sprint_id)
         return True
 
     def complete_from_merge_in_transaction(
@@ -2362,6 +2365,8 @@ class SprintWorkUnitStore:
                 },
                 actor_kind="system",
             )
+        if changed:
+            self._queue_delivery_terminal(sprint_id)
         if not changed or not dispatch or sprint["lifecycle"] != "armed":
             return []
         planner = self._require_participant(
@@ -2372,6 +2377,75 @@ class SprintWorkUnitStore:
         return self._dispatch_ready_locked(
             sprint_id,
             planner_participant_id=planner,
+        )
+
+    def _queue_delivery_terminal(self, sprint_id: int) -> None:
+        state = self.con.execute(
+            "SELECT s.lifecycle,COUNT(u.work_unit_id) AS total,"
+            "COALESCE(SUM(u.disposition='completed'),0) AS completed,"
+            "COALESCE(SUM(u.disposition='cancelled'),0) AS cancelled "
+            "FROM sprints s LEFT JOIN sprint_work_units u USING (sprint_id) "
+            "WHERE s.sprint_id=? GROUP BY s.lifecycle",
+            (sprint_id,),
+        ).fetchone()
+        if (
+            state is None
+            or state["lifecycle"] != "armed"
+            or not state["total"]
+            or state["total"] != state["completed"] + state["cancelled"]
+        ):
+            return
+        total = int(state["total"])
+        if self.con.execute(
+            "SELECT 1 FROM sprint_events WHERE sprint_id=? "
+            "AND event_type='sprint.delivery_terminal' "
+            "AND json_extract(payload,'$.terminal_count')=?",
+            (sprint_id, total),
+        ).fetchone():
+            return
+        reviewers = self.con.execute(
+            "SELECT participant_id FROM sprint_participants "
+            "WHERE sprint_id=? AND role='reviewer' ORDER BY participant_id",
+            (sprint_id,),
+        ).fetchall()
+        base_key = f"sprint:{sprint_id}:delivery-terminal:{total}"
+        body = (
+            f"All planned delivery work for Sprint {sprint_id} is terminal "
+            f"({total} units: {int(state['completed'])} completed, "
+            f"{int(state['cancelled'])} cancelled). Begin whole-Sprint "
+            "conformance per sprint_rev — compile the evidence packet, judge "
+            "integrated main, then send the Planner either a re-enter decision "
+            "or your conclude decision."
+        )
+        from sprint_message_delivery import SprintMessageStore
+
+        messages = SprintMessageStore(self.con)
+        for reviewer in reviewers:
+            participant_id = int(reviewer["participant_id"])
+            key = (
+                base_key
+                if len(reviewers) == 1
+                else f"{base_key}:reviewer:{participant_id}"
+            )
+            messages.send_in_transaction(
+                sprint_id,
+                to_participant_id=participant_id,
+                message_kind="notification",
+                body=body,
+                actionable=False,
+                declared_type="new",
+                idempotency_key=key,
+            )
+        self._event(
+            sprint_id,
+            "sprint.delivery_terminal",
+            None,
+            {
+                "terminal_count": total,
+                "completed_count": int(state["completed"]),
+                "cancelled_count": int(state["cancelled"]),
+            },
+            actor_kind="system",
         )
 
     def _queue_planner_merge_bypass(

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -282,6 +282,7 @@ class SprintLifecycleStore:
                     "work_wake_ids": work_wake_ids,
                 },
             )
+            SprintWorkUnitStore(self.con)._queue_delivery_terminal(sprint_id)
         return wake_ids
 
     def transition(

--- a/tests/fixtures/sprint_v2_acceptance.json
+++ b/tests/fixtures/sprint_v2_acceptance.json
@@ -79,7 +79,7 @@
     {
       "scenario": "FnB authority can compile evidence when the Planner is unavailable",
       "file": "tests/test_sprint_close.py",
-      "test": "test_only_planner_or_admin_compiles_and_participants_read_timeline"
+      "test": "test_planner_admin_and_participating_reviewer_compile_evidence"
     },
     {
       "scenario": "Restart preserves every non-terminal lifecycle state",

--- a/tests/test_sprint_board_api.py
+++ b/tests/test_sprint_board_api.py
@@ -414,6 +414,15 @@ class SprintBoardApiCase(unittest.TestCase):
                 },
             ),
             (
+                "sprint.delivery_terminal",
+                {
+                    "terminal_count": 3,
+                    "completed_count": 2,
+                    "cancelled_count": 1,
+                    "secret": "hidden",
+                },
+            ),
+            (
                 "review.approved",
                 {
                     "work_unit_id": self.ids["unit"],

--- a/tests/test_sprint_close.py
+++ b/tests/test_sprint_close.py
@@ -507,6 +507,34 @@ class ConformanceFollowupTest(SprintCloseCase):
             ).fetchone()[0],
         )
 
+    def test_participating_reviewer_cannot_record_final_report(self):
+        with self.assertRaisesRegex(
+            sprint_domain.SprintAuthorityError, "owning Planner or FnB"
+        ):
+            self.close.record_final_report(
+                self.sprint_id,
+                2,
+                body="Reviewer must not author the final synthesis.",
+                idempotency_key="reviewer-final-report",
+            )
+
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_reports WHERE sprint_id=? "
+                "AND report_kind='final'",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='final_report.recorded'",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+
     def test_only_fnb_dispositions_followup_and_only_pending_is_unresolved(self):
         self.con.execute(
             "INSERT INTO shells "
@@ -717,7 +745,7 @@ class EvidenceCompilerTest(SprintCloseCase):
         )
         self.assertGreater(packet["anomalies"]["events"]["truncated"], 0)
 
-    def test_only_planner_or_admin_compiles_and_participants_read_timeline(self):
+    def test_planner_admin_and_participating_reviewer_compile_evidence(self):
         planner_packet = self.close.compile_evidence_packet(self.sprint_id, 3)
         reviewer_packet = self.close.compile_evidence_packet(self.sprint_id, 2)
         self.assertEqual(

--- a/tests/test_sprint_close.py
+++ b/tests/test_sprint_close.py
@@ -718,10 +718,35 @@ class EvidenceCompilerTest(SprintCloseCase):
         self.assertGreater(packet["anomalies"]["events"]["truncated"], 0)
 
     def test_only_planner_or_admin_compiles_and_participants_read_timeline(self):
+        planner_packet = self.close.compile_evidence_packet(self.sprint_id, 3)
+        reviewer_packet = self.close.compile_evidence_packet(self.sprint_id, 2)
+        self.assertEqual(
+            (self.sprint_id, self.sprint_id),
+            (
+                planner_packet["scope"]["sprint_id"],
+                reviewer_packet["scope"]["sprint_id"],
+            ),
+        )
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (5,'FnB','FNB','admin','prompt',1)"
+        )
+        self.con.commit()
+        self.assertEqual(
+            self.sprint_id,
+            self.close.compile_evidence_packet(self.sprint_id, 5)["scope"][
+                "sprint_id"
+            ],
+        )
         with self.assertRaisesRegex(
-            sprint_domain.SprintAuthorityError, "owning Planner"
+            sprint_domain.SprintAuthorityError, "participating Reviewer"
         ):
             self.close.compile_evidence_packet(self.sprint_id, 1)
+        with self.assertRaisesRegex(
+            sprint_domain.SprintAuthorityError, "participating Reviewer"
+        ):
+            self.close.compile_evidence_packet(self.sprint_id, 4)
         timeline = self.close.timeline(self.sprint_id, 2)
         self.assertEqual(self.sprint_id, timeline["sprint_id"])
         self.assertEqual(

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -882,6 +882,18 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
                 "WHERE event_type='work_unit.completed'"
             ).fetchone()[0],
         )
+        self.assertEqual(
+            (0, 0),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_events "
+                    "WHERE event_type='sprint.delivery_terminal'),"
+                    "(SELECT COUNT(*) FROM wake_message "
+                    "WHERE idempotency_key LIKE 'sprint:%:delivery-terminal:%')"
+                ).fetchone()
+            ),
+        )
         notice = self.con.execute(
             "SELECT m.to_participant_id,m.work_unit_id,m.body,w.state "
             "FROM wake_message m JOIN sprint_wake_messages wm USING (message_id) "

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -660,6 +660,229 @@ class DispatchGateTest(SprintWorkDispatchCase):
         )
 
 
+class DeliveryTerminalTest(SprintWorkDispatchCase):
+    def terminal_messages(self) -> list[sqlite3.Row]:
+        return self.con.execute(
+            "SELECT p.shell_id,m.message_kind,m.body,m.declared_type,"
+            "m.actionable,m.disposition,m.idempotency_key "
+            "FROM wake_message m JOIN sprint_participants p "
+            "ON p.participant_id=m.to_participant_id "
+            "WHERE m.sprint_id=? AND m.idempotency_key LIKE ? "
+            "ORDER BY p.shell_id",
+            (self.sprint_id, f"sprint:{self.sprint_id}:delivery-terminal:%"),
+        ).fetchall()
+
+    def terminal_events(self) -> list[sqlite3.Row]:
+        return self.con.execute(
+            "SELECT actor_kind,actor_shell_id,payload FROM sprint_events "
+            "WHERE sprint_id=? AND event_type='sprint.delivery_terminal' "
+            "ORDER BY event_id",
+            (self.sprint_id,),
+        ).fetchall()
+
+    def mark_merge_ready(self, unit_id: int, shell_id: int) -> None:
+        self.assertEqual(
+            "accepted",
+            self.messages.mark_read(self.assignment_message(unit_id), shell_id),
+        )
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='merge_ready' "
+            "WHERE work_unit_id=?",
+            (unit_id,),
+        )
+        self.con.commit()
+
+    def complete_merge(self, unit_id: int, key: str) -> None:
+        with db_driver.write_transaction(self.con, "test.merge_observed"):
+            self.units.complete_from_merge_in_transaction(
+                self.sprint_id,
+                (unit_id,),
+                transition_key=key,
+            )
+
+    def assert_episode(self, terminal_count: int, completed: int, cancelled: int):
+        base = f"sprint:{self.sprint_id}:delivery-terminal:{terminal_count}"
+        messages = [
+            row
+            for row in self.terminal_messages()
+            if row["idempotency_key"] == base
+            or str(row["idempotency_key"]).startswith(f"{base}:")
+        ]
+        self.assertEqual([2, 5], [int(row["shell_id"]) for row in messages])
+        participant_ids = {
+            int(row["shell_id"]): int(row["participant_id"])
+            for row in self.con.execute(
+                "SELECT shell_id,participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND role='reviewer'",
+                (self.sprint_id,),
+            )
+        }
+        self.assertEqual(
+            [
+                f"{base}:reviewer:{participant_ids[2]}",
+                f"{base}:reviewer:{participant_ids[5]}",
+            ],
+            [str(row["idempotency_key"]) for row in messages],
+        )
+        expected_body = (
+            f"All planned delivery work for Sprint {self.sprint_id} is terminal "
+            f"({terminal_count} units: {completed} completed, {cancelled} "
+            "cancelled). Begin whole-Sprint conformance per sprint_rev — compile "
+            "the evidence packet, judge integrated main, then send the Planner "
+            "either a re-enter decision or your conclude decision."
+        )
+        self.assertEqual(
+            [
+                ("notification", expected_body, "new", 0, None),
+                ("notification", expected_body, "new", 0, None),
+            ],
+            [
+                (
+                    row["message_kind"],
+                    row["body"],
+                    row["declared_type"],
+                    int(row["actionable"]),
+                    row["disposition"],
+                )
+                for row in messages
+            ],
+        )
+        event = self.terminal_events()[-1]
+        self.assertEqual(("system", None), (event["actor_kind"], event["actor_shell_id"]))
+        self.assertEqual(
+            {
+                "terminal_count": terminal_count,
+                "completed_count": completed,
+                "cancelled_count": cancelled,
+            },
+            json.loads(event["payload"]),
+        )
+
+    def test_pause_resume_serial_units_wake_reviewers_on_final_merge(self) -> None:
+        first = self.create_unit(developer=1, title="First")
+        second = self.create_unit(
+            developer=1, dependencies=(first,), title="Final"
+        )
+        self.lifecycle.arm(self.sprint_id, 3)
+        self.lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="Reference pause",
+        )
+        self.lifecycle.resume(
+            self.sprint_id, sprint_domain.LifecycleActor("planner", 3)
+        )
+
+        self.mark_merge_ready(first, 1)
+        self.complete_merge(first, "merged-first")
+        self.assertEqual([], self.terminal_messages())
+        self.assertEqual([], self.terminal_events())
+
+        self.mark_merge_ready(second, 1)
+        self.complete_merge(second, "merged-final")
+
+        self.assertEqual([(first, "completed"), (second, "completed")], self.dispositions())
+        self.assertEqual(2, len(self.terminal_messages()))
+        self.assertEqual(1, len(self.terminal_events()))
+        self.assert_episode(2, 2, 0)
+
+    def test_paused_report_completion_wakes_only_on_resume(self) -> None:
+        report = self.create_unit(developer=1, output_kind="report_only")
+        self.lifecycle.arm(self.sprint_id, 3)
+        self.messages.mark_read(self.assignment_message(report), 1)
+        self.lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="Inspect report",
+        )
+
+        self.units.complete(self.sprint_id, report, 1, result="Report #1")
+
+        self.assertEqual([], self.terminal_messages())
+        self.assertEqual([], self.terminal_events())
+        self.lifecycle.resume(
+            self.sprint_id, sprint_domain.LifecycleActor("planner", 3)
+        )
+        self.assertEqual(2, len(self.terminal_messages()))
+        self.assertEqual(1, len(self.terminal_events()))
+        self.assert_episode(1, 1, 0)
+
+    def test_single_reviewer_uses_the_canonical_episode_key(self) -> None:
+        self.con.execute(
+            "DELETE FROM sprint_participants WHERE sprint_id=? AND shell_id=5",
+            (self.sprint_id,),
+        )
+        self.con.commit()
+        report = self.create_unit(developer=1, output_kind="report_only")
+        self.lifecycle.arm(self.sprint_id, 3)
+        self.messages.mark_read(self.assignment_message(report), 1)
+
+        self.units.complete(self.sprint_id, report, 1, result="Only report")
+
+        messages = self.terminal_messages()
+        self.assertEqual(1, len(messages))
+        self.assertEqual(2, int(messages[0]["shell_id"]))
+        self.assertEqual(
+            f"sprint:{self.sprint_id}:delivery-terminal:1",
+            messages[0]["idempotency_key"],
+        )
+        self.assertEqual(1, len(self.terminal_events()))
+
+    def test_cancelling_the_last_planned_unit_wakes_reviewers(self) -> None:
+        upstream = self.create_unit(developer=1, title="Cancelled upstream")
+        downstream = self.create_unit(
+            developer=4,
+            dependencies=(upstream,),
+            title="Cancelled downstream",
+        )
+        self.units.cancel(self.sprint_id, upstream, 3, reason="No longer needed")
+        self.lifecycle.arm(self.sprint_id, 3)
+        self.assertEqual([(upstream, "cancelled"), (downstream, "planned")], self.dispositions())
+
+        self.units.cancel(self.sprint_id, downstream, 3, reason="No work remains")
+
+        self.assertEqual(2, len(self.terminal_messages()))
+        self.assertEqual(1, len(self.terminal_events()))
+        self.assert_episode(2, 0, 2)
+
+    def test_episode_replay_dedupes_and_added_scope_refires_with_fresh_key(self) -> None:
+        first = self.create_unit(developer=1, output_kind="report_only")
+        self.lifecycle.arm(self.sprint_id, 3)
+        self.messages.mark_read(self.assignment_message(first), 1)
+        self.units.complete(self.sprint_id, first, 1, result="First report")
+        self.assert_episode(1, 1, 0)
+
+        self.lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="Replay episode",
+        )
+        self.lifecycle.resume(
+            self.sprint_id, sprint_domain.LifecycleActor("planner", 3)
+        )
+        self.assertEqual(2, len(self.terminal_messages()))
+        self.assertEqual(1, len(self.terminal_events()))
+
+        second = self.create_unit(developer=1, output_kind="no_code")
+        self.units.dispatch_ready(self.sprint_id)
+        self.messages.mark_read(self.assignment_message(second), 1)
+        self.units.complete(self.sprint_id, second, 1, result="Second result")
+        self.assertEqual(4, len(self.terminal_messages()))
+        self.assertEqual(2, len(self.terminal_events()))
+        self.assert_episode(2, 2, 0)
+
+        self.lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="Replay expanded episode",
+        )
+        self.lifecycle.resume(
+            self.sprint_id, sprint_domain.LifecycleActor("planner", 3)
+        )
+        self.assertEqual(4, len(self.terminal_messages()))
+        self.assertEqual(2, len(self.terminal_events()))
+
+
 class ProductionPulseTest(SprintWorkDispatchCase):
     def test_armed_pulse_enqueues_every_parallel_ready_lane(self) -> None:
         first = self.create_unit(developer=1, wave=4)

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -845,6 +845,23 @@ class DeliveryTerminalTest(SprintWorkDispatchCase):
         self.assertEqual(1, len(self.terminal_events()))
         self.assert_episode(2, 0, 2)
 
+    def test_arming_all_cancelled_sprint_wakes_reviewers(self) -> None:
+        first = self.create_unit(developer=1, title="Cancelled first")
+        second = self.create_unit(developer=4, title="Cancelled second")
+        self.units.cancel(self.sprint_id, first, 3, reason="No longer needed")
+        self.units.cancel(self.sprint_id, second, 3, reason="No work remains")
+        self.assertEqual([], self.terminal_messages())
+        self.assertEqual([], self.terminal_events())
+
+        self.lifecycle.arm(self.sprint_id, 3)
+
+        self.assertEqual(
+            [(first, "cancelled"), (second, "cancelled")], self.dispositions()
+        )
+        self.assertEqual(2, len(self.terminal_messages()))
+        self.assertEqual(1, len(self.terminal_events()))
+        self.assert_episode(2, 0, 2)
+
     def test_episode_replay_dedupes_and_added_scope_refires_with_fresh_key(self) -> None:
         first = self.create_unit(developer=1, output_kind="report_only")
         self.lifecycle.arm(self.sprint_id, 3)


### PR DESCRIPTION
## What shipped

- Task 274: added the transactional `sprint.delivery_terminal` event and durable Reviewer notification when the last work unit becomes completed/cancelled through merge observation, report/no-code completion, or cancellation.
- Task 275: added resume-time catch-up after re-arming, including merge observations projected while paused.
- Task 276: allowed participating Reviewers to compile the read-only evidence packet while preserving Planner/FnB access and every other close authority.
- Task 277: added the delivery-terminal and compile-authority matrix beside the existing Sprint lifecycle suites.

The existing board event allowlist now projects the three delivery-terminal count fields. No endpoint, page, schema, table, daemon, or skill asset was added.

## Verification

`/home/j3d1/Repos/sc-cachy/.venv/bin/python -m pytest tests -q`

Result: **1729 passed, 1 skipped, 876 subtests passed in 111.90s**.

## Edge cases covered

- final merge after pause → resume → serial work units
- final report-only/no-code completion
- cancellation completing an all-cancelled set
- no wake mid-Sprint, while paused, or for a grant-bypassed merge
- resume-time all-terminal catch-up
- same-count replay dedupe and fresh-key re-fire after added scope
- one notification per participating Reviewer, with exact body/type/actionability and system event payload
- Reviewer, Planner, and FnB compile access; Developer and non-participating Planner refusal

## Judgment calls

- `wake_message.idempotency_key` is globally unique. A single-Reviewer Sprint uses the canonical `sprint:<id>:delivery-terminal:<terminal_count>` key exactly; multi-Reviewer delivery retains that namespace and appends `:reviewer:<participant_id>` so every Reviewer receives a distinct durable message without a schema change.
- The full-suite event-emitter contract required adding `sprint.delivery_terminal` to the existing board projection allowlist. This exposes only the three count fields and does not create or change an endpoint.
