### PR TITLE
fix(sprint): close on conformance approval

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2625,11 +2625,14 @@ class Handler(BaseHTTPRequestHandler):
                     shell_id,
                     body=body.get("body") or "",
                     findings=findings,
+                    planner_handoff=body.get("planner_handoff") or "",
                     idempotency_key=body.get("idempotency_key") or "",
                 )
                 return self._send(201 if receipt.created else 200, {
                     "report_id": receipt.report_id,
                     "followup_ids": list(receipt.followup_ids),
+                    "planner_message_id": receipt.planner_message_id,
+                    "planner_wake_id": receipt.planner_wake_id,
                     "created": receipt.created,
                 })
             if path == "/_sc/sprint/followup-disposition":

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2625,14 +2625,18 @@ class Handler(BaseHTTPRequestHandler):
                     shell_id,
                     body=body.get("body") or "",
                     findings=findings,
-                    planner_handoff=body.get("planner_handoff") or "",
+                    final_report=body.get("final_report") or "",
+                    reason=body.get("reason") or "",
+                    terminal_outcome=body.get("terminal_outcome") or "",
                     idempotency_key=body.get("idempotency_key") or "",
                 )
                 return self._send(201 if receipt.created else 200, {
                     "report_id": receipt.report_id,
                     "followup_ids": list(receipt.followup_ids),
+                    "final_report_id": receipt.final_report_id,
                     "planner_message_id": receipt.planner_message_id,
                     "planner_wake_id": receipt.planner_wake_id,
+                    "completed": receipt.completed,
                     "created": receipt.created,
                 })
             if path == "/_sc/sprint/followup-disposition":

--- a/.super-coder/assets/skills/sprint_close/SKILL.md
+++ b/.super-coder/assets/skills/sprint_close/SKILL.md
@@ -104,13 +104,18 @@ so, it defers `record-conformance` and sends the Planner a durable re-enter
 decision naming the new spec tasks and suggested unit projection. The added
 units run through delivery and produce a fresh delivery-terminal wake.
 
-For a clean pass or post-Sprint-only findings, the Reviewer records its report
-and findings with `sc sprint record-conformance`. Every recorded finding becomes
-a pending follow-up for FnB review; it is not also reopened as an editing lane.
-A safety finding may still demand immediate operator action.
+For a clean pass or post-Sprint-only findings, the Reviewer prepares its report,
+findings, final Sprint report, and full conclude handoff before calling
+`sc sprint record-conformance`. That one transaction records the report and
+follow-ups and publishes an actionable Re-enter message plus wake to the
+originating Planner. Every recorded finding becomes a pending follow-up for FnB
+review; it is not also reopened as an editing lane. A safety finding may still
+demand immediate operator action.
 
-Verify report id, follow-up ids, author identity, and idempotent replay before
-synthesis.
+Verify report id, follow-up ids, Planner message id, Planner wake id, author
+identity, and idempotent replay. The engine prepends the generated report and
+follow-up ids to the Reviewer-authored handoff; no second conclude message is
+sent.
 
 FnB records one terminal disposition per follow-up. `accepted` acknowledges
 ship-as-is; `resolved` and `dismissed` require a resolution file.
@@ -172,7 +177,8 @@ The Reviewer writes a concise report that answers:
 Name discrepancies; do not smooth them into a success narrative. A recovered
 stall can be a successful Sprint when the failure stayed durable, visible, and
 contained. Evidence packets, conformance drafts, and final report drafts belong
-under `shared/sprints/sprint-<n>/`.
+under `shared/sprints/sprint-<n>/`. The Reviewer finishes this report before
+the atomic conformance write and includes it unchanged in the Planner handoff.
 
 ## Pause and abort reports
 
@@ -188,13 +194,15 @@ nothing.
 
 ## Terminal handoff
 
-The Planner writes the Reviewer-authored final synthesis unchanged and passes it
-to `complete`; the surface commits the append-only `final` report before
-attempting the lifecycle transition. Omitting the report is permitted under
-advisory close-out, but the evidence packet records the gap. Abort only on a
-Reviewer decision or FnB override. Terminal state stops Sprint services and
-removes live pills while retaining conversations, messages, events, PR evidence,
-reports, and follow-ups.
+The Planner receives the actionable conclude handoff created atomically with
+conformance, accepts it, writes the Reviewer-authored final synthesis unchanged,
+and passes it to `complete`; the surface commits the append-only `final` report
+before attempting the lifecycle transition. Omitting the report is permitted
+under advisory close-out, but the evidence packet records the gap. Abort only
+on a Reviewer decision or FnB override. Terminal state resolves the accepted
+close-handoff liveness expectation, stops Sprint services, and removes live
+pills while retaining conversations, messages, events, PR evidence, reports,
+and follow-ups.
 
 Immediately before `complete`, re-run `sc sprint inbox --sprint <id>` to drain
 newly arrived messages, mark every handled informational message read with

--- a/.super-coder/assets/skills/sprint_close/SKILL.md
+++ b/.super-coder/assets/skills/sprint_close/SKILL.md
@@ -7,9 +7,11 @@ common: false
 
 # sprint_close — synthesize and finish
 
-Use as the owning Planner when a Reviewer close decision arrives, or when abort
-has been chosen. The delivery-terminal wake starts closeout with the Reviewer;
-the Reviewer decides and authors, and the Planner executes.
+Use as the owning Planner when a Reviewer control decision or completed-Sprint
+receipt arrives, or when abort has been chosen. The delivery-terminal wake
+starts closeout with the Reviewer. A clean conformance approval closes the
+Sprint atomically; the Planner is informed after closure and takes no second
+close action.
 On entry or any wake, load `sprint_close`, run `sc sprint inbox --sprint <id>`,
 inspect the durable message, and accept or decline it only when actionable.
 
@@ -23,8 +25,8 @@ question, answer, blocker, or context message, run `accept` for that message.
 For informational messages it only marks the message read; it does not change
 Sprint or work-unit state.
 
-Planner-bound close/conformance messages are Re-enter wakes resolved through
-the active-chat registry. A verified live turn is never displaced; delivery
+The clean-close receipt is an engine-wide Re-enter wake because Sprint-scoped
+delivery stops at terminal state. A verified live turn is never displaced; delivery
 waits for its natural boundary and drains every undelivered message. An idle
 Re-enter resumes the registry chat, while coordinate mode makes it an idle New
 ticket chat after FnB closes the Planner chat. Automatic pause preserves that
@@ -60,7 +62,8 @@ If a Sprint command is rejected or transport fails, the write or handoff is
 incomplete. Correct and retry when safe. If the relay itself fails, surface the
 attempted command and durable evidence to FnB; do not invent an alternate
 delivery protocol. The Reviewer decides whether evidence warrants pause,
-re-plan, cancellation, or conclusion; the Planner executes that decision. FnB
+re-plan, cancellation, or conclusion; the Planner executes control decisions,
+while clean conformance approval executes its own close. FnB
 retains the board-level override from decision #46. Send any needed participant
 context before the Planner acts; an active relay is not available after the
 lifecycle becomes paused.
@@ -71,6 +74,8 @@ fallbacks.
 
 On a durable Reviewer pause decision (or live FnB override), the Planner runs
 `sc sprint pause --sprint <id> --reason <decision-reason>`.
+For any Sprint-scoped control wake, re-run `sc sprint inbox --sprint <id>`
+before acting; the engine-wide clean-close receipt is already self-contained.
 
 ## Sprint artifact paths
 
@@ -105,17 +110,18 @@ decision naming the new spec tasks and suggested unit projection. The added
 units run through delivery and produce a fresh delivery-terminal wake.
 
 For a clean pass or post-Sprint-only findings, the Reviewer prepares its report,
-findings, final Sprint report, and full conclude handoff before calling
-`sc sprint record-conformance`. That one transaction records the report and
-follow-ups and publishes an actionable Re-enter message plus wake to the
-originating Planner. Every recorded finding becomes a pending follow-up for FnB
-review; it is not also reopened as an editing lane. A safety finding may still
-demand immediate operator action.
+findings, final Sprint report, reason, and outcome before calling
+`sc sprint record-conformance`. That one transaction records both reports and
+follow-ups, completes the Sprint, resolves terminal liveness, and publishes an
+informational engine-wide Re-enter receipt plus wake to the originating Planner.
+Every recorded finding becomes a pending follow-up for FnB review; it is not
+also reopened as an editing lane. A safety finding may still demand immediate
+operator action.
 
-Verify report id, follow-up ids, Planner message id, Planner wake id, author
-identity, and idempotent replay. The engine prepends the generated report and
-follow-up ids to the Reviewer-authored handoff; no second conclude message is
-sent.
+Verify conformance report id, final report id, follow-up ids, completed state,
+Planner message id, Planner wake id, author identity, and idempotent replay. The
+engine generates the completion receipt from those committed facts; no Planner
+close command or second conclude message follows.
 
 FnB records one terminal disposition per follow-up. `accepted` acknowledges
 ship-as-is; `resolved` and `dismissed` require a resolution file.
@@ -178,7 +184,7 @@ Name discrepancies; do not smooth them into a success narrative. A recovered
 stall can be a successful Sprint when the failure stayed durable, visible, and
 contained. Evidence packets, conformance drafts, and final report drafts belong
 under `shared/sprints/sprint-<n>/`. The Reviewer finishes this report before
-the atomic conformance write and includes it unchanged in the Planner handoff.
+the atomic conformance write; that write stores it unchanged as the final report.
 
 ## Pause and abort reports
 
@@ -194,33 +200,26 @@ nothing.
 
 ## Terminal handoff
 
-The Planner receives the actionable conclude handoff created atomically with
-conformance, accepts it, writes the Reviewer-authored final synthesis unchanged,
-and passes it to `complete`; the surface commits the append-only `final` report
-before attempting the lifecycle transition. Omitting the report is permitted
-under advisory close-out, but the evidence packet records the gap. Abort only
-on a Reviewer decision or FnB override. Terminal state resolves the accepted
-close-handoff liveness expectation, stops Sprint services, and removes live
-pills while retaining conversations, messages, events, PR evidence, reports,
-and follow-ups.
+The Reviewer's successful clean `record-conformance` command is the terminal
+handoff. It stores the Reviewer-authored final synthesis, transitions the Sprint
+to `completed`, resolves terminal liveness, and queues an informational Planner
+receipt in one transaction. The Planner does not accept a close decision or run
+`complete`; the receipt confirms the Sprint is already terminal.
 
-Immediately before `complete`, re-run `sc sprint inbox --sprint <id>` to drain
-newly arrived messages, mark every handled informational message read with
-`accept`, and confirm the final report file is the intended synthesis. This is
-the last pre-terminal evidence read.
+Immediately before `record-conformance`, the Reviewer drains the Sprint inbox,
+confirms the final report, reason, outcome, and stable key, then performs the
+atomic command as the literal last action. Terminal state stops Sprint services
+and removes live pills while retaining conversations, messages, events, PR
+evidence, reports, and follow-ups.
 
-Keep the final report at about 6,000 characters or fewer; 8,000 is the hard
-maximum. Run `wc -m < <path>` before the typed terminal handoff, then require
-the successful report receipt and lifecycle transition.
+The standalone `complete` surface remains only for an FnB-directed fallback.
+Abort remains a Planner action on a Reviewer decision or FnB override:
 
 ```text
-sc sprint complete --sprint <id> --reason <summary> --outcome <outcome> \
-  --report-file <path> --key <stable-key>
 sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
 ```
 
-After `complete` succeeds, emit one bounded final response from its receipt:
-final report id, follow-up list, integrated SHA, and evidence links. Run no
-further Sprint command. Terminal lifecycle removes Sprint authority and live
-pills but does not close the shell's registry chat; FnB close remains the one
-unconditional chat-displacement path.
+After `record-conformance` succeeds, emit one bounded final response from its
+receipt and run no further Sprint command. Terminal lifecycle removes Sprint
+authority and live pills but does not close the shell's registry chat; FnB close
+remains the one unconditional chat-displacement path.

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -166,9 +166,11 @@ artifact directory are working material only.
 Pause, cancel, re-enter, and conclude are Reviewer decisions and Planner
 actions. A valid decision arrives as a durable Reviewer → Planner Re-enter
 message and names the decision, evidence, target ids, reason, and exact
-requested transition. Accept the actionable message, verify it came from the
-assigned Reviewer, and execute that transition without re-adjudicating the
-decision. Record the decision message id and action receipt together.
+requested transition. The clean conclude handoff is actionable and is created
+atomically with conformance; other freeform decisions are informational. Mark
+each handled message through `accept`, verify it came from the assigned
+Reviewer, and execute that transition without re-adjudicating the decision.
+Record the decision message id and action receipt together.
 
 The FnB board-level override from decision #46 is unaffected: a live FnB
 instruction may direct or supersede any action. Name that override in the
@@ -255,11 +257,12 @@ delivery-terminal wake; the Planner does not initiate the next conformance pass.
 
 ### Conclude or abort
 
-The Reviewer decides when the Sprint is done, records conformance, authors the
-final Sprint report, and sends a conclude decision containing the conformance
-receipt, follow-up ids, exact reason/outcome, stable key, and full report body.
-Write that Reviewer-authored body to `<reviewer-report>` unchanged, then perform
-the close action:
+The Reviewer decides when the Sprint is done and atomically records conformance,
+follow-ups, the actionable conclude message, and its wake. The engine prepends
+the conformance report and follow-up ids to the Reviewer-authored decision,
+which carries the exact reason/outcome, stable completion key, and full final
+report body. Accept that message before acting, write the Reviewer-authored body
+to `<reviewer-report>` unchanged, then perform the close action:
 
 ```text
 sc sprint complete --sprint <id> --reason <reviewer-decision-reason> \
@@ -276,6 +279,7 @@ sc sprint compile-report --sprint <id> --limit 50 \
   > shared/sprints/sprint-<n>/evidence.json
 ```
 
+Do not wait for or request a second conclude message after the atomic receipt.
 Abort is likewise an action taken only on a Reviewer decision or FnB override;
 it is terminal and deletes nothing.
 
@@ -309,7 +313,9 @@ sc sprint dispatch --sprint <id>
    immediately. Run no trailing command. Empty dispatch is still the final
    action for that handoff turn; investigate only on a later durable wake.
 
-On receipt, re-run `sc sprint inbox --sprint <id>`, accept the conclude message,
-execute its exact close action through the protocol above, and confirm the typed
-transition succeeded. After `complete` succeeds, emit its bounded receipt and
-run no further Sprint command. The Planner does not author a second report.
+On receipt, re-run `sc sprint inbox --sprint <id>`, accept the actionable
+conclude message, execute its exact close action through the protocol above,
+and confirm the typed transition succeeded. Completion resolves the accepted
+handoff liveness expectation. After `complete` succeeds, emit its bounded
+receipt and run no further Sprint command. The Planner does not author a second
+report or wait for a second handoff.

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -21,8 +21,8 @@ The armed runtime owns scheduled dispatch, unread wake recovery, liveness
 evaluation, and registered-PR observation. React to its durable inbox and wake
 facts; use the Planner turn for dispatch and exact execution of durable Reviewer
 decisions. The Reviewer owns pause, cancel, and conclude decisions plus the
-conformance and final Sprint reports. The Planner owns the corresponding state
-transitions.
+conformance and final Sprint reports. The Planner owns control transitions;
+clean conformance approval performs its own atomic terminal transition.
 
 The active-chat registry is the only current-chat authority; zero or one chat
 per shell is legal. Every wake message creates delivery intent and a wake turn
@@ -163,14 +163,17 @@ artifact directory are working material only.
 
 ## Reviewer decision actions
 
-Pause, cancel, re-enter, and conclude are Reviewer decisions and Planner
-actions. A valid decision arrives as a durable Reviewer → Planner Re-enter
+Pause, cancel, re-enter, and abort are Reviewer decisions and Planner actions.
+A valid control decision arrives as a durable Reviewer → Planner Re-enter
 message and names the decision, evidence, target ids, reason, and exact
-requested transition. The clean conclude handoff is actionable and is created
-atomically with conformance; other freeform decisions are informational. Mark
-each handled message through `accept`, verify it came from the assigned
+requested transition. Clean conformance instead closes atomically and sends an
+informational engine-wide completion receipt. Mark each handled Sprint message
+through `accept`, verify it came from the assigned
 Reviewer, and execute that transition without re-adjudicating the decision.
 Record the decision message id and action receipt together.
+Re-run `sc sprint inbox --sprint <id>` before acting on any Sprint-scoped
+control decision; the engine-wide completion receipt requires no Sprint inbox
+acceptance.
 
 The FnB board-level override from decision #46 is unaffected: a live FnB
 instruction may direct or supersede any action. Name that override in the
@@ -257,18 +260,12 @@ delivery-terminal wake; the Planner does not initiate the next conformance pass.
 
 ### Conclude or abort
 
-The Reviewer decides when the Sprint is done and atomically records conformance,
-follow-ups, the actionable conclude message, and its wake. The engine prepends
-the conformance report and follow-up ids to the Reviewer-authored decision,
-which carries the exact reason/outcome, stable completion key, and full final
-report body. Accept that message before acting, write the Reviewer-authored body
-to `<reviewer-report>` unchanged, then perform the close action:
-
-```text
-sc sprint complete --sprint <id> --reason <reviewer-decision-reason> \
-  --outcome <reviewer-decision-outcome> --report-file <reviewer-report> \
-  --key <reviewer-decision-key>
-```
+The Reviewer decides when the Sprint is done. A clean `record-conformance`
+command atomically stores conformance, follow-ups, the Reviewer-authored final
+report, completed lifecycle, and an informational engine-wide Planner receipt.
+When that Re-enter arrives, confirm the receipt names the expected Sprint,
+reports, outcome, and completed state. Do not run `complete`; closure is already
+durable and the notification has no actionable liveness expectation.
 
 Do not run `compile-report` by default, synthesize the final report, or
 editorialize the Reviewer body. The Reviewer compiles its own evidence. A
@@ -279,7 +276,7 @@ sc sprint compile-report --sprint <id> --limit 50 \
   > shared/sprints/sprint-<n>/evidence.json
 ```
 
-Do not wait for or request a second conclude message after the atomic receipt.
+Do not wait for or request a conclude action message after the completion receipt.
 Abort is likewise an action taken only on a Reviewer decision or FnB override;
 it is terminal and deletes nothing.
 
@@ -313,9 +310,7 @@ sc sprint dispatch --sprint <id>
    immediately. Run no trailing command. Empty dispatch is still the final
    action for that handoff turn; investigate only on a later durable wake.
 
-On receipt, re-run `sc sprint inbox --sprint <id>`, accept the actionable
-conclude message, execute its exact close action through the protocol above,
-and confirm the typed transition succeeded. Completion resolves the accepted
-handoff liveness expectation. After `complete` succeeds, emit its bounded
-receipt and run no further Sprint command. The Planner does not author a second
-report or wait for a second handoff.
+On a clean completion receipt, verify the named Sprint is terminal and record
+the bounded receipt; run no close command. The Planner does not author a second
+report, accept an actionable handoff, or wait for another actor to finish the
+Sprint.

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -110,28 +110,28 @@ artifact directory are working material only.
 ## Control and conclude decisions
 
 The Reviewer owns all pause, cancel, and conclude decisions and recommendations.
-The Planner owns all resulting actions. Base a decision on durable Sprint state,
+The Planner owns control actions; clean conformance approval atomically performs
+its own close. Base a decision on durable Sprint state,
 the exact bound revisions, current work/PR facts, liveness evidence, and any
 ratified judgment; ambiguous silence is not enough to corrupt a disposition.
 
 Send pause, resume, replan, re-enter, cancel, and abort decisions through the
-durable `send` surface above. A clean conclude instead rides the atomic
-`record-conformance` handoff below. Every Reviewer → Planner route is Re-enter.
+durable `send` surface above. A clean conclude instead runs the atomic
+`record-conformance` close below. Every Reviewer → Planner route is Re-enter.
 The Reviewer-authored body must name:
 
 - `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, `conclude`, or
   `abort`;
 - the evidence and rationale owned by the Reviewer;
 - exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
