### PR TITLE
fix(migrate): honor FK-off intent — marker for bare-PRAGMA migrations

### DIFF
--- a/.super-coder/migrations/0002_roadmap_add_retired_status.sql
+++ b/.super-coder/migrations/0002_roadmap_add_retired_status.sql
@@ -19,6 +19,7 @@
 -- defensively in case a future caller has it enabled; it must toggle outside
 -- a transaction, hence the placement around BEGIN/COMMIT.
 
+-- migrate: foreign-keys-off
 PRAGMA foreign_keys=OFF;
 
 BEGIN;

--- a/.super-coder/migrations/0003_repo_navigation.sql
+++ b/.super-coder/migrations/0003_repo_navigation.sql
@@ -18,6 +18,7 @@
 --                              only where connections is still empty. workspace is
 --                              left in place (retired, unrendered) — see schema.sql.
 
+-- migrate: foreign-keys-off
 PRAGMA foreign_keys=OFF;
 
 BEGIN;

--- a/.super-coder/migrations/0164_wake_message_delivery.sql
+++ b/.super-coder/migrations/0164_wake_message_delivery.sql
@@ -4,6 +4,7 @@
 -- participant columns remain as optional workflow context, while delivery and
 -- coalescing are keyed directly to the receiving shell.
 
+-- migrate: foreign-keys-off
 PRAGMA foreign_keys=OFF;
 
 BEGIN;

--- a/.super-coder/migrations/0168_retire_sprint_conversation_topology.sql
+++ b/.super-coder/migrations/0168_retire_sprint_conversation_topology.sql
@@ -5,6 +5,7 @@
 -- lanes or carry parent/context topology.  The one-open-chat invariant is now
 -- universal instead of exempting conversation_scope='sprint'.
 
+-- migrate: foreign-keys-off
 PRAGMA foreign_keys=OFF;
 
 BEGIN;

--- a/.super-coder/migrations/0173_force_new_wake_delivery.sql
+++ b/.super-coder/migrations/0173_force_new_wake_delivery.sql
@@ -3,6 +3,12 @@
 -- Preserve the generalized 0164 wake schema while accepting the third declared
 -- type.  Quiet observation is receiver-wake state, separate from available_at,
 -- which remains the retry/recovery scheduling boundary.
+--
+-- migrate: foreign-keys-off
+-- (The bare PRAGMA below is a no-op inside the runner's transaction; the
+-- marker is what actually disables enforcement. Without it the DROP TABLE
+-- wake_message fails on any install whose sprint_wake_messages /
+-- sprint_liveness_expectations tables are non-empty.)
 
 PRAGMA foreign_keys=OFF;
 


### PR DESCRIPTION
migrate.py only disables foreign_keys when the file carries the `-- migrate: foreign-keys-off` marker (migrate.py:37); a bare `PRAGMA foreign_keys=OFF;` inside the runner's wrapping transaction is a no-op.

**Impact:** 0173's wake_message table rebuild runs with enforcement ON, so `DROP TABLE wake_message` fails with `FOREIGN KEY constraint failed` on any install whose `sprint_wake_messages` / `sprint_liveness_expectations` tables are non-empty. Hit on dos-app during the 2026-08-04 fleet update (engine fbd993b → 15be251); rst-c/ami passed only because their child tables were empty — a data-dependent failure, invisible on clean installs.

**Fix:** add the marker to 0173 and the four other bare-PRAGMA migrations (0002, 0003, 0164, 0168 — already applied fleet-wide, but a fresh replay should behave as authored).

**Verification:** ran the fixed chain against a copy of the failing dos-app live DB — 0173–0178 apply clean, `PRAGMA foreign_key_check` empty, wake_message (65) and child rows (33) preserved; re-run reports nothing pending.

FnB-directed fleet rollout context: this unblocks dos-app, dos-arch, md-converter, subfloor-marketing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)