### PR TITLE
fix(sprint): gate undelivered force-new messages out of inbox and accept

### DIFF
--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -351,9 +351,15 @@ class SprintMessageStore:
         )
 
     def inbox(self, sprint_id: int, shell_id: int) -> list[sqlite3.Row]:
+        # An undelivered force-new message stays invisible: its wake must
+        # rotate the chat and launch a fresh run, so an older turn polling
+        # the inbox ahead of delivery must not see (and then resolve) it.
+        # Other declared types may be read early by a live turn — that is the
+        # coalescing design their wakes exist to make unnecessary.
         return self.con.execute(
             "SELECT m.* FROM wake_message m "
             "WHERE m.sprint_id=? AND m.receiver_shell_id=? AND m.read_at IS NULL "
+            "AND (m.delivered_at IS NOT NULL OR m.declared_type<>'force-new') "
             "ORDER BY m.message_id",
             (sprint_id, shell_id),
         ).fetchall()
@@ -656,6 +662,13 @@ class SprintMessageStore:
         ).fetchone()
         if row is None:
             raise KeyError(f"Sprint message {message_id} is not addressed to shell")
+        if row["delivered_at"] is None and row["declared_type"] == "force-new":
+            # Resolving a force-new message ahead of delivery would cancel
+            # its pending wake and swallow the rotation it exists to force;
+            # the recipient acts on it only once its wake has delivered.
+            raise SprintInvariantError(
+                f"Sprint message {message_id} has not been delivered yet"
+            )
         return row
 
     def _cancel_resolved_wakes(self, message_id: int) -> None:

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -164,6 +164,20 @@ class SprintCliApiTest(unittest.TestCase):
                 (initial_wake,),
             ).fetchone()[0]
         )
+        # Stamp only the assignment wake delivered (the arming wake must stay
+        # pending for the surfaces below): reading a force-new assignment
+        # requires confirmed delivery.
+        con.execute(
+            "UPDATE wake_message SET delivered_at=datetime('now') "
+            "WHERE message_id=?",
+            (initial_message,),
+        )
+        con.execute(
+            "UPDATE sprint_wake_outbox SET state='delivered',"
+            "delivered_at=datetime('now') WHERE wake_id=?",
+            (initial_wake,),
+        )
+        con.commit()
         sprint_message_delivery.SprintMessageStore(con).mark_read(initial_message, 1)
         cls.registered_pr_id = int(
             con.execute(
@@ -269,6 +283,46 @@ class SprintCliApiTest(unittest.TestCase):
         self.assertEqual((1, None, None, "re-enter"), message[:4])
         self.assertIn("number=85", message[4])
         self.assertIn("event=green", message[4])
+
+    def deliver_message(self, message_id: int) -> None:
+        # The delivery worker is out of frame in these surface tests: stamp
+        # the one queued message delivered so its recipient may read it.
+        con = sqlite3.connect(self.db)
+        try:
+            con.execute(
+                "UPDATE sprint_wake_outbox SET state='delivered',"
+                "delivered_at=datetime('now') WHERE state='pending' "
+                "AND wake_id IN (SELECT wake_id FROM sprint_wake_messages "
+                "WHERE message_id=?)",
+                (message_id,),
+            )
+            con.execute(
+                "UPDATE wake_message SET delivered_at=datetime('now') "
+                "WHERE message_id=? AND delivered_at IS NULL",
+                (message_id,),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+    def deliver_sprint_messages(self, sprint_id: int) -> None:
+        con = sqlite3.connect(self.db)
+        try:
+            con.execute(
+                "UPDATE sprint_wake_outbox SET state='delivered',"
+                "delivered_at=datetime('now') WHERE state='pending' "
+                "AND wake_id IN (SELECT wm.wake_id FROM sprint_wake_messages wm "
+                "JOIN wake_message m USING (message_id) WHERE m.sprint_id=?)",
+                (sprint_id,),
+            )
+            con.execute(
+                "UPDATE wake_message SET delivered_at=datetime('now') "
+                "WHERE sprint_id=? AND delivered_at IS NULL",
+                (sprint_id,),
+            )
+            con.commit()
+        finally:
+            con.close()
 
     def seed_declaration(self, suffix: str) -> tuple[int, int, int]:
         con = sqlite3.connect(self.db)
@@ -702,6 +756,7 @@ class SprintCliApiTest(unittest.TestCase):
         )
         self.assertTrue(replanned["changed"])
         self.run_cli(TOKENS["planner"], "arm", "--sprint", str(sprint_id))
+        self.deliver_sprint_messages(sprint_id)
 
         inbox = self.run_cli(
             TOKENS["developer"], "inbox", "--sprint", str(sprint_id)
@@ -1069,6 +1124,7 @@ class SprintCliApiTest(unittest.TestCase):
             "cli-review-request",
         )
         self.assertTrue(request["created"])
+        self.deliver_message(request["message_id"])
 
         con = sqlite3.connect(self.db)
         con.row_factory = sqlite3.Row

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -407,6 +407,7 @@ class SprintLiveProof(unittest.TestCase):
             "--key",
             f"proof:{pr_number}:review:1",
         )
+        self.deliver_browser_turns()
         self.assertEqual(
             "accepted", messages.mark_read(handoff["message_id"], reviewer)
         )
@@ -442,6 +443,7 @@ class SprintLiveProof(unittest.TestCase):
                 "--key",
                 f"proof:{pr_number}:review:2",
             )