-- for conclude, the stable completion key and full Reviewer-authored final
-  Sprint report body — the engine prepends the committed conformance report and
-  follow-up ids; and
 - any immediate safety impact that the FnB must see.
 
 The Planner marks the message handled, verifies the assigned Reviewer, and
-executes exactly that transition; the atomic conclude handoff is actionable.
-The Reviewer never runs the pause, replan, cancel, resume, complete, or abort
-action. If the action is rejected, inspect the returned durable state and issue
+executes exactly that control transition. The clean completion receipt is
+informational because the Sprint is already terminal. The Reviewer never runs
+the standalone pause, replan, cancel, resume, complete, or abort action; its
+clean `record-conformance` command owns the narrow automatic close. If a control
+action is rejected, inspect the returned durable state and issue
 a new decision only when the evidence supports one; never ask the Planner to
 improvise around a precondition.
 
@@ -266,10 +266,10 @@ After classifying the requirements, choose exactly one branch:
   After three re-entry episodes in one Sprint, escalate the non-convergence to
   FnB instead of starting another patch round.
 - **Clean or post-Sprint-only findings.** Prepare the conformance report,
-  findings, final Sprint report, and full `conclude` handoff. Submit them
-  through the atomic `record-conformance` protocol below: the engine commits
-  the evidence, Planner message, and wake together. Do not send a second
-  conclude message.
+  findings, final Sprint report, reason, and outcome. Submit them through the
+  atomic `record-conformance` protocol below: the engine commits the evidence,
+  completed lifecycle, informational Planner receipt, and wake together. Do not
+  send a separate conclude message.
 
 ## Whole-Sprint conformance
 
@@ -313,25 +313,25 @@ as its author and answer:
 
 Keep the final report at about 6,000 characters or fewer and below the 8,000
 hard maximum; run `wc -m < <report>`. Do not smooth discrepancies into a
-success narrative. Write one Planner handoff file containing the `conclude`
-decision, evidence and rationale, exact reason/outcome and stable completion
-key, and the full final report body. Keep the complete handoff below 8,000
-characters. The engine prepends the committed conformance report id and
-follow-up ids; the Planner submits the report body unchanged and owns only the
-close action.
+success narrative. Keep the final report below 8,000 characters, then choose
+the exact completion reason, terminal outcome, and stable completion key. The
+engine stores the final report unchanged and generates the Planner receipt from
+the committed report and follow-up identities.
 
 Record the clean branch as one atomic final write:
 
 ```text
 sc sprint record-conformance \
   --sprint <id> --body-file <report> --findings-file <json> \
-  --planner-handoff-file <conclude-handoff> --key <stable-pass-key>
+  --final-report-file <final-report> --reason <reason> --outcome <outcome> \
+  --key <stable-pass-key>
 ```
 
-The receipt must name the report id, follow-up ids, Planner message id, and
-Planner wake id. This creates append-only conformance evidence, pending
-follow-ups, and one actionable Planner Re-enter in the same transaction. Never
-record conformance first and then send around it; send no second conclude message.
+The receipt must name the conformance report id, final report id, follow-up ids,
+completed state, Planner message id, and Planner wake id. This creates
+append-only evidence, pending follow-ups, terminal lifecycle, and one
+informational engine-wide Planner Re-enter in the same transaction. Never
+record conformance first and then close around it; send no conclude message.
 Never reopen an editing
 lane after recording; the re-enter branch defers the report until added scope
 reaches terminal disposition and a fresh delivery-terminal wake starts the next
@@ -343,8 +343,8 @@ For unit review, follow the ordered verdict procedure above: inbox handling and
 all evidence work precede `record-review`; the durable verdict is the literal
 last action, then the Reviewer stops.
 
-For the clean or post-Sprint-only branch, require the report, findings, and
-Planner handoff to replay idempotently. For the re-enter or abort branch,
+For the clean or post-Sprint-only branch, require both reports, findings,
+reason, and outcome to replay idempotently. For the re-enter or abort branch,
 confirm that the decision body carries the complete evidence and exact
 requested action. Then complete this final handoff order:
 
@@ -353,8 +353,8 @@ requested action. Then complete this final handoff order:
 2. Confirm every Reviewer-authored artifact and decision body is final and
    below its 8,000-character hard maximum.
 3. For a clean conclude, run the atomic `record-conformance` command above as
-   the literal final action. When it confirms all four receipt identities,
-   stop immediately; send no second conclude message.
+   the literal final action. When it confirms completed state and all receipt
+   identities, stop immediately; the Planner is already notified.
 4. For re-enter or abort, deliver the decision to the Planner as the literal
    final action:
 

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -114,22 +114,26 @@ The Planner owns all resulting actions. Base a decision on durable Sprint state,
 the exact bound revisions, current work/PR facts, liveness evidence, and any
 ratified judgment; ambiguous silence is not enough to corrupt a disposition.
 
-Send each decision to the Planner through the durable `send` surface above. The
-Reviewer → Planner route is Re-enter. The body must name:
+Send pause, resume, replan, re-enter, cancel, and abort decisions through the
+durable `send` surface above. A clean conclude instead rides the atomic
+`record-conformance` handoff below. Every Reviewer → Planner route is Re-enter.
+The Reviewer-authored body must name:
 
 - `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, `conclude`, or
   `abort`;
 - the evidence and rationale owned by the Reviewer;
 - exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
-- for conclude, the conformance report/follow-up ids, stable completion key,
-  and full Reviewer-authored final Sprint report body; and
+- for conclude, the stable completion key and full Reviewer-authored final
+  Sprint report body — the engine prepends the committed conformance report and
+  follow-up ids; and
 - any immediate safety impact that the FnB must see.
 
-The Planner accepts the actionable message, verifies the assigned Reviewer,
-and executes exactly that transition. The Reviewer never runs the pause,
-replan, cancel, resume, complete, or abort action. If the action is rejected, inspect
-the returned durable state and issue a new decision only when the evidence
-supports one; never ask the Planner to improvise around a precondition.
+The Planner marks the message handled, verifies the assigned Reviewer, and
+executes exactly that transition; the atomic conclude handoff is actionable.
+The Reviewer never runs the pause, replan, cancel, resume, complete, or abort
+action. If the action is rejected, inspect the returned durable state and issue
+a new decision only when the evidence supports one; never ask the Planner to
+improvise around a precondition.
 
 The FnB board-level override from decision #46 is unaffected. A live FnB
 instruction can direct or supersede any decision; preserve it as a distinct
@@ -261,9 +265,11 @@ After classifying the requirements, choose exactly one branch:
   Developer/Reviewer routing. The durable decision is the failed-pass record.
   After three re-entry episodes in one Sprint, escalate the non-convergence to
   FnB instead of starting another patch round.
-- **Clean or post-Sprint-only findings.** Record conformance. Any remaining
-  findings become follow-ups for FnB disposition, then send the Planner the
-  `conclude` decision through the existing close protocol.
+- **Clean or post-Sprint-only findings.** Prepare the conformance report,
+  findings, final Sprint report, and full `conclude` handoff. Submit them
+  through the atomic `record-conformance` protocol below: the engine commits
+  the evidence, Planner message, and wake together. Do not send a second
+  conclude message.
 
 ## Whole-Sprint conformance
 
@@ -290,27 +296,12 @@ JSON findings array:
 ]
 ```
 
-Record both atomically only after choosing the clean or post-Sprint-only
-branch:
-
 Keep the conformance report and each finding body at about 6,000 characters or
 fewer; 8,000 is the hard maximum for each. Run `wc -m < <report>` and length-check
-each finding body before submission. Require the successful report and
-follow-up receipt before stopping.
+each finding body before submission.
 
-```text
-sc sprint record-conformance \
-  --sprint <id> --body-file <report> --findings-file <json> \
-  --key <stable-pass-key>
-```
-
-This creates append-only conformance evidence and pending follow-ups for FnB
-disposition. Never record conformance first and then reopen an editing lane;
-the re-enter branch defers the report until the added scope reaches terminal
-disposition and a fresh delivery-terminal wake starts the next episode. Surface
-any immediate safety risk to FnB.
-
-Then author the final Sprint report. Name the Reviewer as its author and answer:
+Before recording conformance, author the final Sprint report. Name the Reviewer
+as its author and answer:
 
 1. Which exact scope and revisions governed?
 2. What shipped, through which work units and PRs?
@@ -322,11 +313,29 @@ Then author the final Sprint report. Name the Reviewer as its author and answer:
 
 Keep the final report at about 6,000 characters or fewer and below the 8,000
 hard maximum; run `wc -m < <report>`. Do not smooth discrepancies into a
-success narrative. If the Sprint is done, send the Planner a `conclude`
-decision containing the full report body and the exact completion arguments
-defined in the control protocol. The Planner submits that body unchanged and
-owns only the close action. If the Sprint is not done, send the appropriate
-pause, re-plan, cancel, or abort decision instead.
+success narrative. Write one Planner handoff file containing the `conclude`
+decision, evidence and rationale, exact reason/outcome and stable completion
+key, and the full final report body. Keep the complete handoff below 8,000
+characters. The engine prepends the committed conformance report id and
+follow-up ids; the Planner submits the report body unchanged and owns only the
+close action.
+
+Record the clean branch as one atomic final write:
+
+```text
+sc sprint record-conformance \
+  --sprint <id> --body-file <report> --findings-file <json> \
+  --planner-handoff-file <conclude-handoff> --key <stable-pass-key>
+```
+
+The receipt must name the report id, follow-up ids, Planner message id, and
+Planner wake id. This creates append-only conformance evidence, pending
+follow-ups, and one actionable Planner Re-enter in the same transaction. Never
+record conformance first and then send around it; send no second conclude message.
+Never reopen an editing
+lane after recording; the re-enter branch defers the report until added scope
+reaches terminal disposition and a fresh delivery-terminal wake starts the next
+episode. Surface any immediate safety risk to FnB.
 
 ## Stop
 
@@ -334,22 +343,25 @@ For unit review, follow the ordered verdict procedure above: inbox handling and
 all evidence work precede `record-review`; the durable verdict is the literal
 last action, then the Reviewer stops.
 
-For the clean or post-Sprint-only branch, require the report and findings to
-replay idempotently. For the re-enter or abort branch, confirm that the decision
-body carries the complete evidence and exact requested action. Then complete
-this final handoff order:
+For the clean or post-Sprint-only branch, require the report, findings, and
+Planner handoff to replay idempotently. For the re-enter or abort branch,
+confirm that the decision body carries the complete evidence and exact
+requested action. Then complete this final handoff order:
 
 1. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
    mark every handled informational message read with `accept`.
-2. Confirm the Reviewer-authored re-enter, abort, or conclude decision body is
-   final and below the 8,000-character hard maximum.
-3. As the literal final action of the turn, deliver that decision to the
-   Planner:
+2. Confirm every Reviewer-authored artifact and decision body is final and
+   below its 8,000-character hard maximum.
+3. For a clean conclude, run the atomic `record-conformance` command above as
+   the literal final action. When it confirms all four receipt identities,
+   stop immediately; send no second conclude message.
+4. For re-enter or abort, deliver the decision to the Planner as the literal
+   final action:
 
 ```text
 sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
   --key <stable-decision-handoff-key>
 ```
 
-4. When the command confirms the durable write and Planner wake, stop
+5. When the command confirms the durable write and Planner wake, stop
    immediately. Run no trailing command until another native wake arrives.

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -120,8 +120,7 @@ durable `send` surface above. A clean conclude instead runs the atomic
 `record-conformance` close below. Every Reviewer → Planner route is Re-enter.
 The Reviewer-authored body must name:
 
-- `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, `conclude`, or
-  `abort`;
+- `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, or `abort`;
 - the evidence and rationale owned by the Reviewer;
 - exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
 - any immediate safety impact that the FnB must see.

--- a/.super-coder/migrations/0179_reseed_atomic_sprint_closeout.sql
+++ b/.super-coder/migrations/0179_reseed_atomic_sprint_closeout.sql
@@ -677,8 +677,7 @@ durable `send` surface above. A clean conclude instead runs the atomic
 `record-conformance` close below. Every Reviewer → Planner route is Re-enter.
 The Reviewer-authored body must name:
 
-- `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, `conclude`, or
-  `abort`;
+- `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, or `abort`;
 - the evidence and rationale owned by the Reviewer;
 - exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
 - any immediate safety impact that the FnB must see.

