### PR TITLE
feat(sprint): exhaust terminal pickup episodes

### DIFF
--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -117,6 +117,22 @@ _EVENT_FIELDS = {
     "conformance.recorded": frozenset({"report_id", "followup_count", "followup_ids"}),
     "final_report.recorded": frozenset({"report_id"}),
     "followup.dispositioned": frozenset({"followup_id", "disposition", "resolution"}),
+    "wake.pickup_exhausted": frozenset(
+        {
+            "sprint_id",
+            "participant_id",
+            "shell",
+            "role",
+            "work_unit_id",
+            "message_id",
+            "wake_id",
+            "conversation_id",
+            "run_state",
+            "error_code",
+            "failure_class",
+            "attempt_count",
+        }
+    ),
     "wake.requeued": frozenset({"failed_wake_id", "replacement_wake_id"}),
     "liveness.nudged": frozenset(
         {"expectation_message_id", "silence_episode", "nudge_message_id"}

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -1184,6 +1184,12 @@ class SprintLifecycleStore:
         rows = self.con.execute(
             "SELECT w.wake_id,w.sprint_id AS wake_sprint_id,"
             "m.to_participant_id AS participant_id,w.state,w.idempotency_key,"
+            "w.attempt_count AS wake_attempt_count,MIN(m.message_id) AS message_id,"
+            "(SELECT detail.work_unit_id FROM wake_message detail "
+            "JOIN sprint_wake_messages detail_wm "
+            "ON detail_wm.message_id=detail.message_id "
+            "WHERE detail_wm.wake_id=w.wake_id AND detail.read_at IS NULL "
+            "ORDER BY detail.message_id LIMIT 1) AS work_unit_id,"
             "CASE WHEN COUNT(*)=COUNT(m.delivered_at) "
             "THEN MIN(m.delivered_at) END AS delivered_at "
             "FROM sprint_wake_outbox w "
@@ -1220,12 +1226,7 @@ class SprintLifecycleStore:
             )
             busy_prefix = f"sprint-recovery:{sprint_id}:busy:"
             busy_recovery = wake_key.startswith(busy_prefix)
-            if (
-                (wake_key.startswith("sprint-recovery:") and not busy_recovery)
-                or ":failed-wake:" in wake_key
-            ):
-                continue
-            if busy_recovery and not shell_busy:
+            if ":failed-wake:" in wake_key:
                 continue
             if self._participant_has_pickup_turn(participant_id):
                 continue
@@ -1289,6 +1290,53 @@ class SprintLifecycleStore:
                     "backoff_seconds": backoff_seconds,
                 }
             else:
+                if row["state"] == "delivered":
+                    episode_attempt, lineage_valid = self._pickup_episode_attempt(
+                        sprint_id,
+                        old_wake_id,
+                    )
+                    evidence_valid = self._pickup_turn_evidence_valid(row, turn)
+                    run_state = turn["run_state"]
+                    if not evidence_valid or not lineage_valid:
+                        pause_reason = "wake_pickup_evidence_invalid"
+                        failure_class = "evidence_invalid"
+                        error_code = "WAKE_PICKUP_EVIDENCE_INVALID"
+                    elif run_state == "unknown":
+                        pause_reason = "wake_pickup_unknown"
+                        failure_class = "native_unknown"
+                        error_code = str(turn["error_code"])
+                    elif episode_attempt >= 2 and run_state == "failed":
+                        pause_reason = "wake_pickup_failed"
+                        failure_class = "native_failed"
+                        error_code = str(turn["error_code"])
+                    elif episode_attempt >= 2 and run_state == "succeeded":
+                        pause_reason = "wake_pickup_unread"
+                        failure_class = "terminal_unread"
+                        error_code = "WAKE_PICKUP_UNREAD"
+                    else:
+                        pause_reason = None
+
+                    if pause_reason is not None:
+                        pause_receipt = self._exhaust_pickup_in_transaction(
+                            sprint_id=sprint_id,
+                            participant_id=participant_id,
+                            wake_id=old_wake_id,
+                            message_id=int(row["message_id"]),
+                            work_unit_id=(
+                                int(row["work_unit_id"])
+                                if row["work_unit_id"] is not None
+                                else None
+                            ),
+                            turn=turn,
+                            pause_reason=pause_reason,
+                            error_code=error_code,
+                            failure_class=failure_class,
+                            attempt_count=episode_attempt,
+                        )
+                        return _WakeReconcileResult(
+                            tuple(sorted(set(replacements))),
+                            pause_receipt,
+                        )
                 recovery_key = (
                     f"sprint-resume:{sprint_id}:failed-wake:{old_wake_id}"
                     if row["state"] == "failed"
@@ -1468,6 +1516,203 @@ class SprintLifecycleStore:
             )
             replacements.append(new_wake_id)
         return _WakeReconcileResult(tuple(sorted(set(replacements))))
+
+    def _pickup_episode_attempt(
+        self,
+        sprint_id: int,
+        wake_id: int,
+    ) -> tuple[int, bool]:
+        rows = self.con.execute(
+            "SELECT payload FROM sprint_events WHERE sprint_id=? "
+            "AND event_type='wake.requeued' "
+            "AND json_extract(payload,'$.replacement_wake_id')=? "
+            "ORDER BY event_id",
+            (sprint_id, wake_id),
+        ).fetchall()
+        pickup_rows = []
+        for row in rows:
+            payload = json.loads(row["payload"])
+            if payload.get("classification") in {
+                "shell_busy",
+                "contention_episode_reset",
+            }:
+                continue
+            if payload.get("prior_wake_id") is not None:
+                pickup_rows.append(payload)
+        if not pickup_rows:
+            return 1, True
+        valid = all(
+            isinstance(payload.get("prior_wake_id"), int)
+            and self.con.execute(
+                "SELECT 1 FROM sprint_wake_outbox WHERE wake_id=?",
+                (payload["prior_wake_id"],),
+            ).fetchone()
+            is not None
+            for payload in pickup_rows
+        )
+        return 2, valid
+
+    @staticmethod
+    def _pickup_turn_evidence_valid(
+        wake: sqlite3.Row,
+        turn: dict[str, str | int | bool | None],
+    ) -> bool:
+        if turn["turn_live"]:
+            return True
+        if (
+            turn["attempt_number"] is None
+            or turn["target_conversation_id"] is None
+            or turn["attempt_outcome"] != "delivered"
+            or int(turn["attempt_number"]) != int(wake["wake_attempt_count"])
+        ):
+            return False
+        run_state = turn["run_state"]
+        message_state = turn["message_state"]
+        error_code = turn["error_code"]
+        if run_state == "succeeded":
+            return message_state == "completed" and error_code is None
+        if run_state in {"failed", "unknown"}:
+            return (
+                message_state == "failed"
+                and isinstance(error_code, str)
+                and bool(error_code.strip())
+            )
+        return False
+
+    def _exhaust_pickup_in_transaction(
+        self,
+        *,
+        sprint_id: int,
+        participant_id: int,
+        wake_id: int,
+        message_id: int,
+        work_unit_id: int | None,
+        turn: dict[str, str | int | bool | None],
+        pause_reason: str,
+        error_code: str,
+        failure_class: str,
+        attempt_count: int,
+    ) -> PauseReceipt:
+        participant = self.con.execute(
+            "SELECT p.role,sh.shortname,sh.shell_id "
+            "FROM sprint_participants p JOIN shells sh USING (shell_id) "
+            "WHERE p.sprint_id=? AND p.participant_id=?",
+            (sprint_id, participant_id),
+        ).fetchone()
+        if participant is None:
+            raise SprintInvariantError("Sprint participant does not exist")
+        conversation_id = (
+            str(turn["target_conversation_id"])
+            if turn["target_conversation_id"] is not None
+            else None
+        )
+        facts = {
+            "sprint_id": sprint_id,
+            "participant_id": participant_id,
+            "shell": str(participant["shortname"]),
+            "role": str(participant["role"]),
+            "work_unit_id": work_unit_id,
+            "message_id": message_id,
+            "wake_id": wake_id,
+            "conversation_id": conversation_id,
+            "run_state": turn["run_state"],
+            "error_code": error_code,
+            "failure_class": failure_class,
+            "attempt_count": attempt_count,
+        }
+        self._event(
+            sprint_id,
+            "wake.pickup_exhausted",
+            LifecycleActor("system"),
+            facts,
+        )
+        closed_conversation_id = self._close_exhausted_pickup_conversation(
+            participant_id=participant_id,
+            wake_id=wake_id,
+            conversation_id=conversation_id,
+            run_state=turn["run_state"],
+        )
+        detail = {
+            **facts,
+            "error_detail": str(turn["error_detail"] or "")[:2000] or None,
+        }
+        receipt = self._pause_in_transaction(
+            self._sprint(sprint_id),
+            LifecycleActor("system"),
+            reason=pause_reason,
+            detail=detail,
+            notice_body=(
+                f"Sprint {sprint_id} paused: pickup {failure_class} for "
+                f"{participant['role']} shell {participant['shortname']} "
+                f"(work unit {work_unit_id}, message {message_id}, wake {wake_id}, "
+                f"{error_code}). Inspect the pause report, repair the named route "
+                "or service, then use an authorized resume."
+            ),
+        )
+        if closed_conversation_id is None:
+            return receipt
+        return PauseReceipt(
+            receipt.changed,
+            receipt.report_id,
+            receipt.interrupt_run_ids,
+            tuple(
+                sorted(
+                    set(receipt.notification_conversation_ids)
+                    | {closed_conversation_id}
+                )
+            ),
+        )
+
+    def _close_exhausted_pickup_conversation(
+        self,
+        *,
+        participant_id: int,
+        wake_id: int,
+        conversation_id: str | None,
+        run_state: str | int | bool | None,
+    ) -> str | None:
+        if conversation_id is None or run_state not in {"failed", "unknown"}:
+            return None
+        row = self.con.execute(
+            "SELECT c.state,c.shell_id FROM conversations c "
+            "JOIN sprint_participants p ON p.shell_id=c.shell_id "
+            "WHERE c.conversation_id=? AND p.participant_id=?",
+            (conversation_id, participant_id),
+        ).fetchone()
+        if row is None or row["state"] != "error":
+            return None
+        shell_id = int(row["shell_id"])
+        active = active_chat_registry.get(self.con, shell_id)
+        if active is not None and active.chat_id == conversation_id:
+            if active_chat_registry.has_live_process(active):
+                return None
+            closed = active_chat_registry.close_for_displacement(
+                self.con,
+                shell_id,
+                allow_live_process=False,
+            )
+            if closed is None:
+                return None
+        else:
+            changed = self.con.execute(
+                "UPDATE conversations SET state='closed',closed_at=datetime('now'),"
+                "last_activity_at=datetime('now'),version=version+1 "
+                "WHERE conversation_id=? AND state='error'",
+                (conversation_id,),
+            ).rowcount
+            if changed != 1:
+                return None
+        sprint_participant_chats._append_event(
+            self.con,
+            conversation_id,
+            "conversation.closed",
+            {
+                "reason": "wake pickup exhausted",
+                "state": "closed",
+                "wake_id": wake_id,
+            },
+        )
+        return conversation_id
 
     @staticmethod
     def _busy_recovery_origin(wake_key: str, sprint_id: int) -> int:

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -165,6 +165,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         wake_id: int,
         *,
         error_code: str,
+        run_state: str = "failed",
         slot_state: str = "busy",
     ) -> None:
         def deliver(conversation_id: str, prompt: str, key: str) -> str:
@@ -187,19 +188,25 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                     "INSERT INTO conversation_runs "
                     "(conversation_id,shell_id,trigger_message_id,state,"
                     "lease_owner,lease_expires_at,started_at,ended_at,error_code,"
-                    "error_detail) SELECT ?,shell_id,?,'failed','test-broker',"
+                    "error_detail) SELECT ?,shell_id,?,?,'test-broker',"
                     "'2026-08-01 00:00:01','2026-08-01 00:00:00',"
                     "'2026-08-01 00:00:01',?,? FROM conversations "
                     "WHERE conversation_id=?",
                     (
                         conversation_id,
                         message_id,
+                        run_state,
                         error_code,
                         detail,
                         conversation_id,
                     ),
                 ).lastrowid
             )
+            for state in ("queued", "running", "error"):
+                self.con.execute(
+                    "UPDATE conversations SET state=? WHERE conversation_id=?",
+                    (state, conversation_id),
+                )
             self.con.commit()
             return f"conversation-run:{run_id}"
 
@@ -952,7 +959,71 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ),
         )
 
-    def test_non_busy_failed_turn_keeps_one_shot_recovery(self):
+    def test_unknown_first_turn_pauses_without_replacement(self):
+        message = self.send("unknown-first-turn")
+        original = int(message.wake_id)
+        self.fail_wake_turn(
+            original,
+            error_code="HARNESS_SESSION_DISCOVERY_FAILED",
+            run_state="unknown",
+        )
+        unknown_conversation = str(
+            self.con.execute(
+                "SELECT target_conversation_id FROM sprint_wake_attempts "
+                "WHERE wake_id=? ORDER BY attempt_number DESC LIMIT 1",
+                (original,),
+            ).fetchone()[0]
+        )
+
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="unknown-first-turn",
+            ),
+        )
+
+        self.assertEqual(
+            ("paused", None, original, 0),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,m.read_at,wm.wake_id,"
+                    "(SELECT COUNT(*) FROM sprint_wake_outbox recovery "
+                    "WHERE recovery.sprint_id=s.sprint_id "
+                    "AND recovery.idempotency_key LIKE 'sprint-recovery:%') "
+                    "FROM sprints s JOIN wake_message m ON m.sprint_id=s.sprint_id "
+                    "JOIN sprint_wake_messages wm USING (message_id) "
+                    "WHERE s.sprint_id=? AND m.message_id=?",
+                    (self.sprint_id, message.message_id),
+                ).fetchone()
+            ),
+        )
+        exhausted = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='wake.pickup_exhausted'",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual(
+            {
+                "attempt_count": 1,
+                "conversation_id": unknown_conversation,
+                "error_code": "HARNESS_SESSION_DISCOVERY_FAILED",
+                "failure_class": "native_unknown",
+                "message_id": message.message_id,
+                "participant_id": self.developer_id,
+                "role": "developer",
+                "run_state": "unknown",
+                "shell": "DEV1",
+                "sprint_id": self.sprint_id,
+                "wake_id": original,
+                "work_unit_id": self.unit_id,
+            },
+            exhausted,
+        )
+
+    def test_non_busy_failed_turn_replaces_once_then_exhausts_atomically(self):
         wake_count = self.con.execute(
             "SELECT COUNT(*) FROM sprint_wake_outbox WHERE sprint_id=?",
             (self.sprint_id,),
@@ -979,6 +1050,27 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         )
         self.con.commit()
         self.fail_wake_turn(replacement, error_code="HARNESS_ROUTE_MISMATCH")
