### PR TITLE
feat(sprint): canonical routes and arm preflight

### DIFF
--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -29,7 +29,8 @@
   "conversation": {
     "contract_version": 1,
     "minimum_cli_version": "2.1.220",
-    "verified_cli_version": "2.1.220",
+    "maximum_cli_version_exclusive": "2.2.0",
+    "verified_cli_version": "2.1.222",
     "driver": "claude-print",
     "session_ref": { "source": "system.init", "field": "session_id" },
     "start": {

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -28,6 +28,7 @@
   "conversation": {
     "contract_version": 1,
     "minimum_cli_version": "0.145.0",
+    "maximum_cli_version_exclusive": "0.147.0",
     "verified_cli_version": "0.145.0",
     "driver": "codex-app-server",
     "session_ref": { "source": "thread.start", "field": "thread.id" },

--- a/.super-coder/adapters/opencode/adapter.json
+++ b/.super-coder/adapters/opencode/adapter.json
@@ -32,6 +32,7 @@
   "conversation": {
     "contract_version": 1,
     "minimum_cli_version": "1.18.9",
+    "maximum_cli_version_exclusive": "1.19.0",
     "verified_cli_version": "1.18.9",
     "driver": "opencode-server",
     "session_ref": { "source": "session.create", "field": "id" },

--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -760,32 +760,17 @@ def _wait_for_cli_release(shell) -> str | None:
 def _create_conversation(con, operator: dict, headers, body: dict):
     _only_fields(body, {"shell_id", "title", "harness", "model", "effort"})
     key = _idempotency_key(headers)
-    request_hash = _request_hash(body)
     shell_id = _integer(body.get("shell_id"), "shell_id")
 
-    # Cheap idempotent replay and all external preparation happen before the
-    # write reservation. The transaction repeats every authoritative DB read.
+    # Read a possible replay before preparation, but compare it only after the
+    # request has been resolved to the same canonical route stored for a new
+    # conversation. The transaction repeats every authoritative DB read.
     existing = con.execute(
         "SELECT conversation_id,creation_request_hash FROM conversations "
         "WHERE owner_user_id=? "
         "AND creation_idempotency_key=?",
         (operator["user_id"], key),
     ).fetchone()
-    if existing is not None:
-        if existing["creation_request_hash"] != request_hash:
-            raise ApiError(
-                409,
-                "CONVERSATION_IDEMPOTENCY_CONFLICT",
-                "Idempotency-Key was reused with a different request",
-            )
-        row = _require_conversation(
-            con, existing["conversation_id"], operator["user_id"]
-        )
-        return _json(
-            201,
-            _conversation_projection(row),
-            [("Location", f"/api/conversations/{row['conversation_id']}")],
-        )
 
     shell = con.execute(
         "SELECT shell_id,display_name,shortname,flavor FROM shells "
@@ -800,16 +785,6 @@ def _create_conversation(con, operator: dict, headers, body: dict):
             "shell is unknown, deleted, or unavailable to this operator",
         )
     _refuse_admin_browser_chat(shell)
-    if active_chat_registry.get(con, shell_id) is None:
-        live_state = _wait_for_cli_release(shell)
-        if live_state is not None:
-            raise ApiError(
-                409,
-                "SHELL_BUSY",
-                f"shell {shell['shortname']!r} has a live CLI session; "
-                "close it before opening a browser chat",
-                {"shell_id": shell_id, "state": live_state},
-            )
 
     defaults = run_mod.flavor_defaults(con).get(shell["flavor"])
     harness = body.get("harness")
@@ -826,25 +801,29 @@ def _create_conversation(con, operator: dict, headers, body: dict):
             "HARNESS_CONVERSATION_UNSUPPORTED",
             f"harness {harness!r} has no browser conversation adapter",
         )
-    model = body.get("model")
-    if model is None and defaults:
-        model = defaults["models"].get(harness)
-    model = _nonblank(model, "model", maximum=255, optional=True)
-    if harness == "opencode" and model is None:
-        raise ApiError(
-            422,
-            "HARNESS_MODEL_REQUIRED",
-            "OpenCode browser conversations require an exact model from a "
-            "provider connected in OpenCode",
-        )
+    selected_model = _nonblank(
+        body.get("model"), "model", maximum=255, optional=True
+    )
     effort = _nonblank(body.get("effort"), "effort", maximum=64, optional=True)
     adapter = run_mod.load_adapter(harness)
-    if effort is None:
-        effort = run_mod.default_headless_effort(adapter)
     try:
-        run_mod.validate_headless_request(adapter, model, effort)
+        resolved = run_mod.resolve_headless_route(
+            harness=harness,
+            adapter=adapter,
+            flavor_model=(
+                (defaults.get("models") or {}).get(harness)
+                if defaults
+                else None
+            ),
+            model=selected_model,
+            effort=effort,
+        )
     except ValueError as exc:
         raise ApiError(422, "HARNESS_ROUTE_INVALID", str(exc)) from exc
+    harness = resolved.harness
+    provider = resolved.provider
+    model = resolved.model
+    effort = resolved.effort
     title = _nonblank(body.get("title"), "title", maximum=200, optional=True)
     worktree = run_mod.shell_work_dir(shell["shortname"], shell["flavor"])
     worktree = worktree.resolve(strict=False)
@@ -855,9 +834,45 @@ def _create_conversation(con, operator: dict, headers, body: dict):
             "the shell worktree path exists but is not a directory",
             {"shell_id": shell_id},
         )
+    request_hash = _request_hash(
+        {
+            "shell_id": shell_id,
+            "title": title,
+            "harness": harness,
+            "provider": provider,
+            "model": model,
+            "effort": effort,
+            "worktree": str(worktree),
+        }
+    )
+    if existing is not None:
+        if existing["creation_request_hash"] != request_hash:
+            raise ApiError(
+                409,
+                "CONVERSATION_IDEMPOTENCY_CONFLICT",
+                "Idempotency-Key was reused with a different request",
+            )
+        row = _require_conversation(
+            con, existing["conversation_id"], operator["user_id"]
+        )
+        return _json(
+            201,
+            _conversation_projection(row),
+            [("Location", f"/api/conversations/{row['conversation_id']}")],
+        )
+
+    if active_chat_registry.get(con, shell_id) is None:
+        live_state = _wait_for_cli_release(shell)
+        if live_state is not None:
+            raise ApiError(
+                409,
+                "SHELL_BUSY",
+                f"shell {shell['shortname']!r} has a live CLI session; "
+                "close it before opening a browser chat",
+                {"shell_id": shell_id, "state": live_state},
+            )
 
     conversation_id = "cv_" + uuid.uuid4().hex
-    provider = run_mod.session_provider(harness, model)
     closed_id = None
     with db_driver.write_transaction(con, "conversation.create.close_active"):
         existing = con.execute(

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1995,6 +1995,8 @@ class Handler(BaseHTTPRequestHandler):
     def _sprint_error(self, exc: Exception):
         if isinstance(exc, sprint_domain.SprintAuthorityError):
             return self._send(403, {"error": str(exc)})
+        if isinstance(exc, sprint_domain.SprintPreflightError):
+            return self._send(422, {"error": str(exc)})
         if isinstance(exc, sprint_domain.SprintInvariantError):
             return self._send(409, {"error": str(exc)})
         if isinstance(exc, KeyError):

--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -105,12 +105,21 @@ def checked_probe_result(
     minimum = conversation.get("minimum_cli_version")
     maximum = conversation.get("maximum_cli_version_exclusive")
     verified = conversation.get("verified_cli_version")
-    if not all(
-        isinstance(item, str) and item for item in (minimum, maximum, verified)
-    ):
+    compatibility = {
+        "minimum_cli_version": minimum,
+        "maximum_cli_version_exclusive": maximum,
+        "verified_cli_version": verified,
+    }
+    missing = [
+        key
+        for key, value in compatibility.items()
+        if not isinstance(value, str) or not value
+    ]
+    if missing:
         raise AdapterError(
             "HARNESS_MANIFEST_INVALID",
-            f"harness compatibility range is incomplete: {harness}",
+            f"harness compatibility manifest is missing "
+            f"{', '.join(missing)}: {harness}",
         )
     if version_tuple(version) < version_tuple(minimum):
         raise AdapterError(
@@ -602,10 +611,23 @@ def load_manifest(harness: str) -> dict[str, Any]:
             "HARNESS_MANIFEST_INVALID",
             f"harness has no supported conversation contract: {harness}",
         )
-    if not conversation.get("maximum_cli_version_exclusive"):
+    compatibility = {
+        "minimum_cli_version": conversation.get("minimum_cli_version"),
+        "maximum_cli_version_exclusive": conversation.get(
+            "maximum_cli_version_exclusive"
+        ),
+        "verified_cli_version": conversation.get("verified_cli_version"),
+    }
+    missing = [
+        key
+        for key, value in compatibility.items()
+        if not isinstance(value, str) or not value
+    ]
+    if missing:
         raise AdapterError(
             "HARNESS_MANIFEST_INVALID",
-            f"harness compatibility range is incomplete: {harness}",
+            f"harness compatibility manifest is missing "
+            f"{', '.join(missing)}: {harness}",
         )
     declared_events = frozenset(conversation.get("normalized_events") or ())
     if declared_events != NORMALIZED_EVENTS:

--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -89,6 +89,49 @@ class ProbeResult:
     version: str
     minimum_version: str
     capabilities: AdapterCapabilities
+    maximum_version_exclusive: str
+    verified_version: str
+    compatibility: str
+
+
+def checked_probe_result(
+    *,
+    harness: str,
+    manifest: Mapping[str, Any],
+    capabilities: AdapterCapabilities,
+    version: str,
+) -> ProbeResult:
+    conversation = manifest.get("conversation") or {}
+    minimum = conversation.get("minimum_cli_version")
+    maximum = conversation.get("maximum_cli_version_exclusive")
+    verified = conversation.get("verified_cli_version")
+    if not all(
+        isinstance(item, str) and item for item in (minimum, maximum, verified)
+    ):
+        raise AdapterError(
+            "HARNESS_MANIFEST_INVALID",
+            f"harness compatibility range is incomplete: {harness}",
+        )
+    if version_tuple(version) < version_tuple(minimum):
+        raise AdapterError(
+            "HARNESS_VERSION_UNSUPPORTED",
+            f"{harness} {version} is older than required {minimum}",
+        )
+    if version_tuple(version) >= version_tuple(maximum):
+        raise AdapterError(
+            "HARNESS_VERSION_UNSUPPORTED",
+            f"{harness} {version} is outside supported range "
+            f"[{minimum}, {maximum})",
+        )
+    return ProbeResult(
+        harness=harness,
+        version=version,
+        minimum_version=minimum,
+        capabilities=capabilities,
+        maximum_version_exclusive=maximum,
+        verified_version=verified,
+        compatibility=("verified" if version == verified else "supported"),
+    )
 
 
 @dataclass(frozen=True)
@@ -252,17 +295,11 @@ class ConversationAdapter(abc.ABC):
         raise NotImplementedError
 
     def _probe_result(self, version: str) -> ProbeResult:
-        minimum = self.manifest["conversation"]["minimum_cli_version"]
-        if version_tuple(version) < version_tuple(minimum):
-            raise AdapterError(
-                "HARNESS_VERSION_UNSUPPORTED",
-                f"{self.harness} {version} is older than required {minimum}",
-            )
-        return ProbeResult(
+        return checked_probe_result(
             harness=self.harness,
-            version=version,
-            minimum_version=minimum,
+            manifest=self.manifest,
             capabilities=self.capabilities,
+            version=version,
         )
 
 
@@ -564,6 +601,11 @@ def load_manifest(harness: str) -> dict[str, Any]:
         raise AdapterError(
             "HARNESS_MANIFEST_INVALID",
             f"harness has no supported conversation contract: {harness}",
+        )
+    if not conversation.get("maximum_cli_version_exclusive"):
+        raise AdapterError(
+            "HARNESS_MANIFEST_INVALID",
+            f"harness compatibility range is incomplete: {harness}",
         )
     declared_events = frozenset(conversation.get("normalized_events") or ())
     if declared_events != NORMALIZED_EVENTS:

--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -247,7 +247,9 @@ sc_harness_status() {
     docker exec "$CNAME" python3 "$S/harness_versions.py" 2>/dev/null \
       || echo "  (could not probe $CNAME)"
   else
-    echo "harness CLIs: sandbox '$CNAME' is not running — ./sc launch to start it."
+    echo "harness CLIs (runtime and compatibility):"
+    echo "  runtime:   sandbox '$CNAME' · not running"
+    echo "  adapters:  unavailable until ./sc launch starts that runtime"
   fi
   echo "harness epoch: image built with ${built:-<none — predates the epoch seam>} · stored ${stored}"
   # A rolled-but-unbuilt epoch is the actionable state: the operator asked for

--- a/.super-coder/scripts/harness_versions.py
+++ b/.super-coder/scripts/harness_versions.py
@@ -18,6 +18,8 @@ be able to hang a launch banner — and a missing harness is reported, not fatal
 from __future__ import annotations
 
 import json
+import os
+import re
 import shutil
 import subprocess
 import sys
@@ -46,13 +48,96 @@ def versions() -> dict[str, str | None]:
     return {name: probe(name) for name in HARNESSES}
 
 
+def compatibility_status() -> dict[str, dict[str, str | None]]:
+    """Report runtime binaries through the adapters' shared range contract."""
+    from conversation_adapters import ADAPTER_TYPES, AdapterError
+    from conversation_adapters.base import (
+        AdapterCapabilities,
+        checked_probe_result,
+        load_manifest,
+    )
+
+    found: dict[str, dict[str, str | None]] = {}
+    for name in HARNESSES:
+        raw_version = probe(name)
+        match = re.search(r"\d+\.\d+\.\d+", raw_version or "")
+        version = match.group(0) if match else None
+        if name not in ADAPTER_TYPES:
+            found[name] = {
+                "version": raw_version,
+                "compatibility": None,
+                "minimum_version": None,
+                "maximum_version_exclusive": None,
+                "verified_version": None,
+                "error": None,
+            }
+            continue
+        if version is None:
+            found[name] = {
+                "version": None,
+                "compatibility": None,
+                "minimum_version": None,
+                "maximum_version_exclusive": None,
+                "verified_version": None,
+                "error": "HARNESS_UNAVAILABLE",
+            }
+            continue
+        manifest = {}
+        try:
+            manifest = load_manifest(name)
+            result = checked_probe_result(
+                harness=name,
+                manifest=manifest,
+                capabilities=AdapterCapabilities.from_manifest(manifest),
+                version=version,
+            )
+        except AdapterError as exc:
+            conversation = manifest.get("conversation", {})
+            found[name] = {
+                "version": version,
+                "compatibility": None,
+                "minimum_version": conversation.get("minimum_cli_version"),
+                "maximum_version_exclusive": conversation.get(
+                    "maximum_cli_version_exclusive"
+                ),
+                "verified_version": conversation.get("verified_cli_version"),
+                "error": exc.code,
+            }
+            continue
+        found[name] = {
+            "version": result.version,
+            "compatibility": result.compatibility,
+            "minimum_version": result.minimum_version,
+            "maximum_version_exclusive": result.maximum_version_exclusive,
+            "verified_version": result.verified_version,
+            "error": None,
+        }
+    return found
+
+
 def main(argv: list[str]) -> int:
-    found = versions()
+    provenance = "sandbox" if os.environ.get("SC_SANDBOX") else "host"
+    found = compatibility_status()
     if "--json" in argv:
-        print(json.dumps(found, indent=2))
+        print(json.dumps({"runtime": provenance, "harnesses": found}, indent=2))
         return 0
-    for name, version in found.items():
-        print(f"  {name:9} {version or '— not installed'}")
+    print(f"  runtime:   {provenance}")
+    for name, status in found.items():
+        version = status["version"]
+        compatibility = status["compatibility"]
+        if status["error"]:
+            detail = f"{version or '—'} · {status['error']}"
+        elif version and compatibility:
+            detail = (
+                f"{version} · {compatibility} · supported "
+                f"[{status['minimum_version']}, "
+                f"{status['maximum_version_exclusive']})"
+            )
+        elif version:
+            detail = version
+        else:
+            detail = "— not installed"
+        print(f"  {name:9} {detail}")
     return 0
 
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -124,7 +124,8 @@ def resolve_headless_route(
     resolved_model = model if model is not None else flavor_model
     if not isinstance(resolved_model, str) or not resolved_model.strip():
         raise ValueError(
-            f"harness '{harness}' has no model selected or flavor default"
+            f"harness '{harness}' cannot resolve a model: no model was supplied "
+            "and no flavor default exists for it; supply an explicit model"
         )
     if effort is not None and (
         not isinstance(effort, str) or not effort.strip()

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -73,15 +73,6 @@ DEFAULT_HEADLESS_PROMPT = "Check your inbox and act on your unread messages."
 SESSION_OPEN_RETRY_DELAYS_S = (0.1, 0.3)
 
 
-def resolve_headless_model(flag_model: "str | None", fdef: "dict | None",
-                           harness: str) -> "str | None":
-    """Headless model resolution: an explicit -m wins; else the shell's
-    (flavor, harness) default; else None — the harness picks its own."""
-    if flag_model:
-        return flag_model
-    return fdef["models"].get(harness) if fdef else None
-
-
 def _headless_effort_args(hcfg: dict, effort: "str | None",
                           harness: str = "?") -> list[str]:
     if not effort:
@@ -105,6 +96,50 @@ def headless_effort_env(adapter: dict, effort: "str | None") -> dict[str, str]:
 def default_headless_effort(adapter: dict) -> "str | None":
     """Use high only when the adapter has an effort transport."""
     return "high" if ((adapter.get("headless") or {}).get("effort")) else None
+
+
+class ResolvedHeadlessRoute(NamedTuple):
+    harness: str
+    provider: str | None
+    model: str
+    effort: str | None
+
+
+def resolve_headless_route(
+    *,
+    harness: str,
+    adapter: dict,
+    flavor_model: "str | None",
+    model: "str | None",
+    effort: "str | None",
+) -> ResolvedHeadlessRoute:
+    """Resolve and validate the immutable route stored for a headless turn.
+
+    Explicit model and effort strings are validated without normalization so
+    the caller's selected bytes remain part of the durable route.  Defaults
+    are applied here, before any request is hashed or conversation is stored.
+    """
+    if not isinstance(harness, str) or not harness.strip():
+        raise ValueError("harness must be a non-empty string")
+    resolved_model = model if model is not None else flavor_model
+    if not isinstance(resolved_model, str) or not resolved_model.strip():
+        raise ValueError(
+            f"harness '{harness}' has no model selected or flavor default"
+        )
+    if effort is not None and (
+        not isinstance(effort, str) or not effort.strip()
+    ):
+        raise ValueError("effort must be a non-empty string when supplied")
+    resolved_effort = (
+        effort if effort is not None else default_headless_effort(adapter)
+    )
+    validate_headless_request(adapter, resolved_model, resolved_effort)
+    return ResolvedHeadlessRoute(
+        harness=harness,
+        provider=session_provider(harness, resolved_model),
+        model=resolved_model,
+        effort=resolved_effort,
+    )
 
 
 def validate_headless_request(adapter: dict, model: "str | None",
@@ -1097,17 +1132,23 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
     # headless plan defaults to high only when the adapter can transport it;
     # OpenCode's no-effort seam stays unset instead of failing before launch.
     flavor_model = fdef["models"].get(harness) if fdef else None
-    session_model = model or flavor_model
-    session_effort = (
-        effort if effort is not None
-        else (default_headless_effort(adapter) if headless else None)
-    )
     if headless:
         try:
-            validate_headless_request(adapter, session_model, session_effort)
+            resolved_route = resolve_headless_route(
+                harness=harness,
+                adapter=adapter,
+                flavor_model=flavor_model,
+                model=model,
+                effort=effort,
+            )
         except ValueError as e:
             con.close()
             raise LaunchError(str(e)) from e
+        session_model = resolved_route.model
+        session_effort = resolved_route.effort
+    else:
+        session_model = model or flavor_model
+        session_effort = effort
 
     # Pre-session analytics sweep — same correctness dependency as main():
     # open_session's stub-reuse check relies on the previous boot's usage
@@ -1440,17 +1481,22 @@ def main() -> None:
     # OpenCode exposes none and keeps the model's own default.
     flavor_model = fdef["models"].get(harness) if fdef else None
     adapter = load_adapter(harness)
-    session_model = (resolve_headless_model(flag_model, fdef, harness)
-                     if headless else flavor_model)
-    session_effort = (
-        flag_effort if flag_effort is not None
-        else (default_headless_effort(adapter) if headless else None)
-    )
     if headless:
         try:
-            validate_headless_request(adapter, session_model, session_effort)
+            resolved_route = resolve_headless_route(
+                harness=harness,
+                adapter=adapter,
+                flavor_model=flavor_model,
+                model=flag_model,
+                effort=flag_effort,
+            )
         except ValueError as e:
             sys.exit(f"sc run: {e}")
+        session_model = resolved_route.model
+        session_effort = resolved_route.effort
+    else:
+        session_model = flavor_model
+        session_effort = None
 
     feedback = not headless and not os.environ.get("RENDER_ONLY")
     map_note = None

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -63,6 +63,10 @@ class SprintInvariantError(SprintLifecycleError):
     """The durable Sprint plan is not eligible for the requested transition."""
 
 
+class SprintPreflightError(SprintInvariantError):
+    """The selected participant route is incompatible with this runtime."""
+
+
 @dataclass(frozen=True)
 class LifecycleActor:
     kind: str
@@ -326,13 +330,13 @@ class SprintLifecycleStore:
                 sprint_id,
             )
         except sprint_participant_chats.SprintConversationError as exc:
-            raise SprintInvariantError(str(exc)) from exc
+            raise SprintPreflightError(str(exc)) from exc
         fingerprint = self._route_fingerprint(routes)
         for harness in dict.fromkeys(route.harness for route in routes):
             try:
                 self.probe_harness(harness)
             except AdapterError as exc:
-                raise SprintInvariantError(str(exc)) from exc
+                raise SprintPreflightError(str(exc)) from exc
         return fingerprint
 
     def _participant_selection_fingerprint(self, sprint_id: int) -> str:

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -18,6 +18,7 @@ import conversation_broker
 import conversation_events
 import db_driver
 import sprint_participant_chats
+from conversation_adapters import AdapterError, ProbeResult, adapter_for
 
 SPRINT_TRANSITIONS = {
     "prepared": frozenset({"armed", "aborted"}),
@@ -227,11 +228,15 @@ class SprintLifecycleStore:
         *,
         interrupt_run: Callable[[int], bool] | None = None,
         notify_commit: Callable[[], bool] | None = None,
+        probe_harness: Callable[[str], ProbeResult] | None = None,
     ) -> None:
         self.con = con
         self.con.row_factory = sqlite3.Row
         self.interrupt_run = interrupt_run or conversation_broker.interrupt_run
         self.notify_commit = notify_commit or conversation_broker.notify_commit
+        self.probe_harness = probe_harness or (
+            lambda harness: adapter_for(harness).probe()
+        )
 
     def armed_sprint_id(self) -> int | None:
         row = self.con.execute(
@@ -247,6 +252,10 @@ class SprintLifecycleStore:
         and work-unit dispositions together.
         """
         actor = LifecycleActor("planner", planner_shell_id)
+        preflight_fingerprint = self._preflight_arm(
+            sprint_id,
+            actor,
+        )
         with db_driver.write_transaction(self.con, "sprint.arm"):
             sprint = self._sprint(sprint_id)
             if sprint["lifecycle"] != "prepared":
@@ -256,6 +265,14 @@ class SprintLifecycleStore:
             self._require_edge(sprint["lifecycle"], "armed")
             self._authorize(sprint, "armed", actor)
             planner_participant, selections = self._validate_arm_plan(sprint)
+            current_fingerprint = self._participant_selection_fingerprint(
+                sprint_id
+            )
+            if current_fingerprint != preflight_fingerprint:
+                raise SprintInvariantError(
+                    "participant launch selections changed during harness "
+                    "preflight; retry arm"
+                )
             self._update_lifecycle(
                 sprint_id,
                 current="prepared",
@@ -284,6 +301,70 @@ class SprintLifecycleStore:
             )
             SprintWorkUnitStore(self.con)._queue_delivery_terminal(sprint_id)
         return wake_ids
+
+    def _preflight_arm(
+        self,
+        sprint_id: int,
+        actor: LifecycleActor,
+    ) -> str:
+        """Probe one immutable route snapshot before arm takes a write lock."""
+        if self.con.in_transaction:
+            raise SprintInvariantError(
+                "arm harness preflight requires a connection outside a transaction"
+            )
+        sprint = self._sprint(sprint_id)
+        if sprint["lifecycle"] != "prepared":
+            raise SprintStateError(
+                f"arm() requires prepared; found {sprint['lifecycle']}"
+            )
+        self._require_edge(sprint["lifecycle"], "armed")
+        self._authorize(sprint, "armed", actor)
+        self._validate_arm_plan(sprint)
+        try:
+            routes = sprint_participant_chats.prepare_sprint_participant_routes(
+                self.con,
+                sprint_id,
+            )
+        except sprint_participant_chats.SprintConversationError as exc:
+            raise SprintInvariantError(str(exc)) from exc
+        fingerprint = self._route_fingerprint(routes)
+        for harness in dict.fromkeys(route.harness for route in routes):
+            try:
+                self.probe_harness(harness)
+            except AdapterError as exc:
+                raise SprintInvariantError(str(exc)) from exc
+        return fingerprint
+
+    def _participant_selection_fingerprint(self, sprint_id: int) -> str:
+        try:
+            routes = sprint_participant_chats.prepare_sprint_participant_routes(
+                self.con,
+                sprint_id,
+            )
+        except sprint_participant_chats.SprintConversationError as exc:
+            raise SprintInvariantError(str(exc)) from exc
+        return self._route_fingerprint(routes)
+
+    @staticmethod
+    def _route_fingerprint(
+        routes: tuple[sprint_participant_chats.PreparedParticipantRoute, ...],
+    ) -> str:
+        snapshot = [
+            {
+                "participant_id": route.participant_id,
+                "shell_id": route.shell_id,
+                "role": route.role,
+                "shortname": route.shortname,
+                "harness": route.harness,
+                "provider": route.provider,
+                "model": route.model,
+                "effort": route.effort,
+                "worktree": route.worktree,
+            }
+            for route in routes
+        ]
+        payload = json.dumps(snapshot, separators=(",", ":"), sort_keys=True)
+        return hashlib.sha256(payload.encode()).hexdigest()
 
     def transition(
         self,

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -59,6 +59,19 @@ class PreparedSprintWake:
     worktree: str
 
 
+@dataclass(frozen=True)
+class PreparedParticipantRoute:
+    participant_id: int
+    shell_id: int
+    role: str
+    shortname: str
+    harness: str
+    provider: str | None
+    model: str
+    effort: str | None
+    worktree: str
+
+
 def wake_prompt(sprint_id: int, role: str) -> str:
     try:
         label, skill = _WAKE_ROLES[role]
@@ -91,6 +104,15 @@ def _nonblank(value: str | None, field: str, *, maximum: int) -> str:
     if len(value) > maximum:
         raise SprintConversationError(f"{field} exceeds {maximum} characters")
     return value
+
+
+def _browser_adapter(harness: str) -> dict:
+    adapter = run_mod.load_adapter(harness)
+    if not adapter.get("conversation"):
+        raise SprintConversationError(
+            f"harness '{harness}' has no browser conversation adapter"
+        )
+    return adapter
 
 
 def _linked_to_participant(con, participant_id: int, conversation_id: str) -> bool:
@@ -182,19 +204,25 @@ def prepare_shell_wake_conversation(con, shell_id: int) -> PreparedShellWake:
         or run_mod._configured_harness()
         or "claude"
     )
-    model = (
+    selected_model = (
         str(prior["model"])
         if prior is not None and prior["model"] is not None
-        else defaults.get("models", {}).get(harness)
+        else None
     )
-    adapter = run_mod.load_adapter(harness)
-    effort = (
+    adapter = _browser_adapter(harness)
+    selected_effort = (
         str(prior["effort"])
         if prior is not None and prior["effort"] is not None
-        else run_mod.default_headless_effort(adapter)
+        else None
     )
     try:
-        run_mod.validate_headless_request(adapter, model, effort)
+        resolved = run_mod.resolve_headless_route(
+            harness=harness,
+            adapter=adapter,
+            flavor_model=defaults.get("models", {}).get(harness),
+            model=selected_model,
+            effort=selected_effort,
+        )
     except ValueError as exc:
         raise SprintConversationError(str(exc)) from exc
     worktree = run_mod.shell_work_dir(shell["shortname"], shell["flavor"])
@@ -202,12 +230,60 @@ def prepare_shell_wake_conversation(con, shell_id: int) -> PreparedShellWake:
         shell_id=int(shell["shell_id"]),
         owner_user_id=int(shell["user_id"]),
         shortname=str(shell["shortname"]),
-        harness=harness,
-        provider=run_mod.session_provider(harness, model),
-        model=model,
-        effort=effort,
+        harness=resolved.harness,
+        provider=resolved.provider,
+        model=resolved.model,
+        effort=resolved.effort,
         worktree=str(worktree.resolve(strict=False)),
     )
+
+
+def prepare_sprint_participant_routes(
+    con,
+    sprint_id: int,
+) -> tuple[PreparedParticipantRoute, ...]:
+    """Read and canonicalize one ordered snapshot of participant routes."""
+    rows = con.execute(
+        "SELECT p.participant_id,p.shell_id,p.role,p.harness,p.model,p.effort,"
+        "sh.shortname,sh.flavor,fd.model AS flavor_model "
+        "FROM sprint_participants p "
+        "JOIN shells sh ON sh.shell_id=p.shell_id "
+        "LEFT JOIN flavor_defaults fd "
+        "ON fd.flavor=sh.flavor AND fd.harness=p.harness "
+        "WHERE p.sprint_id=? ORDER BY "
+        "CASE p.role WHEN 'planner' THEN 0 WHEN 'developer' THEN 1 ELSE 2 END,"
+        "p.participant_id",
+        (sprint_id,),
+    ).fetchall()
+    prepared: list[PreparedParticipantRoute] = []
+    for row in rows:
+        harness = str(row["harness"])
+        adapter = _browser_adapter(harness)
+        try:
+            resolved = run_mod.resolve_headless_route(
+                harness=harness,
+                adapter=adapter,
+                flavor_model=row["flavor_model"],
+                model=row["model"],
+                effort=row["effort"],
+            )
+        except ValueError as exc:
+            raise SprintConversationError(str(exc)) from exc
+        worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
+        prepared.append(
+            PreparedParticipantRoute(
+                participant_id=int(row["participant_id"]),
+                shell_id=int(row["shell_id"]),
+                role=str(row["role"]),
+                shortname=str(row["shortname"]),
+                harness=resolved.harness,
+                provider=resolved.provider,
+                model=resolved.model,
+                effort=resolved.effort,
+                worktree=str(worktree.resolve(strict=False)),
+            )
+        )
+    return tuple(prepared)
 
 
 def create_shell_wake_conversation(
@@ -227,6 +303,7 @@ def create_shell_wake_conversation(
         "effort": route.effort,
         "harness": route.harness,
         "model": route.model,
+        "provider": route.provider,
         "shell_id": route.shell_id,
         "wake_id": wake_id,
         "worktree": route.worktree,
@@ -288,11 +365,14 @@ def prepare_wake_conversation(
     """Resolve a Sprint participant route before any active chat is closed."""
     row = con.execute(
         "SELECT p.participant_id,p.sprint_id,p.shell_id,p.harness,p.model,p.effort,"
-        "s.conversation_generation,sh.shortname,sh.flavor,owner.user_id "
+        "s.conversation_generation,sh.shortname,sh.flavor,owner.user_id,"
+        "fd.model AS flavor_model "
         "FROM sprint_participants p "
         "JOIN sprints s ON s.sprint_id=p.sprint_id "
         "JOIN shells sh ON sh.shell_id=p.shell_id "
         "JOIN shells owner ON owner.shell_id=s.originating_planner_shell_id "
+        "LEFT JOIN flavor_defaults fd "
+        "ON fd.flavor=sh.flavor AND fd.harness=p.harness "
         "WHERE p.participant_id=? AND p.sprint_id=?",
         (participant_id, sprint_id),
     ).fetchone()
@@ -305,9 +385,16 @@ def prepare_wake_conversation(
         "Sprint conversation generation",
         maximum=32,
     )
-    adapter = run_mod.load_adapter(str(row["harness"]))
+    harness = str(row["harness"])
+    adapter = _browser_adapter(harness)
     try:
-        run_mod.validate_headless_request(adapter, row["model"], row["effort"])
+        resolved = run_mod.resolve_headless_route(
+            harness=harness,
+            adapter=adapter,
+            flavor_model=row["flavor_model"],
+            model=row["model"],
+            effort=row["effort"],
+        )
     except ValueError as exc:
         raise SprintConversationError(str(exc)) from exc
     worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
@@ -317,10 +404,10 @@ def prepare_wake_conversation(
         shell_id=int(row["shell_id"]),
         owner_user_id=int(row["user_id"]),
         shortname=str(row["shortname"]),
-        harness=str(row["harness"]),
-        provider=run_mod.session_provider(row["harness"], row["model"]),
-        model=str(row["model"]) if row["model"] is not None else None,
-        effort=str(row["effort"]) if row["effort"] is not None else None,
+        harness=resolved.harness,
+        provider=resolved.provider,
+        model=resolved.model,
+        effort=resolved.effort,
         generation=generation,
         worktree=str(worktree.resolve(strict=False)),
     )
@@ -339,22 +426,6 @@ def create_prepared_wake_conversation(
         raise WakeConversationBusy("another chat became active before wake creation")
 
     key = f"generation:{route.generation}:wake:{wake_id}"
-    existing = con.execute(
-        "SELECT conversation_id,state FROM conversations "
-        "WHERE owner_user_id=? AND creation_idempotency_key=?",
-        (route.owner_user_id, key),
-    ).fetchone()
-    if existing is not None:
-        if existing["state"] == "closed":
-            raise SprintConversationError("idempotent wake chat is already closed")
-        conversation_id = str(existing["conversation_id"])
-        if not _linked_to_participant(con, route.participant_id, conversation_id):
-            raise SprintConversationError(
-                "idempotent wake chat belongs to another participant"
-            )
-        active_chat_registry.register(con, route.shell_id, conversation_id)
-        return conversation_id
-
     request = {
         "effort": route.effort,
         "harness": route.harness,
@@ -365,6 +436,27 @@ def create_prepared_wake_conversation(
         "wake_id": wake_id,
         "worktree": route.worktree,
     }
+    request_hash = _request_hash(request)
+    existing = con.execute(
+        "SELECT conversation_id,state,creation_request_hash FROM conversations "
+        "WHERE owner_user_id=? AND creation_idempotency_key=?",
+        (route.owner_user_id, key),
+    ).fetchone()
+    if existing is not None:
+        if existing["state"] == "closed":
+            raise SprintConversationError("idempotent wake chat is already closed")
+        if existing["creation_request_hash"] != request_hash:
+            raise SprintConversationError(
+                "idempotent wake chat route no longer matches its request"
+            )
+        conversation_id = str(existing["conversation_id"])
+        if not _linked_to_participant(con, route.participant_id, conversation_id):
+            raise SprintConversationError(
+                "idempotent wake chat belongs to another participant"
+            )
+        active_chat_registry.register(con, route.shell_id, conversation_id)
+        return conversation_id
+
     conversation_id = "cv_" + uuid.uuid4().hex
     con.execute(
         "INSERT INTO conversations "
@@ -382,7 +474,7 @@ def create_prepared_wake_conversation(
             request["worktree"],
             f"Sprint {route.sprint_id} · Wake {wake_id} · {route.shortname}",
             key,
-            _request_hash(request),
+            request_hash,
         ),
     )
     _append_created_event(

--- a/tests/fixtures/conversations/capability_probes.json
+++ b/tests/fixtures/conversations/capability_probes.json
@@ -1,8 +1,9 @@
 {
-  "probe_date": "2026-07-29",
+  "probe_date": "2026-08-05",
   "required_harnesses": {
     "opencode": {
       "verified_cli_version": "1.18.9",
+      "maximum_cli_version_exclusive": "1.19.0",
       "driver": "opencode-server",
       "native_ref_shape": "ses_<opaque>",
       "observed_events": [
@@ -23,7 +24,8 @@
       }
     },
     "claude": {
-      "verified_cli_version": "2.1.220",
+      "verified_cli_version": "2.1.222",
+      "maximum_cli_version_exclusive": "2.2.0",
       "driver": "claude-print",
       "native_ref_shape": "uuid",
       "observed_events": [
@@ -43,6 +45,7 @@
     },
     "codex": {
       "verified_cli_version": "0.145.0",
+      "maximum_cli_version_exclusive": "0.147.0",
       "driver": "codex-app-server",
       "native_ref_shape": "uuid",
       "observed_events": [

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -702,7 +702,7 @@ class ConversationAdapterTest(unittest.TestCase):
                 ):
                     adapter._probe_result(upper)
 
-    def test_verified_probe_result_and_missing_upper_manifest_contract(self) -> None:
+    def test_verified_probe_result_names_missing_manifest_keys(self) -> None:
         adapter, _native = self.build("claude")
         result = adapter._probe_result("2.1.222")
         self.assertEqual(result.compatibility, "verified")
@@ -716,7 +716,21 @@ class ConversationAdapterTest(unittest.TestCase):
         invalid = ClaudeAdapter(runner=FakeClaudeRunner(), manifest=manifest)
         with self.assertRaisesRegex(
             AdapterError,
-            "HARNESS_MANIFEST_INVALID: harness compatibility range is incomplete",
+            "HARNESS_MANIFEST_INVALID: harness compatibility manifest is missing "
+            "maximum_cli_version_exclusive: claude",
+        ):
+            invalid._probe_result("2.1.222")
+
+        missing_verified = json.loads(json.dumps(manifest))
+        missing_verified["conversation"]["maximum_cli_version_exclusive"] = "2.2.0"
+        del missing_verified["conversation"]["verified_cli_version"]
+        invalid = ClaudeAdapter(
+            runner=FakeClaudeRunner(), manifest=missing_verified
+        )
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_MANIFEST_INVALID: harness compatibility manifest is missing "
+            "verified_cli_version: claude",
         ):
             invalid._probe_result("2.1.222")
 
@@ -729,7 +743,8 @@ class ConversationAdapterTest(unittest.TestCase):
             mock.patch.object(base_adapter, "ADAPTERS", manifest_root),
             self.assertRaisesRegex(
                 AdapterError,
-                "HARNESS_MANIFEST_INVALID: harness compatibility range is incomplete",
+                "HARNESS_MANIFEST_INVALID: harness compatibility manifest is missing "
+                "maximum_cli_version_exclusive: claude",
             ),
         ):
             base_adapter.load_manifest("claude")

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -35,6 +36,7 @@ from conversation_adapters import (  # noqa: E402
 )
 from conversation_adapters import codex as codex_adapter
 from conversation_adapters import opencode as opencode_adapter
+from conversation_adapters import base as base_adapter
 from conversation_adapters.base import SubprocessRunner
 
 KIMI_FIXTURES = ROOT / "tests" / "fixtures" / "conversations" / "kimi"
@@ -664,6 +666,73 @@ class ConversationAdapterTest(unittest.TestCase):
     def tearDown(self) -> None:
         self.linked_vm.stop()
         self.temp.cleanup()
+
+    def test_declared_compatibility_ranges_enforce_closed_open_boundaries(self) -> None:
+        cases = {
+            "claude": ("2.1.219", "2.1.220", "2.1.222", "2.2.0"),
+            "codex": ("0.144.999", "0.145.0", "0.146.1", "0.147.0"),
+            "opencode": ("1.18.8", "1.18.9", "1.18.13", "1.19.0"),
+            "kimi": ("0.29.999", "0.30.0", "0.33.0", "0.34.0"),
+        }
+        for harness, (below, lower, current, upper) in cases.items():
+            with self.subTest(harness=harness):
+                adapter, _native = self.build(harness)
+                lower_result = adapter._probe_result(lower)
+                current_result = adapter._probe_result(current)
+                self.assertEqual(lower_result.minimum_version, lower)
+                self.assertEqual(current_result.version, current)
+                self.assertEqual(
+                    current_result.compatibility,
+                    (
+                        "verified"
+                        if current
+                        == adapter.manifest["conversation"]["verified_cli_version"]
+                        else "supported"
+                    ),
+                )
+                self.assertEqual(current_result.maximum_version_exclusive, upper)
+                with self.assertRaisesRegex(
+                    AdapterError,
+                    rf"{harness} {re.escape(below)} is older than required {re.escape(lower)}",
+                ):
+                    adapter._probe_result(below)
+                with self.assertRaisesRegex(
+                    AdapterError,
+                    rf"{harness} {re.escape(upper)} is outside supported range",
+                ):
+                    adapter._probe_result(upper)
+
+    def test_verified_probe_result_and_missing_upper_manifest_contract(self) -> None:
+        adapter, _native = self.build("claude")
+        result = adapter._probe_result("2.1.222")
+        self.assertEqual(result.compatibility, "verified")
+        self.assertEqual(result.verified_version, "2.1.222")
+        self.assertEqual(result.maximum_version_exclusive, "2.2.0")
+
+        manifest = json.loads(
+            (ROOT / ".super-coder" / "adapters" / "claude" / "adapter.json").read_text()
+        )
+        del manifest["conversation"]["maximum_cli_version_exclusive"]
+        invalid = ClaudeAdapter(runner=FakeClaudeRunner(), manifest=manifest)
+        with self.assertRaisesRegex(
+            AdapterError,
+            "HARNESS_MANIFEST_INVALID: harness compatibility range is incomplete",
+        ):
+            invalid._probe_result("2.1.222")
+
+        manifest_root = self.root / "adapters"
+        (manifest_root / "claude").mkdir(parents=True)
+        (manifest_root / "claude" / "adapter.json").write_text(
+            json.dumps(manifest)
+        )
+        with (
+            mock.patch.object(base_adapter, "ADAPTERS", manifest_root),
+            self.assertRaisesRegex(
+                AdapterError,
+                "HARNESS_MANIFEST_INVALID: harness compatibility range is incomplete",
+            ),
+        ):
+            base_adapter.load_manifest("claude")
 
     def write_claude_session(
         self,

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -964,7 +964,7 @@ class ConversationResourceTest(ConversationApiCase):
             ],
         )
 
-    def test_opencode_requires_an_exact_resolved_model(self) -> None:
+    def test_opencode_uses_the_common_unresolved_model_refusal(self) -> None:
         with mock.patch.object(
             conversation_routes.run_mod,
             "flavor_defaults",
@@ -982,9 +982,12 @@ class ConversationResourceTest(ConversationApiCase):
                 key="opencode-no-model",
             )
         self.assertEqual(status, 422)
-        self.assertEqual(error["error"]["code"], "HARNESS_MODEL_REQUIRED")
-        self.assertIn("provider connected in OpenCode",
-                      error["error"]["message"])
+        self.assertEqual(error["error"]["code"], "HARNESS_ROUTE_INVALID")
+        self.assertEqual(
+            error["error"]["message"],
+            "harness 'opencode' cannot resolve a model: no model was supplied "
+            "and no flavor default exists for it; supply an explicit model",
+        )
 
         status, _, created = self.request(
             "POST",
@@ -999,9 +1002,10 @@ class ConversationResourceTest(ConversationApiCase):
         self.assertEqual(status, 201, created)
         self.assertEqual(created["route"]["model"], "openai/gpt-connected")
 
-    def test_kimi_create_allows_native_default_model_and_resolves_route(
+    def test_kimi_create_refuses_unresolved_model_before_writing_a_chat(
         self,
     ) -> None:
+        resolver = conversation_routes.run_mod.resolve_headless_route
         with mock.patch.object(
             conversation_routes.run_mod,
             "flavor_defaults",
@@ -1011,36 +1015,39 @@ class ConversationResourceTest(ConversationApiCase):
                     "models": {},
                 }
             },
-        ):
-            status, _, created = self.request(
+        ), mock.patch.object(
+            conversation_routes.run_mod,
+            "resolve_headless_route",
+            wraps=resolver,
+        ) as resolve:
+            status, _, error = self.request(
                 "POST",
                 "/api/conversations",
                 body={"shell_id": 1, "harness": "kimi"},
-                key="kimi-native-default",
+                key="kimi-unresolved-model",
             )
-        self.assertEqual(status, 201, created)
+        self.assertEqual(status, 422, error)
         self.assertEqual(
-            created["route"],
-            {
-                "harness": "kimi",
-                "provider": "kimi",
-                "model": None,
-                "effort": "high",
-            },
+            error["error"]["code"],
+            "HARNESS_ROUTE_INVALID",
         )
-        con = self.connect()
-        try:
-            row = con.execute(
-                "SELECT harness,provider,model,effort FROM conversations "
-                "WHERE conversation_id=?",
-                (created["conversation_id"],),
-            ).fetchone()
-        finally:
-            con.close()
         self.assertEqual(
-            tuple(row),
-            ("kimi", "kimi", None, "high"),
+            error["error"]["message"],
+            "harness 'kimi' cannot resolve a model: no model was supplied and "
+            "no flavor default exists for it; supply an explicit model",
         )
+        resolve.assert_called_once_with(
+            harness="kimi",
+            adapter=mock.ANY,
+            flavor_model=None,
+            model=None,
+            effort=None,
+        )
+        with closing(self.connect()) as con:
+            self.assertEqual(
+                con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0],
+                0,
+            )
 
     def test_create_is_idempotent_and_never_exposes_native_identity(self) -> None:
         first = self.create(title="API")

--- a/tests/test_conversation_capabilities.py
+++ b/tests/test_conversation_capabilities.py
@@ -67,16 +67,30 @@ class ConversationCapabilityContractTest(unittest.TestCase):
                 )
                 self.assertFalse(execution["sandbox_flag_required"])
                 self.assertRegex(conversation["minimum_cli_version"], VERSION)
+                self.assertRegex(
+                    conversation["maximum_cli_version_exclusive"], VERSION
+                )
                 self.assertEqual(
                     conversation["verified_cli_version"],
                     probe["verified_cli_version"],
                 )
-                if harness != "kimi":
-                    self.assertEqual(
-                        conversation["minimum_cli_version"],
-                        conversation["verified_cli_version"],
-                        "the spike uses the live-probed version as its floor",
-                    )
+                self.assertEqual(
+                    conversation["maximum_cli_version_exclusive"],
+                    probe["maximum_cli_version_exclusive"],
+                )
+                self.assertLessEqual(
+                    tuple(map(int, conversation["minimum_cli_version"].split("."))),
+                    tuple(map(int, conversation["verified_cli_version"].split("."))),
+                )
+                self.assertLess(
+                    tuple(map(int, conversation["verified_cli_version"].split("."))),
+                    tuple(
+                        map(
+                            int,
+                            conversation["maximum_cli_version_exclusive"].split("."),
+                        )
+                    ),
+                )
                 self.assertEqual(conversation["driver"], probe["driver"])
                 self.assertEqual(
                     set(conversation["capabilities"]),

--- a/tests/test_conversation_launch.py
+++ b/tests/test_conversation_launch.py
@@ -33,7 +33,7 @@ def make_run(
     *,
     conversation_id: str = "cv_" + "a" * 32,
     harness: str = "codex",
-    model: str = "gpt-test",
+    model: str | None = "gpt-test",
     session_before: str | None = None,
 ) -> BrokerRun:
     return BrokerRun(
@@ -119,6 +119,74 @@ def test_preparer_returns_canonical_environment_and_archive(launch_case):
         "effort": "high",
         "headless_prompt": "Do the work",
     }]
+
+
+def test_preexisting_null_model_chat_refuses_turn_and_preserves_row(launch_case):
+    db_path, worktree = launch_case
+    conversation_id = "cv_" + "a" * 32
+    con = sqlite3.connect(db_path)
+    con.execute(
+        "DELETE FROM conversations WHERE conversation_id=?", (conversation_id,)
+    )
+    con.execute(
+        "INSERT INTO conversations "
+        "(conversation_id,shell_id,owner_user_id,harness,provider,model,"
+        "effort,worktree,state,creation_idempotency_key,creation_request_hash) "
+        "VALUES (?,1,1,'kimi','kimi',NULL,'high',?,'idle',"
+        "'legacy-null-create','legacy-null-hash')",
+        (conversation_id, str(worktree)),
+    )
+    con.commit()
+    con.close()
+
+    adapter = {
+        "harness": "kimi",
+        "headless": {
+            "launch": ["kimi", "--prompt", "{prompt}"],
+            "model_flag": "--model",
+            "effort": {"flag": "--effort"},
+        },
+    }
+
+    def prepare(**kwargs):
+        try:
+            run_mod.resolve_headless_route(
+                harness=kwargs["harness"],
+                adapter=adapter,
+                flavor_model=None,
+                model=kwargs["model"],
+                effort=kwargs["effort"],
+            )
+        except ValueError as exc:
+            raise run_mod.LaunchError(str(exc)) from exc
+        raise AssertionError("a legacy NULL route must not become dispatchable")
+
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=prepare,
+        liveness=lambda: {"supported": True, "processes": []},
+    )
+    with pytest.raises(ConversationLaunchError) as caught:
+        preparer(make_run(worktree, harness="kimi", model=None))
+
+    assert caught.value.code == "CONVERSATION_LAUNCH_REFUSED"
+    assert caught.value.detail == (
+        "harness 'kimi' cannot resolve a model: no model was supplied and no "
+        "flavor default exists for it; supply an explicit model"
+    )
+    con = sqlite3.connect(db_path)
+    try:
+        assert con.execute(
+            "SELECT harness,provider,model,state FROM conversations "
+            "WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone() == ("kimi", "kimi", None, "idle")
+        assert con.execute(
+            "SELECT COUNT(*) FROM conversation_runs WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()[0] == 0
+    finally:
+        con.close()
 
 
 def test_preparer_refuses_a_cli_process_holding_the_shell(launch_case):

--- a/tests/test_harness_epoch.py
+++ b/tests/test_harness_epoch.py
@@ -382,6 +382,19 @@ class ScHarnessCommands(unittest.TestCase):
              f"{self.fx.scripts / 'harness_versions.py'}"],
         )
 
+    def test_harness_status_keeps_stopped_runtime_provenance_with_compatibility(self):
+        result = self.fx.run("harness-status", SC_TEST_RUNNING="")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "runtime:   sandbox 'sc-fork' · not running",
+            result.stdout,
+        )
+        self.assertIn(
+            "adapters:  unavailable until ./sc launch starts that runtime",
+            result.stdout,
+        )
+        self.assertNotIn("9.9.9", result.stdout)
+
     def test_harness_status_flags_an_image_that_owes_a_rebuild(self):
         self.fx.run("build", "--harnesses")
         result = self.fx.run("harness-status", SC_TEST_LABEL="2020-01-01")

--- a/tests/test_harness_versions.py
+++ b/tests/test_harness_versions.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Runtime provenance and adapter compatibility status contracts."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+
+import harness_versions  # noqa: E402
+
+
+STATUS = {
+    "codex": {
+        "version": "0.145.0",
+        "compatibility": "verified",
+        "minimum_version": "0.145.0",
+        "maximum_version_exclusive": "0.147.0",
+        "verified_version": "0.145.0",
+        "error": None,
+    }
+}
+
+
+def test_runtime_binary_version_is_checked_against_adapter_range() -> None:
+    with (
+        mock.patch.object(harness_versions, "HARNESSES", ("claude",)),
+        mock.patch.object(
+            harness_versions,
+            "probe",
+            return_value="2.1.222 (Claude Code)",
+        ),
+    ):
+        assert harness_versions.compatibility_status() == {
+            "claude": {
+                "version": "2.1.222",
+                "compatibility": "verified",
+                "minimum_version": "2.1.220",
+                "maximum_version_exclusive": "2.2.0",
+                "verified_version": "2.1.222",
+                "error": None,
+            }
+        }
+
+
+def test_text_status_couples_host_provenance_and_compatibility() -> None:
+    output = io.StringIO()
+    with (
+        mock.patch.object(harness_versions, "compatibility_status", return_value=STATUS),
+        mock.patch.dict(os.environ, {}, clear=True),
+        redirect_stdout(output),
+    ):
+        assert harness_versions.main([]) == 0
+
+    assert output.getvalue().splitlines() == [
+        "  runtime:   host",
+        "  codex     0.145.0 · verified · supported [0.145.0, 0.147.0)",
+    ]
+
+
+def test_json_status_couples_sandbox_provenance_and_compatibility() -> None:
+    output = io.StringIO()
+    with (
+        mock.patch.object(harness_versions, "compatibility_status", return_value=STATUS),
+        mock.patch.dict(os.environ, {"SC_SANDBOX": "1"}, clear=True),
+        redirect_stdout(output),
+    ):
+        assert harness_versions.main(["--json"]) == 0
+
+    assert json.loads(output.getvalue()) == {
+        "runtime": "sandbox",
+        "harnesses": STATUS,
+    }

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -374,6 +374,59 @@ class HeadlessSessionFailureTest(unittest.TestCase):
         atomic_write.assert_not_called()
         execvpe.assert_not_called()
 
+    def test_sc_run_headless_refuses_missing_model_before_session_creation(self) -> None:
+        con = mock.Mock()
+        con.execute.return_value.fetchall.return_value = []
+        chosen = {"shell_id": 1, "shortname": "DEV1", "flavor": "dev"}
+        fdefaults = {
+            "dev": {"default_harness": "kimi", "models": {}}
+        }
+        open_session = mock.Mock()
+        ensure_worktree = mock.Mock()
+        execvpe = mock.Mock()
+
+        with mock.patch.dict(run.os.environ, {}, clear=True), \
+                mock.patch.object(
+                    run.sys, "argv",
+                    ["run.py", "--headless", "DEV1", "--harness", "kimi"]), \
+                mock.patch.object(run, "open_db", return_value=con), \
+                mock.patch.object(
+                    run.seed_skills, "sync_engine_skills", return_value=[]), \
+                mock.patch.object(
+                    run, "authenticate", return_value={"user_id": 1}), \
+                mock.patch.object(run, "flavor_defaults", return_value=fdefaults), \
+                mock.patch.object(run, "list_shells", return_value=[chosen]), \
+                mock.patch.object(run, "pick_shell", return_value=chosen), \
+                mock.patch.object(
+                    run.shell_liveness, "compute",
+                    return_value={"supported": False, "indeterminate": 0}), \
+                mock.patch.object(run, "ensure_harness_path"), \
+                mock.patch.object(
+                    run, "load_adapter",
+                    return_value={
+                        "harness": "kimi",
+                        "headless": {
+                            "launch": ["kimi", "--prompt", "{prompt}"],
+                            "model_flag": "--model",
+                            "effort": {"flag": "--effort"},
+                        },
+                    },
+                ), \
+                mock.patch.object(run, "open_session", open_session), \
+                mock.patch.object(run, "ensure_worktree", ensure_worktree), \
+                mock.patch.object(run.os, "execvpe", execvpe), \
+                self.assertRaises(SystemExit) as raised:
+            run.main()
+
+        self.assertEqual(
+            str(raised.exception),
+            "sc run: harness 'kimi' cannot resolve a model: no model was "
+            "supplied and no flavor default exists for it; supply an explicit model",
+        )
+        open_session.assert_not_called()
+        ensure_worktree.assert_not_called()
+        execvpe.assert_not_called()
+
 
 LAUNCH_RECORDS = """
 CREATE TABLE shell_launch_records (

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -159,7 +159,9 @@ class SprintCliApiTest(unittest.TestCase):
             ).lastrowid
         )
         con.commit()
-        initial_wake = sprint_domain.SprintLifecycleStore(con).arm(cls.sprint_id, 3)[0]
+        initial_wake = sprint_domain.SprintLifecycleStore(
+            con, probe_harness=lambda _harness: None
+        ).arm(cls.sprint_id, 3)[0]
         initial_message = int(
             con.execute(
                 "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",
@@ -238,7 +240,16 @@ class SprintCliApiTest(unittest.TestCase):
     def run_cli(self, token: str, *argv: str) -> dict:
         mem.SC_API_TOKEN = token
         output = io.StringIO()
-        with contextlib.redirect_stdout(output):
+        adapter = mock.Mock()
+        adapter.probe.return_value = None
+        with (
+            mock.patch.object(
+                server.sprint_domain,
+                "adapter_for",
+                return_value=adapter,
+            ),
+            contextlib.redirect_stdout(output),
+        ):
             self.assertEqual(0, sprint_cli.main(list(argv)))
         return json.loads(output.getvalue())
 

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -151,6 +151,11 @@ class SprintLiveProof(unittest.TestCase):
         output = io.StringIO()
         with (
             mock.patch.object(
+                server.sprint_domain,
+                "adapter_for",
+                return_value=mock.Mock(probe=mock.Mock(return_value=None)),
+            ),
+            mock.patch.object(
                 server.sprint_pr_watcher,
                 "GitHubPullRequestReader",
                 return_value=self.github,
@@ -648,7 +653,9 @@ class SprintLiveProof(unittest.TestCase):
 
     def test_conversation_and_watcher_writes_share_wal_without_lock_loss(self) -> None:
         sprint_id, _document_id, units = self.prepare(((1, 2, ()),))
-        sprint_domain.SprintLifecycleStore(self.con).arm(sprint_id, 3)
+        sprint_domain.SprintLifecycleStore(
+            self.con, probe_harness=lambda _harness: None
+        ).arm(sprint_id, 3)
         self.deliver_browser_turns()
         self.accept_assignment(units[0], 1)
         self.github.set(3001, "OPEN", checks="PENDING")

--- a/tests/test_sprint_liveness.py
+++ b/tests/test_sprint_liveness.py
@@ -148,9 +148,9 @@ class SprintLivenessCase(unittest.TestCase):
             (self.sprint_id, self.unit_id, task_id),
         )
         self.con.commit()
-        wake_id = sprint_domain.SprintLifecycleStore(self.con).arm(
-            self.sprint_id, 3
-        )[0]
+        wake_id = sprint_domain.SprintLifecycleStore(
+            self.con, probe_harness=lambda _harness: None
+        ).arm(self.sprint_id, 3)[0]
         self.assignment_message_id = int(
             self.con.execute(
                 "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",

--- a/tests/test_sprint_message_delivery.py
+++ b/tests/test_sprint_message_delivery.py
@@ -329,7 +329,9 @@ class SprintMessageCase(unittest.TestCase):
             ).lastrowid
         )
         self.con.commit()
-        self.lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        self.lifecycle = sprint_domain.SprintLifecycleStore(
+            self.con, probe_harness=lambda _harness: None
+        )
         initial_wake = self.lifecycle.arm(self.sprint_id, 3)[0]
         setup_delivery = delivery.SprintWakeDeliveryService(self.con)
         planner_delivery: list[str] = []
@@ -2420,6 +2422,53 @@ class ParticipantRelayTest(SprintMessageCase):
                 "WHERE conversation_id=?",
                 (conversation_id,),
             ).fetchone()[0],
+        )
+
+    def test_closed_planner_reenter_uses_the_open_chat_canonical_route(self) -> None:
+        original = self.con.execute(
+            "SELECT c.conversation_id,c.harness,c.provider,c.model,c.effort,"
+            "c.worktree FROM active_shell_chats active "
+            "JOIN conversations c ON c.conversation_id=active.chat_id "
+            "WHERE active.shell_id=3"
+        ).fetchone()
+        self.assertEqual("codex", original["harness"])
+        self.assertEqual("openai", original["provider"])
+        self.assertIsInstance(original["model"], str)
+        self.assertNotEqual("", original["model"])
+        self.assertEqual("high", original["effort"])
+
+        with self.con:
+            closed = active_chat_registry.close_for_wake(self.con, 3)
+        self.assertEqual(original["conversation_id"], closed.chat_id)
+
+        receipt = self.messages.relay(
+            self.sprint_id,
+            from_shell_id=1,
+            to_shortname="PLN1",
+            body="Planner re-entry after the originating chat closed.",
+            idempotency_key="participant-send:closed-planner-reenter",
+        )
+        observed: list[str] = []
+        outcome = delivery.SprintWakeDeliveryService(self.con).deliver_once(
+            "closed-planner-reenter",
+            lambda conversation, _prompt, _key: (
+                observed.append(conversation) or "closed-planner-run"
+            ),
+        )
+
+        self.assertEqual(receipt.wake_id, outcome.wake_id)
+        self.assertEqual(1, len(observed))
+        self.assertNotEqual(original["conversation_id"], observed[0])
+        replacement = self.con.execute(
+            "SELECT harness,provider,model,effort,worktree "
+            "FROM conversations WHERE conversation_id=?",
+            (observed[0],),
+        ).fetchone()
+        self.assertEqual(
+            tuple(original[field] for field in (
+                "harness", "provider", "model", "effort", "worktree"
+            )),
+            tuple(replacement),
         )
 
     def test_delivery_reroutes_when_the_created_wake_chat_closes(self) -> None:

--- a/tests/test_sprint_participant_chats.py
+++ b/tests/test_sprint_participant_chats.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import sys
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -15,11 +17,13 @@ sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
 
 import active_chat_registry
 import sprint_participant_chats
+from conversation_broker import BrokerRun
+from conversation_launch import ConversationLaunchPreparer
 
 
 @contextmanager
-def substrate():
-    con = sqlite3.connect(":memory:")
+def substrate(database: str = ":memory:"):
+    con = sqlite3.connect(database)
     con.row_factory = sqlite3.Row
     con.executescript(
         """
@@ -29,7 +33,15 @@ def substrate():
           shell_id INTEGER PRIMARY KEY,
           shortname TEXT NOT NULL,
           flavor TEXT,
-          user_id INTEGER REFERENCES users(user_id)
+          user_id INTEGER REFERENCES users(user_id),
+          is_deleted INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE flavor_defaults (
+          flavor TEXT NOT NULL,
+          harness TEXT NOT NULL,
+          model TEXT NOT NULL,
+          is_default INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (flavor, harness)
         );
         CREATE TABLE roadmap (feature_id INTEGER PRIMARY KEY, title TEXT NOT NULL);
         CREATE TABLE sprints (
@@ -127,7 +139,12 @@ def substrate():
         INSERT INTO users VALUES (1);
         INSERT INTO roadmap VALUES (31,'Collaborative orchestration');
         INSERT INTO shells VALUES
-          (10,'DEV1','dev',1),(20,'REV1','reviewer',1),(30,'PLN1','planner',1);
+          (10,'DEV1','dev',1,0),(20,'REV1','reviewer',1,0),
+          (30,'PLN1','planner',1,0);
+        INSERT INTO flavor_defaults VALUES
+          ('dev','codex','gpt-test',1),
+          ('reviewer','kimi','kimi-test',1),
+          ('planner','codex','planner-test',1);
         INSERT INTO sprints VALUES
           (7,31,30,'0123456789abcdef0123456789abcdef','armed',NULL);
         INSERT INTO sprint_participants
@@ -281,6 +298,126 @@ def test_new_wake_requires_committed_close_then_preserves_history() -> None:
                 "ORDER BY participant_conversation_id"
             )
         ] == [(first,), (second,)]
+
+
+def test_closed_planner_reenter_persists_canonical_default_route(tmp_path) -> None:
+    db_path = tmp_path / "shell.db"
+    with substrate(str(db_path)) as con:
+        first = create_wake(con, wake_id=45, participant_id=103)
+        con.execute("BEGIN")
+        closed = active_chat_registry.close_for_wake(con, 30)
+        con.execute(
+            "UPDATE sprint_participants SET model=NULL,effort=NULL "
+            "WHERE participant_id=103"
+        )
+        con.commit()
+        assert closed is not None and closed.chat_id == first
+
+        replacement = create_wake(con, wake_id=46, participant_id=103)
+        stored = con.execute(
+            "SELECT harness,provider,model,effort,worktree,title,"
+            "creation_request_hash "
+            "FROM conversations WHERE conversation_id=?",
+            (replacement,),
+        ).fetchone()
+
+    broker_run = BrokerRun(
+        run_id=7,
+        conversation_id=replacement,
+        message_id=8,
+        shell_id=30,
+        harness=stored["harness"],
+        provider=stored["provider"],
+        model=stored["model"],
+        effort=stored["effort"],
+        worktree=Path(stored["worktree"]),
+        title=stored["title"],
+        body="Pick up the Planner handoff",
+        session_before=None,
+        session_after=None,
+        runner_ref=None,
+        state="leased",
+    )
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=lambda **_: SimpleNamespace(
+            cwd=stored["worktree"],
+            archive_id=42,
+            harness="codex",
+            model="planner-test",
+            effort="high",
+            env={},
+        ),
+        liveness=lambda: {"supported": True, "processes": []},
+    )
+
+    context, archive_id = preparer(broker_run)
+
+    assert archive_id == 42
+    assert context.model == "planner-test"
+    assert context.effort == "high"
+    assert tuple(
+        stored[field] for field in ("harness", "provider", "model", "effort")
+    ) == (
+        "codex",
+        "openai",
+        "planner-test",
+        "high",
+    )
+    expected_request = {
+        "effort": "high",
+        "harness": "codex",
+        "model": "planner-test",
+        "participant_id": 103,
+        "provider": "openai",
+        "sprint_id": 7,
+        "wake_id": 46,
+        "worktree": stored["worktree"],
+    }
+    assert stored["creation_request_hash"] == hashlib.sha256(
+        json.dumps(expected_request, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+
+
+def test_explicit_participant_route_is_preserved_byte_for_byte() -> None:
+    with substrate() as con:
+        exact_model = "GPT-Test@Exact/Case"
+        exact_effort = "xHigh"
+        con.execute(
+            "UPDATE sprint_participants SET model=?,effort=? "
+            "WHERE participant_id=101",
+            (exact_model, exact_effort),
+        )
+        con.commit()
+
+        conversation_id = create_wake(con, wake_id=47)
+        stored = con.execute(
+            "SELECT model,effort FROM conversations WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()
+
+        assert tuple(stored) == (exact_model, exact_effort)
+
+
+def test_unresolvable_participant_route_creates_no_chat() -> None:
+    with substrate() as con:
+        con.execute(
+            "UPDATE sprint_participants SET model=NULL,effort=NULL "
+            "WHERE participant_id=103"
+        )
+        con.execute(
+            "DELETE FROM flavor_defaults WHERE flavor='planner' AND harness='codex'"
+        )
+        con.commit()
+
+        with pytest.raises(
+            sprint_participant_chats.SprintConversationError,
+            match="has no model selected or flavor default",
+        ):
+            create_wake(con, wake_id=48, participant_id=103)
+
+        assert con.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] == 0
+        assert con.execute("SELECT COUNT(*) FROM active_shell_chats").fetchone()[0] == 0
 
 
 def test_flat_link_rejects_cross_shell_and_is_immutable() -> None:

--- a/tests/test_sprint_participant_chats.py
+++ b/tests/test_sprint_participant_chats.py
@@ -412,7 +412,10 @@ def test_unresolvable_participant_route_creates_no_chat() -> None:
 
         with pytest.raises(
             sprint_participant_chats.SprintConversationError,
-            match="has no model selected or flavor default",
+            match=(
+                "no model was supplied and no flavor default exists for it; "
+                "supply an explicit model"
+            ),
         ):
             create_wake(con, wake_id=48, participant_id=103)
 

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -52,7 +52,9 @@ class SprintDomainCase(unittest.TestCase):
             ),
         )
         self.con.commit()
-        self.store = sprint_domain.SprintLifecycleStore(self.con)
+        self.store = sprint_domain.SprintLifecycleStore(
+            self.con, probe_harness=lambda _harness: None
+        )
         self.serial = 0
 
     def create_sprint(
@@ -975,7 +977,9 @@ class ArmedServiceSwitchTest(SprintDomainCase):
                     "VALUES (1,1,2,'Unit','Output')"
                 )
                 seed.commit()
-                sprint_domain.SprintLifecycleStore(seed).arm(1, 3)
+                sprint_domain.SprintLifecycleStore(
+                    seed, probe_harness=lambda _harness: None
+                ).arm(1, 3)
 
             calls: list[tuple[int, str]] = []
             with closing(db_driver.connect(path)) as restarted:

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -22,6 +22,7 @@ import server
 import sprint_domain
 import sprint_message_delivery as delivery
 import sprint_runtime
+from conversation_adapters import AdapterError
 
 
 def apply_schema(con: sqlite3.Connection) -> None:
@@ -117,7 +118,9 @@ class SprintWorkDispatchCase(unittest.TestCase):
         ]
         self.con.commit()
         self.units = sprint_domain.SprintWorkUnitStore(self.con)
-        self.lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        self.lifecycle = sprint_domain.SprintLifecycleStore(
+            self.con, probe_harness=lambda _harness: None
+        )
         self.messages = delivery.SprintMessageStore(self.con)
         self.next_task = 0
 
@@ -185,6 +188,163 @@ class SprintWorkDispatchCase(unittest.TestCase):
 
 
 class DispatchGateTest(SprintWorkDispatchCase):
+    def assert_arm_left_no_writes(self) -> None:
+        self.assertEqual(
+            ("prepared", 0, 0, 0),
+            (
+                self.con.execute(
+                    "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                    (self.sprint_id,),
+                ).fetchone()[0],
+                self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0],
+                self.con.execute(
+                    "SELECT COUNT(*) FROM sprint_wake_outbox"
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                    "AND event_type='lifecycle.armed'",
+                    (self.sprint_id,),
+                ).fetchone()[0],
+            ),
+        )
+
+    def test_arm_probes_each_distinct_harness_once_outside_write_transaction(self) -> None:
+        self.create_unit(developer=1)
+        observed: list[tuple[str, bool]] = []
+        lifecycle = sprint_domain.SprintLifecycleStore(
+            self.con,
+            probe_harness=lambda harness: observed.append(
+                (harness, self.con.in_transaction)
+            ),
+        )
+
+        lifecycle.arm(self.sprint_id, 3)
+
+        self.assertEqual([("codex", False), ("kimi", False)], observed)
+
+    def test_arm_default_preflight_uses_the_conversation_adapter_probe(self) -> None:
+        self.create_unit(developer=1)
+        adapters = {
+            harness: mock.Mock(
+                probe=mock.Mock(
+                    side_effect=lambda: self.assertFalse(self.con.in_transaction)
+                )
+            )
+            for harness in ("codex", "kimi")
+        }
+        with mock.patch.object(
+            sprint_domain,
+            "adapter_for",
+            side_effect=lambda harness: adapters[harness],
+        ) as adapter_factory:
+            sprint_domain.SprintLifecycleStore(self.con).arm(self.sprint_id, 3)
+
+        self.assertEqual(
+            [mock.call("codex"), mock.call("kimi")],
+            adapter_factory.call_args_list,
+        )
+        adapters["codex"].probe.assert_called_once_with()
+        adapters["kimi"].probe.assert_called_once_with()
+
+    def test_arm_rejects_missing_binary_before_any_write(self) -> None:
+        self.create_unit(developer=1)
+
+        def unavailable(harness: str):
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                f"cannot probe {harness}",
+                retryable=True,
+            )
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "HARNESS_UNAVAILABLE",
+        ):
+            sprint_domain.SprintLifecycleStore(
+                self.con, probe_harness=unavailable
+            ).arm(self.sprint_id, 3)
+
+        self.assert_arm_left_no_writes()
+
+    def test_arm_rejects_unknown_adapter_before_any_write(self) -> None:
+        self.create_unit(developer=1)
+        self.con.execute(
+            "UPDATE sprint_participants SET harness='unknown-harness' "
+            "WHERE sprint_id=? AND role='planner'",
+            (self.sprint_id,),
+        )
+        self.con.commit()
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "unknown-harness.*no browser conversation adapter",
+        ):
+            self.lifecycle.arm(self.sprint_id, 3)
+
+        self.assert_arm_left_no_writes()
+
+    def test_arm_rejects_out_of_range_harness_before_any_write(self) -> None:
+        self.create_unit(developer=1)
+
+        def unsupported(harness: str):
+            raise AdapterError(
+                "HARNESS_VERSION_UNSUPPORTED",
+                f"{harness} 99.0.0 is outside supported range [1.0.0, 2.0.0)",
+            )
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "HARNESS_VERSION_UNSUPPORTED",
+        ):
+            sprint_domain.SprintLifecycleStore(
+                self.con, probe_harness=unsupported
+            ).arm(self.sprint_id, 3)
+
+        self.assert_arm_left_no_writes()
+
+    def test_arm_selection_race_returns_retryable_conflict_without_lifecycle_writes(
+        self,
+    ) -> None:
+        self.create_unit(developer=1)
+        raced = False
+
+        def mutate_once(_harness: str):
+            nonlocal raced
+            if raced:
+                return None
+            raced = True
+            self.con.execute(
+                "UPDATE sprint_participants SET model='raced-model' "
+                "WHERE sprint_id=? AND role='planner'",
+                (self.sprint_id,),
+            )
+            self.con.commit()
+            return None
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "changed during harness preflight; retry arm",
+        ) as caught:
+            sprint_domain.SprintLifecycleStore(
+                self.con, probe_harness=mutate_once
+            ).arm(self.sprint_id, 3)
+
+        self.assert_arm_left_no_writes()
+        handler = object.__new__(server.Handler)
+        handler._send = lambda status, body: (status, body)
+        self.assertEqual(
+            (
+                409,
+                {
+                    "error": (
+                        "participant launch selections changed during harness "
+                        "preflight; retry arm"
+                    )
+                },
+            ),
+            handler._sprint_error(caught.exception),
+        )
+
     def test_ready_units_launch_in_parallel_regardless_of_wave_or_reviewer(self) -> None:
         late_wave = self.create_unit(developer=1, wave=9, title="Late wave")
         early_wave = self.create_unit(developer=4, wave=0, title="Early wave")

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -259,12 +259,18 @@ class DispatchGateTest(SprintWorkDispatchCase):
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError,
             "HARNESS_UNAVAILABLE",
-        ):
+        ) as caught:
             sprint_domain.SprintLifecycleStore(
                 self.con, probe_harness=unavailable
             ).arm(self.sprint_id, 3)
 
         self.assert_arm_left_no_writes()
+        handler = object.__new__(server.Handler)
+        handler._send = lambda status, body: (status, body)
+        self.assertEqual(
+            (422, {"error": "HARNESS_UNAVAILABLE: cannot probe codex"}),
+            handler._sprint_error(caught.exception),
+        )
 
     def test_arm_rejects_unknown_adapter_before_any_write(self) -> None:
         self.create_unit(developer=1)
@@ -278,9 +284,10 @@ class DispatchGateTest(SprintWorkDispatchCase):
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError,
             "unknown-harness.*no browser conversation adapter",
-        ):
+        ) as caught:
             self.lifecycle.arm(self.sprint_id, 3)
 
+        self.assertIsInstance(caught.exception, sprint_domain.SprintPreflightError)
         self.assert_arm_left_no_writes()
 
     def test_arm_rejects_out_of_range_harness_before_any_write(self) -> None:
@@ -295,11 +302,12 @@ class DispatchGateTest(SprintWorkDispatchCase):
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError,
             "HARNESS_VERSION_UNSUPPORTED",
-        ):
+        ) as caught:
             sprint_domain.SprintLifecycleStore(
                 self.con, probe_harness=unsupported
             ).arm(self.sprint_id, 3)
 
+        self.assertIsInstance(caught.exception, sprint_domain.SprintPreflightError)
         self.assert_arm_left_no_writes()
 
     def test_arm_selection_race_returns_retryable_conflict_without_lifecycle_writes(


### PR DESCRIPTION
## Summary

- enforce closed-open harness compatibility ranges and report runtime provenance with compatibility
- resolve participant, browser-chat, and headless CLI routes before hashing or persistence through one shared headless resolver
- preflight distinct harnesses before arm writes; return HTTP 422 for unusable harness routes and preserve HTTP 409 for selection races

## Compatibility proof

Host binaries verified directly on this bare-metal seat:

- Claude 2.1.222; supported [2.1.220, 2.2.0)
- Codex 0.145.0; supported [0.145.0, 0.147.0), admitting field build 0.146.1
- OpenCode 1.18.9; supported [1.18.9, 1.19.0), admitting field build 1.18.13

Kimi files were not changed by this branch. Before DEV3 Unit 1 merged, the full suite was 1907 passed with 9 expected Kimi-only manifest-range failures. After rebasing onto Units 1 and 3 at `a389249`, all adapter boundary checks are green.

## Red before green

On unpatched code, `test_closed_planner_reenter_persists_canonical_default_route` reproduced issue #1056: a Codex Planner participant with NULL model and effort created a replacement chat whose first launch failed `HARNESS_ROUTE_MISMATCH` because canonical preparation changed model/effort. The same test passes with model `planner-test` and effort `high` resolved before request hashing and storage.

## Review fix round

- Engine-wide browser-chat creation now calls `resolve_headless_route`, the same resolver used by Sprint and `sc run` headless creation. If no explicit model or flavor default exists, creation returns HTTP 422 with the harness, cause, and explicit-model remedy; it returns no 201 and writes no conversation row. OpenCode has no special case.
- Pre-existing NULL-model conversations are retained without mutation or deletion. Their next turn is refused as `CONVERSATION_LAUNCH_REFUSED` before a run or prompt dispatch; the operator must close/recreate the chat with an explicit model. A regression test asserts the row remains and zero runs are created.
- Sprint adapter/binary/version preflight refusals use HTTP 422. The exact participant-selection race remains HTTP 409 and both statuses are covered.
- Manifest failures now name the missing compatibility key, including the reviewed `verified_cli_version`-only case.
- Stock Kimi flavor defaults remain outside this PR under flag #216; this change makes their absence honest and early.

## Verification

- `./sc test`: 1967 passed, 1 skipped
- focused route, adapter, browser API, headless CLI, launch, Sprint arm, and participant-chat suites: 180 passed, 45 subtests passed
- `./sc verify`: linked-worktree invocation refused without mutation under known issue #769; canonical verify passed in an isolated clone of exact pushed head `3649fc03130ffc3b41df8f8d980dfce107255659`
- `git diff --check`: green

No task-scope deviations. The verify substitution is the assignment's prescribed workaround for #769.

Closes #1056.