--- a/.super-coder/migrations/0179_reseed_atomic_sprint_closeout.sql
+++ b/.super-coder/migrations/0179_reseed_atomic_sprint_closeout.sql
@@ -1,0 +1,938 @@
+-- 0179 — make Reviewer conformance and Planner close handoff atomic.
+-- Full-body UPSERTs converge the three closeout role skills.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_close',
+  'Close or abort a Sprints v2 run — boot whole-Sprint conformance, compile the bounded evidence packet, synthesize the final report, preserve follow-ups, and transition terminally without deleting history.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_close — synthesize and finish
+
+Use as the owning Planner when a Reviewer close decision arrives, or when abort
+has been chosen. The delivery-terminal wake starts closeout with the Reviewer;
+the Reviewer decides and authors, and the Planner executes.
+On entry or any wake, load `sprint_close`, run `sc sprint inbox --sprint <id>`,
+inspect the durable message, and accept or decline it only when actionable.
+
+```text
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Use `accept` or `decline` for actionable work. After acting on an informational
+question, answer, blocker, or context message, run `accept` for that message.
+For informational messages it only marks the message read; it does not change
+Sprint or work-unit state.
+
+Planner-bound close/conformance messages are Re-enter wakes resolved through
+the active-chat registry. A verified live turn is never displaced; delivery
+waits for its natural boundary and drains every undelivered message. An idle
+Re-enter resumes the registry chat, while coordinate mode makes it an idle New
+ticket chat after FnB closes the Planner chat. Automatic pause preserves that
+mode; FnB pause/resume returns to supervise. The inactivity ceiling and reaper
+own silent or unlinked processes, not this skill.
+
+## Questions, answers, blockers, and failures
+
+Put a concrete question, answer, blocker, or context request in a short body
+file, then send it to the conformance Reviewer or participant who owns the fact:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Answer incoming questions through `send`, confirm that write, then mark the
+handled question read with `accept`. For a blocker, relay the evidence, impact,
+and exact action needed to every directly affected Sprint participant, and
+surface the exceptional recovery need separately to FnB. Continue safe
+synthesis, but stop at a decision boundary when the answer is required. Do not
+send duplicate reminders; unread recovery owns re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the write or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command and durable evidence to FnB; do not invent an alternate
+delivery protocol. The Reviewer decides whether evidence warrants pause,
+re-plan, cancellation, or conclusion; the Planner executes that decision. FnB
+retains the board-level override from decision #46. Send any needed participant
+context before the Planner acts; an active relay is not available after the
+lifecycle becomes paused.
+
+Treat an exhausted recovery wake as bounded manual-recovery evidence for FnB;
+preserve the unread message and failed wake, and do not create recursive
+fallbacks.
+
+On a durable Reviewer pause decision (or live FnB override), the Planner runs
+`sc sprint pause --sprint <id> --reason <decision-reason>`.
+
+## Sprint artifact paths
+
+Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
+report drafts, and Dev scratch proof) go to the gitignored
+`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
+PR''d in the work repo; a review-notes commit is a finding.
+
+DB rows stay the durable record: judgments via `record-review`, report bodies in
+`sprint_reports`, and decisions in the durable relay. Files in the Sprint
+artifact directory are working material only.
+
+## Delivery-terminal entry
+
+When every planned work unit becomes terminal, the engine sends the
+delivery-terminal wake directly to the participating Reviewer. That wake is the
+close protocol''s entry signal; the Planner does not need to notice terminal
+state or request conformance.
+
+On entry, the Reviewer re-reads work units, dependencies, registered PRs,
+checks, merge observations, task membership, pending actionable messages, and
+active native runs. If any unit is non-terminal, the wake is stale and the
+Reviewer exits until the next delivery-terminal episode. Close-out is advisory:
+the packet surfaces gaps but never replaces Reviewer judgment or the FnB
+board-level override. Do not infer code completion from PR state alone.
+
+## Conformance boundary
+
+The Reviewer first decides whether any finding requires in-Sprint patching. If
+so, it defers `record-conformance` and sends the Planner a durable re-enter
+decision naming the new spec tasks and suggested unit projection. The added
+units run through delivery and produce a fresh delivery-terminal wake.
+
+For a clean pass or post-Sprint-only findings, the Reviewer prepares its report,
+findings, final Sprint report, and full conclude handoff before calling
+`sc sprint record-conformance`. That one transaction records the report and
+follow-ups and publishes an actionable Re-enter message plus wake to the
+originating Planner. Every recorded finding becomes a pending follow-up for FnB
+review; it is not also reopened as an editing lane. A safety finding may still
+demand immediate operator action.
+
+Verify report id, follow-up ids, Planner message id, Planner wake id, author
+identity, and idempotent replay. The engine prepends the generated report and
+follow-up ids to the Reviewer-authored handoff; no second conclude message is
+sent.
+
+FnB records one terminal disposition per follow-up. `accepted` acknowledges
+ship-as-is; `resolved` and `dismissed` require a resolution file.
+
+Keep a resolution at about 6,000 characters or fewer; 8,000 is the hard
+maximum. Run `wc -m < <path>` and require a successful durable disposition.
+
+```text
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition accepted
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition resolved --resolution-file <path>
+```
+
+## Compile bounded evidence
+
+The participating Reviewer generates the packet through the authenticated
+production surface by default. Planner and FnB compilation remain valid when
+FnB explicitly directs the fallback:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Increase the per-section bound only when the default truncation counters show
+that synthesis needs more detail; the maximum is 200. Follow the packet''s full
+timeline and participant-conversation links for raw history. Never paste the
+entire event stream into the final report.
+
+The packet supplies:
+
+- scope and lifecycle times;
+- exact bound spec revisions and recorded mid-Sprint edits;
+- planned versus actual work;
+- PR outcomes and links;
+- judgments and deviations;
+- pause, resume, recovery, interrupt, and drift evidence;
+- wake states, attempts, liveness aggregates, nudges, and escalations;
+- anomalies with bounded detail;
+- unresolved units, actionable messages, and follow-ups; and
+- links to the complete timeline and every participant conversation.
+
+The compiler does not decide whether a deviation was wise or an anomaly was
+acceptable. That judgment remains the Reviewer''s.
+
+## Final report
+
+The Reviewer writes a concise report that answers:
+
+1. What scope and exact revisions governed the Sprint?
+2. What was planned, what actually shipped, and which PRs produced it?
+3. Which judgments and intentional deviations shaped the result?
+4. What failed, retried, paused, recovered, or remained anomalous?
+5. What did conformance conclude?
+6. Which unresolved items and follow-ups now require FnB disposition?
+7. Where can the complete evidence be inspected?
+
+Name discrepancies; do not smooth them into a success narrative. A recovered
+stall can be a successful Sprint when the failure stayed durable, visible, and
+contained. Evidence packets, conformance drafts, and final report drafts belong
+under `shared/sprints/sprint-<n>/`. The Reviewer finishes this report before
+the atomic conformance write and includes it unchanged in the Planner handoff.
+
+## Pause and abort reports
+
+When closing after a pause, include the integrity threat, deterministic state at
+pause, interrupt delivery, reconciliation, spec drift, judgment, and resume
+outcome. Keep this section behind the pause/recovery evidence seam; missing
+optional pause facts must not prevent compiling an otherwise valid packet.
+
+Abort is terminal and history-preserving. Its report names reason, completed
+work, partial artifacts, outstanding work, active interruption outcome, and
+recovery disposition. A prepared Sprint may abort with a stub report; delete
+nothing.
+
+## Terminal handoff
+
+The Planner receives the actionable conclude handoff created atomically with
+conformance, accepts it, writes the Reviewer-authored final synthesis unchanged,
+and passes it to `complete`; the surface commits the append-only `final` report
+before attempting the lifecycle transition. Omitting the report is permitted
+under advisory close-out, but the evidence packet records the gap. Abort only
+on a Reviewer decision or FnB override. Terminal state resolves the accepted
+close-handoff liveness expectation, stops Sprint services, and removes live
+pills while retaining conversations, messages, events, PR evidence, reports,
+and follow-ups.
+
+Immediately before `complete`, re-run `sc sprint inbox --sprint <id>` to drain
+newly arrived messages, mark every handled informational message read with
+`accept`, and confirm the final report file is the intended synthesis. This is
+the last pre-terminal evidence read.
+
+Keep the final report at about 6,000 characters or fewer; 8,000 is the hard
+maximum. Run `wc -m < <path>` before the typed terminal handoff, then require
+the successful report receipt and lifecycle transition.
+
+```text
+sc sprint complete --sprint <id> --reason <summary> --outcome <outcome> \
+  --report-file <path> --key <stable-key>
+sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
+```
+
+After `complete` succeeds, emit one bounded final response from its receipt:
+final report id, follow-up list, integrated SHA, and evidence links. Run no
+further Sprint command. Terminal lifecycle removes Sprint authority and live
+pills but does not close the shell''s registry chat; FnB close remains the one
+unconditional chat-displacement path.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch ready lanes and execute Reviewer decisions through durable re-plan, pause, cancel, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
+
+Use as the originating Planner after `sprint_prep` arms the Sprint. The system
+captures deterministic facts; the Reviewer decides and documents, and the
+Planner acts. Execute Reviewer decisions without taking over their judgment or
+report authorship. The FnB retains the board-level override established by
+decision #46.
+On every wake or re-entry, load `sprint_pln`, run the exact inbox command below,
+and inspect the durable message before deciding what to do.
+
+## Start from durable state
+
+The armed runtime owns scheduled dispatch, unread wake recovery, liveness
+evaluation, and registered-PR observation. React to its durable inbox and wake
+facts; use the Planner turn for dispatch and exact execution of durable Reviewer
+decisions. The Reviewer owns pause, cancel, and conclude decisions plus the
+conformance and final Sprint reports. The Planner owns the corresponding state
+transitions.
+
+The active-chat registry is the only current-chat authority; zero or one chat
+per shell is legal. Every wake message creates delivery intent and a wake turn
+drains every undelivered message for the receiver. Assignments and review
+requests use Force-new delivery: a live turn finishes, the receiver remains
+quiet for the configured grace interval, then delivery atomically closes the
+exact registry chat and starts a fresh chat with the complete undelivered
+bundle. Concurrent Force-new wakes coalesce into one rotation, and retries reuse
+the chat created for their own wake. Participants must stop cleanly after typed
+handoffs so the next forced delivery can cross the quiet boundary. The
+inactivity ceiling and registry reaper remain the fallback for a silent hung
+turn.
+
+Planner-bound messages are Re-enter. Plain New remains separate and is eligible
+immediately. It enters a verified live turn at its natural boundary and rotates only when the
+registry chat is idle. Re-enter resumes the registry chat; no registry row
+behaves as New.
+
+FnB controls the Planner mode with the close button. Keeping the Planner chat
+open supervises one continuous thread. Closing it during an armed Sprint sets
+coordinate mode, so later idle Planner-bound Re-enters open fresh ticket chats;
+FnB pause/resume returns to supervise. Automatic pauses preserve that choice.
+Neither mode displaces a live turn. The inactivity ceiling closes a silent hung
+chat, and the registry reaper terminates its now-unlinked process.
+
+Read the Sprint inbox, lifecycle, bound spec revisions, work-unit graph,
+participant routes, active conversations, registered PRs, unresolved
+expectations, and recent anomalies. Viewing a participant conversation is
+observation, not activity; never manufacture progress from browser presence.
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Release every dependency-ready lane through the production surface:
+
+```text
+sc sprint dispatch --sprint <id>
+```
+
+The returned ids are wake identities. Work-unit disposition and messages are
+the authoritative release facts. Dispatch is safe to repeat: occupied Developer
+lanes and stable assignment generations prevent double booking.
+
+Accept or decline only when the inbox item is actionable. After acting on an
+informational question, answer, blocker, or evidence message, run `accept` for
+that message. For informational messages it only marks the message read; it does
+not change Sprint or work-unit state.
+
+## Running loop
+
+- Keep dependencies as the only hard sequence. When reality requires a re-plan,
+  give the Reviewer the current projection and evidence, then execute the exact
+  decision it returns; never rewrite completed history.
+- Let Developers own their PRs through green, review, correction, and merge.
+  Let Reviewers own verdicts and Sprint decisions. Do not proxy routine
+  handoffs or substitute Planner judgment for a Reviewer decision.
+- Consume passive system facts without waking yourself into every transition.
+  Route a decision boundary to the Reviewer; act when its Re-enter decision
+  message arrives.
+- Record the Reviewer decision identity, the exact action taken, and the action
+  receipt. Do not rewrite its rationale as Planner-authored judgment evidence.
+- A mid-Sprint spec edit is allowed only by the owning Planner or FnB. Record
+  the prior and new exact revision hashes. When acting as Planner, require a
+  durable Reviewer decision before the edit. The running Sprint remains bound
+  to its approved revision unless that decision explicitly says otherwise.
+
+The armed runtime evaluates liveness on its five-second pulse. A one-shot
+diagnostic/evaluation is available when evidence requires it:
+
+```text
+sc sprint monitor --sprint <id>
+```
+
+Run `monitor` once for concrete evidence, then return control to native
+delivery. It evaluates only due accepted expectations and its
+nudge/escalation identities are durable. Use Sprint-native wakes for
+coordination. Do not start a recurring shell loop, scheduled job, manual
+participant boot, or external PR watcher to track Sprint state.
+
+`monitor` carries no evidence about the PR watcher. When a
+watcher-dependent gate has stalled, use the separate bounded read once:
+
+```text
+sc sprint watcher-state --sprint <id>
+```
+
+It distinguishes a stale or never-started watcher from red, pending, or absent
+PR observation and includes the newest bounded poll failures. Do not repeat it
+as a polling loop; act on the evidence, then return control to native delivery.
+
+## Questions, answers, blockers, and failures
+
+Put a concrete question, answer, decision, blocker, or useful context in a short
+body file and address the participant who owns the needed fact or action:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Answer incoming questions through `send` so the answer is durable and wakes the
+asker, confirm that write, then mark the handled question read with `accept`.
+For a cross-unit blocker, send evidence, impact, and the exact action needed to
+every directly affected participant. Continue safe independent governance, but
+stop at a decision boundary when an answer is required. Do not spam duplicates
+when no response is immediate; unread recovery owns re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the write or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command and durable evidence to FnB; do not invent an alternate
+delivery protocol. When a Developer reports an integrity concern, relay its
+evidence, impact, and recommendation to the Reviewer. When the Reviewer returns
+a decision, execute it through the protocol below. Send any needed participant
+context before pausing; an active relay is not available after the lifecycle
+becomes paused.
+
+## Sprint artifact paths
+
+Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
+report drafts, and Dev scratch proof) go to the gitignored
+`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
+PR''d in the work repo; a review-notes commit is a finding.
+
+DB rows stay the durable record: judgments via `record-review`, report bodies in
+`sprint_reports`, and decisions in the durable relay. Files in the Sprint
+artifact directory are working material only.
+
+## Reviewer decision actions
+
+Pause, cancel, re-enter, and conclude are Reviewer decisions and Planner
+actions. A valid decision arrives as a durable Reviewer → Planner Re-enter
+message and names the decision, evidence, target ids, reason, and exact
+requested transition. The clean conclude handoff is actionable and is created
+atomically with conformance; other freeform decisions are informational. Mark
+each handled message through `accept`, verify it came from the assigned
+Reviewer, and execute that transition without re-adjudicating the decision.
+Record the decision message id and action receipt together.
+
+The FnB board-level override from decision #46 is unaffected: a live FnB
+instruction may direct or supersede any action. Name that override in the
+evidence instead of attributing it to the Reviewer.
+
+If a requested action fails a lifecycle, authority, or disposition precondition,
+do not substitute a different action. Send the refusal and current durable state
+back to the Reviewer (or surface it directly to FnB for an FnB override), then
+stop at that decision boundary.
+
+### Pause or resume
+
+On a Reviewer pause decision, transition durably, stop external Sprint services,
+persist interrupt intent, preserve every partial artifact, and retain the
+Reviewer judgment and evidence for recovery:
+
+```text
+sc sprint pause --sprint <id> --reason <reviewer-decision-reason>
+```
+
+Resume only on a later Reviewer decision or an FnB override. Reconcile native
+runs, unread messages, pending wakes, work units, registered PRs, capacity, and
+spec drift, then act with the supplied reason:
+
+```text
+sc sprint resume --sprint <id> [--reason <reviewer-reconciliation-decision>]
+```
+
+An exhausted recovery wake is bounded manual-recovery evidence, not a retry
+loop. Preserve the unread message and failed wake, involve FnB, and do not create
+recursive fallbacks. Drift informs; it never silently blocks resume.
+
+### Cancel or re-plan
+
+A Reviewer cancel decision must name one unreleased work unit and its retained
+terminal reason. Execute exactly that cancellation:
+
+```text
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reviewer-decision-reason>
+```
+
+For a Reviewer re-plan decision, apply its complete projection; never infer
+omitted fields or alter a released or completed lane:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  --developer-shell <id> --reviewer-shell <id> --wave <n> \
+  [--depends-on <work-unit-id>] [--output-kind code|report-only|no-code]
+```
+
+If a Developer or Reviewer declines, preserve the reason and ask the Reviewer
+for the replacement routing decision before issuing a fresh assignment.
+
+### Re-enter after conformance
+
+A Reviewer `re-enter` decision names the in-Sprint findings, the tasks to add
+to the governing spec document with title and description, and the suggested
+unit grouping, waves, dependencies, and routing. Preserve that projection; do
+not silently absorb extra scope or turn post-Sprint findings into delivery work.
+
+Cut every named task against the governing spec document:
+
+```text
+sc mem task add "<task-title>" --feature <feature-id> \
+  --doc <governing-spec-document-id> --seq <next-seq> \
+  --desc "<task-description>"
+```
+
+Create the requested bound work units from those task ids, wiring the Reviewer''s
+waves and dependencies directly:
+
+```text
+sc sprint plan-unit --sprint <id> \
+  --developer-shell <id> --reviewer-shell <id> --title <title> \
+  --expected-output-file <path> --task <task-id> \
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>] \
+  [--output-kind code|report-only|no-code]
+```
+
+After every named task is bound and the dependency graph matches the decision,
+release the new ready lanes with `sc sprint dispatch --sprint <id>`. When the
+added work reaches terminal disposition, the engine sends the Reviewer the next
+delivery-terminal wake; the Planner does not initiate the next conformance pass.
+
+### Conclude or abort
+
+The Reviewer decides when the Sprint is done and atomically records conformance,
+follow-ups, the actionable conclude message, and its wake. The engine prepends
+the conformance report and follow-up ids to the Reviewer-authored decision,
+which carries the exact reason/outcome, stable completion key, and full final
+report body. Accept that message before acting, write the Reviewer-authored body
+to `<reviewer-report>` unchanged, then perform the close action:
+
+```text
+sc sprint complete --sprint <id> --reason <reviewer-decision-reason> \
+  --outcome <reviewer-decision-outcome> --report-file <reviewer-report> \
+  --key <reviewer-decision-key>
+```
+
+Do not run `compile-report` by default, synthesize the final report, or
+editorialize the Reviewer body. The Reviewer compiles its own evidence. A
+Planner compile remains a valid FnB-directed fallback:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Do not wait for or request a second conclude message after the atomic receipt.
+Abort is likewise an action taken only on a Reviewer decision or FnB override;
+it is terminal and deletes nothing.
+
+## Handoffs and stop
+
+Planner → Developer assignments and Developer → Reviewer review requests use
+Force-new delivery; Developer/Reviewer → Planner results are Re-enter. Forced
+delivery starts a fresh chat only after the prior live turn ends and the quiet
+grace passes, coalescing all receiver messages into the bundle. These are
+delivery guarantees, not a parent/child chat topology. The Planner receives no
+PR-event wakes; Developer-owned subscriptions carry red, green, and externally
+closed facts directly to the owning Developer.
+
+Never dispatch the next wave from a merge-observation turn. The Developer''s
+merged-work handoff wake is the only normal next-wave dispatch trigger. On that
+wake, complete the turn in this exact order:
+
+1. Run `sc sprint inbox --sprint <id>` and inspect the durable merged-work
+   handoff plus current work-unit and dependency state.
+2. Act on every earlier informational item and mark each handled item read with
+   `accept`, including the Developer handoff.
+3. Finish all reconciliation, judgment recording, and other Planner
+   bookkeeping. No work remains after this step.
+4. As the literal final action of the turn, release dependency-ready lanes:
+
+```text
+sc sprint dispatch --sprint <id>
+```
+
+5. When the command confirms the durable assignment writes and New wakes, stop
+   immediately. Run no trailing command. Empty dispatch is still the final
+   action for that handoff turn; investigate only on a later durable wake.
+
+On receipt, re-run `sc sprint inbox --sprint <id>`, accept the actionable
+conclude message, execute its exact close action through the protocol above,
+and confirm the typed transition succeeded. Completion resolves the accepted
+handoff liveness expectation. After `complete` succeeds, emit its bounded
+receipt and run no further Sprint command. The Planner does not author a second
+report or wait for a second handoff.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_rev',
+  'Review Sprints v2 work and whole-Sprint conformance — own pause, cancel, and conclude decisions, author the conformance and Sprint reports, and direct Planner actions through durable messages.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_rev — independent review and conformance
+
+Use in one of two modes: a work-unit PR review during the loop, or the final
+whole-Sprint conformance pass. Pre-declaration QAQC is a third entry condition,
+before a Sprint exists. The evidence differs; independence does not. The
+Reviewer decides and documents; the Planner acts. The FnB retains the
+board-level override established by decision #46.
+
+## Entry and durable state
+
+Pre-declaration QAQC begins from an explicit Planner or FnB request. Read the
+exact current spec document and sign that body directly; there is no Sprint id
+or Sprint inbox to inspect yet:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
+
+Once a Sprint is armed, every review or conformance entry arrives through its
+durable wake/inbox. On every wake or re-entry, load `sprint_rev`, inspect the
+message, and accept the actionable request before beginning:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+```
+
+Decline an actionable request you cannot take, with a concrete reason:
+
+```text
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Use `accept` or `decline` for actionable work. After acting on an informational
+question, answer, blocker, or context message, run `accept` for that message.
+For informational messages it only marks the message read; it does not change
+Sprint or work-unit state.
+
+Review requests use Force-new delivery. A live turn is allowed to finish;
+then, after the receiver has stayed quiet for the configured grace interval,
+delivery atomically closes the exact registry chat and starts a fresh chat with
+the complete undelivered message bundle. Concurrent Force-new requests coalesce
+into that one rotation, and a retry resumes the chat created for its own wake
+instead of rotating again. Stop cleanly after every typed verdict or decision
+handoff so the next request can cross the quiet boundary. The inactivity ceiling
+and registry reaper remain the fallback for a silent hung turn.
+
+Plain New remains separate and is eligible immediately. It enters a verified
+live turn at its natural boundary and rotates only when the registry chat is idle. Re-enter
+resumes the registry chat; no registry row behaves as New. Reviewer verdicts to
+Developers and decisions to Planners are Re-enter. Reviewers never receive
+PR-event subscription wakes.
+
+## Questions, answers, blockers, and failures
+
+Put a concrete question, answer, blocker, or useful context in a short body file
+and send it to the participant who can act. Ask the Developer for missing PR
+evidence and the Planner for durable state or action-feasibility facts. Do not
+delegate Reviewer judgment to the Planner:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --key <stable-key>
+```
+
+Answer incoming questions through `send` so the answer is durable and wakes the
+asker, confirm that write, then mark the handled question read with `accept`. A
+blocker or integrity concern is evidence for your decision. If action is needed,
+send the Planner the decision, impact, exact action, and recommendation through
+the protocol below. Continue independent safe review, but stop when missing
+facts prevent an honest decision at the decision boundary. Do not send duplicate
+reminders; unread recovery owns re-waking.
+
+Choose one stable key for the intended recipient and exact body. Reuse it only
+when retrying that same write; use a new key when the recipient or body changes.
+
+Keep this Sprint message or result at about 6,000 characters or fewer; 8,000
+characters is the hard maximum. Before submitting, run `wc -m < <path>` and
+condense if needed. The handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake where applicable.
+
+If a Sprint command is rejected or transport fails, the verdict or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command, evidence, impact, and recommendation to FnB; do not invent an
+alternate delivery protocol. A Reviewer decides whether the condition warrants
+continuing, re-planning, pausing, cancellation, or conclusion, but does not
+invoke the lifecycle transition. Send the durable decision to the Planner, who
+executes it. A live FnB board-level override may supersede that decision and
+must be recorded as FnB authority, not Reviewer judgment.
+
+## Sprint artifact paths
+
+Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
+report drafts, and Dev scratch proof) go to the gitignored
+`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
+PR''d in the work repo; a review-notes commit is a finding.
+
+DB rows stay the durable record: judgments via `record-review`, report bodies in
+`sprint_reports`, and decisions in the durable relay. Files in the Sprint
+artifact directory are working material only.
+
+## Control and conclude decisions
+
+The Reviewer owns all pause, cancel, and conclude decisions and recommendations.
+The Planner owns all resulting actions. Base a decision on durable Sprint state,
+the exact bound revisions, current work/PR facts, liveness evidence, and any
+ratified judgment; ambiguous silence is not enough to corrupt a disposition.
+
+Send pause, resume, replan, re-enter, cancel, and abort decisions through the
+durable `send` surface above. A clean conclude instead rides the atomic
+`record-conformance` handoff below. Every Reviewer → Planner route is Re-enter.
+The Reviewer-authored body must name:
+
+- `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, `conclude`, or
+  `abort`;
+- the evidence and rationale owned by the Reviewer;
+- exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
+- for conclude, the stable completion key and full Reviewer-authored final
+  Sprint report body — the engine prepends the committed conformance report and
+  follow-up ids; and
+- any immediate safety impact that the FnB must see.
+
+The Planner marks the message handled, verifies the assigned Reviewer, and
+executes exactly that transition; the atomic conclude handoff is actionable.
+The Reviewer never runs the pause, replan, cancel, resume, complete, or abort
+action. If the action is rejected, inspect the returned durable state and issue
+a new decision only when the evidence supports one; never ask the Planner to
+improvise around a precondition.
+
+The FnB board-level override from decision #46 is unaffected. A live FnB
+instruction can direct or supersede any decision; preserve it as a distinct
+authority record.
+
+## Severity rubric
+
+This skill owns severity. The governing spec intentionally does not.
+
+- **Critical** — active security/authority violation, destructive corruption,
+  or a condition that makes continued operation unsafe.
+- **Major** — wrong behavior, data loss, broken invariant, material spec
+  violation, or a loop/recovery path that can silently wedge delivery.
+- **Medium** — a concrete correctness or recovery gap likely to bite normal
+  use soon, including missing negative enforcement or an unreliable handoff.
+- **Low** — bounded cleanup, clarity, test depth, or resilience improvement that
+  does not make the delivered behavior wrong now.
+
+During a work-unit review, Critical/Major/Medium block approval; Low is a
+report note. During close-out conformance, severity does not decide timing: the
+Reviewer judges whether each finding requires in-Sprint patching or is an
+acceptable post-Sprint follow-up.
+
+## Work-unit review
+
+Accept the actionable review request. Its readiness body must be only the bare
+locator: submitting or resubmitting intent, PR URL, registered Sprint PR id,
+exact head SHA, and work-unit id. Treat scope narrative, verification evidence,
+judgment rationale, or review-focus steering in that body as a protocol defect;
+do not use it to frame the review. Neither party writes PR comments or
+annotations, and the PR body contains only the work-unit id and spec reference.
+
+Review the exact bound spec revision and the full diff at the request''s exact
+head, then inspect checks, tests, relevant runtime evidence, and ratified
+judgments. Each round is clean: no prior Developer evidence or prose is input,
+and prior findings are cleared only when the code at the new head proves they
+are cleared. Review code quality, edge cases/failure paths, and spec
+conformance. Trace the real path; do not trust names or PR prose.
+
+### Red-check doctrine
+
+Accepted-red is not a legal review outcome. A departure that leaves checks
+failing is never acceptable: do not note the failure and approve anyway. The
+review handoff remains green-only, without exception or waiver.
+
+`Note it and pass anyway` is the acceptance-shaped anti-pattern. In the
+dos-arch incident, a Reviewer accepted known-failing tests as a scoped
+departure and created a deadlock: the green-only handoff gate could never pass.
+Decision #93 records why this no-waiver rule exists.
+
+When failing checks are within the lane''s ratified scope, record
+`changes_requested` so the Developer fixes them and re-establishes green. When
+the failures are outside that scope, name the blocking failures in the finding
+and send the Planner a `replan` decision through the control protocol. The
+Planner must either widen the lane explicitly or cut a follow-up work unit; the
+current lane remains unapproved until the resulting work is green.
+
+Read resolved closure evidence through the authenticated memory surface; no SQL
+or mutation is needed. Use the exact form for a cited flag and the scoped form
+to audit every resolved flag attached to the feature:
+
+```text
+sc mem get flags <flag-id>
+sc mem get flags --feature <feature-id> --resolved
+```
+
+Findings must state:
+
+- severity and concise title;
+- violated behavior or invariant;
+- exact code/evidence location;
+- a reproducible consequence; and
+- the fix boundary, without prescribing unnecessary architecture.
+
+Complete a unit verdict in this exact order:
+
+1. Finish the review, findings, and verdict body; no inspection remains after
+   this step.
+2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+3. Run `wc -m < <path>`; keep the verdict near 6,000 characters and below the
+   8,000-character hard maximum.
+4. As the literal final action of the turn, record the typed verdict through
+   the authenticated surface:
+
+```text
+sc sprint record-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --verdict changes_requested --body-file <path> --key <stable-key>
+```
+
+5. When the command confirms the durable write and Developer wake, stop
+   immediately. Run no trailing command.
+
+Use `approved` only when no Critical/Major/Medium finding remains. The engine
+checks that the request was accepted and still binds to the reviewed head,
+records judgment evidence, sends a Re-enter wake to the Developer, and
+resolves the review liveness expectation. Do not message around this surface;
+an unrecorded verdict cannot unlock merge.
+
+## Delivery-terminal closeout
+
+The `sprint.delivery_terminal` notification is the entry signal for
+whole-Sprint conformance. On that wake, inspect the inbox and current work-unit
+state first. If any non-terminal unit is visible, the wake is stale: mark the
+informational notification handled with `accept`, exit, and await the next
+episode''s delivery-terminal wake.
+
+Compile the bounded evidence packet first and do so yourself, then judge
+integrated `main` against every governing bound revision, exact recorded
+mid-Sprint revision fact, and ratified judgment:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Increase the bound only when truncation counters show the default omitted
+needed evidence; 200 is the maximum. The packet supplies facts, not judgment.
+If every work unit was cancelled and nothing shipped, the honest decision is
+`abort`, not `conclude`.
+
+After classifying the requirements, choose exactly one branch:
+
+- **In-Sprint patching required.** Do not run `record-conformance`. Send the
+  Planner a durable `re-enter` decision naming every blocking finding; each
+  spec task to cut against the governing spec document, with title and
+  description; and the suggested unit grouping, waves, dependencies, and
+  Developer/Reviewer routing. The durable decision is the failed-pass record.
+  After three re-entry episodes in one Sprint, escalate the non-convergence to
+  FnB instead of starting another patch round.
+- **Clean or post-Sprint-only findings.** Prepare the conformance report,
+  findings, final Sprint report, and full `conclude` handoff. Submit them
+  through the atomic `record-conformance` protocol below: the engine commits
+  the evidence, Planner message, and wake together. Do not send a second
+  conclude message.
+
+## Whole-Sprint conformance
+
+Review the integrated system, not unit diffs. Classify each requirement as:
+
+- `as-specced`;
+- `deviated-intentionally` with its ratified judgment;
+- `deviated-silently`; or
+- `unimplemented`.
+
+The last two are findings. Include spec document id and work-unit id when known.
+For the clean or post-Sprint-only branch, write the conformance report and a
+JSON findings array:
+
+```json
+[
+  {
+    "severity": "Major",
+    "title": "Integrated seam diverges",
+    "body": "Evidence and consequence.",
+    "spec_document_id": 46,
+    "work_unit_id": 9
+  }
+]
+```
+
+Keep the conformance report and each finding body at about 6,000 characters or
+fewer; 8,000 is the hard maximum for each. Run `wc -m < <report>` and length-check
+each finding body before submission.
+
+Before recording conformance, author the final Sprint report. Name the Reviewer
+as its author and answer:
+
+1. Which exact scope and revisions governed?
+2. What shipped, through which work units and PRs?
+3. Which Reviewer judgments and ratified deviations shaped the result?
+4. What failed, retried, paused, recovered, or remained anomalous?
+5. What did conformance conclude?
+6. Which follow-ups or unresolved items require FnB disposition?
+7. Where is the complete evidence?
+
+Keep the final report at about 6,000 characters or fewer and below the 8,000
+hard maximum; run `wc -m < <report>`. Do not smooth discrepancies into a
+success narrative. Write one Planner handoff file containing the `conclude`
+decision, evidence and rationale, exact reason/outcome and stable completion
+key, and the full final report body. Keep the complete handoff below 8,000
+characters. The engine prepends the committed conformance report id and
+follow-up ids; the Planner submits the report body unchanged and owns only the
+close action.
+
+Record the clean branch as one atomic final write:
+
+```text
+sc sprint record-conformance \
+  --sprint <id> --body-file <report> --findings-file <json> \
+  --planner-handoff-file <conclude-handoff> --key <stable-pass-key>
+```
+
+The receipt must name the report id, follow-up ids, Planner message id, and
+Planner wake id. This creates append-only conformance evidence, pending
+follow-ups, and one actionable Planner Re-enter in the same transaction. Never
+record conformance first and then send around it; send no second conclude message.
+Never reopen an editing
+lane after recording; the re-enter branch defers the report until added scope
+reaches terminal disposition and a fresh delivery-terminal wake starts the next
+episode. Surface any immediate safety risk to FnB.
+
+## Stop
+
+For unit review, follow the ordered verdict procedure above: inbox handling and
+all evidence work precede `record-review`; the durable verdict is the literal
+last action, then the Reviewer stops.
+
+For the clean or post-Sprint-only branch, require the report, findings, and
+Planner handoff to replay idempotently. For the re-enter or abort branch,
+confirm that the decision body carries the complete evidence and exact
+requested action. Then complete this final handoff order:
+
+1. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+2. Confirm every Reviewer-authored artifact and decision body is final and
+   below its 8,000-character hard maximum.
+3. For a clean conclude, run the atomic `record-conformance` command above as
+   the literal final action. When it confirms all four receipt identities,
+   stop immediately; send no second conclude message.
+4. For re-enter or abort, deliver the decision to the Planner as the literal
+   final action:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --key <stable-decision-handoff-key>
+```
+
+5. When the command confirms the durable write and Planner wake, stop
+   immediately. Run no trailing command until another native wake arrives.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/migrations/0179_reseed_atomic_sprint_closeout.sql
+++ b/.super-coder/migrations/0179_reseed_atomic_sprint_closeout.sql
@@ -1,4 +1,4 @@
--- 0179 — make Reviewer conformance and Planner close handoff atomic.
+-- 0179 — make Reviewer conformance and Sprint completion atomic.
 -- Full-body UPSERTs converge the three closeout role skills.
 
 BEGIN;
