### PR TITLE
feat(sprints): honor sanctioned quiet liveness

### DIFF
--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3939,6 +3939,12 @@ failure paths. A local exploratory number is not merge evidence. Record real CI
 failures, anomalous infrastructure failures, retries, review friction, and
 known departures for the final report.
 
+Immediately before a typed Developer handoff (`complete-unit`, `register-pr`,
+or `request-review`), re-run `sc sprint inbox --sprint <id>` once and act on
+anything new; a ruling may have arrived during the build. This is a once-only
+pre-handoff check. After the handoff confirms its durable write, stop without a
+further inbox pass.
+
 An explicitly planned report-only or no-code lane completes with its durable
 result instead of a PR. Code lanes cannot use this path; they complete only
 after merge authorization and observation.
@@ -3975,8 +3981,8 @@ registered PR.
 Complete a review handoff in this exact order:
 
 1. Finish the readiness claim and every local verification step.
-2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
-   mark every handled informational message read with `accept`.
+2. Perform the once-only typed-handoff inbox check above, act on newly arrived
+   messages, and mark every handled informational message read with `accept`.
 3. Run `wc -m < <path>`; keep the claim near 6,000 characters and below the
    8,000-character hard maximum.
 4. As the literal final action of the turn, send the typed handoff with one
@@ -4044,7 +4050,8 @@ the Reviewer decides whether to continue, re-plan, or pause and the Planner
 executes that decision.
 
 Stop when the unit is merged and reported, declined, awaiting Planner/FnB
-recovery, or returned to review. For normal review and merge handoffs, the
+recovery, returned to review, or paused awaiting a native PR-fact or verdict
+wake. For normal review and merge handoffs, the
 ordered procedures above place inbox handling before the typed handoff and make
 that handoff the turn''s last action. Ask the Planner for later work only after
 the current editing lane is terminal.',

--- a/.super-coder/migrations/0172_sanctioned_pause_liveness.sql
+++ b/.super-coder/migrations/0172_sanctioned_pause_liveness.sql
@@ -1,11 +1,16 @@
----
-name: sprint_dev
-description: Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge only after live authorization, and record judgment without overlapping edits.
-category: workflow
-common: false
----
+-- 0172 — reseed sanctioned-pause Developer guidance.
+-- Full-body UPSERT converges existing installations to spec #96's once-only
+-- pre-handoff inbox check and named native-wake pause state.
 
-# sprint_dev — own one editing lane
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_dev',
+  'Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge only after live authorization, and record judgment without overlapping edits.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_dev — own one editing lane
 
 Use for an actionable work-unit assignment in an armed Sprint. Marking that
 Sprint message read is acceptance and starts work immediately. If you cannot
@@ -29,10 +34,10 @@ Sprint or work-unit state.
 Read the assignment, expected output, bound spec revision, dependencies,
 assigned Reviewer, repository/worktree, merge grant, and prior judgments. One
 Developer shell may own one active work unit in the Sprint. Do not start a
-second editing lane or edit another shell's worktree.
+second editing lane or edit another shell''s worktree.
 
 If the requirement is ambiguous, choose the shippable reading within your
-unit's scope, record the choice and rationale, and continue. Escalate changes to
+unit''s scope, record the choice and rationale, and continue. Escalate changes to
 the unit boundary, interfaces another unit consumes, deliverable cuts, or scope
 growth to the Planner.
 