+            self.deliver_browser_turns()
             self.assertEqual(
                 "accepted", messages.mark_read(handoff["message_id"], reviewer)
             )

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -1063,6 +1063,13 @@ class ForceNewLivenessGateTest(SprintLivenessCase):
         self.assertEqual(failure.key, observed["last_failure_key"])
         self.assertEqual(stamp(self.clock.value), observed["last_evaluated_at"])
 
+        delivered = sprint_message_delivery.SprintWakeDeliveryService(
+            self.con
+        ).deliver_once(
+            "liveness-force-release",
+            lambda _conversation, _prompt, _key: "liveness-force-release-run",
+        )
+        self.assertEqual(force.wake_id, delivered.wake_id)
         self.assertIsNone(self.messages.mark_read(force.message_id, 1))
         self.advance(10)
         released = monitor.evaluate(self.sprint_id)[0]

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -623,6 +623,118 @@ class AcceptanceAndDeclineTest(SprintMessageCase):
         )
 
 
+class ForceNewInboxDeliveryGateTest(SprintMessageCase):
+    def test_undelivered_force_new_stays_unavailable_until_rotation(self) -> None:
+        # The Developer's previous turn is still live and its lane is done;
+        # the Planner queues the next lane as a Force-new assignment.
+        pid, start_ticks = active_chat_registry.process_identity(str(os.getpid()))
+        self.con.execute(
+            "UPDATE active_shell_chats SET process_pid=?,process_start_ticks=? "
+            "WHERE shell_id=1",
+            (pid, start_ticks),
+        )
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='completed',"
+            "completed_at=datetime('now'),updated_at=datetime('now') "
+            "WHERE work_unit_id=?",
+            (self.unit_id,),
+        )
+        next_unit_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output,disposition) "
+                "VALUES (?,1,2,'Next unit','Ship it','ready')",
+                (self.sprint_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+        assignment = self.messages.send(
+            self.sprint_id,
+            to_participant_id=self.developer_id,
+            from_participant_id=self.planner_id,
+            work_unit_id=next_unit_id,
+            message_kind="work_assignment",
+            body="next lane",
+            actionable=True,
+            declared_type="force-new",
+            idempotency_key="force-next-lane",
+        )
+
+        # The old live turn polls its inbox: the undelivered force-new stays
+        # invisible, and acting on it by id is refused outright.
+        self.assertEqual([], list(self.messages.inbox(self.sprint_id, 1)))
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "not been delivered"
+        ):
+            self.messages.mark_read(assignment.message_id, 1)
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "not been delivered"
+        ):
+            self.messages.decline(assignment.message_id, 1, "wrong lane")
+        self.assertEqual(
+            "ready",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (next_unit_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            "pending",
+            self.con.execute(
+                "SELECT state FROM sprint_wake_outbox WHERE wake_id=?",
+                (assignment.wake_id,),
+            ).fetchone()[0],
+        )
+
+        # Live process defers the wake; the old turn ending starts the quiet
+        # gate, and the boundary rotates delivery into a fresh chat.
+        clock = [datetime(2099, 7, 31, 12, 0, tzinfo=timezone.utc)]
+        service = delivery.SprintWakeDeliveryService(
+            self.con,
+            now=lambda: clock[0],
+            force_new_quiet_seconds=5,
+        )
+        self.assertIsNone(service.claim_next("live-turn-pulse"))
+        self.con.execute(
+            "UPDATE active_shell_chats SET process_pid=NULL,"
+            "process_start_ticks=NULL WHERE shell_id=1"
+        )
+        self.con.commit()
+        self.assertIsNone(service.claim_next("first-quiet-pulse"))
+        clock[0] += timedelta(seconds=5)
+        conversations: list[str] = []
+        outcome = service.deliver_once(
+            "rotation-worker",
+            lambda conversation, _prompt, _key: (
+                conversations.append(conversation) or "rotation-run"
+            ),
+        )
+        self.assertEqual(assignment.wake_id, outcome.wake_id)
+        self.assertEqual("delivered", outcome.state)
+        self.assertEqual(1, len(conversations))
+        self.assertNotEqual(self.developer_conversation_id, conversations[0])
+
+        # Only the new run sees and accepts the assignment.
+        self.assertEqual(
+            [assignment.message_id],
+            [
+                row["message_id"]
+                for row in self.messages.inbox(self.sprint_id, 1)
+            ],
+        )
+        self.assertEqual(
+            "accepted", self.messages.mark_read(assignment.message_id, 1)
+        )
+        self.assertEqual(
+            "active",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (next_unit_id,),
+            ).fetchone()[0],
+        )
+
+
 class WakeAvailabilityTest(SprintMessageCase):
     def test_plain_new_uses_normal_immediate_availability(self) -> None:
         sent = self.send("immediate-new", declared_type="new")

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -48,7 +48,23 @@ class SprintReviewLoopCase(SprintPRWatcherCase):
             idempotency_key=key,
         )
 