@@ -11,9 +11,11 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
   0,
   '# sprint_close — synthesize and finish
 
-Use as the owning Planner when a Reviewer close decision arrives, or when abort
-has been chosen. The delivery-terminal wake starts closeout with the Reviewer;
-the Reviewer decides and authors, and the Planner executes.
+Use as the owning Planner when a Reviewer control decision or completed-Sprint
+receipt arrives, or when abort has been chosen. The delivery-terminal wake
+starts closeout with the Reviewer. A clean conformance approval closes the
+Sprint atomically; the Planner is informed after closure and takes no second
+close action.
 On entry or any wake, load `sprint_close`, run `sc sprint inbox --sprint <id>`,
 inspect the durable message, and accept or decline it only when actionable.
 
@@ -27,8 +29,8 @@ question, answer, blocker, or context message, run `accept` for that message.
 For informational messages it only marks the message read; it does not change
 Sprint or work-unit state.
 
-Planner-bound close/conformance messages are Re-enter wakes resolved through
-the active-chat registry. A verified live turn is never displaced; delivery
+The clean-close receipt is an engine-wide Re-enter wake because Sprint-scoped
+delivery stops at terminal state. A verified live turn is never displaced; delivery
 waits for its natural boundary and drains every undelivered message. An idle
 Re-enter resumes the registry chat, while coordinate mode makes it an idle New
 ticket chat after FnB closes the Planner chat. Automatic pause preserves that
@@ -64,7 +66,8 @@ If a Sprint command is rejected or transport fails, the write or handoff is
 incomplete. Correct and retry when safe. If the relay itself fails, surface the
 attempted command and durable evidence to FnB; do not invent an alternate
 delivery protocol. The Reviewer decides whether evidence warrants pause,
-re-plan, cancellation, or conclusion; the Planner executes that decision. FnB
+re-plan, cancellation, or conclusion; the Planner executes control decisions,
+while clean conformance approval executes its own close. FnB
 retains the board-level override from decision #46. Send any needed participant
 context before the Planner acts; an active relay is not available after the
 lifecycle becomes paused.
@@ -75,6 +78,8 @@ fallbacks.
 
 On a durable Reviewer pause decision (or live FnB override), the Planner runs
 `sc sprint pause --sprint <id> --reason <decision-reason>`.
+For any Sprint-scoped control wake, re-run `sc sprint inbox --sprint <id>`
+before acting; the engine-wide clean-close receipt is already self-contained.
 
 ## Sprint artifact paths
 
@@ -109,17 +114,18 @@ decision naming the new spec tasks and suggested unit projection. The added
 units run through delivery and produce a fresh delivery-terminal wake.
 
 For a clean pass or post-Sprint-only findings, the Reviewer prepares its report,
-findings, final Sprint report, and full conclude handoff before calling
-`sc sprint record-conformance`. That one transaction records the report and
-follow-ups and publishes an actionable Re-enter message plus wake to the
-originating Planner. Every recorded finding becomes a pending follow-up for FnB
-review; it is not also reopened as an editing lane. A safety finding may still
-demand immediate operator action.
+findings, final Sprint report, reason, and outcome before calling
+`sc sprint record-conformance`. That one transaction records both reports and
+follow-ups, completes the Sprint, resolves terminal liveness, and publishes an
+informational engine-wide Re-enter receipt plus wake to the originating Planner.
+Every recorded finding becomes a pending follow-up for FnB review; it is not
+also reopened as an editing lane. A safety finding may still demand immediate
+operator action.
 
-Verify report id, follow-up ids, Planner message id, Planner wake id, author
-identity, and idempotent replay. The engine prepends the generated report and
-follow-up ids to the Reviewer-authored handoff; no second conclude message is
-sent.
+Verify conformance report id, final report id, follow-up ids, completed state,
+Planner message id, Planner wake id, author identity, and idempotent replay. The
+engine generates the completion receipt from those committed facts; no Planner
+close command or second conclude message follows.
 
 FnB records one terminal disposition per follow-up. `accepted` acknowledges
 ship-as-is; `resolved` and `dismissed` require a resolution file.
@@ -182,7 +188,7 @@ Name discrepancies; do not smooth them into a success narrative. A recovered
 stall can be a successful Sprint when the failure stayed durable, visible, and
 contained. Evidence packets, conformance drafts, and final report drafts belong
 under `shared/sprints/sprint-<n>/`. The Reviewer finishes this report before
-the atomic conformance write and includes it unchanged in the Planner handoff.
+the atomic conformance write; that write stores it unchanged as the final report.
 
 ## Pause and abort reports
 
@@ -198,36 +204,29 @@ nothing.
 
 ## Terminal handoff
 
-The Planner receives the actionable conclude handoff created atomically with
-conformance, accepts it, writes the Reviewer-authored final synthesis unchanged,
-and passes it to `complete`; the surface commits the append-only `final` report
-before attempting the lifecycle transition. Omitting the report is permitted
-under advisory close-out, but the evidence packet records the gap. Abort only
-on a Reviewer decision or FnB override. Terminal state resolves the accepted
-close-handoff liveness expectation, stops Sprint services, and removes live
-pills while retaining conversations, messages, events, PR evidence, reports,
-and follow-ups.
+The Reviewer''s successful clean `record-conformance` command is the terminal
+handoff. It stores the Reviewer-authored final synthesis, transitions the Sprint
+to `completed`, resolves terminal liveness, and queues an informational Planner
+receipt in one transaction. The Planner does not accept a close decision or run
+`complete`; the receipt confirms the Sprint is already terminal.
 
-Immediately before `complete`, re-run `sc sprint inbox --sprint <id>` to drain
-newly arrived messages, mark every handled informational message read with
-`accept`, and confirm the final report file is the intended synthesis. This is
-the last pre-terminal evidence read.
+Immediately before `record-conformance`, the Reviewer drains the Sprint inbox,
+confirms the final report, reason, outcome, and stable key, then performs the
+atomic command as the literal last action. Terminal state stops Sprint services
+and removes live pills while retaining conversations, messages, events, PR
+evidence, reports, and follow-ups.
 
-Keep the final report at about 6,000 characters or fewer; 8,000 is the hard
-maximum. Run `wc -m < <path>` before the typed terminal handoff, then require
-the successful report receipt and lifecycle transition.
+The standalone `complete` surface remains only for an FnB-directed fallback.
+Abort remains a Planner action on a Reviewer decision or FnB override:
 
 ```text
-sc sprint complete --sprint <id> --reason <summary> --outcome <outcome> \
-  --report-file <path> --key <stable-key>
 sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
 ```
 
-After `complete` succeeds, emit one bounded final response from its receipt:
-final report id, follow-up list, integrated SHA, and evidence links. Run no
-further Sprint command. Terminal lifecycle removes Sprint authority and live
-pills but does not close the shell''s registry chat; FnB close remains the one
-unconditional chat-displacement path.',
+After `record-conformance` succeeds, emit one bounded final response from its
+receipt and run no further Sprint command. Terminal lifecycle removes Sprint
+authority and live pills but does not close the shell''s registry chat; FnB close
+remains the one unconditional chat-displacement path.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET
@@ -257,8 +256,8 @@ The armed runtime owns scheduled dispatch, unread wake recovery, liveness
 evaluation, and registered-PR observation. React to its durable inbox and wake
 facts; use the Planner turn for dispatch and exact execution of durable Reviewer
 decisions. The Reviewer owns pause, cancel, and conclude decisions plus the
-conformance and final Sprint reports. The Planner owns the corresponding state
-transitions.
+conformance and final Sprint reports. The Planner owns control transitions;
+clean conformance approval performs its own atomic terminal transition.
 
 The active-chat registry is the only current-chat authority; zero or one chat
 per shell is legal. Every wake message creates delivery intent and a wake turn
@@ -399,14 +398,17 @@ artifact directory are working material only.
 
 ## Reviewer decision actions
 
-Pause, cancel, re-enter, and conclude are Reviewer decisions and Planner
-actions. A valid decision arrives as a durable Reviewer → Planner Re-enter
+Pause, cancel, re-enter, and abort are Reviewer decisions and Planner actions.
+A valid control decision arrives as a durable Reviewer → Planner Re-enter
 message and names the decision, evidence, target ids, reason, and exact
-requested transition. The clean conclude handoff is actionable and is created
-atomically with conformance; other freeform decisions are informational. Mark
-each handled message through `accept`, verify it came from the assigned
+requested transition. Clean conformance instead closes atomically and sends an
+informational engine-wide completion receipt. Mark each handled Sprint message
+through `accept`, verify it came from the assigned
 Reviewer, and execute that transition without re-adjudicating the decision.
 Record the decision message id and action receipt together.
+Re-run `sc sprint inbox --sprint <id>` before acting on any Sprint-scoped
+control decision; the engine-wide completion receipt requires no Sprint inbox
+acceptance.
 
 The FnB board-level override from decision #46 is unaffected: a live FnB
 instruction may direct or supersede any action. Name that override in the
@@ -493,18 +495,12 @@ delivery-terminal wake; the Planner does not initiate the next conformance pass.
 
 ### Conclude or abort
 
