### PR TITLE
fix(sprint): honor live turn evidence in delivered-unread wake recovery

### DIFF
--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -1160,6 +1160,11 @@ class SprintLifecycleStore:
                 and turn["run_state"] == "succeeded"
             ):
                 continue
+            # The delivered turn is still queued or actively running: the
+            # receiver has not had its chance to read yet.  Requeuing now
+            # duplicates the wake into the same chat under a fresh key.
+            if turn["turn_live"]:
+                continue
             shell_busy = (
                 turn["run_state"] == "failed"
                 and turn["error_code"] == "SHELL_BUSY"
@@ -1463,7 +1468,9 @@ class SprintLifecycleStore:
             (participant_id,),
         ).fetchone() is not None
 
-    def _wake_turn_evidence(self, wake_id: int) -> dict[str, str | int | None]:
+    def _wake_turn_evidence(
+        self, wake_id: int
+    ) -> dict[str, str | int | bool | None]:
         wake = self.con.execute(
             "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
             (wake_id,),
@@ -1484,18 +1491,22 @@ class SprintLifecycleStore:
                 "run_state": None,
                 "error_code": None,
                 "error_detail": None,
+                "turn_live": False,
             }
         message = self.con.execute(
-            "SELECT message_id,state FROM conversation_messages "
-            "WHERE conversation_id=? AND idempotency_key=?",
+            "SELECT m.message_id,m.state,"
+            "c.state AS conversation_state FROM conversation_messages m "
+            "JOIN conversations c ON c.conversation_id=m.conversation_id "
+            "WHERE m.conversation_id=? AND m.idempotency_key=?",
             (attempt["target_conversation_id"], wake["idempotency_key"]),
         ).fetchone()
         run_state = None
         error_code = None
         error_detail = None
+        turn_live = False
         if message is not None:
             run = self.con.execute(
-                "SELECT state,error_code,error_detail FROM conversation_runs "
+                "SELECT run_id,state,error_code,error_detail FROM conversation_runs "
                 "WHERE trigger_message_id=? "
                 "ORDER BY attempt DESC LIMIT 1",
                 (message["message_id"],),
@@ -1504,6 +1515,28 @@ class SprintLifecycleStore:
                 run_state = str(run["state"])
                 error_code = run["error_code"]
                 error_detail = run["error_detail"]
+            if str(message["conversation_state"]) in {
+                "idle",
+                "queued",
+                "running",
+                "waiting",
+            }:
+                if str(message["state"]) == "queued":
+                    turn_live = True
+                elif (
+                    str(message["state"]) == "running"
+                    and run is not None
+                    and run_state in {"leased", "starting", "running"}
+                ):
+                    turn_live = (
+                        self.con.execute(
+                            "SELECT 1 FROM conversation_events "
+                            "WHERE run_id=? "
+                            "AND event_type='run.interrupt.requested' LIMIT 1",
+                            (run["run_id"],),
+                        ).fetchone()
+                        is None
+                    )
         return {
             "attempt_number": int(attempt["attempt_number"]),
             "target_conversation_id": attempt["target_conversation_id"],
@@ -1513,6 +1546,7 @@ class SprintLifecycleStore:
             "run_state": run_state,
             "error_code": error_code,
             "error_detail": error_detail,
+            "turn_live": turn_live,
         }
 
     def _resolve_review_expectations_in_transaction(

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -1227,6 +1227,149 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ),
         )
 