@@ -83,7 +88,7 @@ pausing; the Planner executes that decision.
 Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
 report drafts, and Dev scratch proof) go to the gitignored
 `shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR'd in the work repo; a review-notes commit is a finding.
+PR''d in the work repo; a review-notes commit is a finding.
 
 DB rows stay the durable record: judgments via `record-review`, report bodies in
 `sprint_reports`, and decisions in the durable relay. Files in the Sprint
@@ -95,7 +100,7 @@ Sync the assigned repository, work on a feature branch, match the surrounding
 code, and implement the smallest complete change. Keep external calls outside
 database transactions. Preserve durable identities and append-only evidence.
 
-Verification must exercise the unit's independent stage gate and realistic
+Verification must exercise the unit''s independent stage gate and realistic
 failure paths. A local exploratory number is not merge evidence. Record real CI
 failures, anomalous infrastructure failures, retries, review friction, and
 known departures for the final report.
@@ -214,5 +219,13 @@ Stop when the unit is merged and reported, declined, awaiting Planner/FnB
 recovery, returned to review, or paused awaiting a native PR-fact or verdict
 wake. For normal review and merge handoffs, the
 ordered procedures above place inbox handling before the typed handoff and make
-that handoff the turn's last action. Ask the Planner for later work only after
-the current editing lane is terminal.
+that handoff the turn''s last action. Ask the Planner for later work only after
+the current editing lane is terminal.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -131,7 +131,6 @@ _EVENT_FIELDS = {
     ),
     "liveness.ci_stalled": frozenset(
         {
-            "expectation_message_id",
             "registered_pr_id",
             "transition_key",
             "backstop_message_id",

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -121,6 +121,22 @@ _EVENT_FIELDS = {
     "liveness.nudged": frozenset(
         {"expectation_message_id", "silence_episode", "nudge_message_id"}
     ),
+    "liveness.sanctioned_quiet": frozenset(
+        {
+            "expectation_message_id",
+            "silence_episode",
+            "suppressor_kind",
+            "evidence_key",
+        }
+    ),
+    "liveness.ci_stalled": frozenset(
+        {
+            "expectation_message_id",
+            "registered_pr_id",
+            "transition_key",
+            "backstop_message_id",
+        }
+    ),
     "liveness.escalated": frozenset(
         {
             "expectation_message_id",

--- a/.super-coder/scripts/sprint_liveness.py
+++ b/.super-coder/scripts/sprint_liveness.py
@@ -23,6 +23,7 @@ from sprint_message_delivery import SprintMessageStore
 EVALUATION_INTERVAL = timedelta(minutes=5)
 GRACE_WINDOW = timedelta(minutes=10)
 ESCALATION_WINDOW = timedelta(minutes=10)
+CI_STALLED_BACKSTOP = timedelta(minutes=90)
 
 _NATIVE_EVIDENCE_EVENTS = (
     "session.started",
@@ -83,6 +84,7 @@ class EvidenceSnapshot:
     strong: Evidence | None
     supporting: tuple[Evidence, ...]
     failure: Evidence | None
+    suppressors: tuple[Evidence, ...]
     unreadable: tuple[str, ...]
 
 
@@ -179,10 +181,15 @@ class SprintEvidenceCollector:
             unreadable.append(quota.unreadable)
 
         failure = max(failures, key=lambda item: item.observed_at, default=None)
+        last_strong_at = _parse(expectation["last_strong_at"])
+        if strong is not None:
+            last_strong_at = max(last_strong_at, strong.observed_at)
+        suppressors = self._suppressors(participant_id, last_strong_at)
         return EvidenceSnapshot(
             strong=strong,
             supporting=tuple(sorted(supporting, key=lambda item: item.key)),
             failure=failure,
+            suppressors=suppressors,
             unreadable=tuple(sorted(set(unreadable))),
         )
 
@@ -310,23 +317,6 @@ class SprintEvidenceCollector:
                 )
             )
 
-        row = self.con.execute(
-            "SELECT message_id,message_kind,created_at FROM wake_message "
-            "WHERE from_participant_id=? AND created_at>=? "
-            "ORDER BY created_at DESC,message_id DESC LIMIT 1",
-            (participant_id, threshold),
-        ).fetchone()
-        if row is not None:
-            candidates.append(
-                Evidence(
-                    f"sprint.message:{row['message_id']}",
-                    f"sprint_message.{row['message_kind']}",
-                    _parse(row["created_at"]),
-                    "strong",
-                    "durable Sprint message authored by the participant",
-                )
-            )
-
         participant = self.con.execute(
             "SELECT sprint_id,shell_id FROM sprint_participants WHERE participant_id=?",
             (participant_id,),
@@ -369,6 +359,56 @@ class SprintEvidenceCollector:
             )
 
         return max(candidates, key=lambda item: (item.observed_at, item.key), default=None)
+
+    def _suppressors(
+        self, participant_id: int, last_strong_at: datetime
+    ) -> tuple[Evidence, ...]:
+        suppressors: list[Evidence] = []
+        rows = self.con.execute(
+            "SELECT pr.registered_pr_id,pr.repository,pr.pr_number,"
+            "t.normalized_state,t.transition_key,t.observed_at "
+            "FROM sprint_registered_prs pr JOIN sprint_pr_transitions t "
+            "ON t.registered_pr_id=pr.registered_pr_id "
+            "WHERE pr.owner_participant_id=? "
+            "AND t.transition_id=(SELECT latest.transition_id "
+            "FROM sprint_pr_transitions latest "
+            "WHERE latest.registered_pr_id=pr.registered_pr_id "
+            "ORDER BY latest.transition_id DESC LIMIT 1) "
+            "AND t.normalized_state IN ('created','pending') "
+            "ORDER BY pr.registered_pr_id",
+            (participant_id,),
+        ).fetchall()
+        for row in rows:
+            suppressors.append(
+                Evidence(
+                    f"pr.transition:{row['transition_key']}",
+                    "pr.awaiting_transition",
+                    _parse(row["observed_at"]),
+                    "suppressor",
+                    (
+                        f"{row['repository']}#{row['pr_number']} is "
+                        f"{row['normalized_state']}"
+                    ),
+                )
+            )
+
+        row = self.con.execute(
+            "SELECT message_id,message_kind,created_at FROM wake_message "
+            "WHERE from_participant_id=? AND created_at>? "
+            "ORDER BY created_at DESC,message_id DESC LIMIT 1",
+            (participant_id, _stamp(last_strong_at)),
+        ).fetchone()
+        if row is not None:
+            suppressors.append(
+                Evidence(
+                    f"sprint.message:{row['message_id']}",
+                    "outbound.handoff",
+                    _parse(row["created_at"]),
+                    "suppressor",
+                    f"durable outbound {row['message_kind']} awaits a reply wake",
+                )
+            )
+        return tuple(sorted(suppressors, key=lambda item: item.key))
 
     def _terminal_failures(
         self, participant_id: int, accepted_at: datetime
@@ -604,6 +644,19 @@ class SprintLivenessMonitor:
             fresh_strong = self._fresh_strong(row, snapshot.strong)
             failure = snapshot.failure
 
+            current_failure = failure is None or not (
+                fresh_strong is not None
+                and fresh_strong.observed_at > failure.observed_at
+            )
+            if failure is not None and current_failure and (
+                failure.observed_at >= last_strong_at
+                or failure.kind in {"quota.exhausted", "process.missing"}
+            ) and (
+                    row["escalated_at"] is None
+                    or failure.key != row["last_failure_key"]
+            ):
+                return self._escalate(row, episode, snapshot, now, failure=failure)
+
             if fresh_strong is not None and (
                 failure is None or fresh_strong.observed_at > failure.observed_at
             ):
@@ -627,15 +680,6 @@ class SprintLivenessMonitor:
                 )
                 return EvaluationOutcome(message_id, "strong-evidence", episode)
 
-            if failure is not None and (
-                failure.observed_at >= last_strong_at
-                or failure.kind in {"quota.exhausted", "process.missing"}
-            ) and (
-                    row["escalated_at"] is None
-                    or failure.key != row["last_failure_key"]
-            ):
-                return self._escalate(row, episode, snapshot, now, failure=failure)
-
             if row["escalated_at"] is not None:
                 self._update_observation(
                     message_id,
@@ -645,6 +689,38 @@ class SprintLivenessMonitor:
                 )
                 action = "supporting-evidence" if snapshot.supporting else "observed"
                 return EvaluationOutcome(message_id, action, episode)
+
+            if snapshot.suppressors:
+                self._send_ci_stalled_backstops(row, snapshot.suppressors, now)
+                suppressor = max(
+                    snapshot.suppressors,
+                    key=lambda item: (item.observed_at, item.key),
+                )
+                event_exists = self.con.execute(
+                    "SELECT 1 FROM sprint_events WHERE sprint_id=? "
+                    "AND event_type='liveness.sanctioned_quiet' "
+                    "AND json_extract(payload,'$.expectation_message_id')=? "
+                    "AND json_extract(payload,'$.silence_episode')=? LIMIT 1",
+                    (int(row["sprint_id"]), message_id, episode),
+                ).fetchone()
+                if event_exists is None:
+                    self._event(
+                        int(row["sprint_id"]),
+                        "liveness.sanctioned_quiet",
+                        {
+                            "expectation_message_id": message_id,
+                            "silence_episode": episode,
+                            "suppressor_kind": suppressor.kind,
+                            "evidence_key": suppressor.key,
+                        },
+                    )
+                self._update_observation(
+                    message_id,
+                    now,
+                    snapshot,
+                    failure_key=failure.key if failure else None,
+                )
+                return EvaluationOutcome(message_id, "sanctioned-quiet", episode)
 
             accepted_silence = now - last_strong_at
             if row["nudge_at"] is None and accepted_silence >= GRACE_WINDOW:
@@ -697,6 +773,82 @@ class SprintLivenessMonitor:
             )
             action = "supporting-evidence" if snapshot.supporting else "observed"
             return EvaluationOutcome(message_id, action, episode)
+
+    def _send_ci_stalled_backstops(
+        self,
+        expectation: sqlite3.Row,
+        suppressors: tuple[Evidence, ...],
+        now: datetime,
+    ) -> None:
+        for suppressor in suppressors:
+            if suppressor.kind != "pr.awaiting_transition":
+                continue
+            if now - suppressor.observed_at < CI_STALLED_BACKSTOP:
+                continue
+            transition_key = suppressor.key.removeprefix("pr.transition:")
+            idempotency_key = f"liveness:ci-stalled:{transition_key}:planner"
+            if self.con.execute(
+                "SELECT 1 FROM wake_message WHERE idempotency_key=?",
+                (idempotency_key,),
+            ).fetchone() is not None:
+                continue
+            pending = self.con.execute(
+                "SELECT pr.registered_pr_id,pr.repository,pr.pr_number,"
+                "t.normalized_state,t.transition_key,t.observed_head_sha,t.observed_at "
+                "FROM sprint_pr_transitions t JOIN sprint_registered_prs pr "
+                "ON pr.registered_pr_id=t.registered_pr_id "
+                "WHERE t.transition_key=? AND pr.sprint_id=?",
+                (transition_key, int(expectation["sprint_id"])),
+            ).fetchone()
+            if pending is None:
+                continue
+            planner_id, route = self.router.prepare(
+                int(expectation["sprint_id"]),
+                now=now,
+                reason=f"CI-stalled backstop for {pending['repository']}#{pending['pr_number']}",
+            )
+            pending_minutes = int(
+                (now - _parse(pending["observed_at"])).total_seconds() // 60
+            )
+            receipt = self.messages.send_in_transaction(
+                int(expectation["sprint_id"]),
+                to_participant_id=planner_id,
+                message_kind="escalation",
+                body=_json(
+                    {
+                        "kind": "ci_stalled",
+                        "registered_pr_id": int(pending["registered_pr_id"]),
+                        "repository": str(pending["repository"]),
+                        "pr_number": int(pending["pr_number"]),
+                        "head_sha": pending["observed_head_sha"],
+                        "normalized_state": str(pending["normalized_state"]),
+                        "transition_key": str(pending["transition_key"]),
+                        "pending_since": str(pending["observed_at"]),
+                        "pending_minutes": pending_minutes,
+                        "mandate": (
+                            "Assess the stalled CI transition and attempt repair "
+                            "by re-triggering checks, closing/reopening, or re-pushing. "
+                            "Pause the Sprint if the runner is genuinely down."
+                        ),
+                        "planner_delivery_route": route,
+                        "pause_option": True,
+                    }
+                ),
+                idempotency_key=idempotency_key,
+                actionable=False,
+                declared_type="re-enter",
+            )
+            if receipt.created:
+                self._event(
+                    int(expectation["sprint_id"]),
+                    "liveness.ci_stalled",
+                    {
+                        "expectation_message_id": int(expectation["message_id"]),
+                        "registered_pr_id": int(pending["registered_pr_id"]),
+                        "transition_key": transition_key,
+                        "backstop_message_id": receipt.message_id,
+                    },
+                )
 
     def _escalate(
         self,

--- a/.super-coder/scripts/sprint_liveness.py
+++ b/.super-coder/scripts/sprint_liveness.py
@@ -126,6 +126,14 @@ class SprintEvidenceCollector:
         accepted_at = _parse(expectation["accepted_at"])
         participant_id = int(expectation["participant_id"])
         strong = self._latest_strong(participant_id, accepted_at)
+        outbound_handoff = self._outbound_handoff(
+            participant_id,
+            accepted_at,
+            int(expectation["message_id"]),
+            strong,
+        )
+        if outbound_handoff is not None:
+            strong = None
         failures = list(self._terminal_failures(participant_id, accepted_at))
         supporting: list[Evidence] = []
         unreadable: list[str] = []
@@ -181,10 +189,7 @@ class SprintEvidenceCollector:
             unreadable.append(quota.unreadable)
 
         failure = max(failures, key=lambda item: item.observed_at, default=None)
-        last_strong_at = _parse(expectation["last_strong_at"])
-        if strong is not None:
-            last_strong_at = max(last_strong_at, strong.observed_at)
-        suppressors = self._suppressors(participant_id, last_strong_at)
+        suppressors = self._suppressors(participant_id, outbound_handoff)
         return EvidenceSnapshot(
             strong=strong,
             supporting=tuple(sorted(supporting, key=lambda item: item.key)),
@@ -361,8 +366,11 @@ class SprintEvidenceCollector:
         return max(candidates, key=lambda item: (item.observed_at, item.key), default=None)
 
     def _suppressors(
-        self, participant_id: int, last_strong_at: datetime
+        self,
+        participant_id: int,
+        outbound_handoff: Evidence | None,
     ) -> tuple[Evidence, ...]:
+        """Collect participant-scoped suppressors; decision #85(3) makes quiet per-shell."""
         suppressors: list[Evidence] = []
         rows = self.con.execute(
             "SELECT pr.registered_pr_id,pr.repository,pr.pr_number,"
@@ -392,23 +400,47 @@ class SprintEvidenceCollector:
                 )
             )
 
+        if outbound_handoff is not None:
+            suppressors.append(outbound_handoff)
+        return tuple(sorted(suppressors, key=lambda item: item.key))
+
+    def _outbound_handoff(
+        self,
+        participant_id: int,
+        accepted_at: datetime,
+        expectation_message_id: int,
+        strong: Evidence | None,
+    ) -> Evidence | None:
         row = self.con.execute(
             "SELECT message_id,message_kind,created_at FROM wake_message "
-            "WHERE from_participant_id=? AND created_at>? "
+            "WHERE from_participant_id=? AND created_at>=? AND message_id>? "
             "ORDER BY created_at DESC,message_id DESC LIMIT 1",
-            (participant_id, _stamp(last_strong_at)),
+            (participant_id, _stamp(accepted_at), expectation_message_id),
         ).fetchone()
-        if row is not None:
-            suppressors.append(
-                Evidence(
-                    f"sprint.message:{row['message_id']}",
-                    "outbound.handoff",
-                    _parse(row["created_at"]),
-                    "suppressor",
-                    f"durable outbound {row['message_kind']} awaits a reply wake",
-                )
-            )
-        return tuple(sorted(suppressors, key=lambda item: item.key))
+        if row is None:
+            return None
+        sent_at = _parse(row["created_at"])
+        turn = self.con.execute(
+            "SELECT r.run_id,r.ended_at FROM conversation_runs r "
+            "JOIN sprint_participant_conversations pc "
+            "ON pc.conversation_id=r.conversation_id "
+            "WHERE pc.sprint_participant_id=? AND r.started_at IS NOT NULL "
+            "AND r.started_at<=? AND (r.ended_at IS NULL OR r.ended_at>=?) "
+            "ORDER BY r.started_at DESC,r.run_id DESC LIMIT 1",
+            (participant_id, _stamp(sent_at), _stamp(sent_at)),
+        ).fetchone()
+        if turn is not None and turn["ended_at"] is None:
+            return None
+        turn_ended_at = _parse(turn["ended_at"]) if turn is not None else sent_at
+        if strong is not None and strong.observed_at > turn_ended_at:
+            return None
+        return Evidence(
+            f"sprint.message:{row['message_id']}",
+            "outbound.handoff",
+            sent_at,
+            "suppressor",
+            f"durable outbound {row['message_kind']} awaits a reply wake",
+        )
 
     def _terminal_failures(
         self, participant_id: int, accepted_at: datetime
@@ -561,6 +593,7 @@ class SprintLivenessMonitor:
         now = self.now().astimezone(timezone.utc)
         if not self._armed(sprint_id):
             return ()
+        self._send_ci_stalled_backstops(sprint_id, now)
         due = self.con.execute(
             "SELECT e.* FROM sprint_liveness_expectations e "
             "JOIN wake_message m ON m.message_id=e.message_id "
@@ -691,7 +724,6 @@ class SprintLivenessMonitor:
                 return EvaluationOutcome(message_id, action, episode)
 
             if snapshot.suppressors:
-                self._send_ci_stalled_backstops(row, snapshot.suppressors, now)
                 suppressor = max(
                     snapshot.suppressors,
                     key=lambda item: (item.observed_at, item.key),
@@ -776,79 +808,85 @@ class SprintLivenessMonitor:
 
     def _send_ci_stalled_backstops(
         self,
-        expectation: sqlite3.Row,
-        suppressors: tuple[Evidence, ...],
+        sprint_id: int,
         now: datetime,
     ) -> None:
-        for suppressor in suppressors:
-            if suppressor.kind != "pr.awaiting_transition":
-                continue
-            if now - suppressor.observed_at < CI_STALLED_BACKSTOP:
-                continue
-            transition_key = suppressor.key.removeprefix("pr.transition:")
-            idempotency_key = f"liveness:ci-stalled:{transition_key}:planner"
-            if self.con.execute(
-                "SELECT 1 FROM wake_message WHERE idempotency_key=?",
-                (idempotency_key,),
-            ).fetchone() is not None:
-                continue
-            pending = self.con.execute(
+        with db_driver.write_transaction(self.con, "sprint.liveness.ci_backstop"):
+            pending_rows = self.con.execute(
                 "SELECT pr.registered_pr_id,pr.repository,pr.pr_number,"
                 "t.normalized_state,t.transition_key,t.observed_head_sha,t.observed_at "
-                "FROM sprint_pr_transitions t JOIN sprint_registered_prs pr "
-                "ON pr.registered_pr_id=t.registered_pr_id "
-                "WHERE t.transition_key=? AND pr.sprint_id=?",
-                (transition_key, int(expectation["sprint_id"])),
-            ).fetchone()
-            if pending is None:
-                continue
-            planner_id, route = self.router.prepare(
-                int(expectation["sprint_id"]),
-                now=now,
-                reason=f"CI-stalled backstop for {pending['repository']}#{pending['pr_number']}",
+                "FROM sprint_registered_prs pr JOIN sprint_pr_transitions t "
+                "ON t.registered_pr_id=pr.registered_pr_id "
+                "WHERE pr.sprint_id=? AND t.transition_id=("
+                "SELECT latest.transition_id FROM sprint_pr_transitions latest "
+                "WHERE latest.registered_pr_id=pr.registered_pr_id "
+                "ORDER BY latest.transition_id DESC LIMIT 1) "
+                "AND t.normalized_state IN ('created','pending') "
+                "AND t.observed_at<=? ORDER BY pr.registered_pr_id",
+                (sprint_id, _stamp(now - CI_STALLED_BACKSTOP)),
+            ).fetchall()
+            for pending in pending_rows:
+                self._send_ci_stalled_backstop(sprint_id, pending, now)
+
+    def _send_ci_stalled_backstop(
+        self,
+        sprint_id: int,
+        pending: sqlite3.Row,
+        now: datetime,
+    ) -> None:
+        transition_key = str(pending["transition_key"])
+        idempotency_key = f"liveness:ci-stalled:{transition_key}:planner"
+        if self.con.execute(
+            "SELECT 1 FROM wake_message WHERE idempotency_key=?",
+            (idempotency_key,),
+        ).fetchone() is not None:
+            return
+        planner_id, route = self.router.prepare(
+            sprint_id,
+            now=now,
+            reason=f"CI-stalled backstop for {pending['repository']}#{pending['pr_number']}",
+        )
+        pending_minutes = int(
+            (now - _parse(pending["observed_at"])).total_seconds() // 60
+        )
+        receipt = self.messages.send_in_transaction(
+            sprint_id,
+            to_participant_id=planner_id,
+            message_kind="escalation",
+            body=_json(
+                {
+                    "kind": "ci_stalled",
+                    "registered_pr_id": int(pending["registered_pr_id"]),
+                    "repository": str(pending["repository"]),
+                    "pr_number": int(pending["pr_number"]),
+                    "head_sha": pending["observed_head_sha"],
+                    "normalized_state": str(pending["normalized_state"]),
+                    "transition_key": str(pending["transition_key"]),
+                    "pending_since": str(pending["observed_at"]),
+                    "pending_minutes": pending_minutes,
+                    "mandate": (
+                        "Assess the stalled CI transition and attempt repair "
+                        "by re-triggering checks, closing/reopening, or re-pushing. "
+                        "Pause the Sprint if the runner is genuinely down."
+                    ),
+                    "planner_delivery_route": route,
+                    "pause_option": True,
+                }
+            ),
+            idempotency_key=idempotency_key,
+            actionable=False,
+            declared_type="re-enter",
+        )
+        if receipt.created:
+            self._event(
+                sprint_id,
+                "liveness.ci_stalled",
+                {
+                    "registered_pr_id": int(pending["registered_pr_id"]),
+                    "transition_key": transition_key,
+                    "backstop_message_id": receipt.message_id,
+                },
             )
-            pending_minutes = int(
-                (now - _parse(pending["observed_at"])).total_seconds() // 60
-            )
-            receipt = self.messages.send_in_transaction(
-                int(expectation["sprint_id"]),
-                to_participant_id=planner_id,
-                message_kind="escalation",
-                body=_json(
-                    {
-                        "kind": "ci_stalled",
-                        "registered_pr_id": int(pending["registered_pr_id"]),
-                        "repository": str(pending["repository"]),
-                        "pr_number": int(pending["pr_number"]),
-                        "head_sha": pending["observed_head_sha"],
-                        "normalized_state": str(pending["normalized_state"]),
-                        "transition_key": str(pending["transition_key"]),
-                        "pending_since": str(pending["observed_at"]),
-                        "pending_minutes": pending_minutes,
-                        "mandate": (
-                            "Assess the stalled CI transition and attempt repair "
-                            "by re-triggering checks, closing/reopening, or re-pushing. "
-                            "Pause the Sprint if the runner is genuinely down."
-                        ),
-                        "planner_delivery_route": route,
-                        "pause_option": True,
-                    }
-                ),
-                idempotency_key=idempotency_key,
-                actionable=False,
-                declared_type="re-enter",
-            )
-            if receipt.created:
-                self._event(
-                    int(expectation["sprint_id"]),
-                    "liveness.ci_stalled",
-                    {
-                        "expectation_message_id": int(expectation["message_id"]),
-                        "registered_pr_id": int(pending["registered_pr_id"]),
-                        "transition_key": transition_key,
-                        "backstop_message_id": receipt.message_id,
-                    },
-                )
 
     def _escalate(
         self,

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -55,8 +55,9 @@ def wake_prompt(sprint_id: int, role: str) -> str:
         f"Sprint {sprint_id} handoff for your {label} role. Load `{skill}`. "
         f"Run `sc sprint inbox --sprint {sprint_id}` now and act on the Sprint "
         f"message(s) using `{skill}`. Confirm every Sprint write succeeds before "
-        f"stopping. If the handoff is not complete, load `{skill}` again and run "
-        f"`sc sprint inbox --sprint {sprint_id}` again."
+        "stopping. If a Sprint command failed or did not confirm its durable write, "
+        "retry that command. Do not re-check the inbox otherwise — new messages "
+        "arrive as their own wakes."
     )
 
 

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -74,7 +74,8 @@
     ".super-coder/migrations/0169_reseed_sprint_v21_guidance.sql",
     ".super-coder/migrations/0170_reseed_sprint_handoff_order.sql",
     ".super-coder/templates/boot.md",
-    ".super-coder/migrations/0171_reseed_sprint_closeout_skills.sql"
+    ".super-coder/migrations/0171_reseed_sprint_closeout_skills.sql",
+    ".super-coder/migrations/0172_sanctioned_pause_liveness.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -16,9 +16,9 @@ ENGINE = ROOT / ".super-coder"
 MIGRATIONS = ENGINE / "migrations"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
-import sprint_domain  # noqa: E402
-import sprint_liveness  # noqa: E402
-import sprint_message_delivery  # noqa: E402
+import sprint_domain
+import sprint_liveness
+import sprint_message_delivery
 
 
 def apply_schema(con: sqlite3.Connection) -> None:
@@ -276,6 +276,358 @@ class SprintLivenessCase(unittest.TestCase):
         )
         self.con.commit()
         return run_id
+
+    def add_pr_transition(
+        self,
+        state: str,
+        minutes: int,
+        *,
+        registered_pr_id: int | None = None,
+        token: str = "first",
+    ) -> int:
+        if registered_pr_id is None:
+            registered_pr_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_registered_prs "
+                    "(sprint_id,owner_participant_id,repository,pr_number) "
+                    "VALUES (?,?,?,?)",
+                    (self.sprint_id, self.developer_id, "acme/widget", 41),
+                ).lastrowid
+            )
+        self.con.execute(
+            "INSERT INTO sprint_pr_transitions "
+            "(registered_pr_id,normalized_state,transition_key,observed_head_sha,"
+            "observed_at) VALUES (?,?,?,?,?)",
+            (
+                registered_pr_id,
+                state,
+                f"transition-{token}",
+                token[0] * 40,
+                stamp(self.started_at + timedelta(minutes=minutes)),
+            ),
+        )
+        self.con.commit()
+        return registered_pr_id
+
+    def add_outbound_handoff(self, minutes: int) -> int:
+        receipt = self.messages.send(
+            self.sprint_id,
+            to_participant_id=self.planner_id,
+            from_participant_id=self.developer_id,
+            message_kind="notification",
+            body="Question awaiting Planner reply",
+            actionable=False,
+            declared_type="re-enter",
+            idempotency_key=f"developer-question:{minutes}",
+        )
+        self.con.execute(
+            "UPDATE wake_message SET created_at=? WHERE message_id=?",
+            (
+                stamp(self.started_at + timedelta(minutes=minutes)),
+                receipt.message_id,
+            ),
+        )
+        self.con.commit()
+        return receipt.message_id
+
+
+class SuppressorCollectorTest(SprintLivenessCase):
+    def test_pending_owned_pr_suppresses_until_green_transition(self) -> None:
+        registered_pr_id = self.add_pr_transition("pending", 1)
+        snapshot = self.monitor().collector.collect(
+            self.expectation(), self.started_at + timedelta(minutes=10)
+        )
+
+        self.assertEqual(
+            [("pr.awaiting_transition", "pr.transition:transition-first")],
+            [(item.kind, item.key) for item in snapshot.suppressors],
+        )
+        self.assertEqual("acme/widget#41 is pending", snapshot.suppressors[0].detail)
+
+        self.add_pr_transition(
+            "green", 2, registered_pr_id=registered_pr_id, token="green"
+        )
+        released = self.monitor().collector.collect(
+            self.expectation(), self.started_at + timedelta(minutes=10)
+        )
+        self.assertEqual((), released.suppressors)
+        self.assertEqual("pr.green", released.strong.kind)
+
+    def test_outbound_handoff_suppresses_only_while_it_is_the_last_act(self) -> None:
+        message_id = self.add_outbound_handoff(6)
+        snapshot = self.monitor().collector.collect(
+            self.expectation(), self.started_at + timedelta(minutes=10)
+        )
+
+        self.assertEqual(
+            [("outbound.handoff", f"sprint.message:{message_id}")],
+            [(item.kind, item.key) for item in snapshot.suppressors],
+        )
+        self.assertNotEqual(
+            f"sprint.message:{message_id}",
+            snapshot.strong.key if snapshot.strong is not None else None,
+        )
+
+        event_id = self.add_native_event("tool.completed", 7)
+        released = self.monitor().collector.collect(
+            self.expectation(), self.started_at + timedelta(minutes=10)
+        )
+        self.assertEqual((), released.suppressors)
+        self.assertEqual(f"conversation.event:{event_id}", released.strong.key)
+
+
+class SanctionedQuietPolicyTest(SprintLivenessCase):
+    def assert_outbound_handoff_suppresses_role(
+        self,
+        *,
+        participant_id: int,
+        shell_id: int,
+        sender_id: int,
+        reply_to_id: int,
+        token: str,
+    ) -> None:
+        self.monitor().resolve(self.assignment_message_id, "role suppressor fixture")
+        inbound = self.messages.send(
+            self.sprint_id,
+            to_participant_id=participant_id,
+            from_participant_id=sender_id,
+            message_kind="notification",
+            body=f"Actionable {token} work",
+            actionable=True,
+            declared_type="re-enter",
+            idempotency_key=f"{token}:inbound",
+        )
+        self.assertEqual(
+            "accepted", self.messages.mark_read(inbound.message_id, shell_id)
+        )
+        expectation = self.expectation(inbound.message_id)
+        role_started_at = parse(expectation["accepted_at"])
+        self.clock.at(role_started_at + timedelta(minutes=5))
+        first = self.monitor().evaluate(self.sprint_id)
+        self.assertEqual("observed", first[0].action)
+
+        outbound = self.messages.send(
+            self.sprint_id,
+            to_participant_id=reply_to_id,
+            from_participant_id=participant_id,
+            message_kind="notification",
+            body=f"{token} handoff awaiting reply",
+            actionable=False,
+            declared_type="re-enter",
+            idempotency_key=f"{token}:outbound",
+        )
+        self.con.execute(
+            "UPDATE wake_message SET created_at=? WHERE message_id=?",
+            (
+                stamp(role_started_at + timedelta(minutes=6)),
+                outbound.message_id,
+            ),
+        )
+        self.con.commit()
+        self.clock.at(role_started_at + timedelta(minutes=10))
+        outcomes = self.monitor().evaluate(self.sprint_id)
+
+        self.assertEqual(1, len(outcomes))
+        self.assertEqual(inbound.message_id, outcomes[0].message_id)
+        self.assertEqual("sanctioned-quiet", outcomes[0].action)
+        self.assertEqual([], self.message_rows("nudge"))
+        event = self.con.execute(
+            "SELECT payload FROM sprint_events "
+            "WHERE event_type='liveness.sanctioned_quiet'"
+        ).fetchone()
+        self.assertEqual(
+            {
+                "expectation_message_id": inbound.message_id,
+                "silence_episode": 1,
+                "suppressor_kind": "outbound.handoff",
+                "evidence_key": f"sprint.message:{outbound.message_id}",
+            },
+            json.loads(event["payload"]),
+        )
+        self.clock.at(role_started_at + timedelta(minutes=100))
+        repeated = self.monitor().evaluate(self.sprint_id)
+        self.assertEqual("sanctioned-quiet", repeated[0].action)
+        self.assertEqual([], self.message_rows("escalation"))
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='liveness.sanctioned_quiet'"
+            ).fetchone()[0],
+        )
+
+    def test_reviewer_outbound_handoff_suppresses_ambiguous_silence(self) -> None:
+        self.assert_outbound_handoff_suppresses_role(
+            participant_id=self.reviewer_id,
+            shell_id=2,
+            sender_id=self.developer_id,
+            reply_to_id=self.planner_id,
+            token="reviewer",
+        )
+
+    def test_planner_outbound_handoff_suppresses_ambiguous_silence(self) -> None:
+        self.assert_outbound_handoff_suppresses_role(
+            participant_id=self.planner_id,
+            shell_id=3,
+            sender_id=self.reviewer_id,
+            reply_to_id=self.developer_id,
+            token="planner",
+        )
+
+    def test_existing_liveness_timing_is_unchanged(self) -> None:
+        self.assertEqual(timedelta(minutes=5), sprint_liveness.EVALUATION_INTERVAL)
+        self.assertEqual(timedelta(minutes=10), sprint_liveness.GRACE_WINDOW)
+        self.assertEqual(timedelta(minutes=10), sprint_liveness.ESCALATION_WINDOW)
+
+    def test_pending_pr_suppresses_nudge_once_per_episode_then_green_releases(self) -> None:
+        registered_pr_id = self.add_pr_transition("pending", 1)
+        monitor = self.monitor()
+
+        self.advance(5)
+        self.assertEqual("strong-evidence", monitor.evaluate(self.sprint_id)[0].action)
+        self.advance(10)
+        self.assertEqual(
+            "sanctioned-quiet", monitor.evaluate(self.sprint_id)[0].action
+        )
+        self.advance(15)
+        self.assertEqual(
+            "sanctioned-quiet", monitor.evaluate(self.sprint_id)[0].action
+        )
+        self.assertEqual([], self.message_rows("nudge"))
+        self.assertEqual([], self.message_rows("escalation"))
+        events = self.con.execute(
+            "SELECT payload FROM sprint_events "
+            "WHERE event_type='liveness.sanctioned_quiet'"
+        ).fetchall()
+        self.assertEqual(1, len(events))
+        self.assertEqual(
+            {
+                "expectation_message_id": self.assignment_message_id,
+                "silence_episode": 2,
+                "suppressor_kind": "pr.awaiting_transition",
+                "evidence_key": "pr.transition:transition-first",
+            },
+            json.loads(events[0]["payload"]),
+        )
+        self.assertEqual(
+            stamp(self.started_at + timedelta(minutes=20)),
+            self.expectation()["next_evaluation_at"],
+        )
+
+        self.add_pr_transition(
+            "green", 16, registered_pr_id=registered_pr_id, token="green"
+        )
+        self.advance(20)
+        self.assertEqual("strong-evidence", monitor.evaluate(self.sprint_id)[0].action)
+        self.advance(30)
+        self.assertEqual("nudged", monitor.evaluate(self.sprint_id)[0].action)
+        self.assertEqual(1, len(self.message_rows("nudge")))
+
+    def test_current_failure_escalates_before_pending_pr_suppression(self) -> None:
+        self.add_pr_transition("pending", 1)
+        failure_at = self.started_at + timedelta(minutes=2)
+
+        def failed(_participant, _accepted, _now):
+            return (
+                None,
+                sprint_liveness.Evidence(
+                    "process:missing:1",
+                    "process.missing",
+                    failure_at,
+                    "failure",
+                    "participant process is missing",
+                ),
+                None,
+            )
+
+        self.advance(5)
+        outcome = self.monitor(failed).evaluate(self.sprint_id)[0]
+        self.assertEqual("escalated", outcome.action)
+        self.assertEqual([], self.message_rows("nudge"))
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='liveness.sanctioned_quiet'"
+            ).fetchone()[0],
+        )
+        payload = json.loads(self.message_rows("escalation")[0]["body"])
+        self.assertEqual("process:missing:1", payload["failure"]["key"])
+
+    def test_ci_stalled_backstop_wakes_planner_once_per_transition(self) -> None:
+        registered_pr_id = self.add_pr_transition("pending", 0)
+        monitor = self.monitor()
+        self.advance(5)
+        self.assertEqual("strong-evidence", monitor.evaluate(self.sprint_id)[0].action)
+
+        self.advance(90)
+        self.assertEqual(
+            "sanctioned-quiet", monitor.evaluate(self.sprint_id)[0].action
+        )
+        backstops = self.message_rows("escalation")
+        self.assertEqual(1, len(backstops))
+        self.assertEqual(self.planner_id, backstops[0]["to_participant_id"])
+        self.assertNotEqual(self.developer_id, backstops[0]["to_participant_id"])
+        payload = json.loads(backstops[0]["body"])
+        self.assertEqual(
+            {
+                "kind": "ci_stalled",
+                "registered_pr_id": registered_pr_id,
+                "repository": "acme/widget",
+                "pr_number": 41,
+                "head_sha": "f" * 40,
+                "normalized_state": "pending",
+                "transition_key": "transition-first",
+                "pending_since": stamp(self.started_at),
+                "pending_minutes": 90,
+                "mandate": (
+                    "Assess the stalled CI transition and attempt repair by "
+                    "re-triggering checks, closing/reopening, or re-pushing. "
+                    "Pause the Sprint if the runner is genuinely down."
+                ),
+                "planner_delivery_route": "delivery-time",
+                "pause_option": True,
+            },
+            payload,
+        )
+        self.assertEqual([], self.message_rows("nudge"))
+
+        self.advance(95)
+        self.assertEqual(
+            "sanctioned-quiet", monitor.evaluate(self.sprint_id)[0].action
+        )
+        self.assertEqual(1, len(self.message_rows("escalation")))
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='liveness.ci_stalled'"
+            ).fetchone()[0],
+        )
+
+        self.add_pr_transition(
+            "green", 96, registered_pr_id=registered_pr_id, token="green"
+        )
+        self.advance(100)
+        self.assertEqual("strong-evidence", monitor.evaluate(self.sprint_id)[0].action)
+        self.add_pr_transition(
+            "pending", 105, registered_pr_id=registered_pr_id, token="second"
+        )
+        self.advance(105)
+        self.assertEqual("strong-evidence", monitor.evaluate(self.sprint_id)[0].action)
+        self.advance(195)
+        self.assertEqual(
+            "sanctioned-quiet", monitor.evaluate(self.sprint_id)[0].action
+        )
+        self.assertEqual(2, len(self.message_rows("escalation")))
+        self.assertEqual(
+            ["transition-first", "transition-second"],
+            [
+                json.loads(row["body"])["transition_key"]
+                for row in self.message_rows("escalation")
+            ],
+        )
+        self.assertEqual([], self.message_rows("nudge"))
 
 
 class FakeClockPolicyTest(SprintLivenessCase):

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -212,7 +212,13 @@ class SprintLivenessCase(unittest.TestCase):
             (kind,),
         ).fetchall()
 
-    def add_native_event(self, event_type: str, minutes: int) -> int:
+    def add_native_event(
+        self,
+        event_type: str,
+        minutes: int,
+        *,
+        run_id: int | None = None,
+    ) -> int:
         conversation_id = self.con.execute(
             "SELECT active.chat_id FROM sprint_participants participant "
             "JOIN active_shell_chats active ON active.shell_id=participant.shell_id "
@@ -229,18 +235,60 @@ class SprintLivenessCase(unittest.TestCase):
         event_id = int(
             self.con.execute(
                 "INSERT INTO conversation_events "
-                "(conversation_id,sequence,event_type,payload,created_at) "
-                "VALUES (?,?,?,'{}',?)",
+                "(conversation_id,sequence,event_type,payload,run_id,created_at) "
+                "VALUES (?,?,?,'{}',?,?)",
                 (
                     conversation_id,
                     sequence,
                     event_type,
+                    run_id,
                     stamp(self.started_at + timedelta(minutes=minutes)),
                 ),
             ).lastrowid
         )
         self.con.commit()
         return event_id
+
+    def add_succeeded_run(self, started_minutes: int, ended_minutes: int) -> int:
+        conversation_id = self.con.execute(
+            "SELECT active.chat_id FROM sprint_participants participant "
+            "JOIN active_shell_chats active ON active.shell_id=participant.shell_id "
+            "WHERE participant.participant_id=?",
+            (self.developer_id,),
+        ).fetchone()[0]
+        token = self.con.execute(
+            "SELECT COUNT(*)+1 FROM conversation_runs"
+        ).fetchone()[0]
+        started_at = stamp(self.started_at + timedelta(minutes=started_minutes))
+        ended_at = stamp(self.started_at + timedelta(minutes=ended_minutes))
+        message_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state,created_at,completed_at) "
+                "VALUES (?,'engine','test','notice','run fixture',?,?,"
+                "'completed',?,?)",
+                (
+                    conversation_id,
+                    f"test-success:{token}",
+                    f"test-success:{token}",
+                    started_at,
+                    ended_at,
+                ),
+            ).lastrowid
+        )
+        run_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,harness_session_after,"
+                "runner_ref,state,lease_owner,lease_expires_at,started_at,"
+                "heartbeat_at,ended_at) VALUES (?,1,?,'session','runner','succeeded',"
+                "'test','2999-01-01 00:00:00',?,?,?)",
+                (conversation_id, message_id, started_at, ended_at, ended_at),
+            ).lastrowid
+        )
+        self.con.commit()
+        return run_id
 
     def add_terminal_run(
         self, state: str, minutes: int, error_code: str | None = None
@@ -353,8 +401,15 @@ class SuppressorCollectorTest(SprintLivenessCase):
         self.assertEqual((), released.suppressors)
         self.assertEqual("pr.green", released.strong.kind)
 
-    def test_outbound_handoff_suppresses_only_while_it_is_the_last_act(self) -> None:
+    def test_outbound_handoff_ignores_its_turn_then_releases_on_new_run(self) -> None:
+        handoff_run_id = self.add_succeeded_run(5, 7)
         message_id = self.add_outbound_handoff(6)
+        tool_event_id = self.add_native_event(
+            "tool.completed", 6, run_id=handoff_run_id
+        )
+        completed_event_id = self.add_native_event(
+            "run.completed", 7, run_id=handoff_run_id
+        )
         snapshot = self.monitor().collector.collect(
             self.expectation(), self.started_at + timedelta(minutes=10)
         )
@@ -363,17 +418,31 @@ class SuppressorCollectorTest(SprintLivenessCase):
             [("outbound.handoff", f"sprint.message:{message_id}")],
             [(item.kind, item.key) for item in snapshot.suppressors],
         )
-        self.assertNotEqual(
-            f"sprint.message:{message_id}",
-            snapshot.strong.key if snapshot.strong is not None else None,
+        self.assertIsNone(snapshot.strong)
+        self.assertEqual(
+            [("tool.completed", handoff_run_id), ("run.completed", handoff_run_id)],
+            [
+                (row["event_type"], row["run_id"])
+                for row in self.con.execute(
+                    "SELECT event_type,run_id FROM conversation_events "
+                    "WHERE event_id IN (?,?) ORDER BY event_id",
+                    (tool_event_id, completed_event_id),
+                )
+            ],
         )
 
-        event_id = self.add_native_event("tool.completed", 7)
+        new_run_id = self.add_succeeded_run(11, 12)
+        self.add_native_event("run.completed", 12, run_id=new_run_id)
         released = self.monitor().collector.collect(
-            self.expectation(), self.started_at + timedelta(minutes=10)
+            self.expectation(), self.started_at + timedelta(minutes=15)
         )
         self.assertEqual((), released.suppressors)
-        self.assertEqual(f"conversation.event:{event_id}", released.strong.key)
+        self.assertIsNotNone(released.strong)
+        self.assertEqual(
+            f"run.heartbeat:{new_run_id}:"
+            f"{stamp(self.started_at + timedelta(minutes=12))}",
+            released.strong.key,
+        )
 
 
 class SanctionedQuietPolicyTest(SprintLivenessCase):
@@ -628,6 +697,37 @@ class SanctionedQuietPolicyTest(SprintLivenessCase):
             ],
         )
         self.assertEqual([], self.message_rows("nudge"))
+
+    def test_ci_stalled_backstop_does_not_require_a_live_expectation(self) -> None:
+        registered_pr_id = self.add_pr_transition("pending", 0)
+        self.assertTrue(
+            self.monitor().resolve(
+                self.assignment_message_id,
+                "owner has no remaining live expectation",
+            )
+        )
+        self.advance(90)
+
+        self.assertEqual((), self.monitor().evaluate(self.sprint_id))
+        backstops = self.message_rows("escalation")
+        self.assertEqual(1, len(backstops))
+        self.assertEqual(self.planner_id, backstops[0]["to_participant_id"])
+        self.assertEqual(
+            registered_pr_id,
+            json.loads(backstops[0]["body"])["registered_pr_id"],
+        )
+        event = self.con.execute(
+            "SELECT payload FROM sprint_events "
+            "WHERE event_type='liveness.ci_stalled'"
+        ).fetchone()
+        self.assertEqual(
+            {
+                "registered_pr_id": registered_pr_id,
+                "transition_key": "transition-first",
+                "backstop_message_id": backstops[0]["message_id"],
+            },
+            json.loads(event["payload"]),
+        )
 
 
 class FakeClockPolicyTest(SprintLivenessCase):

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -1194,9 +1194,9 @@ class WakeDeliveryTest(SprintMessageCase):
                         "Load `sprint_dev`. Run `sc sprint inbox --sprint "
                         f"{self.sprint_id}` now and act on the Sprint message(s) using "
                         "`sprint_dev`. Confirm every Sprint write succeeds before "