-The Reviewer decides when the Sprint is done and atomically records conformance,
-follow-ups, the actionable conclude message, and its wake. The engine prepends
-the conformance report and follow-up ids to the Reviewer-authored decision,
-which carries the exact reason/outcome, stable completion key, and full final
-report body. Accept that message before acting, write the Reviewer-authored body
-to `<reviewer-report>` unchanged, then perform the close action:
-
-```text
-sc sprint complete --sprint <id> --reason <reviewer-decision-reason> \
-  --outcome <reviewer-decision-outcome> --report-file <reviewer-report> \
-  --key <reviewer-decision-key>
-```
+The Reviewer decides when the Sprint is done. A clean `record-conformance`
+command atomically stores conformance, follow-ups, the Reviewer-authored final
+report, completed lifecycle, and an informational engine-wide Planner receipt.
+When that Re-enter arrives, confirm the receipt names the expected Sprint,
+reports, outcome, and completed state. Do not run `complete`; closure is already
+durable and the notification has no actionable liveness expectation.
 
 Do not run `compile-report` by default, synthesize the final report, or
 editorialize the Reviewer body. The Reviewer compiles its own evidence. A
@@ -515,7 +511,7 @@ sc sprint compile-report --sprint <id> --limit 50 \
   > shared/sprints/sprint-<n>/evidence.json
 ```
 
-Do not wait for or request a second conclude message after the atomic receipt.
+Do not wait for or request a conclude action message after the completion receipt.
 Abort is likewise an action taken only on a Reviewer decision or FnB override;
 it is terminal and deletes nothing.
 
@@ -549,12 +545,10 @@ sc sprint dispatch --sprint <id>
    immediately. Run no trailing command. Empty dispatch is still the final
    action for that handoff turn; investigate only on a later durable wake.
 
-On receipt, re-run `sc sprint inbox --sprint <id>`, accept the actionable
-conclude message, execute its exact close action through the protocol above,
-and confirm the typed transition succeeded. Completion resolves the accepted
-handoff liveness expectation. After `complete` succeeds, emit its bounded
-receipt and run no further Sprint command. The Planner does not author a second
-report or wait for a second handoff.',
+On a clean completion receipt, verify the named Sprint is terminal and record
+the bounded receipt; run no close command. The Planner does not author a second
+report, accept an actionable handoff, or wait for another actor to finish the
+Sprint.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET
@@ -673,28 +667,28 @@ artifact directory are working material only.
 ## Control and conclude decisions
 
 The Reviewer owns all pause, cancel, and conclude decisions and recommendations.
-The Planner owns all resulting actions. Base a decision on durable Sprint state,
+The Planner owns control actions; clean conformance approval atomically performs
+its own close. Base a decision on durable Sprint state,
 the exact bound revisions, current work/PR facts, liveness evidence, and any
 ratified judgment; ambiguous silence is not enough to corrupt a disposition.
 
 Send pause, resume, replan, re-enter, cancel, and abort decisions through the
-durable `send` surface above. A clean conclude instead rides the atomic
-`record-conformance` handoff below. Every Reviewer → Planner route is Re-enter.
+durable `send` surface above. A clean conclude instead runs the atomic
+`record-conformance` close below. Every Reviewer → Planner route is Re-enter.
 The Reviewer-authored body must name:
 
 - `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, `conclude`, or
   `abort`;
 - the evidence and rationale owned by the Reviewer;
 - exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
-- for conclude, the stable completion key and full Reviewer-authored final
-  Sprint report body — the engine prepends the committed conformance report and
-  follow-up ids; and
 - any immediate safety impact that the FnB must see.
 
 The Planner marks the message handled, verifies the assigned Reviewer, and
-executes exactly that transition; the atomic conclude handoff is actionable.
-The Reviewer never runs the pause, replan, cancel, resume, complete, or abort
-action. If the action is rejected, inspect the returned durable state and issue
+executes exactly that control transition. The clean completion receipt is
+informational because the Sprint is already terminal. The Reviewer never runs
+the standalone pause, replan, cancel, resume, complete, or abort action; its
+clean `record-conformance` command owns the narrow automatic close. If a control
+action is rejected, inspect the returned durable state and issue
 a new decision only when the evidence supports one; never ask the Planner to
 improvise around a precondition.
 
@@ -829,10 +823,10 @@ After classifying the requirements, choose exactly one branch:
   After three re-entry episodes in one Sprint, escalate the non-convergence to
   FnB instead of starting another patch round.
 - **Clean or post-Sprint-only findings.** Prepare the conformance report,
-  findings, final Sprint report, and full `conclude` handoff. Submit them
-  through the atomic `record-conformance` protocol below: the engine commits
-  the evidence, Planner message, and wake together. Do not send a second
-  conclude message.
+  findings, final Sprint report, reason, and outcome. Submit them through the
+  atomic `record-conformance` protocol below: the engine commits the evidence,
+  completed lifecycle, informational Planner receipt, and wake together. Do not
+  send a separate conclude message.
 
 ## Whole-Sprint conformance
 
@@ -876,25 +870,25 @@ as its author and answer:
 
 Keep the final report at about 6,000 characters or fewer and below the 8,000
 hard maximum; run `wc -m < <report>`. Do not smooth discrepancies into a
-success narrative. Write one Planner handoff file containing the `conclude`
-decision, evidence and rationale, exact reason/outcome and stable completion
-key, and the full final report body. Keep the complete handoff below 8,000
-characters. The engine prepends the committed conformance report id and
-follow-up ids; the Planner submits the report body unchanged and owns only the
-close action.
+success narrative. Keep the final report below 8,000 characters, then choose
+the exact completion reason, terminal outcome, and stable completion key. The
+engine stores the final report unchanged and generates the Planner receipt from
+the committed report and follow-up identities.
 
 Record the clean branch as one atomic final write:
 
 ```text
 sc sprint record-conformance \
   --sprint <id> --body-file <report> --findings-file <json> \
-  --planner-handoff-file <conclude-handoff> --key <stable-pass-key>
+  --final-report-file <final-report> --reason <reason> --outcome <outcome> \
+  --key <stable-pass-key>
 ```
 
-The receipt must name the report id, follow-up ids, Planner message id, and
-Planner wake id. This creates append-only conformance evidence, pending
-follow-ups, and one actionable Planner Re-enter in the same transaction. Never
-record conformance first and then send around it; send no second conclude message.
+The receipt must name the conformance report id, final report id, follow-up ids,
+completed state, Planner message id, and Planner wake id. This creates
+append-only evidence, pending follow-ups, terminal lifecycle, and one
+informational engine-wide Planner Re-enter in the same transaction. Never
+record conformance first and then close around it; send no conclude message.
 Never reopen an editing
 lane after recording; the re-enter branch defers the report until added scope
 reaches terminal disposition and a fresh delivery-terminal wake starts the next
@@ -906,8 +900,8 @@ For unit review, follow the ordered verdict procedure above: inbox handling and
 all evidence work precede `record-review`; the durable verdict is the literal
 last action, then the Reviewer stops.
 
-For the clean or post-Sprint-only branch, require the report, findings, and
-Planner handoff to replay idempotently. For the re-enter or abort branch,
+For the clean or post-Sprint-only branch, require both reports, findings,
+reason, and outcome to replay idempotently. For the re-enter or abort branch,
 confirm that the decision body carries the complete evidence and exact
 requested action. Then complete this final handoff order:
 
@@ -916,8 +910,8 @@ requested action. Then complete this final handoff order:
 2. Confirm every Reviewer-authored artifact and decision body is final and
    below its 8,000-character hard maximum.
 3. For a clean conclude, run the atomic `record-conformance` command above as
-   the literal final action. When it confirms all four receipt identities,
-   stop immediately; send no second conclude message.
+   the literal final action. When it confirms completed state and all receipt
+   identities, stop immediately; the Planner is already notified.
 4. For re-enter or abort, deliver the decision to the Planner as the literal
    final action:
 

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -329,9 +329,9 @@ def cmd_record_conformance(args: argparse.Namespace) -> int:
             "sprint_id": args.sprint,
             "body": _text(args.body_file, "conformance body"),
             "findings": _json_array(args.findings_file),
-            "planner_handoff": _text(
-                args.planner_handoff_file, "Planner handoff"
-            ),
+            "final_report": _text(args.final_report_file, "final report body"),
+            "reason": args.reason,
+            "terminal_outcome": args.outcome,
             "idempotency_key": args.key,
         },
         idempotent=True,
@@ -571,8 +571,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--findings-file", required=True, help=FINDINGS_FILE_HELP
     )
     conformance.add_argument(
-        "--planner-handoff-file", required=True, help=PAYLOAD_FILE_HELP
+        "--final-report-file", required=True, help=PAYLOAD_FILE_HELP
     )
+    conformance.add_argument("--reason", required=True)
+    conformance.add_argument("--outcome", required=True)
     conformance.add_argument("--key", required=True, help="stable retry identity")
     conformance.set_defaults(fn=cmd_record_conformance)
 

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -329,6 +329,9 @@ def cmd_record_conformance(args: argparse.Namespace) -> int:
             "sprint_id": args.sprint,
             "body": _text(args.body_file, "conformance body"),
             "findings": _json_array(args.findings_file),
+            "planner_handoff": _text(
+                args.planner_handoff_file, "Planner handoff"
+            ),
             "idempotency_key": args.key,
         },
         idempotent=True,
@@ -566,6 +569,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     conformance.add_argument(
         "--findings-file", required=True, help=FINDINGS_FILE_HELP
+    )
+    conformance.add_argument(
+        "--planner-handoff-file", required=True, help=PAYLOAD_FILE_HELP
     )
     conformance.add_argument("--key", required=True, help="stable retry identity")
     conformance.set_defaults(fn=cmd_record_conformance)

--- a/.super-coder/scripts/sprint_close.py
+++ b/.super-coder/scripts/sprint_close.py
@@ -22,6 +22,8 @@ MAX_SECTION_LIMIT = 200
 class ConformanceReceipt:
     report_id: int
     followup_ids: tuple[int, ...]
+    planner_message_id: int
+    planner_wake_id: int
     created: bool
 
 
@@ -45,16 +47,21 @@ class SprintCloseStore:
         *,
         body: str,
         findings: Iterable[dict[str, Any]],
+        planner_handoff: str,
         idempotency_key: str,
     ) -> ConformanceReceipt:
-        """Commit one conformance report and its post-Sprint follow-ups."""
+        """Commit conformance evidence and its Planner handoff atomically."""
         body = self._required(body, "conformance body")
+        planner_handoff = self._required(planner_handoff, "Planner handoff")
         idempotency_key = self._required(
             idempotency_key, "idempotency key", maximum=220
         )
         normalized = tuple(self._normalize_finding(item) for item in findings)
         with db_driver.write_transaction(self.con, "sprint.close.conformance"):
-            self._require_reviewer(sprint_id, reviewer_shell_id)
+            reviewer_participant_id = self._require_reviewer(
+                sprint_id, reviewer_shell_id
+            )
+            planner_participant_id = self._planner_participant_id(sprint_id)
             lifecycle = self._lifecycle(sprint_id)
             if lifecycle != "armed":
                 raise SprintInvariantError(
@@ -67,7 +74,25 @@ class SprintCloseStore:
                 (sprint_id, idempotency_key),
             ).fetchone()
             if existing is not None:
-                return self._replay_receipt(existing, body, normalized, idempotency_key)
+                report_id, followup_ids = self._replay_evidence(
+                    existing, body, normalized, idempotency_key
+                )
+                handoff = self._send_planner_handoff(
+                    sprint_id,
+                    reviewer_participant_id=reviewer_participant_id,
+                    planner_participant_id=planner_participant_id,
+                    report_id=report_id,
+                    followup_ids=followup_ids,
+                    body=planner_handoff,
+                    idempotency_key=idempotency_key,
+                )
+                return ConformanceReceipt(
+                    report_id,
+                    followup_ids,
+                    handoff.message_id,
+                    self._required_wake_id(handoff.wake_id),
+                    False,
+                )
 
             report_id = int(
                 self.con.execute(
@@ -100,6 +125,16 @@ class SprintCloseStore:
                         ).lastrowid
                     )
                 )
+            handoff = self._send_planner_handoff(
+                sprint_id,
+                reviewer_participant_id=reviewer_participant_id,
+                planner_participant_id=planner_participant_id,
+                report_id=report_id,
+                followup_ids=tuple(followup_ids),
+                body=planner_handoff,
+                idempotency_key=idempotency_key,
+            )
+            planner_wake_id = self._required_wake_id(handoff.wake_id)
             self._event(
                 sprint_id,
                 "conformance.recorded",
@@ -108,9 +143,17 @@ class SprintCloseStore:
                     "report_id": report_id,
                     "followup_count": len(followup_ids),
                     "followup_ids": followup_ids,
+                    "planner_message_id": handoff.message_id,
+                    "planner_wake_id": planner_wake_id,
                 },
             )
-        return ConformanceReceipt(report_id, tuple(followup_ids), True)
+        return ConformanceReceipt(
+            report_id,
+            tuple(followup_ids),
+            handoff.message_id,
+            planner_wake_id,
+            True,
+        )
 
     def record_final_report(
         self,
@@ -588,15 +631,67 @@ class SprintCloseStore:
                 "only Sprint participants or FnB may read the timeline"
             )
 
-    def _require_reviewer(self, sprint_id: int, shell_id: int) -> None:
+    def _require_reviewer(self, sprint_id: int, shell_id: int) -> int:
         role = self.con.execute(
-            "SELECT role FROM sprint_participants WHERE sprint_id=? AND shell_id=?",
+            "SELECT participant_id,role FROM sprint_participants "
+            "WHERE sprint_id=? AND shell_id=?",
             (sprint_id, shell_id),
         ).fetchone()
         if role is None or role["role"] != "reviewer":
             raise SprintAuthorityError(
                 "only a participating Reviewer may record conformance"
             )
+        return int(role["participant_id"])
+
+    def _planner_participant_id(self, sprint_id: int) -> int:
+        planner = self.con.execute(
+            "SELECT participant.participant_id FROM sprints sprint "
+            "JOIN sprint_participants participant "
+            "ON participant.sprint_id=sprint.sprint_id "
+            "AND participant.shell_id=sprint.originating_planner_shell_id "
+            "WHERE sprint.sprint_id=? AND participant.role='planner'",
+            (sprint_id,),
+        ).fetchone()
+        if planner is None:
+            raise SprintInvariantError(
+                "Sprint has no originating Planner participant"
+            )
+        return int(planner["participant_id"])
+
+    def _send_planner_handoff(
+        self,
+        sprint_id: int,
+        *,
+        reviewer_participant_id: int,
+        planner_participant_id: int,
+        report_id: int,
+        followup_ids: tuple[int, ...],
+        body: str,
+        idempotency_key: str,
+    ) -> Any:
+        from sprint_message_delivery import SprintMessageStore
+
+        followups = ",".join(str(value) for value in followup_ids) or "none"
+        rendered_body = (
+            f"Conformance recorded: report_id={report_id}; "
+            f"followup_ids={followups}.\n\n{body}"
+        )
+        return SprintMessageStore(self.con).send_in_transaction(
+            sprint_id,
+            to_participant_id=planner_participant_id,
+            message_kind="notification",
+            body=rendered_body,
+            idempotency_key=f"{idempotency_key}:planner-handoff",
+            from_participant_id=reviewer_participant_id,
+            actionable=True,
+            declared_type="re-enter",
+        )
+
+    @staticmethod
+    def _required_wake_id(wake_id: int | None) -> int:
+        if wake_id is None:
+            raise SprintInvariantError("Planner handoff has no delivery intent")
+        return int(wake_id)
 
     def _lifecycle(self, sprint_id: int) -> str:
         row = self.con.execute(
@@ -624,13 +719,13 @@ class SprintCloseStore:
                 f"work unit {work_unit_id} does not belong to Sprint {sprint_id}"
             )
 