+        failed_conversation = str(
+            self.con.execute(
+                "SELECT target_conversation_id FROM sprint_wake_attempts "
+                "WHERE wake_id=? ORDER BY attempt_number DESC LIMIT 1",
+                (replacement,),
+            ).fetchone()[0]
+        )
+        other_conversations = {
+            str(row["conversation_id"]): str(row["state"])
+            for row in self.con.execute(
+                "SELECT conversation_id,state FROM conversations "
+                "WHERE conversation_id<>?",
+                (failed_conversation,),
+            )
+        }
+        transcript_before = int(
+            self.con.execute(
+                "SELECT COUNT(*) FROM conversation_messages WHERE conversation_id=?",
+                (failed_conversation,),
+            ).fetchone()[0]
+        )
 
         self.assertEqual(
             (),
@@ -993,6 +1085,170 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                 "SELECT COUNT(*) FROM sprint_wake_outbox WHERE sprint_id=?",
                 (self.sprint_id,),
             ).fetchone()[0],
+        )
+        self.assertEqual(
+            ("paused", None, replacement, "closed"),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,m.read_at,wm.wake_id,c.state "
+                    "FROM sprints s JOIN wake_message m ON m.sprint_id=s.sprint_id "
+                    "JOIN sprint_wake_messages wm USING (message_id) "
+                    "JOIN conversations c ON c.conversation_id=? "
+                    "WHERE s.sprint_id=? AND m.message_id=?",
+                    (failed_conversation, self.sprint_id, message.message_id),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            transcript_before,
+            self.con.execute(
+                "SELECT COUNT(*) FROM conversation_messages WHERE conversation_id=?",
+                (failed_conversation,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            other_conversations,
+            {
+                str(row["conversation_id"]): str(row["state"])
+                for row in self.con.execute(
+                    "SELECT conversation_id,state FROM conversations "
+                    "WHERE conversation_id<>?",
+                    (failed_conversation,),
+                )
+            },
+        )
+        closed = json.loads(
+            self.con.execute(
+                "SELECT payload FROM conversation_events "
+                "WHERE conversation_id=? AND event_type='conversation.closed' "
+                "ORDER BY sequence DESC LIMIT 1",
+                (failed_conversation,),
+            ).fetchone()[0]
+        )
+        self.assertEqual(
+            {
+                "reason": "wake pickup exhausted",
+                "state": "closed",
+                "wake_id": replacement,
+            },
+            closed,
+        )
+        report = json.loads(
+            self.con.execute(
+                "SELECT body FROM sprint_reports WHERE sprint_id=? "
+                "AND report_kind='pause' ORDER BY report_id DESC LIMIT 1",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual("wake_pickup_failed", report["reason"])
+        self.assertEqual(2, report["detail"]["attempt_count"])
+        self.assertEqual("native_failed", report["detail"]["failure_class"])
+        self.assertEqual("HARNESS_ROUTE_MISMATCH", report["detail"]["error_code"])
+        self.assertIn(
+            "already has a live CLI session", report["detail"]["error_detail"]
+        )
+        notice = self.con.execute(
+            "SELECT body FROM wake_message WHERE sprint_id IS NULL "
+            "AND receiver_shell_id=3 AND idempotency_key LIKE 'sprint-pause:%'"
+        ).fetchall()
+        self.assertEqual(1, len(notice))
+        self.assertIn("use an authorized resume", notice[0]["body"])
+
+        before_replay = self.con.total_changes
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="post-pause-replay",
+            ),
+        )
+        self.assertEqual(before_replay, self.con.total_changes)
+
+    def test_succeeded_unread_turn_replaces_once_then_pauses_without_closing_chat(self):
+        message = self.send("succeeded-unread")
+        original = int(message.wake_id)
+        self.deliver_wake_with_turn(original, terminal=True)
+        replacement = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="succeeded-unread-first",
+        )[0]
+        self.deliver_wake_with_turn(replacement, terminal=True)
+        conversation_id = str(
+            self.con.execute(
+                "SELECT target_conversation_id FROM sprint_wake_attempts "
+                "WHERE wake_id=? ORDER BY attempt_number DESC LIMIT 1",
+                (replacement,),
+            ).fetchone()[0]
+        )
+
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="succeeded-unread-second",
+            ),
+        )
+        self.assertEqual(
+            ("paused", None, replacement, "waiting"),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,m.read_at,wm.wake_id,c.state "
+                    "FROM sprints s JOIN wake_message m ON m.sprint_id=s.sprint_id "
+                    "JOIN sprint_wake_messages wm USING (message_id) "
+                    "JOIN conversations c ON c.conversation_id=? "
+                    "WHERE s.sprint_id=? AND m.message_id=?",
+                    (conversation_id, self.sprint_id, message.message_id),
+                ).fetchone()
+            ),
+        )
+        event = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='wake.pickup_exhausted'",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual("WAKE_PICKUP_UNREAD", event["error_code"])
+        self.assertEqual("terminal_unread", event["failure_class"])
+        self.assertEqual("succeeded", event["run_state"])
+        self.assertEqual(2, event["attempt_count"])
+
+    def test_missing_terminal_evidence_pauses_as_integrity_anomaly(self):
+        message = self.send("missing-evidence")
+        wake_id = int(message.wake_id)
+        self.deliver_wake_with_turn(wake_id, terminal=True)
+        self.con.execute(
+            "UPDATE sprint_wake_attempts SET target_conversation_id=NULL "
+            "WHERE wake_id=?",
+            (wake_id,),
+        )
+        self.con.commit()
+
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="missing-evidence",
+            ),
+        )
+        event = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='wake.pickup_exhausted'",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual("WAKE_PICKUP_EVIDENCE_INVALID", event["error_code"])
+        self.assertEqual("evidence_invalid", event["failure_class"])
+        self.assertEqual(
+            "wake_pickup_evidence_invalid",
+            json.loads(
+                self.con.execute(
+                    "SELECT body FROM sprint_reports WHERE sprint_id=? "
+                    "AND report_kind='pause'",
+                    (self.sprint_id,),
+                ).fetchone()[0]
+            )["reason"],
         )
 
     def test_resume_repairs_delivered_unread_assignment_once(self):