-                        "stopping. If the handoff is not complete, load `sprint_dev` "
-                        "again and run `sc sprint inbox --sprint "
-                        f"{self.sprint_id}` again.\n\n"
+                        "stopping. If a Sprint command failed or did not confirm its "
+                        "durable write, retry that command. Do not re-check the inbox "
+                        "otherwise — new messages arrive as their own wakes.\n\n"
                         f"## wake_message #{sent.message_id} "
                         "(declared Re-Enter)\n\nbody for deliver"
                     ),
@@ -1254,9 +1254,10 @@ class WakeDeliveryTest(SprintMessageCase):
                 f"Sprint {self.sprint_id} handoff for your {label} role. "
                 f"Load `{skill}`. Run `sc sprint inbox --sprint {self.sprint_id}` "
                 f"now and act on the Sprint message(s) using `{skill}`. Confirm "
-                "every Sprint write succeeds before stopping. If the handoff is "
-                f"not complete, load `{skill}` again and run `sc sprint inbox "
-                f"--sprint {self.sprint_id}` again.\n\n"
+                "every Sprint write succeeds before stopping. If a Sprint command "
+                "failed or did not confirm its durable write, retry that command. "
+                "Do not re-check the inbox otherwise — new messages arrive as their "
+                "own wakes.\n\n"
                 f"## wake_message #{sent.message_id} (declared Re-Enter)\n\n"
                 "PR #321, message 987, work unit 654, sha deadbeef",
             )