-    def _replay_receipt(
+    def _replay_evidence(
         self,
         report: sqlite3.Row,
         body: str,
         findings: tuple[dict[str, Any], ...],
         key: str,
-    ) -> ConformanceReceipt:
+    ) -> tuple[int, tuple[int, ...]]:
         if report["body"] != body:
             raise SprintInvariantError(
                 "conformance idempotency key was reused with different input"
@@ -654,10 +749,9 @@ class SprintCloseStore:
             raise SprintInvariantError(
                 f"conformance idempotency key {key!r} was reused with different findings"
             )
-        return ConformanceReceipt(
+        return (
             int(report["report_id"]),
             tuple(int(row["followup_id"]) for row in rows),
-            False,
         )
 
     @classmethod

--- a/.super-coder/scripts/sprint_close.py
+++ b/.super-coder/scripts/sprint_close.py
@@ -12,6 +12,7 @@ import db_driver
 from sprint_domain import (
     SprintAuthorityError,
     SprintInvariantError,
+    SprintLifecycleStore,
 )
 
 DEFAULT_SECTION_LIMIT = 50
@@ -22,8 +23,10 @@ MAX_SECTION_LIMIT = 200
 class ConformanceReceipt:
     report_id: int
     followup_ids: tuple[int, ...]
+    final_report_id: int
     planner_message_id: int
     planner_wake_id: int
+    completed: bool
     created: bool
 
 
@@ -47,26 +50,25 @@ class SprintCloseStore:
         *,
         body: str,
         findings: Iterable[dict[str, Any]],
-        planner_handoff: str,
+        final_report: str,
+        reason: str,
+        terminal_outcome: str,
         idempotency_key: str,
     ) -> ConformanceReceipt:
-        """Commit conformance evidence and its Planner handoff atomically."""
+        """Commit conformance, terminal close, and Planner receipt atomically."""
         body = self._required(body, "conformance body")
-        planner_handoff = self._required(planner_handoff, "Planner handoff")
+        final_report = self._required(final_report, "final report body")
+        reason = self._required(reason, "completion reason", maximum=2000)
+        terminal_outcome = self._required(
+            terminal_outcome, "terminal outcome", maximum=2000
+        )
         idempotency_key = self._required(
             idempotency_key, "idempotency key", maximum=220
         )
         normalized = tuple(self._normalize_finding(item) for item in findings)
         with db_driver.write_transaction(self.con, "sprint.close.conformance"):
-            reviewer_participant_id = self._require_reviewer(
-                sprint_id, reviewer_shell_id
-            )
-            planner_participant_id = self._planner_participant_id(sprint_id)
-            lifecycle = self._lifecycle(sprint_id)
-            if lifecycle != "armed":
-                raise SprintInvariantError(
-                    f"conformance requires an armed Sprint, not {lifecycle}"
-                )
+            self._require_reviewer(sprint_id, reviewer_shell_id)
+            planner_shell_id = self._planner_shell_id(sprint_id)
             existing = self.con.execute(
                 "SELECT report_id,body FROM sprint_reports "
                 "WHERE sprint_id=? AND report_kind='conformance' "
@@ -77,21 +79,44 @@ class SprintCloseStore:
                 report_id, followup_ids = self._replay_evidence(
                     existing, body, normalized, idempotency_key
                 )
-                handoff = self._send_planner_handoff(
+                final_report_id = self._replay_final_report(
                     sprint_id,
-                    reviewer_participant_id=reviewer_participant_id,
-                    planner_participant_id=planner_participant_id,
+                    reviewer_shell_id=reviewer_shell_id,
+                    body=final_report,
+                    idempotency_key=idempotency_key,
+                )
+                self._replay_completion(
+                    sprint_id,
+                    reviewer_shell_id=reviewer_shell_id,
+                    reason=reason,
+                    terminal_outcome=terminal_outcome,
+                    idempotency_key=idempotency_key,
+                )
+                notification = self._send_planner_notification(
+                    sprint_id,
+                    reviewer_shell_id=reviewer_shell_id,
+                    planner_shell_id=planner_shell_id,
                     report_id=report_id,
                     followup_ids=followup_ids,
-                    body=planner_handoff,
+                    final_report_id=final_report_id,
+                    reason=reason,
+                    terminal_outcome=terminal_outcome,
                     idempotency_key=idempotency_key,
                 )
                 return ConformanceReceipt(
                     report_id,
                     followup_ids,
-                    handoff.message_id,
-                    self._required_wake_id(handoff.wake_id),
+                    final_report_id,
+                    notification.message_id,
+                    self._required_wake_id(notification.wake_id),
+                    True,
                     False,
+                )
+
+            lifecycle = self._lifecycle(sprint_id)
+            if lifecycle != "armed":
+                raise SprintInvariantError(
+                    f"conformance requires an armed Sprint, not {lifecycle}"
                 )
 
             report_id = int(
@@ -125,33 +150,51 @@ class SprintCloseStore:
                         ).lastrowid
                     )
                 )
-            handoff = self._send_planner_handoff(
+            final_report_id = self._insert_final_report(
                 sprint_id,
-                reviewer_participant_id=reviewer_participant_id,
-                planner_participant_id=planner_participant_id,
-                report_id=report_id,
-                followup_ids=tuple(followup_ids),
-                body=planner_handoff,
+                reviewer_shell_id=reviewer_shell_id,
+                body=final_report,
                 idempotency_key=idempotency_key,
             )
-            planner_wake_id = self._required_wake_id(handoff.wake_id)
+            notification = self._send_planner_notification(
+                sprint_id,
+                reviewer_shell_id=reviewer_shell_id,
+                planner_shell_id=planner_shell_id,
+                report_id=report_id,
+                followup_ids=tuple(followup_ids),
+                final_report_id=final_report_id,
+                reason=reason,
+                terminal_outcome=terminal_outcome,
+                idempotency_key=idempotency_key,
+            )
+            planner_wake_id = self._required_wake_id(notification.wake_id)
             self._event(
                 sprint_id,
                 "conformance.recorded",
                 reviewer_shell_id,
                 {
                     "report_id": report_id,
+                    "final_report_id": final_report_id,
                     "followup_count": len(followup_ids),
                     "followup_ids": followup_ids,
-                    "planner_message_id": handoff.message_id,
+                    "planner_message_id": notification.message_id,
                     "planner_wake_id": planner_wake_id,
                 },
+            )
+            SprintLifecycleStore(self.con).complete_from_conformance_in_transaction(
+                sprint_id,
+                reviewer_shell_id,
+                reason=reason,
+                terminal_outcome=terminal_outcome,
+                idempotency_key=idempotency_key,
             )
         return ConformanceReceipt(
             report_id,
             tuple(followup_ids),
-            handoff.message_id,
+            final_report_id,
+            notification.message_id,
             planner_wake_id,
+            True,
             True,
         )
 
@@ -643,9 +686,9 @@ class SprintCloseStore:
             )
         return int(role["participant_id"])
 
-    def _planner_participant_id(self, sprint_id: int) -> int:
+    def _planner_shell_id(self, sprint_id: int) -> int:
         planner = self.con.execute(
-            "SELECT participant.participant_id FROM sprints sprint "
+            "SELECT sprint.originating_planner_shell_id FROM sprints sprint "
             "JOIN sprint_participants participant "
             "ON participant.sprint_id=sprint.sprint_id "
             "AND participant.shell_id=sprint.originating_planner_shell_id "
@@ -656,41 +699,43 @@ class SprintCloseStore:
             raise SprintInvariantError(
                 "Sprint has no originating Planner participant"
             )
-        return int(planner["participant_id"])
+        return int(planner["originating_planner_shell_id"])
 
-    def _send_planner_handoff(
+    def _send_planner_notification(
         self,
         sprint_id: int,
         *,
-        reviewer_participant_id: int,
-        planner_participant_id: int,
+        reviewer_shell_id: int,
+        planner_shell_id: int,
         report_id: int,
         followup_ids: tuple[int, ...],
-        body: str,
+        final_report_id: int,
+        reason: str,
+        terminal_outcome: str,
         idempotency_key: str,
     ) -> Any:
         from sprint_message_delivery import SprintMessageStore
 
         followups = ",".join(str(value) for value in followup_ids) or "none"
         rendered_body = (
-            f"Conformance recorded: report_id={report_id}; "
-            f"followup_ids={followups}.\n\n{body}"
+            f"Sprint {sprint_id} completed by Reviewer conformance. "
+            f"conformance_report_id={report_id}; final_report_id={final_report_id}; "
+            f"followup_ids={followups}; outcome={terminal_outcome}.\n\n"
+            f"Reason: {reason}"
         )
-        return SprintMessageStore(self.con).send_in_transaction(
-            sprint_id,
-            to_participant_id=planner_participant_id,
+        return SprintMessageStore(self.con).send_to_shell_in_transaction(
+            planner_shell_id,
             message_kind="notification",
             body=rendered_body,
-            idempotency_key=f"{idempotency_key}:planner-handoff",
-            from_participant_id=reviewer_participant_id,
-            actionable=True,
+            idempotency_key=f"{idempotency_key}:planner-completed",
+            sender_shell_id=reviewer_shell_id,
             declared_type="re-enter",
         )
 
     @staticmethod
     def _required_wake_id(wake_id: int | None) -> int:
         if wake_id is None:
-            raise SprintInvariantError("Planner handoff has no delivery intent")
+            raise SprintInvariantError("Planner completion notice has no delivery intent")
         return int(wake_id)
 
     def _lifecycle(self, sprint_id: int) -> str:
@@ -753,6 +798,85 @@ class SprintCloseStore:
             int(report["report_id"]),
             tuple(int(row["followup_id"]) for row in rows),
         )
+
+    def _insert_final_report(
+        self,
+        sprint_id: int,
+        *,
+        reviewer_shell_id: int,
+        body: str,
+        idempotency_key: str,
+    ) -> int:
+        return int(
+            self.con.execute(
+                "INSERT INTO sprint_reports "
+                "(sprint_id,report_kind,author_shell_id,body,idempotency_key) "
+                "VALUES (?,'final',?,?,?)",
+                (
+                    sprint_id,
+                    reviewer_shell_id,
+                    body,
+                    f"{idempotency_key}:final-report",
+                ),
+            ).lastrowid
+        )
+
+    def _replay_final_report(
+        self,
+        sprint_id: int,
+        *,
+        reviewer_shell_id: int,
+        body: str,
+        idempotency_key: str,
+    ) -> int:
+        row = self.con.execute(
+            "SELECT report_id,author_shell_id,body FROM sprint_reports "
+            "WHERE sprint_id=? AND report_kind='final' AND idempotency_key=?",
+            (sprint_id, f"{idempotency_key}:final-report"),
+        ).fetchone()
+        if row is None or (
+            int(row["author_shell_id"]) != reviewer_shell_id or row["body"] != body
+        ):
+            raise SprintInvariantError(
+                "conformance idempotency key was reused with a different final report"
+            )
+        return int(row["report_id"])
+
+    def _replay_completion(
+        self,
+        sprint_id: int,
+        *,
+        reviewer_shell_id: int,
+        reason: str,
+        terminal_outcome: str,
+        idempotency_key: str,
+    ) -> None:
+        sprint = self.con.execute(
+            "SELECT lifecycle,terminal_outcome FROM sprints WHERE sprint_id=?",
+            (sprint_id,),
+        ).fetchone()
+        event = self.con.execute(
+            "SELECT payload FROM sprint_events WHERE sprint_id=? "
+            "AND event_type='lifecycle.completed' AND actor_kind='participant' "
+            "AND actor_shell_id=? ORDER BY event_id DESC LIMIT 1",
+            (sprint_id, reviewer_shell_id),
+        ).fetchone()
+        expected = {
+            "from": "armed",
+            "reason": reason,
+            "via": "conformance",
+            "idempotency_key": idempotency_key,
+        }
+        if (
+            sprint is None
+            or sprint["lifecycle"] != "completed"
+            or sprint["terminal_outcome"] != terminal_outcome
+            or event is None
+            or json.loads(event["payload"]) != expected
+        ):
+            raise SprintInvariantError(
+                "conformance idempotency key was reused with different completion"
+            )
 
     @classmethod
     def _normalize_finding(cls, finding: Any) -> dict[str, Any]:

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -1985,6 +1985,14 @@ class SprintLifecycleStore:
         )
         if result.rowcount != 1:
             raise SprintStateError("Sprint lifecycle changed concurrently")
+        if target in {"completed", "aborted"}:
+            self.con.execute(
+                "UPDATE sprint_liveness_expectations "
+                "SET resolved_at=datetime('now'),resolution=?,"
+                "next_evaluation_at=NULL "
+                "WHERE sprint_id=? AND resolved_at IS NULL",
+                (f"sprint.{target}", sprint_id),
+            )
 
     def _clear_coordinate_mode(
         self,

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -341,6 +341,55 @@ class SprintLifecycleStore:
             )
         return True
 
+    def complete_from_conformance_in_transaction(
+        self,
+        sprint_id: int,
+        reviewer_shell_id: int,
+        *,
+        reason: str,
+        terminal_outcome: str,
+        idempotency_key: str,
+    ) -> None:
+        """Project Reviewer conformance approval as an atomic terminal edge."""
+        if not self.con.in_transaction:
+            raise RuntimeError("conformance completion requires an active transaction")
+        reason = self._required_text(reason, "completion reason", 2000)
+        terminal_outcome = self._required_text(
+            terminal_outcome, "terminal outcome", 2000
+        )
+        idempotency_key = self._required_text(
+            idempotency_key, "conformance idempotency key", 220
+        )
+        sprint = self._sprint(sprint_id)
+        current = str(sprint["lifecycle"])
+        self._require_edge(current, "completed")
+        reviewer = self.con.execute(
+            "SELECT 1 FROM sprint_participants WHERE sprint_id=? AND shell_id=? "
+            "AND role='reviewer'",
+            (sprint_id, reviewer_shell_id),
+        ).fetchone()
+        if reviewer is None:
+            raise SprintAuthorityError(
+                "only a participating Reviewer may complete through conformance"
+            )
+        self._update_lifecycle(
+            sprint_id,
+            current=current,
+            target="completed",
+            outcome=terminal_outcome,
+        )
+        self._event(
+            sprint_id,
+            "lifecycle.completed",
+            LifecycleActor("participant", reviewer_shell_id),
+            {
+                "from": current,
+                "reason": reason,
+                "via": "conformance",
+                "idempotency_key": idempotency_key,
+            },
+        )
+
     def pause(
         self,
         sprint_id: int,

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -79,7 +79,8 @@
     ".super-coder/migrations/0173_force_new_wake_delivery.sql",
     ".super-coder/migrations/0174_reseed_force_new_wake_skills.sql",
     ".super-coder/migrations/0176_reseed_sprint_red_check_doctrine.sql",
-    ".super-coder/migrations/0178_reseed_sprint_watcher_state_skills.sql"
+    ".super-coder/migrations/0178_reseed_sprint_watcher_state_skills.sql",
+    ".super-coder/migrations/0179_reseed_atomic_sprint_closeout.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -1019,11 +1019,17 @@ class SprintCliApiTest(unittest.TestCase):
                     [{"severity": "Low", "title": "Note", "body": "Track it"}]
                 )
             ),
-            "--planner-handoff-file",
-            self.write("decision: conclude\nComplete the Sprint."),
+            "--final-report-file",
+            self.write("Final Sprint report"),
+            "--reason",
+            "Reviewer approved integrated conformance",
+            "--outcome",
+            "accepted",
             "--key",
             "surface-conformance",
         )
+        self.assertTrue(conformance["completed"])
+        self.assertIsInstance(conformance["final_report_id"], int)
         followup_id = conformance["followup_ids"][0]
         with self.assertRaisesRegex(SystemExit, "HTTP 403.*only FnB"):
             self.run_cli(
@@ -1047,23 +1053,6 @@ class SprintCliApiTest(unittest.TestCase):
             "accepted",
         )
         self.assertTrue(disposition["changed"])
-
-        completed = self.run_cli(
-            TOKENS["planner"],
-            "complete",
-            "--sprint",
-            str(sprint_id),
-            "--reason",
-            "close",
-            "--outcome",
-            "accepted",
-            "--report-file",
-            self.write("Final Sprint report"),
-            "--key",
-            "surface-final-report",
-        )
-        self.assertTrue(completed["changed"])
-        self.assertIsInstance(completed["report_id"], int)
 
         con = sqlite3.connect(self.db)
         try:
@@ -1416,12 +1405,17 @@ class SprintCliApiTest(unittest.TestCase):
             self.write("Integrated conformance complete."),
             "--findings-file",
             findings,
-            "--planner-handoff-file",
-            self.write("decision: conclude\nComplete the Sprint."),
+            "--final-report-file",
+            self.write("Reviewer-authored final Sprint report."),
+            "--reason",
+            "Reviewer approved integrated conformance",
+            "--outcome",
+            "accepted",
             "--key",
             "cli-conformance",
         )
         self.assertEqual(1, len(conformance["followup_ids"]))
+        self.assertTrue(conformance["completed"])
         report = self.run_cli(
             TOKENS["planner"],
             "compile-report",

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -1019,6 +1019,8 @@ class SprintCliApiTest(unittest.TestCase):
                     [{"severity": "Low", "title": "Note", "body": "Track it"}]
                 )
             ),
+            "--planner-handoff-file",
+            self.write("decision: conclude\nComplete the Sprint."),
             "--key",
             "surface-conformance",
         )
@@ -1414,6 +1416,8 @@ class SprintCliApiTest(unittest.TestCase):
             self.write("Integrated conformance complete."),
             "--findings-file",
             findings,
+            "--planner-handoff-file",
+            self.write("decision: conclude\nComplete the Sprint."),
             "--key",
             "cli-conformance",
         )

--- a/tests/test_sprint_close.py
+++ b/tests/test_sprint_close.py
@@ -14,14 +14,23 @@ ENGINE = ROOT / ".super-coder"
 MIGRATIONS = ENGINE / "migrations"
 MIGRATION = MIGRATIONS / "0150_sprint_close_reports.sql"
 SURFACE_MIGRATION = MIGRATIONS / "0152_sprint_surface_completion.sql"
-PLANNER_HANDOFF = "decision: conclude\nComplete the Sprint with the attached report."
+FINAL_REPORT = "Reviewer final report: integrated Sprint scope conforms."
+COMPLETION_REASON = "Reviewer approved integrated conformance"
+TERMINAL_OUTCOME = "accepted"
 
 
-def rendered_handoff(report_id: int, followup_ids: tuple[int, ...]) -> str:
+def rendered_notification(
+    sprint_id: int,
+    report_id: int,
+    final_report_id: int,
+    followup_ids: tuple[int, ...],
+) -> str:
     followups = ",".join(str(value) for value in followup_ids) or "none"
     return (
-        f"Conformance recorded: report_id={report_id}; "
-        f"followup_ids={followups}.\n\n{PLANNER_HANDOFF}"
+        f"Sprint {sprint_id} completed by Reviewer conformance. "
+        f"conformance_report_id={report_id}; final_report_id={final_report_id}; "
+        f"followup_ids={followups}; outcome={TERMINAL_OUTCOME}.\n\n"
+        f"Reason: {COMPLETION_REASON}"
     )
 
 sys.path[:0] = [str(ENGINE / "scripts"), str(ROOT / "tests")]
@@ -54,6 +63,11 @@ class SprintCloseCase(SprintDomainCase):
         }
         finding.update(overrides)
         return finding
+
+    def record_conformance(self, *args, **kwargs):
+        kwargs.setdefault("reason", COMPLETION_REASON)
+        kwargs.setdefault("terminal_outcome", TERMINAL_OUTCOME)
+        return self.close.record_conformance(*args, **kwargs)
 
 
 class SprintCloseMigrationTest(unittest.TestCase):
@@ -180,35 +194,62 @@ class ConformanceFollowupTest(SprintCloseCase):
             ValueError,
             "conformance body is 8001 characters; maximum is 8000",
         ):
-            self.close.record_conformance(
+            self.record_conformance(
                 self.sprint_id,
                 2,
                 body="x" * 8001,
                 findings=[],
-                planner_handoff=PLANNER_HANDOFF,
+                final_report=FINAL_REPORT,
                 idempotency_key="oversize-conformance",
             )
         with self.assertRaisesRegex(
             ValueError,
             "finding body is 8001 characters; maximum is 8000",
         ):
-            self.close.record_conformance(
+            self.record_conformance(
                 self.sprint_id,
                 2,
                 body="bounded",
                 findings=[self.finding(body="x" * 8001)],
-                planner_handoff=PLANNER_HANDOFF,
+                final_report=FINAL_REPORT,
                 idempotency_key="oversize-finding",
             )
-        with self.assertRaisesRegex(ValueError, "Planner handoff is required"):
-            self.close.record_conformance(
+        with self.assertRaisesRegex(ValueError, "final report body is required"):
+            self.record_conformance(
                 self.sprint_id,
                 2,
                 body="bounded",
                 findings=[],
-                planner_handoff=" ",
-                idempotency_key="empty-planner-handoff",
+                final_report=" ",
+                idempotency_key="empty-final-report",
             )
+        with self.assertRaisesRegex(
+            ValueError,
+            "final report body is 8001 characters; maximum is 8000",
+        ):
+            self.record_conformance(
+                self.sprint_id,
+                2,
+                body="bounded",
+                findings=[],
+                final_report="x" * 8001,
+                idempotency_key="oversize-final-report",
+            )
+        for field, error in (
+            ("reason", "completion reason is required"),
+            ("terminal_outcome", "terminal outcome is required"),
+        ):
+            kwargs = {
+                "body": "bounded",
+                "findings": [],
+                "final_report": FINAL_REPORT,
+                "reason": COMPLETION_REASON,
+                "terminal_outcome": TERMINAL_OUTCOME,
+                "idempotency_key": f"empty-{field}",
+                field: " ",
+            }
+            with self.assertRaisesRegex(ValueError, error):
+                self.close.record_conformance(self.sprint_id, 2, **kwargs)
         self.assertEqual(
             (0, 0),
             tuple(
@@ -220,12 +261,12 @@ class ConformanceFollowupTest(SprintCloseCase):
             ),
         )
 
-        conformance = self.close.record_conformance(
+        conformance = self.record_conformance(
             self.sprint_id,
             2,
             body="x" * 8000,
             findings=[self.finding(body="x" * 8000)],
-            planner_handoff=PLANNER_HANDOFF,
+                final_report=FINAL_REPORT,
             idempotency_key="bounded-conformance",
         )
         self.assertTrue(conformance.created)
@@ -266,31 +307,16 @@ class ConformanceFollowupTest(SprintCloseCase):
             )
         )
 
-        with self.assertRaisesRegex(
-            ValueError,
-            "final report body is 8001 characters; maximum is 8000",
-        ):
-            self.close.record_final_report(
-                self.sprint_id,
-                3,
-                body="x" * 8001,
-                idempotency_key="oversize-final",
-            )
         self.assertEqual(
-            0,
-            self.con.execute(
-                "SELECT COUNT(*) FROM sprint_reports WHERE sprint_id=? "
-                "AND report_kind='final'",
-                (self.sprint_id,),
-            ).fetchone()[0],
+            (1, FINAL_REPORT),
+            tuple(
+                self.con.execute(
+                    "SELECT COUNT(*),body FROM sprint_reports WHERE sprint_id=? "
+                    "AND report_kind='final'",
+                    (self.sprint_id,),
+                ).fetchone()
+            ),
         )
-        final = self.close.record_final_report(
-            self.sprint_id,
-            3,
-            body="x" * 8000,
-            idempotency_key="bounded-final",
-        )
-        self.assertTrue(final.created)
 
     def test_database_rejects_cross_sprint_report_and_spec_links(self):
         other_sprint_id, _ = self.create_sprint()
@@ -327,12 +353,12 @@ class ConformanceFollowupTest(SprintCloseCase):
             )
         ]
 