+    def deliver_message(self, message_id: int) -> None:
+        """Stamp one message delivered, mimicking wake delivery finalize."""
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET state='delivered',"
+            "delivered_at=datetime('now') WHERE state='pending' AND wake_id IN "
+            "(SELECT wake_id FROM sprint_wake_messages WHERE message_id=?)",
+            (message_id,),
+        )
+        self.con.execute(
+            "UPDATE wake_message SET delivered_at=datetime('now') "
+            "WHERE message_id=? AND delivered_at IS NULL",
+            (message_id,),
+        )
+        self.con.commit()
+
     def accept_review(self, message_id: int) -> None:
+        self.deliver_message(message_id)
         self.assertEqual("accepted", self.messages.mark_read(message_id, 2))
 
     def approve(self, key: str = "approved-1"):

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -156,6 +156,15 @@ class SprintWorkDispatchCase(unittest.TestCase):
             ).fetchone()[0]
         )
 
+    def deliver_pending_wakes(self) -> None:
+        service = delivery.SprintWakeDeliveryService(
+            self.con, force_new_quiet_seconds=0
+        )
+        while service.deliver_once(
+            "test-wake-worker", lambda _conversation, _prompt, _key: "run-ref"
+        ):
+            pass
+
     def dispositions(self) -> list[tuple[int, str]]:
         return [
             tuple(row)
@@ -303,6 +312,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
             [(first, "ready"), (same_shell, "planned"), (blocked, "planned")],
             self.dispositions(),
         )
+        self.deliver_pending_wakes()
         self.assertEqual(
             "accepted",
             self.messages.mark_read(self.assignment_message(first), 1),
@@ -347,6 +357,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
             developer=4, title="Report", output_kind="report_only"
         )
         self.lifecycle.arm(self.sprint_id, 3)
+        self.deliver_pending_wakes()
         self.messages.mark_read(self.assignment_message(code), 1)
         self.messages.mark_read(self.assignment_message(report), 4)
 
@@ -390,6 +401,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
             output_kind="report_only",
         )
         self.lifecycle.arm(self.sprint_id, 3)
+        self.deliver_pending_wakes()
         self.messages.mark_read(self.assignment_message(report), 1)
 
         with self.assertRaisesRegex(
@@ -503,6 +515,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
             (first_message,),
         ).fetchone()[0]
 
+        self.deliver_pending_wakes()
         self.messages.decline(first_message, 1, "capacity changed")
         released = self.units.dispatch_ready(self.sprint_id)
 
@@ -598,6 +611,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
         )
 
         self.lifecycle.arm(self.sprint_id, 3)