@@ -1188,7 +1444,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ],
         )
 
-    def test_error_conversation_queued_turn_does_not_suppress_recovery(self):
+    def test_error_conversation_with_no_run_pauses_as_invalid_evidence(self):
         message = self.send("pickup-error-conversation")
         old_wake = int(message.wake_id)
         self.deliver_wake_with_turn(old_wake, terminal=False)
@@ -1212,17 +1468,17 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             sprint_domain.LifecycleActor("planner", 3),
         )
 
-        self.assertEqual(1, len(receipt.requeued_wake_ids))
-        replacement = receipt.requeued_wake_ids[0]
-        self.assertNotEqual(old_wake, replacement)
+        self.assertEqual((), receipt.requeued_wake_ids)
         self.assertEqual(
-            (replacement, "pending"),
+            ("paused", old_wake, "wake_pickup_evidence_invalid"),
             tuple(
                 self.con.execute(
-                    "SELECT wm.wake_id,w.state FROM sprint_wake_messages wm "
-                    "JOIN sprint_wake_outbox w USING (wake_id) "
-                    "WHERE wm.message_id=?",
-                    (message.message_id,),
+                    "SELECT s.lifecycle,wm.wake_id,"
+                    "json_extract(r.body,'$.reason') "
+                    "FROM sprints s JOIN sprint_reports r USING (sprint_id) "
+                    "JOIN sprint_wake_messages wm ON wm.message_id=? "
+                    "WHERE s.sprint_id=? ORDER BY r.report_id DESC LIMIT 1",
+                    (message.message_id, self.sprint_id),
                 ).fetchone()
             ),
         )