+    def _activate_unregistered_chat(self, key: str, shell_id: int = 1) -> str:
+        """Give the shell an active chat the Sprint never registered.
+
+        This is the Originating Planner's normal shape: its chat predates the
+        Sprint, so re-enter wakes resolve into a conversation with no
+        sprint_participant_conversations row.
+        """
+        self.con.execute(
+            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
+            "WHERE shell_id=? AND state<>'closed'",
+            (shell_id,),
+        )
+        conversation_id = str(
+            self.con.execute(
+                "INSERT INTO conversations "
+                "(shell_id,owner_user_id,harness,worktree,state,"
+                "creation_idempotency_key,creation_request_hash) "
+                "SELECT shell_id,owner_user_id,harness,worktree,'idle',?,? "
+                "FROM conversations WHERE shell_id=? LIMIT 1 "
+                "RETURNING conversation_id",
+                (key, key, shell_id),
+            ).fetchone()[0]
+        )
+        self.con.execute(
+            "INSERT INTO active_shell_chats (shell_id,chat_id) VALUES (?,?) "
+            "ON CONFLICT(shell_id) DO UPDATE SET chat_id=excluded.chat_id",
+            (shell_id, conversation_id),
+        )
+        self.con.commit()
+        return conversation_id
+
+    def test_unregistered_conversation_queued_turn_suppresses_recovery(self):
+        target = self._activate_unregistered_chat("gui-chat-queued")
+        message = self.send("pickup-unregistered-queued")
+        old_wake = int(message.wake_id)
+        _, wake_key = self.deliver_wake_with_turn(old_wake, terminal=False)
+        self.assertEqual(
+            target,
+            self.con.execute(
+                "SELECT target_conversation_id FROM sprint_wake_attempts "
+                "WHERE wake_id=? ORDER BY attempt_number DESC LIMIT 1",
+                (old_wake,),
+            ).fetchone()[0],
+        )
+
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="unregistered-queued-turn",
+            ),
+        )
+
+        self.con.execute(
+            "UPDATE conversation_messages SET state='running' "
+            "WHERE idempotency_key=?",
+            (wake_key,),
+        )
+        self.con.execute(
+            "UPDATE conversation_messages SET state='completed',"
+            "completed_at=datetime('now') WHERE idempotency_key=?",
+            (wake_key,),
+        )
+        self.con.commit()
+
+        replacements = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="unregistered-turn-finished-unread",
+        )
+        self.assertEqual(1, len(replacements))
+        self.assertEqual(
+            f"sprint-recovery:{self.sprint_id}:delivered-unread:{old_wake}",
+            self.con.execute(
+                "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
+                (replacements[0],),
+            ).fetchone()[0],
+        )
+
+    def test_unregistered_conversation_running_turn_suppresses_recovery(self):
+        target = self._activate_unregistered_chat("gui-chat-running")
+        message = self.send("pickup-unregistered-running")
+        old_wake = int(message.wake_id)
+        _, wake_key = self.deliver_wake_with_turn(old_wake, terminal=False)
+        trigger_message_id = int(
+            self.con.execute(
+                "SELECT message_id FROM conversation_messages "
+                "WHERE idempotency_key=?",
+                (wake_key,),
+            ).fetchone()[0]
+        )
+        self.con.execute(
+            "UPDATE conversation_messages SET state='running' "
+            "WHERE message_id=?",
+            (trigger_message_id,),
+        )
+        run_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,state,lease_owner,"
+                "lease_expires_at,started_at,heartbeat_at) "
+                "SELECT ?,shell_id,?,'running','test-broker',"
+                "'2999-01-01 00:00:00','2026-08-01 00:00:00',"
+                "'2026-08-01 00:00:00' FROM conversations "
+                "WHERE conversation_id=?",
+                (target, trigger_message_id, target),
+            ).lastrowid
+        )
+        self.con.execute(
+            "UPDATE conversations SET state='running' WHERE conversation_id=?",
+            (target,),
+        )
+        self.con.commit()
+
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="unregistered-running-turn",
+            ),
+        )
+
+        self.con.execute(
+            "UPDATE conversation_runs SET state='succeeded',"
+            "ended_at=datetime('now'),exit_code=0 WHERE run_id=?",
+            (run_id,),
+        )
+        self.con.execute(
+            "UPDATE conversation_messages SET state='completed',"
+            "completed_at=datetime('now') WHERE message_id=?",
+            (trigger_message_id,),
+        )
+        self.con.execute(
+            "UPDATE conversations SET state='waiting' WHERE conversation_id=?",
+            (target,),
+        )
+        self.con.commit()
+
+        replacements = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="unregistered-running-finished-unread",
+        )
+        self.assertEqual(1, len(replacements))
+
     def test_paused_decline_keeps_one_planner_wake_across_resume(self):
         assignment = self.send(
             "paused-decline-recovery",


### PR DESCRIPTION
## Bug

Duplicate wake messages during Sprints: the same `wake_message` was delivered twice (or more) into the same chat. Observed live in the sc-cachy install's Sprint 1 — the Planner received `wake_message #50` twice with identical content, plus repeated empty "transport wakes" (see wakes 57→59, 60→61, 62→63 in that install's engine DB).

## Root cause

`_reconcile_unread_wakes_in_transaction` (sprint_domain.py) recovers wakes whose messages are delivered-but-unread. It computes `_wake_turn_evidence(old_wake_id)` — which correctly sees the just-delivered turn — but never consults it for Sprint-scoped wakes. Its only liveness guard is `_participant_has_pickup_turn`, which joins through `sprint_participant_conversations`.

The Originating Planner's chat predates the Sprint and is never registered in that table, so the guard is permanently blind for the Planner (and for any wake delivered before a participant conversation is registered). Sequence, repeated for every Planner wake:

1. Wake delivers into the Planner's active chat; turn enqueued (`queued`/`running`).
2. Next 5-second pulse: message is delivered-but-unread, pickup guard sees nothing → wake declared lost.
3. Reconciler resets `delivered_at=NULL`, mints `sprint-recovery:<sprint>:delivered-unread:<wake>` with a **fresh idempotency key**, re-points the messages.
4. The recovery wake re-delivers the identical prompt into the same chat — the enqueue dedupe can't catch it because the key differs.

The `sprint-recovery:` prefix skip stops a third round, so each wake doubles exactly once. The reconciler even recorded the evidence against itself: all twelve `wake.requeued` events in Sprint 1 carry `prior_turn_state` of `queued` or `running`.

## Fix

`_wake_turn_evidence` now renders a `turn_live` verdict — latest attempt's turn is `queued`, or `running` with a live un-interrupted run, in an open conversation — using the same liveness criteria `_participant_has_pickup_turn` already applies, but anchored on the wake's actual target conversation instead of the registration table. The delivered-unread branch skips recovery while `turn_live` holds.

Recovery semantics preserved:
- turn terminally finishes (succeeded/failed) with the message still unread → one recovery wake fires, as before;
- error-state conversation with a stranded queued turn → still recovers (`test_error_conversation_queued_turn_does_not_suppress_recovery` unchanged);
- SHELL_BUSY chain and failed-wake resume paths unchanged (a failed run is never `turn_live`).

## Tests

Two regressions in `tests/test_sprint_recovery.py` reproduce the Planner shape (active chat with no `sprint_participant_conversations` row): queued-turn and running-turn variants, both red on main, green here. Full suite: 1815 passed, 907 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)