+        self.deliver_pending_wakes()
         self.messages.mark_read(self.assignment_message(upstream), 1)
         self.units.complete(
             self.sprint_id, upstream, 1, result="Upstream planning result"
@@ -681,6 +695,7 @@ class DeliveryTerminalTest(SprintWorkDispatchCase):
         ).fetchall()
 
     def mark_merge_ready(self, unit_id: int, shell_id: int) -> None:
+        self.deliver_pending_wakes()
         self.assertEqual(
             "accepted",
             self.messages.mark_read(self.assignment_message(unit_id), shell_id),
@@ -789,6 +804,7 @@ class DeliveryTerminalTest(SprintWorkDispatchCase):
     def test_paused_report_completion_wakes_only_on_resume(self) -> None:
         report = self.create_unit(developer=1, output_kind="report_only")
         self.lifecycle.arm(self.sprint_id, 3)
+        self.deliver_pending_wakes()
         self.messages.mark_read(self.assignment_message(report), 1)
         self.lifecycle.pause(
             self.sprint_id,
@@ -815,6 +831,7 @@ class DeliveryTerminalTest(SprintWorkDispatchCase):
         self.con.commit()
         report = self.create_unit(developer=1, output_kind="report_only")
         self.lifecycle.arm(self.sprint_id, 3)
+        self.deliver_pending_wakes()
         self.messages.mark_read(self.assignment_message(report), 1)
 
         self.units.complete(self.sprint_id, report, 1, result="Only report")
@@ -865,6 +882,7 @@ class DeliveryTerminalTest(SprintWorkDispatchCase):
     def test_episode_replay_dedupes_and_added_scope_refires_with_fresh_key(self) -> None:
         first = self.create_unit(developer=1, output_kind="report_only")
         self.lifecycle.arm(self.sprint_id, 3)
+        self.deliver_pending_wakes()
         self.messages.mark_read(self.assignment_message(first), 1)
         self.units.complete(self.sprint_id, first, 1, result="First report")
         self.assert_episode(1, 1, 0)
@@ -882,6 +900,7 @@ class DeliveryTerminalTest(SprintWorkDispatchCase):
 
         second = self.create_unit(developer=1, output_kind="no_code")
         self.units.dispatch_ready(self.sprint_id)
+        self.deliver_pending_wakes()
         self.messages.mark_read(self.assignment_message(second), 1)
         self.units.complete(self.sprint_id, second, 1, result="Second result")
         self.assertEqual(4, len(self.terminal_messages()))


### PR DESCRIPTION
## The bug (sprint blocker, reported from the sc-cachy install — its flag #181)

An ordering hole between the Sprint inbox and Force-new delivery:

1. A force-new assignment is queued and intentionally held undelivered while the previous Developer turn is live (the quiet gate).
2. `sc sprint inbox` nevertheless exposed it — the query checked only `read_at IS NULL`, never `delivered_at`.
3. The old live turn accepted it. Acceptance marked the work unit active and `_cancel_resolved_wakes` cancelled the still-pending wake.
4. The rotation to a fresh chat never happened; no new run launched; the assignee sat idle. Observed live as accepted+read messages with `delivered_at = NULL`, units active, and no corresponding conversation/run.

## The fix — scoped to force-new deliberately

- `SprintMessageStore.inbox` hides undelivered **force-new** messages.
- `_recipient_message` refuses read/accept/decline of an undelivered force-new with `SprintInvariantError` ("has not been delivered yet"), which the API already maps to a self-describing HTTP 409.

Other declared types remain early-readable by a live turn: that early-read-then-cancel path is the deliberate coalescing design their wakes exist to make unnecessary (a first cut gating *all* undelivered messages broke 43 tests that encode exactly that semantics). Force-new alone carries delivery side effects — chat rotation and a fresh run — that early acceptance destroys.

## Tests

- New regression test (`ForceNewInboxDeliveryGateTest`) walks the reported sequence end to end: live turn → force-new queued → inbox empty, accept/decline refused, unit stays `ready`, wake stays `pending` → turn ends → quiet gate elapses → delivery rotates into a fresh chat → only the new run sees and accepts the assignment, unit goes `active`.
- Affected suites now model delivery before acceptance (real delivery-service drain where safe; a targeted `delivered_at` stamp where tests assert on other wakes' states). **No assertion values were changed anywhere.**
- Full suite: 1801 passed; the only failures are the 18 pre-existing environment-dependent operator-surface/dispatcher tests that fail identically on a clean `origin/main` checkout (verified by stash-baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)