### PR TITLE
fix(kimi): accept v2 session state

### DIFF
--- a/.super-coder/adapters/kimi/adapter.json
+++ b/.super-coder/adapters/kimi/adapter.json
@@ -20,7 +20,8 @@
   "conversation": {
     "contract_version": 1,
     "minimum_cli_version": "0.30.0",
-    "verified_cli_version": "0.30.0",
+    "verified_cli_version": "0.33.0",
+    "maximum_cli_version_exclusive": "0.34.0",
     "driver": "kimi-print",
     "session_ref": {
       "source": "native-session-store",

--- a/.super-coder/scripts/conversation_adapters/kimi.py
+++ b/.super-coder/scripts/conversation_adapters/kimi.py
@@ -159,19 +159,47 @@ class KimiAdapter(ConversationAdapter):
                 f"cannot read Kimi session state: {state_path}",
                 retryable=True,
             ) from exc
-        stored = state.get("workDir") if isinstance(state, dict) else None
-        if not isinstance(stored, str) or not stored:
+        if not isinstance(state, dict):
             raise AdapterError(
                 "HARNESS_SESSION_INSPECTION_FAILED",
-                f"Kimi session state has no workDir: {state_path}",
+                f"Kimi session state has no workDir or cwd: {state_path}",
             )
-        stored_path = Path(stored)
-        if not stored_path.is_absolute():
+        stored_paths: dict[str, Path] = {}
+        for field in ("workDir", "cwd"):
+            if field not in state:
+                continue
+            stored = state[field]
+            if not isinstance(stored, str) or not stored:
+                raise AdapterError(
+                    "HARNESS_SESSION_INSPECTION_FAILED",
+                    f"Kimi session {field} is invalid: {state_path}",
+                )
+            stored_path = Path(stored)
+            if not stored_path.is_absolute():
+                raise AdapterError(
+                    "HARNESS_SESSION_INSPECTION_FAILED",
+                    f"Kimi session {field} is not absolute: {state_path}",
+                )
+            try:
+                stored_paths[field] = stored_path.resolve()
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise AdapterError(
+                    "HARNESS_SESSION_INSPECTION_FAILED",
+                    f"cannot resolve Kimi session {field}: {state_path}",
+                    retryable=True,
+                ) from exc
+        if not stored_paths:
             raise AdapterError(
                 "HARNESS_SESSION_INSPECTION_FAILED",
-                f"Kimi session workDir is not absolute: {state_path}",
+                f"Kimi session state has no workDir or cwd: {state_path}",
             )
-        return stored_path.resolve()
+        resolved = set(stored_paths.values())
+        if len(resolved) != 1:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"Kimi session workDir and cwd conflict: {state_path}",
+            )
+        return next(iter(resolved))
 
     @staticmethod
     def _wire_path(session_dir: Path) -> Path:

--- a/tests/fixtures/conversations/capability_probes.json
+++ b/tests/fixtures/conversations/capability_probes.json
@@ -64,7 +64,9 @@
       }
     },
     "kimi": {
-      "verified_cli_version": "0.30.0",
+      "minimum_cli_version": "0.30.0",
+      "verified_cli_version": "0.33.0",
+      "maximum_cli_version_exclusive": "0.34.0",
       "driver": "kimi-print",
       "native_ref_shape": "session_<uuid>",
       "observed_events": [

--- a/tests/fixtures/conversations/kimi/state-v2.json
+++ b/tests/fixtures/conversations/kimi/state-v2.json
@@ -1,0 +1,15 @@
+{
+  "id": "session_11111111-1111-4111-8111-111111111111",
+  "version": 2,
+  "cwd": "/synthetic/worktree",
+  "createdAt": 1700000000000,
+  "updatedAt": 1700000000123,
+  "archived": false,
+  "agents": {
+    "main": {
+      "homedir": "/synthetic/kimi/sessions/wd_synthetic/session_11111111-1111-4111-8111-111111111111/agents/main",
+      "type": "main"
+    }
+  },
+  "custom": {}
+}

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -38,6 +38,7 @@ from conversation_adapters import opencode as opencode_adapter
 from conversation_adapters.base import SubprocessRunner
 
 KIMI_FIXTURES = ROOT / "tests" / "fixtures" / "conversations" / "kimi"
+KIMI_V2_STATE = KIMI_FIXTURES / "state-v2.json"
 
 
 def kimi_step_event(
@@ -404,12 +405,22 @@ class FakeKimiRunner:
         after_prompt: list[dict[str, Any]] | None = None,
         directory: str = "wd_test",
         append: bool = False,
+        state_schema: str = "legacy",
     ) -> tuple[Path, Path]:
         session = root / directory / session_ref
         wire = session / "agents" / "main" / "wire.jsonl"
         wire.parent.mkdir(parents=True, exist_ok=True)
+        if state_schema == "legacy":
+            state = {"workDir": str(worktree)}
+        elif state_schema == "v2":
+            state = json.loads(KIMI_V2_STATE.read_text())
+            state["id"] = session_ref
+            state["cwd"] = str(worktree)
+            state["agents"]["main"]["homedir"] = str(wire.parent)
+        else:
+            raise AssertionError(f"unsupported Kimi state schema: {state_schema}")
         (session / "state.json").write_text(
-            json.dumps({"workDir": str(worktree)}),
+            json.dumps(state),
             encoding="utf-8",
         )
         prompt = (
@@ -462,6 +473,7 @@ class FakeKimiRunner:
                     after_prompt=plan.get("after_prompt"),
                     directory=f"wd_test_{index}",
                     append=resume and index == 0,
+                    state_schema=plan.get("state_schema", "legacy"),
                 )
                 if index == 0:
                     wire = candidate_wire
@@ -1243,6 +1255,169 @@ class ConversationAdapterTest(unittest.TestCase):
         self.assertEqual(
             list(adapter.stream(resumed))[-1].type,
             "run.completed",
+        )
+
+    def test_kimi_state_accepts_legacy_v2_and_equal_dual_fields(self) -> None:
+        session = self.root / "kimi-state-valid"
+        session.mkdir()
+        state_path = session / "state.json"
+        v2_state = json.loads(KIMI_V2_STATE.read_text())
+        v2_state["cwd"] = str(self.root)
+        valid_states = {
+            "legacy": {"workDir": str(self.root)},
+            "v2": v2_state,
+            "equal dual": {
+                "workDir": str(self.root),
+                "cwd": str(self.root / "synthetic" / ".."),
+            },
+        }
+
+        for label, state in valid_states.items():
+            with self.subTest(label=label):
+                state_path.write_text(json.dumps(state), encoding="utf-8")
+                self.assertEqual(
+                    KimiAdapter._state_worktree(session),
+                    self.root,
+                )
+
+    def test_kimi_state_rejects_invalid_or_conflicting_fields(self) -> None:
+        session = self.root / "kimi-state-invalid"
+        session.mkdir()
+        state_path = session / "state.json"
+        invalid_states = {
+            "missing": {},
+            "legacy non-string": {"workDir": 7},
+            "v2 empty": {"cwd": ""},
+            "v2 relative": {"cwd": "relative/worktree"},
+            "legacy invalid alongside v2": {
+                "workDir": None,
+                "cwd": str(self.root),
+            },
+            "v2 invalid alongside legacy": {
+                "workDir": str(self.root),
+                "cwd": [],
+            },
+            "conflicting": {
+                "workDir": str(self.root),
+                "cwd": str(self.root / "other"),
+            },
+            "unresolvable": {"cwd": "/\0"},
+        }
+
+        for label, state in invalid_states.items():
+            with self.subTest(label=label):
+                state_path.write_text(json.dumps(state), encoding="utf-8")
+                with self.assertRaises(AdapterError) as raised:
+                    KimiAdapter._state_worktree(session)
+                self.assertEqual(
+                    raised.exception.code,
+                    "HARNESS_SESSION_INSPECTION_FAILED",
+                )
+
+    def test_kimi_state_rejects_malformed_or_unreadable_json(self) -> None:
+        malformed = self.root / "kimi-state-malformed"
+        malformed.mkdir()
+        (malformed / "state.json").write_text("{", encoding="utf-8")
+        with self.assertRaises(AdapterError) as malformed_error:
+            KimiAdapter._state_worktree(malformed)
+        self.assertEqual(
+            malformed_error.exception.code,
+            "HARNESS_SESSION_INSPECTION_FAILED",
+        )
+
+        unreadable = self.root / "kimi-state-unreadable"
+        (unreadable / "state.json").mkdir(parents=True)
+        with self.assertRaises(AdapterError) as unreadable_error:
+            KimiAdapter._state_worktree(unreadable)
+        self.assertEqual(
+            unreadable_error.exception.code,
+            "HARNESS_SESSION_INSPECTION_FAILED",
+        )
+
+    def test_kimi_v2_state_supports_full_turn_lifecycle_and_exact_slice(
+        self,
+    ) -> None:
+        adapter, runner = self.build("kimi")
+        runner.queue(
+            state_schema="v2",
+            prompt_time=6000,
+            after_prompt=[
+                kimi_step_event("step.end", finish_reason="end_turn"),
+                {
+                    "type": "usage.record",
+                    "usageScope": "turn",
+                    "usage": {"inputOther": 4, "output": 2},
+                },
+                {
+                    "type": "turn.prompt",
+                    "input": [{"type": "text", "text": "later"}],
+                    "origin": {"kind": "user"},
+                    "time": 6001,
+                },
+                {"type": "turn.cancel", "time": 6002},
+            ],
+        )
+
+        turn = adapter.start(self.context, "v2 session")
+
+        state = json.loads(
+            (Path(turn.metadata["session_path"]) / "state.json").read_text()
+        )
+        self.assertEqual(
+            set(state),
+            {
+                "id",
+                "version",
+                "cwd",
+                "createdAt",
+                "updatedAt",
+                "archived",
+                "agents",
+                "custom",
+            },
+        )
+        self.assertEqual(state["version"], 2)
+        self.assertEqual(state["cwd"], str(self.root))
+        self.assertNotIn("workDir", state)
+        self.assertEqual(turn.worktree, self.root)
+        self.assertEqual(
+            Path(turn.metadata["wire_path"]),
+            Path(turn.metadata["session_path"])
+            / "agents"
+            / "main"
+            / "wire.jsonl",
+        )
+
+        turn.opaque.returncode = 0
+        result = adapter.reconcile(turn, self.context)
+        self.assertEqual(result.outcome, "succeeded")
+        self.assertTrue(result.proven)
+        self.assertNotEqual(
+            result.outcome,
+            "cancelled",
+            "a later prompt's cancellation must not enter the exact run slice",
+        )
+        inspection = adapter.inspect(turn.session_ref, self.context)
+        self.assertTrue(inspection.exists)
+        self.assertEqual(inspection.state, "idle")
+        self.assertEqual(inspection.metadata["last_prompt"], "later")
+
+        runner.queue(state_schema="v2", prompt_time=6003)
+        resumed = adapter.resume(turn.session_ref, self.context, "resume v2")
+        self.assertEqual(resumed.session_ref, turn.session_ref)
+        self.assertGreater(
+            resumed.metadata["prompt_offset"],
+            turn.metadata["prompt_offset"],
+        )
+        acknowledged = adapter.interrupt(resumed)
+        self.assertTrue(acknowledged.acknowledged)
+        self.assertEqual(resumed.opaque.signals, [signal.SIGINT])
+        interrupted = adapter.reconcile(resumed, self.context)
+        self.assertEqual(interrupted.outcome, "cancelled")
+        self.assertTrue(interrupted.proven)
+        self.assertEqual(
+            adapter.inspect(resumed.session_ref, self.context).state,
+            "idle",
         )
 
     def test_kimi_new_session_discovery_filters_and_reaps_failures(

--- a/tests/test_conversation_capabilities.py
+++ b/tests/test_conversation_capabilities.py
@@ -71,11 +71,12 @@ class ConversationCapabilityContractTest(unittest.TestCase):
                     conversation["verified_cli_version"],
                     probe["verified_cli_version"],
                 )
-                self.assertEqual(
-                    conversation["minimum_cli_version"],
-                    conversation["verified_cli_version"],
-                    "the spike uses the conservative live-probed version as its floor",
-                )
+                if harness != "kimi":
+                    self.assertEqual(
+                        conversation["minimum_cli_version"],
+                        conversation["verified_cli_version"],
+                        "the spike uses the live-probed version as its floor",
+                    )
                 self.assertEqual(conversation["driver"], probe["driver"])
                 self.assertEqual(
                     set(conversation["capabilities"]),
@@ -138,6 +139,36 @@ class ConversationCapabilityContractTest(unittest.TestCase):
     def test_kimi_uses_prompt_mode_and_native_store_identity(self) -> None:
         conversation = self.adapter("kimi")["conversation"]
         probe = self.probes["required_harnesses"]["kimi"]
+        self.assertEqual(
+            {
+                key: conversation[key]
+                for key in (
+                    "minimum_cli_version",
+                    "verified_cli_version",
+                    "maximum_cli_version_exclusive",
+                )
+            },
+            {
+                "minimum_cli_version": "0.30.0",
+                "verified_cli_version": "0.33.0",
+                "maximum_cli_version_exclusive": "0.34.0",
+            },
+        )
+        self.assertEqual(
+            {
+                key: probe[key]
+                for key in (
+                    "minimum_cli_version",
+                    "verified_cli_version",
+                    "maximum_cli_version_exclusive",
+                )
+            },
+            {
+                "minimum_cli_version": "0.30.0",
+                "verified_cli_version": "0.33.0",
+                "maximum_cli_version_exclusive": "0.34.0",
+            },
+        )
         self.assertEqual(conversation["driver"], "kimi-print")
         self.assertEqual(conversation["session_ref"], {
             "source": "native-session-store",


### PR DESCRIPTION
## Outcome

Kimi conversation discovery now accepts both supported session-state schemas: legacy absolute `workDir` and v2 absolute `cwd`. Dual-field states must resolve to the same path; malformed, missing, empty, relative, conflicting, and unreadable values fail closed with `HARNESS_SESSION_INSPECTION_FAILED`.

The adapter continues to compare the resolved state path exactly with the assigned worktree and uses only `agents/main/wire.jsonl` for run evidence. No directory-hash inference was added.

## Compatibility probe

- Host runtime: Kimi 0.33.0
- Manifest range: `[0.30.0, 0.34.0)`
- Verified version: 0.33.0
- Sanitized fixture preserves the observed v2 key shape without user paths or ids

## Regression proof

Before the adapter patch, the new v2 discovery test failed with:

`HARNESS_SESSION_DISCOVERY_FAILED: Kimi session state has no workDir`

After the patch:

- `python3 tests/test_conversation_adapters.py`: 38 passed
- `python3 tests/test_conversation_capabilities.py`: 5 passed
- `./sc test`: 1,946 passed, 1 skipped
- `./sc render-check`: passed
- critical Ruff, JSON validation, and `git diff --check`: passed
- direct adapter smoke against the real host Kimi 0.33.0 v2 session: passed
- `./sc verify`: passed in a disposable standalone clone of exact head `7ed79432c750d481dfa4ac7e2c1dd61d54d0aa4b`

The linked-worktree invocation itself refused safely under known issue #769, so the destructive gate was run against the exact pushed head in isolation.

Addresses #1055.

Spec #116, task #341.