-        receipt = self.close.record_conformance(
+        receipt = self.record_conformance(
             self.sprint_id,
             2,
             body="Conformance found one integrated departure.",
             findings=[self.finding()],
-            planner_handoff=PLANNER_HANDOFF,
+            final_report=FINAL_REPORT,
             idempotency_key="conformance-pass-1",
         )
 
@@ -380,15 +406,27 @@ class ConformanceFollowupTest(SprintCloseCase):
         payload = json.loads(event["payload"])
         self.assertEqual(receipt.planner_message_id, payload["planner_message_id"])
         self.assertEqual(receipt.planner_wake_id, payload["planner_wake_id"])
-        handoff = self.con.execute(
-            "SELECT sender.shell_id,receiver.shell_id,message.work_unit_id,"
+        final_report = self.con.execute(
+            "SELECT report_kind,author_shell_id,body,idempotency_key "
+            "FROM sprint_reports WHERE report_id=?",
+            (receipt.final_report_id,),
+        ).fetchone()
+        self.assertEqual(
+            (
+                "final",
+                2,
+                FINAL_REPORT,
+                "conformance-pass-1:final-report",
+            ),
+            tuple(final_report),
+        )
+        notification = self.con.execute(
+            "SELECT message.sender_shell_id,message.receiver_shell_id,"
+            "message.sprint_id,message.from_participant_id,"
+            "message.to_participant_id,message.work_unit_id,"
             "message.message_kind,message.body,message.declared_type,"
             "message.actionable,message.idempotency_key "
             "FROM wake_message message "
-            "JOIN sprint_participants sender "
-            "ON sender.participant_id=message.from_participant_id "
-            "JOIN sprint_participants receiver "
-            "ON receiver.participant_id=message.to_participant_id "
             "WHERE message.message_id=?",
             (receipt.planner_message_id,),
         ).fetchone()
@@ -397,13 +435,43 @@ class ConformanceFollowupTest(SprintCloseCase):
                 2,
                 3,
                 None,
+                None,
+                None,
+                None,
                 "notification",
-                rendered_handoff(receipt.report_id, receipt.followup_ids),
+                rendered_notification(
+                    self.sprint_id,
+                    receipt.report_id,
+                    receipt.final_report_id,
+                    receipt.followup_ids,
+                ),
                 "re-enter",
-                1,
-                "conformance-pass-1:planner-handoff",
+                0,
+                "conformance-pass-1:planner-completed",
             ),
-            tuple(handoff),
+            tuple(notification),
+        )
+        lifecycle = self.con.execute(
+            "SELECT lifecycle,terminal_outcome,completed_at FROM sprints "
+            "WHERE sprint_id=?",
+            (self.sprint_id,),
+        ).fetchone()
+        self.assertEqual(("completed", TERMINAL_OUTCOME), tuple(lifecycle)[:2])
+        self.assertIsNotNone(lifecycle["completed_at"])
+        lifecycle_event = self.con.execute(
+            "SELECT actor_kind,actor_shell_id,payload FROM sprint_events "
+            "WHERE sprint_id=? AND event_type='lifecycle.completed'",
+            (self.sprint_id,),
+        ).fetchone()
+        self.assertEqual(("participant", 2), tuple(lifecycle_event)[:2])
+        self.assertEqual(
+            {
+                "from": "armed",
+                "reason": COMPLETION_REASON,
+                "via": "conformance",
+                "idempotency_key": "conformance-pass-1",
+            },
+            json.loads(lifecycle_event["payload"]),
         )
         self.assertEqual(
             [(receipt.planner_wake_id, receipt.planner_message_id)],
@@ -417,71 +485,71 @@ class ConformanceFollowupTest(SprintCloseCase):
             ],
         )
 
-    def test_accepted_planner_handoff_is_live_until_sprint_completion(self):
-        receipt = self.close.record_conformance(
+    def test_planner_receipt_is_informational_after_automatic_completion(self):
+        receipt = self.record_conformance(
             self.sprint_id,
             2,
             body="Integrated conformance is complete.",
             findings=[],
-            planner_handoff=PLANNER_HANDOFF,
+            final_report=FINAL_REPORT,
             idempotency_key="liveness-pass",
         )
+        self.assertTrue(receipt.completed)
         self.assertEqual(
-            "accepted",
-            sprint_message_delivery.SprintMessageStore(self.con).mark_read(
-                receipt.planner_message_id,
-                3,
-                sprint_id=self.sprint_id,
-            ),
-        )
-        self.assertEqual(
-            (None, None),
+            ("completed", TERMINAL_OUTCOME),
             tuple(
                 self.con.execute(
-                    "SELECT resolved_at,resolution "
-                    "FROM sprint_liveness_expectations WHERE message_id=?",
-                    (receipt.planner_message_id,),
+                    "SELECT lifecycle,terminal_outcome FROM sprints "
+                    "WHERE sprint_id=?",
+                    (self.sprint_id,),
                 ).fetchone()
             ),
         )
-
-        sprint_domain.SprintLifecycleStore(self.con).transition(
-            self.sprint_id,
-            "completed",
-            sprint_domain.LifecycleActor("planner", 3),
-            reason="Reviewer concluded",
-            terminal_outcome="accepted",
+        self.assertIsNone(
+            sprint_message_delivery.SprintMessageStore(self.con).mark_read(
+                receipt.planner_message_id,
+                3,
+            )
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_liveness_expectations "
+                "WHERE message_id=?",
+                (receipt.planner_message_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_liveness_expectations "
+                "WHERE sprint_id=? AND resolved_at IS NULL",
+                (self.sprint_id,),
+            ).fetchone()[0],
         )
 
-        resolved = self.con.execute(
-            "SELECT resolved_at,resolution,next_evaluation_at "
-            "FROM sprint_liveness_expectations WHERE message_id=?",
-            (receipt.planner_message_id,),
-        ).fetchone()
-        self.assertIsNotNone(resolved["resolved_at"])
-        self.assertEqual("sprint.completed", resolved["resolution"])
-        self.assertIsNone(resolved["next_evaluation_at"])
-
-    def test_planner_handoff_failure_rolls_back_every_closeout_write(self):
+    def test_planner_notification_failure_rolls_back_every_closeout_write(self):
         self.con.execute(
-            "CREATE TRIGGER reject_planner_handoff BEFORE INSERT ON wake_message "
-            "WHEN NEW.idempotency_key='rollback-pass:planner-handoff' "
-            "BEGIN SELECT RAISE(ABORT,'reject Planner handoff'); END"
+            "CREATE TRIGGER reject_planner_notification BEFORE INSERT ON wake_message "
+            "WHEN NEW.idempotency_key='rollback-pass:planner-completed' "
+            "BEGIN SELECT RAISE(ABORT,'reject Planner notification'); END"
         )
         self.con.commit()
 
-        with self.assertRaisesRegex(sqlite3.IntegrityError, "reject Planner handoff"):
-            self.close.record_conformance(
+        with self.assertRaisesRegex(
+            sqlite3.IntegrityError, "reject Planner notification"
+        ):
+            self.record_conformance(
                 self.sprint_id,
                 2,
                 body="This report must roll back.",
                 findings=[self.finding()],
-                planner_handoff=PLANNER_HANDOFF,
+                final_report=FINAL_REPORT,
                 idempotency_key="rollback-pass",
             )
 
         self.assertEqual(
-            (0, 0, 0, 0),
+            (0, 0, 0, 0, "armed", None),
             tuple(
                 self.con.execute(
                     "SELECT "
@@ -489,69 +557,88 @@ class ConformanceFollowupTest(SprintCloseCase):
                     "(SELECT COUNT(*) FROM sprint_followups WHERE sprint_id=?),"
                     "(SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
                     " AND event_type='conformance.recorded'),"
-                    "(SELECT COUNT(*) FROM wake_message WHERE sprint_id=? "
-                    " AND idempotency_key='rollback-pass:planner-handoff')",
+                    "(SELECT COUNT(*) FROM wake_message "
+                    " WHERE idempotency_key='rollback-pass:planner-completed'),"
+                    "lifecycle,terminal_outcome FROM sprints WHERE sprint_id=?",
                     (self.sprint_id,) * 4,
                 ).fetchone()
             ),
         )
 
     def test_retry_replays_exactly_and_conflicting_input_is_rejected(self):
-        first = self.close.record_conformance(
+        first = self.record_conformance(
             self.sprint_id,
             2,
             body="Review body",
             findings=[self.finding(severity="Low")],
-            planner_handoff=PLANNER_HANDOFF,
+            final_report=FINAL_REPORT,
             idempotency_key="same-pass",
         )
-        replay = self.close.record_conformance(
+        replay = self.record_conformance(
             self.sprint_id,
             2,
             body="Review body",
             findings=[self.finding(severity="Low")],
-            planner_handoff=PLANNER_HANDOFF,
+            final_report=FINAL_REPORT,
             idempotency_key="same-pass",
         )
         self.assertFalse(replay.created)
         self.assertEqual(first.report_id, replay.report_id)
         self.assertEqual(first.followup_ids, replay.followup_ids)
+        self.assertEqual(first.final_report_id, replay.final_report_id)
         self.assertEqual(first.planner_message_id, replay.planner_message_id)
         self.assertEqual(first.planner_wake_id, replay.planner_wake_id)
+        self.assertTrue(replay.completed)
 
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError, "different findings"
         ):
-            self.close.record_conformance(
+            self.record_conformance(
                 self.sprint_id,
                 2,
                 body="Review body",
                 findings=[self.finding(severity="Critical")],
-                planner_handoff=PLANNER_HANDOFF,
+                final_report=FINAL_REPORT,
                 idempotency_key="same-pass",
             )
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError,
-            "idempotency key was reused with different input",
+            "different final report",
         ):
-            self.close.record_conformance(
+            self.record_conformance(
                 self.sprint_id,
                 2,
                 body="Review body",
                 findings=[self.finding(severity="Low")],
-                planner_handoff="decision: conclude\nChanged final report.",
+                final_report="Changed final report.",
                 idempotency_key="same-pass",
             )
+        for field, value in (
+            ("reason", "Changed completion reason"),
+            ("terminal_outcome", "changed-outcome"),
+        ):
+            kwargs = {
+                "body": "Review body",
+                "findings": [self.finding(severity="Low")],
+                "final_report": FINAL_REPORT,
+                "idempotency_key": "same-pass",
+                field: value,
+            }
+            with self.assertRaisesRegex(
+                sprint_domain.SprintInvariantError, "different completion"
+            ):
+                self.record_conformance(self.sprint_id, 2, **kwargs)
         self.assertEqual(
-            (1, 1, 1),
+            (2, 1, 1, 1),
             tuple(
                 self.con.execute(
                     "SELECT "
-                    "(SELECT COUNT(*) FROM sprint_reports WHERE sprint_id=? "
-                    " AND report_kind='conformance'),"
+                    "(SELECT COUNT(*) FROM sprint_reports WHERE sprint_id=?),"
                     "(SELECT COUNT(*) FROM sprint_followups WHERE sprint_id=?),"
-                    "(SELECT COUNT(*) FROM wake_message WHERE sprint_id=? "
-                    " AND idempotency_key='same-pass:planner-handoff')",
+                    "(SELECT COUNT(*) FROM wake_message "
+                    " WHERE idempotency_key='same-pass:planner-completed'),"
+                    "(SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                    " AND event_type='lifecycle.completed')",
                     (self.sprint_id,) * 3,
                 ).fetchone()
             ),
@@ -559,12 +646,12 @@ class ConformanceFollowupTest(SprintCloseCase):
 
     def test_non_object_finding_is_rejected_before_any_report_write(self):
         with self.assertRaisesRegex(TypeError, "must be an object"):
-            self.close.record_conformance(
+            self.record_conformance(
                 self.sprint_id,
                 2,
                 body="Malformed findings",
                 findings=["not an object"],
-                planner_handoff=PLANNER_HANDOFF,
+                final_report=FINAL_REPORT,
                 idempotency_key="malformed-findings",
             )
         self.assertEqual(
@@ -584,23 +671,23 @@ class ConformanceFollowupTest(SprintCloseCase):
         with self.assertRaisesRegex(
             sprint_domain.SprintAuthorityError, "participating Reviewer"
         ):
-            self.close.record_conformance(
+            self.record_conformance(
                 self.sprint_id,
                 1,
                 body="Not a review",
                 findings=[],
-                planner_handoff=PLANNER_HANDOFF,
+                final_report=FINAL_REPORT,
                 idempotency_key="wrong-role",
             )
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError, "not bound"
         ):
-            self.close.record_conformance(
+            self.record_conformance(
                 self.sprint_id,
                 2,
                 body="Bad link",
                 findings=[self.finding(spec_document_id=999)],
-                planner_handoff=PLANNER_HANDOFF,
+                final_report=FINAL_REPORT,
                 idempotency_key="bad-link",
             )
         self.assertEqual(
@@ -710,7 +797,7 @@ class ConformanceFollowupTest(SprintCloseCase):
             "VALUES (5,'FnB','FNB','admin','prompt',1)"
         )
         self.con.commit()
-        receipt = self.close.record_conformance(
+        receipt = self.record_conformance(
             self.sprint_id,
             2,
             body="Two follow-ups",
@@ -718,7 +805,7 @@ class ConformanceFollowupTest(SprintCloseCase):
                 self.finding(title="Accepted"),
                 self.finding(title="Resolved"),
             ],
-            planner_handoff=PLANNER_HANDOFF,
+            final_report=FINAL_REPORT,
             idempotency_key="disposition-pass",
         )
         with self.assertRaisesRegex(
@@ -846,12 +933,12 @@ class EvidenceCompilerTest(SprintCloseCase):
             (registered_pr_id, "c" * 40),
         )
         self.con.commit()
-        self.close.record_conformance(
+        self.record_conformance(
             self.sprint_id,
             2,
             body="Integrated review",
             findings=[self.finding(severity="Low")],
-            planner_handoff=PLANNER_HANDOFF,
+            final_report=FINAL_REPORT,
             idempotency_key="compiler-review",
         )
 

--- a/tests/test_sprint_close.py
+++ b/tests/test_sprint_close.py
@@ -14,10 +14,20 @@ ENGINE = ROOT / ".super-coder"
 MIGRATIONS = ENGINE / "migrations"
 MIGRATION = MIGRATIONS / "0150_sprint_close_reports.sql"
 SURFACE_MIGRATION = MIGRATIONS / "0152_sprint_surface_completion.sql"
+PLANNER_HANDOFF = "decision: conclude\nComplete the Sprint with the attached report."
+
+
+def rendered_handoff(report_id: int, followup_ids: tuple[int, ...]) -> str:
+    followups = ",".join(str(value) for value in followup_ids) or "none"
+    return (
+        f"Conformance recorded: report_id={report_id}; "
+        f"followup_ids={followups}.\n\n{PLANNER_HANDOFF}"
+    )
 
 sys.path[:0] = [str(ENGINE / "scripts"), str(ROOT / "tests")]
 import sprint_close  # noqa: E402
 import sprint_domain  # noqa: E402
+import sprint_message_delivery  # noqa: E402
 from test_sprint_v2_domain import SprintDomainCase, apply_schema  # noqa: E402
 
 
@@ -175,6 +185,7 @@ class ConformanceFollowupTest(SprintCloseCase):
                 2,
                 body="x" * 8001,
                 findings=[],
+                planner_handoff=PLANNER_HANDOFF,
                 idempotency_key="oversize-conformance",
             )
         with self.assertRaisesRegex(
@@ -186,7 +197,17 @@ class ConformanceFollowupTest(SprintCloseCase):
                 2,
                 body="bounded",
                 findings=[self.finding(body="x" * 8001)],
+                planner_handoff=PLANNER_HANDOFF,
                 idempotency_key="oversize-finding",
+            )
+        with self.assertRaisesRegex(ValueError, "Planner handoff is required"):
+            self.close.record_conformance(
+                self.sprint_id,
+                2,
+                body="bounded",
+                findings=[],
+                planner_handoff=" ",
+                idempotency_key="empty-planner-handoff",
             )
         self.assertEqual(
             (0, 0),
@@ -204,6 +225,7 @@ class ConformanceFollowupTest(SprintCloseCase):
             2,
             body="x" * 8000,
             findings=[self.finding(body="x" * 8000)],
+            planner_handoff=PLANNER_HANDOFF,
             idempotency_key="bounded-conformance",
         )
         self.assertTrue(conformance.created)
@@ -310,6 +332,7 @@ class ConformanceFollowupTest(SprintCloseCase):
             2,
             body="Conformance found one integrated departure.",
             findings=[self.finding()],
+            planner_handoff=PLANNER_HANDOFF,
             idempotency_key="conformance-pass-1",
         )
 
@@ -354,6 +377,124 @@ class ConformanceFollowupTest(SprintCloseCase):
         self.assertEqual(
             [receipt.followup_ids[0]], json.loads(event["payload"])["followup_ids"]
         )
+        payload = json.loads(event["payload"])
+        self.assertEqual(receipt.planner_message_id, payload["planner_message_id"])
+        self.assertEqual(receipt.planner_wake_id, payload["planner_wake_id"])
+        handoff = self.con.execute(
+            "SELECT sender.shell_id,receiver.shell_id,message.work_unit_id,"
+            "message.message_kind,message.body,message.declared_type,"
+            "message.actionable,message.idempotency_key "
+            "FROM wake_message message "
+            "JOIN sprint_participants sender "
+            "ON sender.participant_id=message.from_participant_id "
+            "JOIN sprint_participants receiver "
+            "ON receiver.participant_id=message.to_participant_id "
+            "WHERE message.message_id=?",
+            (receipt.planner_message_id,),
+        ).fetchone()
+        self.assertEqual(
+            (
+                2,
+                3,
+                None,
+                "notification",
+                rendered_handoff(receipt.report_id, receipt.followup_ids),
+                "re-enter",
+                1,
+                "conformance-pass-1:planner-handoff",
+            ),
+            tuple(handoff),
+        )
+        self.assertEqual(
+            [(receipt.planner_wake_id, receipt.planner_message_id)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT wake_id,message_id FROM sprint_wake_messages "
+                    "WHERE message_id=?",
+                    (receipt.planner_message_id,),
+                )
+            ],
+        )
+
+    def test_accepted_planner_handoff_is_live_until_sprint_completion(self):
+        receipt = self.close.record_conformance(
+            self.sprint_id,
+            2,
+            body="Integrated conformance is complete.",
+            findings=[],
+            planner_handoff=PLANNER_HANDOFF,
+            idempotency_key="liveness-pass",
+        )
+        self.assertEqual(
+            "accepted",
+            sprint_message_delivery.SprintMessageStore(self.con).mark_read(
+                receipt.planner_message_id,
+                3,
+                sprint_id=self.sprint_id,
+            ),
+        )
+        self.assertEqual(
+            (None, None),
+            tuple(
+                self.con.execute(
+                    "SELECT resolved_at,resolution "
+                    "FROM sprint_liveness_expectations WHERE message_id=?",
+                    (receipt.planner_message_id,),
+                ).fetchone()
+            ),
+        )
+
+        sprint_domain.SprintLifecycleStore(self.con).transition(
+            self.sprint_id,
+            "completed",
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="Reviewer concluded",
+            terminal_outcome="accepted",
+        )
+
+        resolved = self.con.execute(
+            "SELECT resolved_at,resolution,next_evaluation_at "
+            "FROM sprint_liveness_expectations WHERE message_id=?",
+            (receipt.planner_message_id,),
+        ).fetchone()
+        self.assertIsNotNone(resolved["resolved_at"])
+        self.assertEqual("sprint.completed", resolved["resolution"])
+        self.assertIsNone(resolved["next_evaluation_at"])
+
+    def test_planner_handoff_failure_rolls_back_every_closeout_write(self):
+        self.con.execute(
+            "CREATE TRIGGER reject_planner_handoff BEFORE INSERT ON wake_message "
+            "WHEN NEW.idempotency_key='rollback-pass:planner-handoff' "
+            "BEGIN SELECT RAISE(ABORT,'reject Planner handoff'); END"
+        )
+        self.con.commit()
+
+        with self.assertRaisesRegex(sqlite3.IntegrityError, "reject Planner handoff"):
+            self.close.record_conformance(
+                self.sprint_id,
+                2,
+                body="This report must roll back.",
+                findings=[self.finding()],
+                planner_handoff=PLANNER_HANDOFF,
+                idempotency_key="rollback-pass",
+            )
+
+        self.assertEqual(
+            (0, 0, 0, 0),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_reports WHERE sprint_id=?),"
+                    "(SELECT COUNT(*) FROM sprint_followups WHERE sprint_id=?),"
+                    "(SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                    " AND event_type='conformance.recorded'),"
+                    "(SELECT COUNT(*) FROM wake_message WHERE sprint_id=? "
+                    " AND idempotency_key='rollback-pass:planner-handoff')",
+                    (self.sprint_id,) * 4,
+                ).fetchone()
+            ),
+        )
 
     def test_retry_replays_exactly_and_conflicting_input_is_rejected(self):
         first = self.close.record_conformance(
@@ -361,6 +502,7 @@ class ConformanceFollowupTest(SprintCloseCase):
             2,
             body="Review body",
             findings=[self.finding(severity="Low")],
+            planner_handoff=PLANNER_HANDOFF,
             idempotency_key="same-pass",
         )
         replay = self.close.record_conformance(
@@ -368,11 +510,14 @@ class ConformanceFollowupTest(SprintCloseCase):
             2,
             body="Review body",
             findings=[self.finding(severity="Low")],
+            planner_handoff=PLANNER_HANDOFF,
             idempotency_key="same-pass",
         )
         self.assertFalse(replay.created)
         self.assertEqual(first.report_id, replay.report_id)
         self.assertEqual(first.followup_ids, replay.followup_ids)
+        self.assertEqual(first.planner_message_id, replay.planner_message_id)
+        self.assertEqual(first.planner_wake_id, replay.planner_wake_id)
 
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError, "different findings"
@@ -382,14 +527,34 @@ class ConformanceFollowupTest(SprintCloseCase):
                 2,
                 body="Review body",
                 findings=[self.finding(severity="Critical")],
+                planner_handoff=PLANNER_HANDOFF,
+                idempotency_key="same-pass",
+            )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "idempotency key was reused with different input",
+        ):
+            self.close.record_conformance(
+                self.sprint_id,
+                2,
+                body="Review body",
+                findings=[self.finding(severity="Low")],
+                planner_handoff="decision: conclude\nChanged final report.",
                 idempotency_key="same-pass",
             )
         self.assertEqual(
-            1,
-            self.con.execute(
-                "SELECT COUNT(*) FROM sprint_followups WHERE sprint_id=?",
-                (self.sprint_id,),
-            ).fetchone()[0],
+            (1, 1, 1),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_reports WHERE sprint_id=? "
+                    " AND report_kind='conformance'),"
+                    "(SELECT COUNT(*) FROM sprint_followups WHERE sprint_id=?),"
+                    "(SELECT COUNT(*) FROM wake_message WHERE sprint_id=? "
+                    " AND idempotency_key='same-pass:planner-handoff')",
+                    (self.sprint_id,) * 3,
+                ).fetchone()
+            ),
         )
 
     def test_non_object_finding_is_rejected_before_any_report_write(self):