@@ -1258,7 +1514,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         self.con.commit()
         return conversation_id
 
-    def test_unregistered_conversation_queued_turn_suppresses_recovery(self):
+    def test_unregistered_completed_message_without_run_pauses_as_invalid(self):
         target = self._activate_unregistered_chat("gui-chat-queued")
         message = self.send("pickup-unregistered-queued")
         old_wake = int(message.wake_id)
@@ -1281,8 +1537,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         )
 
         self.con.execute(
-            "UPDATE conversation_messages SET state='running' "
-            "WHERE idempotency_key=?",
+            "UPDATE conversation_messages SET state='running' WHERE idempotency_key=?",
             (wake_key,),
         )
         self.con.execute(
@@ -1292,17 +1547,25 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         )
         self.con.commit()
 
-        replacements = self.lifecycle.reconcile_unread_pickup(
-            self.sprint_id,
-            trigger="unregistered-turn-finished-unread",
-        )
-        self.assertEqual(1, len(replacements))
         self.assertEqual(
-            f"sprint-recovery:{self.sprint_id}:delivered-unread:{old_wake}",
-            self.con.execute(
-                "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
-                (replacements[0],),
-            ).fetchone()[0],
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="unregistered-turn-finished-unread",
+            ),
+        )
+        self.assertEqual(
+            ("paused", old_wake, "wake_pickup_evidence_invalid"),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,wm.wake_id,"
+                    "json_extract(r.body,'$.reason') "
+                    "FROM sprints s JOIN sprint_reports r USING (sprint_id) "
+                    "JOIN sprint_wake_messages wm ON wm.message_id=? "
+                    "WHERE s.sprint_id=?",
+                    (message.message_id, self.sprint_id),
+                ).fetchone()
+            ),
         )
 
     def test_unregistered_conversation_running_turn_suppresses_recovery(self):

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -675,6 +675,28 @@ class DispatchGateTest(SprintWorkDispatchCase):
 
 
 class DeliveryTerminalTest(SprintWorkDispatchCase):
