### PR TITLE
feat(boot): engine-owned global boot pointers

### DIFF
--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -2,6 +2,7 @@
   "harness": "claude",
   "launch": ["claude"],
   "boot_artifact": "CLAUDE.md",
+  "global_pointer": ".claude/CLAUDE.md",
   "emit": [],
   "env": {},
   "model": { "flag": "--model" },

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -2,6 +2,7 @@
   "harness": "codex",
   "launch": ["codex", "--dangerously-bypass-hook-trust"],
   "boot_artifact": "AGENTS.md",
+  "global_pointer": ".codex/AGENTS.md",
   "emit": [".codex/hooks.json"],
   "skill_dirs": [".claude/skills", ".agents/skills"],
   "env": {},

--- a/.super-coder/adapters/opencode/adapter.json
+++ b/.super-coder/adapters/opencode/adapter.json
@@ -2,6 +2,7 @@
   "harness": "opencode",
   "launch": ["opencode"],
   "boot_artifact": "AGENTS.md",
+  "global_pointer": ".config/opencode/AGENTS.md",
   "emit": ["opencode.json"],
   "skill_dirs": [".claude/skills", ".opencode/skills"],
   "env": { "OPENCODE_DISABLE_CLAUDE_CODE": "1" },

--- a/.super-coder/scripts/global_pointer.py
+++ b/.super-coder/scripts/global_pointer.py
@@ -1,0 +1,133 @@
+"""Install the engine-owned user-global boot pointers declared by adapters."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+
+ENGINE = Path(__file__).resolve().parents[1]
+SENTINEL = "<!-- managed by super-coder — hand edits are overwritten -->"
+
+
+def _managed_content(template: str) -> str:
+    """Insert the ownership sentinel as the template's second line."""
+    lines = template.splitlines(keepends=True)
+    if not lines:
+        raise ValueError("global pointer template is empty")
+    newline = "\r\n" if lines[0].endswith("\r\n") else "\n"
+    return f"{lines[0]}{SENTINEL}{newline}{''.join(lines[1:])}"
+
+
+def _target_path(
+    adapter: dict,
+    relative: Path,
+    home: Path,
+    environ: Mapping[str, str],
+) -> Path:
+    """Resolve one HOME-relative declaration, including Codex's home override."""
+    if (
+        adapter.get("harness") == "codex"
+        and environ.get("CODEX_HOME")
+        and relative.parts
+        and relative.parts[0] == ".codex"
+    ):
+        return Path(environ["CODEX_HOME"]).expanduser() / Path(*relative.parts[1:])
+    return home / relative
+
+
+def _atomic_replace(path: Path, content: bytes) -> None:
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(content)
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _backup_unmanaged(path: Path, content: bytes) -> Path | None:
+    backup = path.with_name(f"{path.name}.pre-sc.bak")
+    try:
+        fd = os.open(backup, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return None
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(content)
+    return backup
+
+
+def write_global_pointers(
+    engine: Path = ENGINE,
+    *,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> list[Path]:
+    """Converge every declared pointer without blocking install or launch.
+
+    Missing config directories mean that harness is not active on this host and
+    are skipped. Existing unmanaged files are adopted only after a one-time
+    backup; symlinks are never followed or replaced.
+    """
+    env = os.environ if environ is None else environ
+    if env.get("IS_SANDBOX") or env.get("SC_SANDBOX"):
+        return []
+
+    if home is None:
+        raw_home = env.get("HOME")
+        if not raw_home:
+            return []
+        root = Path(raw_home).expanduser()
+    else:
+        root = home
+    try:
+        desired = _managed_content(
+            (engine / "templates" / "global_pointer.md").read_text()
+        ).encode()
+    except (OSError, UnicodeError, ValueError) as exc:
+        print(f"  ⚠ global pointer: template unavailable ({exc})")
+        return []
+
+    written: list[Path] = []
+    for config_path in sorted((engine / "adapters").glob("*/adapter.json")):
+        try:
+            adapter = json.loads(config_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"  ⚠ global pointer: skipped {config_path} ({exc})")
+            continue
+
+        declared = adapter.get("global_pointer")
+        if not declared:
+            continue
+        relative = Path(declared)
+        if relative.is_absolute() or ".." in relative.parts:
+            print(f"  ⚠ global pointer: invalid HOME-relative path {declared!r}")
+            continue
+
+        target = _target_path(adapter, relative, root, env)
+        if not target.parent.is_dir():
+            continue
+        if target.is_symlink():
+            print(f"  ⚠ global pointer: left symlink untouched → {target}")
+            continue
+
+        try:
+            existing = target.read_bytes() if target.exists() else None
+            if existing == desired:
+                continue
+            if existing is not None:
+                lines = existing.splitlines()
+                managed = len(lines) > 1 and lines[1].decode(errors="replace") == SENTINEL
+                if not managed:
+                    backup = _backup_unmanaged(target, existing)
+                    if backup is not None:
+                        print(f"  → global pointer: adopted {target}; backup → {backup}")
+            _atomic_replace(target, desired)
+        except OSError as exc:
+            print(f"  ⚠ global pointer: skipped {target} ({exc})")
+            continue
+        written.append(target)
+    return written

--- a/.super-coder/scripts/install.py
+++ b/.super-coder/scripts/install.py
@@ -52,6 +52,7 @@ IS_MAC = platform.system() == "Darwin"  # guidance arms differ (colima/brew vs s
 sys.path.insert(0, str(ENGINE / "scripts"))
 import callable_floor  # noqa: E402
 import engine_manifest  # noqa: E402
+import global_pointer  # noqa: E402
 import ports as ports_mod  # noqa: E402
 
 
@@ -399,6 +400,7 @@ def update_harnesses() -> dict[str, str]:
         ok = rc == 0
         _report_install(name, ok, rc, out, elapsed, done, cmd)
         status[name] = done if ok else "failed"
+    global_pointer.write_global_pointers()
     return status
 
 
@@ -427,6 +429,7 @@ def ensure_harnesses() -> dict[str, str]:
         dirs = sorted({str(HARNESS_BIN[n].parent) for n in fresh})
         print(f"  ↪ new CLIs live in {', '.join(dirs)} — open a NEW shell (or update "
               f"PATH) before `./sc launch`, since this shell's PATH predates them.")
+    global_pointer.write_global_pointers()
     return status
 
 
@@ -740,6 +743,7 @@ def main(argv: list[str]) -> int:
         print("  --skip-harness-install set — detecting only, not installing")
         for n in HARNESS_INSTALL:
             print(f"  {n:9} {'✓ present' if _harness_installed(n) else 'absent'}")
+        global_pointer.write_global_pointers()
     else:
         ensure_harnesses()
     harness = detect_harness() or "claude"  # claude preferred; both should be present

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -54,6 +54,7 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 import artifact_policy  # noqa: E402
 import callable_floor  # noqa: E402
 import db_driver  # noqa: E402
+import global_pointer  # noqa: E402
 import install  # noqa: E402  — reuse its canonical HARNESS_BIN (one source of truth)
 import git_prune  # noqa: E402  — boot-time prune of provably-merged local branches
 import ports as ports_mod  # noqa: E402  — derive the per-fork API base URL
@@ -1006,6 +1007,8 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
     this seam (open_db, authenticate, ensure_worktree) still sys.exit, so
     callers must also treat SystemExit as a refusal."""
     headless = headless_prompt is not None
+    if not os.environ.get("RENDER_ONLY"):
+        global_pointer.write_global_pointers()
     con = open_db()
     # Same best-effort skill heal as main() — compose's SKILLS block reads
     # what this repairs. RENDER_ONLY never mutates, here as there.
@@ -1237,6 +1240,8 @@ def main() -> None:
         allow_unpinned=owns_engine,
         context="session launch",
     )
+    if not os.environ.get("RENDER_ONLY"):
+        global_pointer.write_global_pointers()
     args = sys.argv[1:]
     first = "--first" in args
     headless = "--headless" in args

--- a/.super-coder/templates/global_pointer.md
+++ b/.super-coder/templates/global_pointer.md
@@ -1,0 +1,21 @@
+# super-coder — Universal Boot Pointer
+
+This file is loaded by the harness for every invocation. It deliberately
+carries no operating content.
+
+Shells boot via `make dos-e` (`make enter`) from a substrate clone. The
+launcher reads live engine state and renders a per-shell boot document in
+`<substrate>/.sc-worktrees/<shortname>/`.
+
+If no per-shell boot document was loaded alongside this file, the session was
+started without the launcher. Stop and run `make dos-e` from the substrate
+clone. There is no fallback path, with one exception:
+
+**Repair mode.** If the operator explicitly states that the engine is down for
+repair (for example, a broken migration during update or a launcher failure),
+proceed without a boot document as a maintenance session, not a shell. The
+engine lives under `<substrate>/.super-coder/`. Its live `shell_db.db` is a
+gitignored cache rebuilt from `schema.sql`, `migrations/`, and
+`.sc-state/content.sql`; those tracked files are the source of truth. Do not
+write memory, seed, or identity. Fix only what the operator points at, then
+hand back to the normal boot path.

--- a/tests/test_global_pointer.py
+++ b/tests/test_global_pointer.py
@@ -1,0 +1,218 @@
+"""Regression coverage for engine-owned user-global boot pointers."""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import global_pointer  # noqa: E402
+
+
+class GlobalPointerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        root = Path(self.tempdir.name)
+        self.engine = root / ".super-coder"
+        self.home = root / "home"
+        (self.engine / "templates").mkdir(parents=True)
+        (self.engine / "adapters").mkdir()
+        self.home.mkdir()
+        self.template = "# Boot pointer\n\nStatic instructions.\n"
+        (self.engine / "templates" / "global_pointer.md").write_text(
+            self.template
+        )
+
+    def add_adapter(self, harness: str, pointer: str | None) -> None:
+        adapter_dir = self.engine / "adapters" / harness
+        adapter_dir.mkdir()
+        config = {"harness": harness}
+        if pointer is not None:
+            config["global_pointer"] = pointer
+        (adapter_dir / "adapter.json").write_text(json.dumps(config))
+
+    @property
+    def desired(self) -> str:
+        return (
+            "# Boot pointer\n"
+            f"{global_pointer.SENTINEL}\n"
+            "\nStatic instructions.\n"
+        )
+
+    def test_fresh_write_has_exact_managed_content(self) -> None:
+        self.add_adapter("claude", ".claude/CLAUDE.md")
+        target = self.home / ".claude" / "CLAUDE.md"
+        target.parent.mkdir()
+
+        written = global_pointer.write_global_pointers(
+            self.engine, home=self.home, environ={}
+        )
+
+        self.assertEqual(written, [target])
+        self.assertEqual(target.read_text(), self.desired)
+        self.assertEqual(target.read_text().splitlines()[1], global_pointer.SENTINEL)
+
+    def test_identical_content_is_a_true_no_op(self) -> None:
+        self.add_adapter("claude", ".claude/CLAUDE.md")
+        target = self.home / ".claude" / "CLAUDE.md"
+        target.parent.mkdir()
+        target.write_text(self.desired)
+
+        with mock.patch.object(global_pointer, "_atomic_replace") as replace:
+            written = global_pointer.write_global_pointers(
+                self.engine, home=self.home, environ={}
+            )
+
+        self.assertEqual(written, [])
+        replace.assert_not_called()
+        self.assertEqual(target.read_text(), self.desired)
+
+    def test_managed_drift_is_rewritten_without_backup(self) -> None:
+        self.add_adapter("claude", ".claude/CLAUDE.md")
+        target = self.home / ".claude" / "CLAUDE.md"
+        target.parent.mkdir()
+        target.write_text(self.desired.replace("Static", "Hand-edited"))
+
+        written = global_pointer.write_global_pointers(
+            self.engine, home=self.home, environ={}
+        )
+
+        self.assertEqual(written, [target])
+        self.assertEqual(target.read_text(), self.desired)
+        self.assertFalse(target.with_name("CLAUDE.md.pre-sc.bak").exists())
+
+    def test_unmanaged_adoption_backs_up_exactly_once(self) -> None:
+        self.add_adapter("claude", ".claude/CLAUDE.md")
+        target = self.home / ".claude" / "CLAUDE.md"
+        backup = target.with_name("CLAUDE.md.pre-sc.bak")
+        target.parent.mkdir()
+        target.write_text("operator original\n")
+
+        first = io.StringIO()
+        with mock.patch("sys.stdout", first):
+            global_pointer.write_global_pointers(
+                self.engine, home=self.home, environ={}
+            )
+        self.assertEqual(target.read_text(), self.desired)
+        self.assertEqual(backup.read_text(), "operator original\n")
+        self.assertIn(str(backup), first.getvalue())
+
+        target.write_text("operator replacement\n")
+        second = io.StringIO()
+        with mock.patch("sys.stdout", second):
+            global_pointer.write_global_pointers(
+                self.engine, home=self.home, environ={}
+            )
+        self.assertEqual(target.read_text(), self.desired)
+        self.assertEqual(backup.read_text(), "operator original\n")
+        self.assertNotIn("backup →", second.getvalue())
+
+    def test_missing_parent_directory_skips_without_creating_it(self) -> None:
+        self.add_adapter("claude", ".claude/CLAUDE.md")
+
+        written = global_pointer.write_global_pointers(
+            self.engine, home=self.home, environ={}
+        )
+
+        self.assertEqual(written, [])
+        self.assertFalse((self.home / ".claude").exists())
+
+    def test_is_sandbox_skips_all_writes(self) -> None:
+        self.add_adapter("claude", ".claude/CLAUDE.md")
+        target = self.home / ".claude" / "CLAUDE.md"
+        target.parent.mkdir()
+
+        written = global_pointer.write_global_pointers(
+            self.engine, home=self.home, environ={"IS_SANDBOX": "1"}
+        )
+
+        self.assertEqual(written, [])
+        self.assertFalse(target.exists())
+
+    def test_symlink_is_left_untouched_with_warning(self) -> None:
+        self.add_adapter("claude", ".claude/CLAUDE.md")
+        target = self.home / ".claude" / "CLAUDE.md"
+        source = self.home / "operator-pointer.md"
+        target.parent.mkdir()
+        source.write_text("operator symlink target\n")
+        target.symlink_to(source)
+        output = io.StringIO()
+
+        with mock.patch("sys.stdout", output):
+            written = global_pointer.write_global_pointers(
+                self.engine, home=self.home, environ={}
+            )
+
+        self.assertEqual(written, [])
+        self.assertTrue(target.is_symlink())
+        self.assertEqual(source.read_text(), "operator symlink target\n")
+        self.assertIn(f"left symlink untouched → {target}", output.getvalue())
+
+    def test_write_failure_warns_and_does_not_raise(self) -> None:
+        self.add_adapter("claude", ".claude/CLAUDE.md")
+        target = self.home / ".claude" / "CLAUDE.md"
+        target.parent.mkdir()
+        output = io.StringIO()
+
+        with (
+            mock.patch.object(
+                global_pointer,
+                "_atomic_replace",
+                side_effect=PermissionError("read-only home"),
+            ),
+            mock.patch("sys.stdout", output),
+        ):
+            written = global_pointer.write_global_pointers(
+                self.engine, home=self.home, environ={}
+            )
+
+        self.assertEqual(written, [])
+        self.assertFalse(target.exists())
+        self.assertIn(f"skipped {target} (read-only home)", output.getvalue())
+
+    def test_codex_home_override_replaces_default_dot_codex_root(self) -> None:
+        self.add_adapter("codex", ".codex/AGENTS.md")
+        codex_home = self.home / "custom-codex"
+        codex_home.mkdir()
+        target = codex_home / "AGENTS.md"
+
+        written = global_pointer.write_global_pointers(
+            self.engine,
+            home=self.home,
+            environ={"CODEX_HOME": str(codex_home)},
+        )
+
+        self.assertEqual(written, [target])
+        self.assertEqual(target.read_text(), self.desired)
+        self.assertFalse((self.home / ".codex").exists())
+
+
+class AdapterDeclarationTest(unittest.TestCase):
+    def test_only_verified_harnesses_declare_global_pointers(self) -> None:
+        expected = {
+            "claude": ".claude/CLAUDE.md",
+            "codex": ".codex/AGENTS.md",
+            "opencode": ".config/opencode/AGENTS.md",
+            "kimi": None,
+            "vibe": None,
+        }
+        actual = {}
+        for harness in expected:
+            config = json.loads(
+                (ROOT / ".super-coder" / "adapters" / harness / "adapter.json").read_text()
+            )
+            actual[harness] = config.get("global_pointer")
+
+        self.assertEqual(actual, expected)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_harness_epoch.py
+++ b/tests/test_harness_epoch.py
@@ -205,6 +205,7 @@ class ScFixture:
             "install.py",
             "callable_floor.py",
             "engine_manifest.py",
+            "global_pointer.py",
             "ports.py",
             "artifact_policy.py",
             "harness_versions.py",

--- a/tests/test_install_fresh_fork.py
+++ b/tests/test_install_fresh_fork.py
@@ -18,7 +18,9 @@ class FreshForkInstallTest(unittest.TestCase):
     def test_noninteractive_install_reaches_durable_completion_marker(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             repo = Path(raw) / "host-project"
+            home = Path(raw) / "home"
             repo.mkdir()
+            home.mkdir()
             shutil.copytree(
                 ROOT / ".super-coder",
                 repo / ".super-coder",
@@ -72,7 +74,7 @@ class FreshForkInstallTest(unittest.TestCase):
                     "Gate",
                 ],
                 cwd=repo,
-                env={**os.environ, "NO_COLOR": "1"},
+                env={**os.environ, "HOME": str(home), "NO_COLOR": "1"},
                 capture_output=True,
                 text=True,
                 timeout=60,

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -41,6 +41,7 @@ class SupervisionFixture:
             "db_backup.py",
             "cli_entry.py",
             "engine_manifest.py",
+            "global_pointer.py",
             "install.py",
         ):
             shutil.copy2(

--- a/tests/test_verify_clean_clone.py
+++ b/tests/test_verify_clean_clone.py
@@ -40,6 +40,10 @@ class VerifyCleanCloneTest(unittest.TestCase):
                 checkout / ".super-coder" / "scripts" / "run.py",
             )
             shutil.copy2(
+                ROOT / ".super-coder" / "scripts" / "global_pointer.py",
+                checkout / ".super-coder" / "scripts" / "global_pointer.py",
+            )
+            shutil.copy2(
                 ROOT / ".super-coder" / "scripts" / "skill_projection.py",
                 checkout / ".super-coder" / "scripts" / "skill_projection.py",
             )


### PR DESCRIPTION
Implements feature #37 / spec #101.

- adds the install-agnostic managed global boot-pointer template
- declares verified Claude, Codex, and OpenCode global paths
- converges pointers at install, update, and launch with one-time unmanaged backups, atomic drift repair, and safe skip/warning behavior
- adds the full pointer regression matrix and isolates test HOME values

Verification:
- ./sc test — 1778 passed, 1 skipped
- ./sc render-check — green