--- a/tests/test_sprint_participant_chats.py
+++ b/tests/test_sprint_participant_chats.py
@@ -164,6 +164,31 @@ def create_wake(
     return conversation_id
 
 
+@pytest.mark.parametrize(
+    ("role", "label", "skill"),
+    (
+        ("developer", "Developer", "sprint_dev"),
+        ("reviewer", "Reviewer", "sprint_rev"),
+        ("planner", "Originating Planner", "sprint_pln"),
+    ),
+)
+def test_wake_prompt_retries_only_unconfirmed_sprint_writes(
+    role: str, label: str, skill: str
+) -> None:
+    prompt = sprint_participant_chats.wake_prompt(23, role)
+
+    assert f"Sprint 23 handoff for your {label} role. Load `{skill}`." in prompt
+    assert "If the handoff is not complete" not in prompt
+    assert "run `sc sprint inbox --sprint 23` again" not in prompt
+    assert (
+        "If a Sprint command failed or did not confirm its durable write, "
+        "retry that command."
+    ) in prompt
+    assert (
+        "Do not re-check the inbox otherwise — new messages arrive as their own wakes."
+    ) in prompt
+
+
 def test_wake_creation_registers_one_chat_and_flat_history() -> None:
     with substrate() as con:
         conversation_id = create_wake(con, wake_id=41)

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -233,12 +233,14 @@ class SprintSkillTest(unittest.TestCase):
 
     def test_closeout_reseed_converges_dirty_rows_and_replays_idempotently(self):
         con = sqlite3.connect(":memory:")
+        reference = sqlite3.connect(":memory:")
         try:
-            con.executescript((ENGINE / "schema.sql").read_text())
-            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
-                if migration.name >= "0171_reseed_sprint_closeout_skills.sql":
-                    break
-                con.executescript(migration.read_text())
+            for target in (con, reference):
+                target.executescript((ENGINE / "schema.sql").read_text())
+                for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                    if migration.name >= "0171_reseed_sprint_closeout_skills.sql":
+                        break
+                    target.executescript(migration.read_text())
             placeholders = ",".join("?" for _ in CLOSEOUT_ROLE_SKILLS)
             con.execute(
                 f"UPDATE skills SET content='stale pre-0171 closeout guidance', "
@@ -251,29 +253,67 @@ class SprintSkillTest(unittest.TestCase):
             ).read_text()
             con.executescript(migration)
             con.executescript(migration)
+            reference.executescript(migration)
 
             for name in sorted(CLOSEOUT_ROLE_SKILLS):
                 with self.subTest(name=name):
-                    expected = seed_skills.parse_skill(
-                        ASSETS / name / "SKILL.md"
-                    )
                     rows = con.execute(
                         "SELECT description,category,command,common,content,is_deleted "
                         "FROM skills WHERE name=?",
                         (name,),
                     ).fetchall()
+                    expected = reference.execute(
+                        "SELECT description,category,command,common,content,is_deleted "
+                        "FROM skills WHERE name=?",
+                        (name,),
+                    ).fetchone()
                     self.assertEqual(len(rows), 1)
-                    self.assertEqual(
-                        tuple(rows[0]),
-                        (
-                            expected["description"],
-                            expected["category"],
-                            expected["command"],
-                            expected["common"],
-                            expected["content"],
-                            0,
-                        ),
-                    )
+                    self.assertEqual(tuple(rows[0]), tuple(expected))
+        finally:
+            con.close()
+            reference.close()
+
+    def test_sanctioned_pause_reseed_converges_developer_guidance(self):
+        con = sqlite3.connect(":memory:")
+        try:
+            con.executescript((ENGINE / "schema.sql").read_text())
+            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name >= "0172_sanctioned_pause_liveness.sql":
+                    break
+                con.executescript(migration.read_text())
+            con.execute(
+                "UPDATE skills SET content='stale pre-0172 guidance',is_deleted=1 "
+                "WHERE name='sprint_dev'"
+            )
+
+            migration = (
+                ENGINE / "migrations" / "0172_sanctioned_pause_liveness.sql"
+            ).read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+
+            expected = seed_skills.parse_skill(
+                ASSETS / "sprint_dev" / "SKILL.md"
+            )
+            actual = con.execute(
+                "SELECT description,category,command,common,content,is_deleted "
+                "FROM skills WHERE name='sprint_dev'"
+            ).fetchone()
+            self.assertEqual(
+                tuple(actual),
+                (
+                    expected["description"],
+                    expected["category"],
+                    expected["command"],
+                    expected["common"],
+                    expected["content"],
+                    0,
+                ),
+            )
+            self.assertIn("This is a once-only\npre-handoff check", actual[4])
+            self.assertIn(
+                "paused awaiting a native PR-fact or verdict\nwake", actual[4]
+            )
         finally:
             con.close()
 

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -982,8 +982,9 @@ class ProductionPulseTest(SprintWorkDispatchCase):
             "`sprint_dev`. Run `sc sprint inbox --sprint "
             f"{self.sprint_id}` now and act on the Sprint message(s) using "
             "`sprint_dev`. Confirm every Sprint write succeeds before stopping. "
-            "If the handoff is not complete, load `sprint_dev` again and run `sc "
-            f"sprint inbox --sprint {self.sprint_id}` again.\n\n"
+            "If a Sprint command failed or did not confirm its durable write, retry "
+            "that command. Do not re-check the inbox otherwise — new messages arrive "
+            "as their own wakes.\n\n"
             f"## wake_message #{wake_message_id} (declared New)\n\n"
             "Unit 1\n\nOutput 1"
         )


### PR DESCRIPTION
## Summary

- replace recursive Sprint wake text with precise durable-write retry guidance
- classify pending owned PRs and outbound handoffs as liveness suppressors, with failure evidence retaining precedence
- emit once-per-episode sanctioned-quiet evidence and a transition-keyed 90-minute Planner CI backstop
- reseed the Developer skill with once-only pre-handoff inbox guidance and a named native-wake pause state

## Verification

- `./sc test` — 1748 passed, 1 skipped
- `./sc render-check` — pass
- focused Ruff — pass
- isolated mypy on changed source modules — pass

## Notes

- 5-minute evaluation cadence, 10-minute grace, and 10-minute escalation window are unchanged.
- Out-of-scope reproducible test teardown noise filed as #995.