@@ -399,6 +564,7 @@ class ConformanceFollowupTest(SprintCloseCase):
                 2,
                 body="Malformed findings",
                 findings=["not an object"],
+                planner_handoff=PLANNER_HANDOFF,
                 idempotency_key="malformed-findings",
             )
         self.assertEqual(
@@ -423,6 +589,7 @@ class ConformanceFollowupTest(SprintCloseCase):
                 1,
                 body="Not a review",
                 findings=[],
+                planner_handoff=PLANNER_HANDOFF,
                 idempotency_key="wrong-role",
             )
         with self.assertRaisesRegex(
@@ -433,6 +600,7 @@ class ConformanceFollowupTest(SprintCloseCase):
                 2,
                 body="Bad link",
                 findings=[self.finding(spec_document_id=999)],
+                planner_handoff=PLANNER_HANDOFF,
                 idempotency_key="bad-link",
             )
         self.assertEqual(
@@ -550,6 +718,7 @@ class ConformanceFollowupTest(SprintCloseCase):
                 self.finding(title="Accepted"),
                 self.finding(title="Resolved"),
             ],
+            planner_handoff=PLANNER_HANDOFF,
             idempotency_key="disposition-pass",
         )
         with self.assertRaisesRegex(
@@ -682,6 +851,7 @@ class EvidenceCompilerTest(SprintCloseCase):
             2,
             body="Integrated review",
             findings=[self.finding(severity="Low")],
+            planner_handoff=PLANNER_HANDOFF,
             idempotency_key="compiler-review",
         )
 

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -493,6 +493,10 @@ class SprintLiveProof(unittest.TestCase):
             self.write_input("Integrated live proof matches its bound contract."),
             "--findings-file",
             self.write_input("[]"),
+            "--planner-handoff-file",
+            self.write_input(
+                "decision: conclude\nComplete from the recorded conformance."
+            ),
             "--key",
             f"proof:{sprint_id}:conformance",
         )

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -493,25 +493,19 @@ class SprintLiveProof(unittest.TestCase):
             self.write_input("Integrated live proof matches its bound contract."),
             "--findings-file",
             self.write_input("[]"),
-            "--planner-handoff-file",
+            "--final-report-file",
             self.write_input(
-                "decision: conclude\nComplete from the recorded conformance."
+                "Reviewer final report: the live proof matches its bound contract."
             ),
-            "--key",
-            f"proof:{sprint_id}:conformance",
-        )
-        self.assertEqual([], receipt["followup_ids"])
-        completed = self.run_cli(
-            3,
-            "complete",
-            "--sprint",
-            str(sprint_id),
             "--reason",
             "delivery and conformance complete",
             "--outcome",
             "accepted",
+            "--key",
+            f"proof:{sprint_id}:conformance",
         )
-        self.assertTrue(completed["changed"])
+        self.assertEqual([], receipt["followup_ids"])
+        self.assertTrue(receipt["completed"])
         packet = self.run_cli(
             3,
             "compile-report",

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -617,11 +617,14 @@ class SprintSkillTest(unittest.TestCase):
             reviewer.index("## Stop")
         ]
         for guidance in (
-            "--planner-handoff-file <conclude-handoff>",
+            "--final-report-file <final-report>",
+            "--reason <reason> --outcome <outcome>",
+            "final report id",
+            "completed state",
             "Planner message id",
             "Planner wake id",
-            "one actionable Planner Re-enter",
-            "send no second conclude message",
+            "informational engine-wide Planner Re-enter",
+            "send no conclude message",
         ):
             self.assertIn(guidance, clean)
         self.assertLess(
@@ -629,12 +632,12 @@ class SprintSkillTest(unittest.TestCase):
             clean.index("sc sprint record-conformance"),
         )
         normalized_planner = " ".join(planner.split())
-        self.assertIn("created atomically with conformance", normalized_planner)
-        self.assertIn("Do not wait for or request a second conclude message", planner)
-        self.assertIn("Completion resolves the accepted handoff", normalized_planner)
+        self.assertIn("clean `record-conformance` command atomically", normalized_planner)
+        self.assertIn("Do not run `complete`", planner)
+        self.assertIn("notification has no actionable liveness expectation", planner)
         normalized_close = " ".join(close.split())
-        self.assertIn("publishes an actionable Re-enter message", normalized_close)
-        self.assertIn("no second conclude message is sent", normalized_close)
+        self.assertIn("completes the Sprint", normalized_close)
+        self.assertIn("informational engine-wide Re-enter receipt", normalized_close)
 
     def test_skills_use_only_the_shipped_shell_command_surface(self):
         expected = {
@@ -729,18 +732,18 @@ class SprintSkillTest(unittest.TestCase):
 
         self.assertIn("## Reviewer decision actions", planner)
         self.assertIn(
-            "pause, cancel, re-enter, and conclude are reviewer decisions",
+            "pause, cancel, re-enter, and abort are reviewer decisions",
             normalized_planner,
         )
         self.assertIn("planner actions", normalized_planner)
         for command in (
             "sc sprint pause --sprint <id>",
             "sc sprint cancel-unit --sprint <id>",
-            "sc sprint complete --sprint <id>",
         ):
             self.assertIn(command, planner)
-        self.assertIn("reviewer-authored body", normalized_planner)
+        self.assertIn("reviewer-authored final report", normalized_planner)
         self.assertIn("does not author a second report", normalized_planner)
+        self.assertIn("do not run `complete`", normalized_planner)
         self.assertNotIn("you decide scope, sequencing, and recovery", normalized_planner)
 
         self.assertIn("## Control and conclude decisions", reviewer)
@@ -883,7 +886,7 @@ class SprintSkillTest(unittest.TestCase):
             "record-conformance": (
                 "--body-file",
                 "--findings-file",
-                "--planner-handoff-file",
+                "--final-report-file",
             ),
             "disposition-followup": ("--resolution-file",),
             "complete": ("--report-file",),
@@ -971,7 +974,7 @@ class SprintSkillTest(unittest.TestCase):
         planner = (ASSETS / "sprint_pln" / "SKILL.md").read_text()
         wave_handoff = planner[
             planner.index("Never dispatch the next wave"):
-            planner.index("On receipt, re-run `sc sprint inbox")
+            planner.index("On a clean completion receipt")
         ]
         self.assertIn(
             "merged-work handoff wake is the only normal next-wave dispatch trigger",
@@ -1000,12 +1003,15 @@ class SprintSkillTest(unittest.TestCase):
             "sc mem get flags --feature <feature-id> --resolved", reviewer
         )
 
-    def test_close_drains_before_complete_and_runs_nothing_after_success(self):
+    def test_close_drains_before_atomic_completion_and_stops_after_success(self):
         close = (ASSETS / "sprint_close" / "SKILL.md").read_text()
-        drain = close.index("Immediately before `complete`, re-run")
-        complete = close.index("sc sprint complete --sprint <id>")
-        self.assertLess(drain, complete)
-        after_success = close.split("After `complete` succeeds", 1)[1]
+        normalized_close = " ".join(close.split())
+        drain = normalized_close.index("Immediately before `record-conformance`")
+        terminal = normalized_close.index(
+            "performs the atomic command as the literal last action"
+        )
+        self.assertLess(drain, terminal)
+        after_success = close.split("After `record-conformance` succeeds", 1)[1]
         normalized = " ".join(after_success.lower().split())
         self.assertIn("run no further sprint command", normalized)
         self.assertNotIn("sc sprint ", after_success.lower())

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -28,6 +28,7 @@ V21_ROLE_SKILLS = set(SKILLS)
 HANDOFF_ROLE_SKILLS = {"sprint_dev", "sprint_rev", "sprint_pln"}
 CLOSEOUT_ROLE_SKILLS = {"sprint_close", "sprint_dev", "sprint_pln", "sprint_rev"}
 FORCE_NEW_ROLE_SKILLS = {"sprint_dev", "sprint_pln", "sprint_rev"}
+ATOMIC_CLOSEOUT_SKILLS = {"sprint_close", "sprint_pln", "sprint_rev"}
 
 ARTIFACT_PATH_RULE = """## Sprint artifact paths
 
@@ -376,6 +377,11 @@ class SprintSkillTest(unittest.TestCase):
             ).read_text()
             con.executescript(migration)
             con.executescript(migration)
+            for later_migration in sorted(
+                (ENGINE / "migrations").glob("*.sql")
+            ):
+                if later_migration.name > "0176_reseed_sprint_red_check_doctrine.sql":
+                    con.executescript(later_migration.read_text())
 
             parsed = seed_skills.parse_skill(ASSETS / "sprint_rev" / "SKILL.md")
             rows = con.execute(
@@ -416,6 +422,11 @@ class SprintSkillTest(unittest.TestCase):
             ).read_text()
             con.executescript(migration)
             con.executescript(migration)
+            for later_migration in sorted(
+                (ENGINE / "migrations").glob("*.sql")
+            ):
+                if later_migration.name > "0178_reseed_sprint_watcher_state_skills.sql":
+                    con.executescript(later_migration.read_text())
 
             for name in ("sprint_dev", "sprint_pln"):
                 with self.subTest(name=name):
@@ -443,6 +454,51 @@ class SprintSkillTest(unittest.TestCase):
                         "carries no evidence about the PR watcher", normalized
                     )
                     self.assertIn("Do not repeat", normalized)
+        finally:
+            con.close()
+
+    def test_atomic_closeout_reseed_matches_assets_and_replays_idempotently(self):
+        con = sqlite3.connect(":memory:")
+        try:
+            con.executescript((ENGINE / "schema.sql").read_text())
+            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name >= "0179_reseed_atomic_sprint_closeout.sql":
+                    break
+                con.executescript(migration.read_text())
+            placeholders = ",".join("?" for _ in ATOMIC_CLOSEOUT_SKILLS)
+            con.execute(
+                f"UPDATE skills SET description='stale',category='stale',"
+                f"command='stale',common=1,content='two separate writes',"
+                f"is_deleted=1 WHERE name IN ({placeholders})",
+                tuple(sorted(ATOMIC_CLOSEOUT_SKILLS)),
+            )
+
+            migration = (
+                ENGINE / "migrations" / "0179_reseed_atomic_sprint_closeout.sql"
+            ).read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+
+            for name in sorted(ATOMIC_CLOSEOUT_SKILLS):
+                with self.subTest(name=name):
+                    parsed = seed_skills.parse_skill(ASSETS / name / "SKILL.md")
+                    rows = con.execute(
+                        "SELECT description,category,command,common,content,is_deleted "
+                        "FROM skills WHERE name=?",
+                        (name,),
+                    ).fetchall()
+                    self.assertEqual(len(rows), 1)
+                    self.assertEqual(
+                        tuple(rows[0]),
+                        (
+                            parsed["description"],
+                            parsed["category"],
+                            parsed["command"],
+                            parsed["common"],
+                            parsed["content"],
+                            0,
+                        ),
+                    )
         finally:
             con.close()
 
@@ -551,6 +607,34 @@ class SprintSkillTest(unittest.TestCase):
         self.assertIn("The participating Reviewer generates the packet", close)
         self.assertIn("Planner and FnB compilation remain valid", close)
         self.assertIn("shared/sprints/sprint-<n>/evidence.json", close)
+
+    def test_clean_closeout_records_and_notifies_planner_in_one_command(self):
+        reviewer = (ASSETS / "sprint_rev" / "SKILL.md").read_text()
+        planner = (ASSETS / "sprint_pln" / "SKILL.md").read_text()
+        close = (ASSETS / "sprint_close" / "SKILL.md").read_text()
+        clean = reviewer[
+            reviewer.index("## Whole-Sprint conformance"):
+            reviewer.index("## Stop")
+        ]
+        for guidance in (
+            "--planner-handoff-file <conclude-handoff>",
+            "Planner message id",
+            "Planner wake id",
+            "one actionable Planner Re-enter",
+            "send no second conclude message",
+        ):
+            self.assertIn(guidance, clean)
+        self.assertLess(
+            clean.index("Before recording conformance, author the final Sprint report"),
+            clean.index("sc sprint record-conformance"),
+        )
+        normalized_planner = " ".join(planner.split())
+        self.assertIn("created atomically with conformance", normalized_planner)
+        self.assertIn("Do not wait for or request a second conclude message", planner)
+        self.assertIn("Completion resolves the accepted handoff", normalized_planner)
+        normalized_close = " ".join(close.split())
+        self.assertIn("publishes an actionable Re-enter message", normalized_close)
+        self.assertIn("no second conclude message is sent", normalized_close)
 
     def test_skills_use_only_the_shipped_shell_command_surface(self):
         expected = {
@@ -796,7 +880,11 @@ class SprintSkillTest(unittest.TestCase):
             "complete-unit": ("--result-file",),
             "request-review": ("--readiness-file",),
             "record-review": ("--body-file",),
-            "record-conformance": ("--body-file", "--findings-file"),
+            "record-conformance": (
+                "--body-file",
+                "--findings-file",
+                "--planner-handoff-file",
+            ),
             "disposition-followup": ("--resolution-file",),
             "complete": ("--report-file",),
         }.items():

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -753,6 +753,11 @@ class SprintSkillTest(unittest.TestCase):
         self.assertIn("author the final Sprint report", reviewer)
         self.assertIn("sc sprint record-conformance", reviewer)
         self.assertIn("sc sprint compile-report", reviewer)
+        self.assertIn(
+            "`decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, or `abort`",
+            reviewer,
+        )
+        self.assertNotIn("`cancel`, `conclude`", reviewer)
         self.assertNotIn("the planner decides whether", normalized_reviewer)
         self.assertNotIn("sc sprint pause --sprint <id>", reviewer)
 


### PR DESCRIPTION
## Summary

- make Reviewer `record-conformance` atomically store conformance, follow-ups,
  the Reviewer-authored final report, and the completed Sprint lifecycle
- resolve terminal liveness and record the lifecycle event in that same
  transaction
- queue an informational engine-wide Re-enter receipt to the originating
  Planner so notification remains deliverable after the Sprint is terminal
- converge Reviewer, Planner, and closeout skills through migration 0179

## Why

Conformance approval is already the Reviewer close decision. Requiring Planner
to accept a message and run `complete` introduced a second actor boundary where
the Sprint could remain armed after approval and require FnB cleanup.

The revised contract is:

1. Reviewer approves integrated conformance.
2. The approval command atomically records all close evidence and completes the
   Sprint.
3. Planner receives an informational completion receipt; no close action is
   required.

Decision #67 remains in force for pause, cancel, re-plan, and re-entry. Clean
conformance completion is the narrow exception recorded in decision #96.

Implements feature #31 and spec document #107.

## Verification

- expanded Sprint suite: 185 passed, 125 subtests passed
- full project suite: 1,822 passed
- `./sc verify`: passed, including clean rebuild and migration 0179
- targeted Ruff and `git diff --check`: passed

## Tooling notes

- `sc lint` path filtering is tracked in #1017
- the earlier unrelated browser timing flake is tracked in #1018; it passed in
  this full-suite run