+    def accept_arming_notification(self) -> None:
+        message_id = int(
+            self.con.execute(
+                "SELECT m.message_id FROM wake_message m "
+                "JOIN sprint_participants p ON p.participant_id=m.to_participant_id "
+                "WHERE m.sprint_id=? AND p.shell_id=3 "
+                "AND m.message_kind='notification' ORDER BY m.message_id LIMIT 1",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertIsNone(self.messages.mark_read(message_id, 3))
+        self.assertEqual(
+            (1, None),
+            tuple(
+                self.con.execute(
+                    "SELECT read_at IS NOT NULL,disposition "
+                    "FROM wake_message WHERE message_id=?",
+                    (message_id,),
+                ).fetchone()
+            ),
+        )
+
     def terminal_messages(self) -> list[sqlite3.Row]:
         return self.con.execute(
             "SELECT p.shell_id,m.message_kind,m.body,m.declared_type,"
@@ -805,6 +827,7 @@ class DeliveryTerminalTest(SprintWorkDispatchCase):
         report = self.create_unit(developer=1, output_kind="report_only")
         self.lifecycle.arm(self.sprint_id, 3)
         self.deliver_pending_wakes()
+        self.accept_arming_notification()
         self.messages.mark_read(self.assignment_message(report), 1)
         self.lifecycle.pause(
             self.sprint_id,
@@ -883,6 +906,7 @@ class DeliveryTerminalTest(SprintWorkDispatchCase):
         first = self.create_unit(developer=1, output_kind="report_only")
         self.lifecycle.arm(self.sprint_id, 3)
         self.deliver_pending_wakes()
+        self.accept_arming_notification()
         self.messages.mark_read(self.assignment_message(first), 1)
         self.units.complete(self.sprint_id, first, 1, result="First report")
         self.assert_episode(1, 1, 0)


### PR DESCRIPTION
## Summary

- classify delivered/unread pickup episodes from durable wake, conversation-message, and run evidence
- pause atomically on unknown, terminal replacement failure/unread success, or contradictory evidence while preserving Sprint messages/transcripts and closing only the exact dead error conversation
- register the bounded `wake.pickup_exhausted` receipt fields in the Sprint board event registry; no other board presentation/runtime work is included

## Ruling 2: production ordering

There is no production window in which a wake can be stamped `delivered` without its conversation message existing. `sprint_runtime.enqueue_conversation_turn()` commits the conversation message, outbox row, conversation state, and acceptance event before returning to `SprintWakeDeliveryService.deliver_once()`. Only after that callback returns does a separate `sprint.wake.delivered` transaction insert the wake-attempt receipt and stamp the wake/messages delivered. A crash before either commit leaves the wake unstamped. The broker may create the run row later, but the committed queued message is live pickup evidence and reconciliation skips it.

The two failing `DeliveryTerminalTest` fixtures used a synthetic `run-ref` callback that created neither the production conversation message nor run evidence. I updated only:

- `test_paused_report_completion_wakes_only_on_resume`
- `test_episode_replay_dedupes_and_added_scope_refires_with_fresh_key`

Both now consume and assert the durable read state of the Planner arming notification before exercising pause/resume delivery-terminal behavior. The old state was impossible in production and caused Unit 3 correctly to classify the synthetic wake as `wake_pickup_evidence_invalid`.

## Verification

Red before green:

- focused baseline: 3 failed, 4 passed
- failures: the two DeliveryTerminal tests above plus `test_event_projection_matches_emitters_and_projects_review_and_conformance_evidence`

Green:

- focused gate: 7 passed
- `./sc test`: 1,945 passed, 1 skipped
- `./sc verify`: linked-worktree invocation refused as known issue #769; canonical verify passed in an isolated clone of exact pushed head `6dfa9809617d95af923dc7398950cdd24dff9463`

Targeted Ruff still reports unrelated baseline findings tracked in #966 and #878; this change does not touch those lines or file mode.

Deviations from Unit 3 scope: none.