### PR TITLE
feat(sprint): reset exhausted pickup episodes on resume

### DIFF
--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -35,6 +35,14 @@ WORK_UNIT_OUTPUT_KINDS = frozenset({"code", "report_only", "no_code"})
 WAKE_CONTENTION_BACKOFF_SECONDS = (15, 60, 180, 300)
 WAKE_CONTENTION_ATTEMPTS = 5
 WAKE_DELIVERY_BACKOFF_SECONDS = (15, 60, 180)
+WAKE_PICKUP_PAUSE_REASONS = frozenset(
+    {
+        "wake_pickup_unknown",
+        "wake_pickup_failed",
+        "wake_pickup_unread",
+        "wake_pickup_evidence_invalid",
+    }
+)
 
 
 def _participant_shell_id(con: sqlite3.Connection, participant_id: int) -> int:
@@ -549,7 +557,7 @@ class SprintLifecycleStore:
                 target="armed",
                 outcome=None,
             )
-            reset_wake_ids = self._reset_contention_episode_in_transaction(
+            reset_wake_ids = self._reset_pickup_episodes_in_transaction(
                 sprint_id,
                 actor,
             )
@@ -635,12 +643,12 @@ class SprintLifecycleStore:
             all_anomalies,
         )
 
-    def _reset_contention_episode_in_transaction(
+    def _reset_pickup_episodes_in_transaction(
         self,
         sprint_id: int,
         actor: LifecycleActor,
     ) -> tuple[int, ...]:
-        """Make a human resume the durable anchor of a fresh busy episode."""
+        """Make an authorized resume the anchor of fresh bounded pickup work."""
         report = self.con.execute(
             "SELECT body FROM sprint_reports WHERE sprint_id=? "
             "AND report_kind='pause' ORDER BY report_id DESC LIMIT 1",
@@ -649,62 +657,132 @@ class SprintLifecycleStore:
         if report is None:
             return ()
         pause = json.loads(str(report["body"]))
-        if pause.get("reason") != "wake_contention_exhausted":
+        pause_reason = pause.get("reason")
+        if pause_reason == "wake_contention_exhausted":
+            wake_ids = (int(pause["detail"]["wake_id"]),)
+            classification = "contention_episode_reset"
+            episode_name = "contention-episode"
+        elif pause_reason in WAKE_PICKUP_PAUSE_REASONS:
+            wake_ids = tuple(
+                int(row[0])
+                for row in self.con.execute(
+                    "SELECT DISTINCT "
+                    "CAST(json_extract(e.payload,'$.wake_id') AS INTEGER) wake_id "
+                    "FROM sprint_events e JOIN sprint_wake_outbox w "
+                    "ON w.wake_id=json_extract(e.payload,'$.wake_id') "
+                    "WHERE e.sprint_id=? AND e.event_type='wake.pickup_exhausted' "
+                    "AND w.sprint_id=e.sprint_id "
+                    "AND w.state IN ('delivered','failed') AND EXISTS ("
+                    "SELECT 1 FROM sprint_wake_messages wm "
+                    "JOIN wake_message m USING (message_id) "
+                    "WHERE wm.wake_id=w.wake_id AND wm.sprint_id=e.sprint_id "
+                    "AND m.read_at IS NULL) ORDER BY wake_id",
+                    (sprint_id,),
+                )
+            )
+            classification = "pickup_episode_reset"
+            episode_name = "pickup-episode"
+        else:
             return ()
-        wake_id = int(pause["detail"]["wake_id"])
-        wake = self.con.execute(
-            "SELECT w.participant_id,w.idempotency_key "
-            "FROM sprint_wake_outbox w "
-            "WHERE w.sprint_id=? AND w.wake_id=? "
+        if not wake_ids:
+            return ()
+
+        placeholders = ",".join("?" for _ in wake_ids)
+        wakes = self.con.execute(
+            "SELECT w.wake_id,w.participant_id,w.receiver_shell_id,"
+            "w.idempotency_key FROM sprint_wake_outbox w "
+            f"WHERE w.sprint_id=? AND w.wake_id IN ({placeholders}) "
             "AND w.state IN ('delivered','failed') AND EXISTS ("
             "SELECT 1 FROM sprint_wake_messages wm "
             "JOIN wake_message m USING (message_id) "
             "WHERE wm.sprint_id=w.sprint_id AND wm.wake_id=w.wake_id "
-            "AND m.read_at IS NULL)",
-            (sprint_id, wake_id),
-        ).fetchone()
-        if wake is None:
-            return ()
-        reset_key = f"sprint-resume:{sprint_id}:contention-episode:{wake_id}"
-        replacement_wake_id = int(
+            "AND m.read_at IS NULL) ORDER BY w.wake_id",
+            (sprint_id, *wake_ids),
+        ).fetchall()
+        grouped: dict[int, list[sqlite3.Row]] = {}
+        for wake in wakes:
+            grouped.setdefault(int(wake["participant_id"]), []).append(wake)
+
+        replacements: list[int] = []
+        for participant_id, participant_wakes in grouped.items():
+            receiver_shell_id = int(participant_wakes[0]["receiver_shell_id"])
+            anchor_wake_id = max(int(wake["wake_id"]) for wake in participant_wakes)
+            reset_key = (
+                f"sprint-resume:{sprint_id}:{episode_name}:{anchor_wake_id}"
+            )
+            deliverable = self.con.execute(
+                "SELECT wake_id,idempotency_key FROM sprint_wake_outbox "
+                "WHERE receiver_shell_id=? AND state='pending'",
+                (receiver_shell_id,),
+            ).fetchone()
+            if deliverable is None:
+                replacement_wake_id = int(
+                    self.con.execute(
+                        "INSERT INTO sprint_wake_outbox "
+                        "(sprint_id,participant_id,receiver_shell_id,idempotency_key,"
+                        "available_at) VALUES (?,?,?,?,datetime('now'))",
+                        (
+                            sprint_id,
+                            participant_id,
+                            receiver_shell_id,
+                            reset_key,
+                        ),
+                    ).lastrowid
+                )
+            else:
+                replacement_wake_id = int(deliverable["wake_id"])
+                if str(deliverable["idempotency_key"]) != reset_key:
+                    self.con.execute(
+                        "UPDATE sprint_wake_outbox SET idempotency_key=?,"
+                        "available_at=datetime('now') WHERE wake_id=? "
+                        "AND state='pending'",
+                        (reset_key, replacement_wake_id),
+                    )
+
+            source_wake_ids = tuple(
+                int(wake["wake_id"]) for wake in participant_wakes
+            )
+            source_placeholders = ",".join("?" for _ in source_wake_ids)
+            unread_message_ids = tuple(
+                int(row[0])
+                for row in self.con.execute(
+                    "SELECT m.message_id FROM sprint_wake_messages wm "
+                    "JOIN wake_message m USING (message_id) "
+                    f"WHERE wm.sprint_id=? AND wm.wake_id IN ({source_placeholders}) "
+                    "AND m.read_at IS NULL ORDER BY m.message_id",
+                    (sprint_id, *source_wake_ids),
+                )
+            )
+            if not unread_message_ids:
+                continue
+            message_placeholders = ",".join("?" for _ in unread_message_ids)
             self.con.execute(
-                "INSERT INTO sprint_wake_outbox "
-                "(sprint_id,participant_id,receiver_shell_id,idempotency_key,"
-                "available_at) VALUES (?,?,?,?,datetime('now'))",
-                (
+                "UPDATE wake_message SET delivered_at=NULL "
+                f"WHERE message_id IN ({message_placeholders})",
+                unread_message_ids,
+            )
+            self.con.execute(
+                "UPDATE sprint_wake_messages SET wake_id=? "
+                f"WHERE message_id IN ({message_placeholders})",
+                (replacement_wake_id, *unread_message_ids),
+            )
+            for wake in participant_wakes:
+                self._event(
                     sprint_id,
-                    int(wake["participant_id"]),
-                    _participant_shell_id(self.con, int(wake["participant_id"])),
-                    reset_key,
-                ),
-            ).lastrowid
-        )
-        self.con.execute(
-            "UPDATE wake_message SET delivered_at=NULL WHERE message_id IN ("
-            "SELECT message_id FROM sprint_wake_messages "
-            "WHERE sprint_id=? AND wake_id=?)",
-            (sprint_id, wake_id),
-        )
-        self.con.execute(
-            "UPDATE sprint_wake_messages SET wake_id=? "
-            "WHERE sprint_id=? AND wake_id=?",
-            (replacement_wake_id, sprint_id, wake_id),
-        )
-        self._event(
-            sprint_id,
-            "wake.requeued",
-            actor,
-            {
-                "trigger": "resume",
-                "classification": "contention_episode_reset",
-                "prior_wake_id": wake_id,
-                "replacement_wake_id": replacement_wake_id,
-                "prior_idempotency_key": str(wake["idempotency_key"]),
-                "idempotency_key": reset_key,
-                "replacement_conversation_id": None,
-            },
-        )
-        return (replacement_wake_id,)
+                    "wake.requeued",
+                    actor,
+                    {
+                        "trigger": "resume",
+                        "classification": classification,
+                        "prior_wake_id": int(wake["wake_id"]),
+                        "replacement_wake_id": replacement_wake_id,
+                        "prior_idempotency_key": str(wake["idempotency_key"]),
+                        "idempotency_key": reset_key,
+                        "replacement_conversation_id": None,
+                    },
+                )
+            replacements.append(replacement_wake_id)
+        return tuple(sorted(set(replacements)))
 
     def abort(
         self,
@@ -1620,6 +1698,7 @@ class SprintLifecycleStore:
             if payload.get("classification") in {
                 "shell_busy",
                 "contention_episode_reset",
+                "pickup_episode_reset",
             }:
                 continue
             if payload.get("prior_wake_id") is not None:

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -959,6 +959,54 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ),
         )
 
+    def test_busy_recovery_with_non_busy_terminal_enters_pickup_episode(self):
+        message = self.send("busy-chain-non-busy-terminal")
+        original = int(message.wake_id)
+        self.fail_wake_turn(original, error_code="SHELL_BUSY")
+        busy_recovery = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="busy-chain-entry",
+        )[0]
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET available_at="
+            "datetime('now','-1 second') WHERE wake_id=?",
+            (busy_recovery,),
+        )
+        self.con.commit()
+        self.fail_wake_turn(
+            busy_recovery,
+            error_code="HARNESS_ROUTE_MISMATCH",
+        )
+
+        replacements = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="busy-chain-non-busy-terminal",
+        )
+
+        self.assertEqual(1, len(replacements))
+        pickup_recovery = replacements[0]
+        self.assertEqual(
+            (
+                "armed",
+                pickup_recovery,
+                f"sprint-recovery:{self.sprint_id}:delivered-unread:{busy_recovery}",
+                "pending",
+                0,
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,wm.wake_id,w.idempotency_key,w.state,"
+                    "(SELECT COUNT(*) FROM sprint_events e "
+                    "WHERE e.sprint_id=s.sprint_id "
+                    "AND e.event_type='wake.pickup_exhausted') "
+                    "FROM sprints s JOIN sprint_wake_messages wm "
+                    "ON wm.message_id=? JOIN sprint_wake_outbox w "
+                    "ON w.wake_id=wm.wake_id WHERE s.sprint_id=?",
+                    (message.message_id, self.sprint_id),
+                ).fetchone()
+            ),
+        )
+
     def test_unknown_first_turn_pauses_without_replacement(self):
         message = self.send("unknown-first-turn")
         original = int(message.wake_id)
@@ -1249,6 +1297,346 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                     (self.sprint_id,),
                 ).fetchone()[0]
             )["reason"],
+        )
+
+    def test_resume_resets_exhausted_pickup_as_one_fresh_bounded_episode(self):
+        first = self.send(
+            "resume-exhausted-first",
+            declared_type="re-enter",
+        )
+        second = self.send(
+            "resume-exhausted-second",
+            declared_type="new",
+        )
+        handled = self.send(
+            "resume-exhausted-handled",
+            declared_type="re-enter",
+        )
+        terminal = int(first.wake_id)
+        self.assertEqual(terminal, second.wake_id)
+        self.assertEqual(terminal, handled.wake_id)
+        self.fail_wake_turn(terminal, error_code="HARNESS_ROUTE_MISMATCH")
+        exhausted = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="resume-exhausted-first-failure",
+        )[0]
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET available_at="
+            "datetime('now','-1 second') WHERE wake_id=?",
+            (exhausted,),
+        )
+        self.con.commit()
+        self.fail_wake_turn(exhausted, error_code="HARNESS_ROUTE_MISMATCH")
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="resume-exhausted-second-failure",
+            ),
+        )
+        self.assertEqual(
+            "paused",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+        self.assertIsNone(self.messages.mark_read(handled.message_id, 1))
+        old_evidence = tuple(
+            self.con.execute(
+                "SELECT w.state,w.attempt_count,w.idempotency_key,"
+                "(SELECT COUNT(*) FROM sprint_wake_attempts a "
+                "WHERE a.wake_id=w.wake_id) "
+                "FROM sprint_wake_outbox w WHERE w.wake_id=?",
+                (exhausted,),
+            ).fetchone()
+        )
+        exhausted_conversation = str(
+            self.con.execute(
+                "SELECT target_conversation_id FROM sprint_wake_attempts "
+                "WHERE wake_id=? ORDER BY attempt_number DESC LIMIT 1",
+                (exhausted,),
+            ).fetchone()[0]
+        )
+        old_conversation_evidence = tuple(
+            self.con.execute(
+                "SELECT c.state,"
+                "(SELECT COUNT(*) FROM conversation_runs r "
+                "WHERE r.conversation_id=c.conversation_id),"
+                "(SELECT COUNT(*) FROM conversation_messages m "
+                "WHERE m.conversation_id=c.conversation_id),"
+                "(SELECT COUNT(*) FROM conversation_events e "
+                "WHERE e.conversation_id=c.conversation_id) "
+                "FROM conversations c WHERE c.conversation_id=?",
+                (exhausted_conversation,),
+            ).fetchone()
+        )
+        wake_count_before_resume = int(
+            self.con.execute("SELECT COUNT(*) FROM sprint_wake_outbox").fetchone()[0]
+        )
+
+        receipt = self.coordinator().resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="the participant route was repaired",
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual(1, len(receipt.requeued_wake_ids))
+        reset_wake = receipt.requeued_wake_ids[0]
+        self.assertEqual(
+            wake_count_before_resume + 1,
+            self.con.execute("SELECT COUNT(*) FROM sprint_wake_outbox").fetchone()[0],
+        )
+        self.assertEqual(
+            (
+                "pending",
+                f"sprint-resume:{self.sprint_id}:pickup-episode:{exhausted}",
+                0,
+                None,
+                None,
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT state,idempotency_key,attempt_count,delivered_at,failed_at "
+                    "FROM sprint_wake_outbox WHERE wake_id=?",
+                    (reset_wake,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            [
+                (first.message_id, reset_wake, 0, 0),
+                (second.message_id, reset_wake, 0, 0),
+                (handled.message_id, exhausted, 1, 1),
+            ],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT m.message_id,wm.wake_id,m.read_at IS NOT NULL,"
+                    "m.delivered_at IS NOT NULL FROM wake_message m "
+                    "JOIN sprint_wake_messages wm USING (message_id) "
+                    "WHERE m.message_id IN (?,?,?) ORDER BY m.message_id",
+                    (first.message_id, second.message_id, handled.message_id),
+                )
+            ],
+        )
+        self.assertEqual(
+            old_evidence,
+            tuple(
+                self.con.execute(
+                    "SELECT w.state,w.attempt_count,w.idempotency_key,"
+                    "(SELECT COUNT(*) FROM sprint_wake_attempts a "
+                    "WHERE a.wake_id=w.wake_id) "
+                    "FROM sprint_wake_outbox w WHERE w.wake_id=?",
+                    (exhausted,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            old_conversation_evidence,
+            tuple(
+                self.con.execute(
+                    "SELECT c.state,"
+                    "(SELECT COUNT(*) FROM conversation_runs r "
+                    "WHERE r.conversation_id=c.conversation_id),"
+                    "(SELECT COUNT(*) FROM conversation_messages m "
+                    "WHERE m.conversation_id=c.conversation_id),"
+                    "(SELECT COUNT(*) FROM conversation_events e "
+                    "WHERE e.conversation_id=c.conversation_id) "
+                    "FROM conversations c WHERE c.conversation_id=?",
+                    (exhausted_conversation,),
+                ).fetchone()
+            ),
+        )
+        reset_events = [
+            json.loads(row[0])
+            for row in self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='wake.requeued' "
+                "AND json_extract(payload,'$.classification')="
+                "'pickup_episode_reset'",
+                (self.sprint_id,),
+            )
+        ]
+        self.assertEqual(1, len(reset_events))
+        self.assertEqual(
+            (exhausted, reset_wake, "resume"),
+            (
+                reset_events[0]["prior_wake_id"],
+                reset_events[0]["replacement_wake_id"],
+                reset_events[0]["trigger"],
+            ),
+        )
+        reconciliation = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='lifecycle.reconciled' "
+                "ORDER BY event_id DESC LIMIT 1",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual([reset_wake], reconciliation["requeued_wake_ids"])
+        self.assertEqual(
+            [first.message_id, second.message_id],
+            reconciliation["unread_message_ids"],
+        )
+
+        wake_count = int(
+            self.con.execute("SELECT COUNT(*) FROM sprint_wake_outbox").fetchone()[0]
+        )
+        replay = self.coordinator().resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="duplicate authorized resume",
+        )
+        self.assertFalse(replay.changed)
+        self.assertEqual((), replay.requeued_wake_ids)
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="duplicate-pulse-before-delivery",
+            ),
+        )
+        self.assertEqual(
+            wake_count,
+            self.con.execute("SELECT COUNT(*) FROM sprint_wake_outbox").fetchone()[0],
+        )
+
+        idle_conversation = self._activate_unregistered_chat(
+            "resume-exhausted-existing-idle"
+        )
+        self.fail_wake_turn(reset_wake, error_code="HARNESS_ROUTE_MISMATCH")
+        reset_conversation = str(
+            self.con.execute(
+                "SELECT target_conversation_id FROM sprint_wake_attempts "
+                "WHERE wake_id=? ORDER BY attempt_number DESC LIMIT 1",
+                (reset_wake,),
+            ).fetchone()[0]
+        )
+        self.assertNotEqual(
+            idle_conversation,
+            reset_conversation,
+            "the coalesced declared New message must rotate at delivery",
+        )
+        next_episode = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="resumed-episode-first-failure",
+        )
+        self.assertEqual(1, len(next_episode))
+        bounded_recovery = next_episode[0]
+        self.assertEqual(
+            f"sprint-recovery:{self.sprint_id}:delivered-unread:{reset_wake}",
+            self.con.execute(
+                "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
+                (bounded_recovery,),
+            ).fetchone()[0],
+        )
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET available_at="
+            "datetime('now','-1 second') WHERE wake_id=?",
+            (bounded_recovery,),
+        )
+        self.con.commit()
+        self.fail_wake_turn(
+            bounded_recovery,
+            error_code="HARNESS_ROUTE_MISMATCH",
+        )
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="resumed-episode-second-failure",
+            ),
+        )
+        self.assertEqual(
+            ("paused", bounded_recovery, 2, 1),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,"
+                    "json_extract(r.body,'$.detail.wake_id'),"
+                    "json_extract(r.body,'$.detail.attempt_count'),"
+                    "(SELECT COUNT(*) FROM sprint_wake_outbox recovery "
+                    "WHERE recovery.idempotency_key=?) "
+                    "FROM sprints s JOIN sprint_reports r USING (sprint_id) "
+                    "WHERE s.sprint_id=? AND r.report_kind='pause' "
+                    "ORDER BY r.report_id DESC LIMIT 1",
+                    (
+                        (
+                            f"sprint-recovery:{self.sprint_id}:"
+                            f"delivered-unread:{reset_wake}"
+                        ),
+                        self.sprint_id,
+                    ),
+                ).fetchone()
+            ),
+        )
+
+    def test_resume_adopts_one_pending_receiver_wake_for_pickup_reset(self):
+        message = self.send("resume-adopt-exhausted")
+        original = int(message.wake_id)
+        self.fail_wake_turn(original, error_code="HARNESS_ROUTE_MISMATCH")
+        exhausted = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="resume-adopt-first-failure",
+        )[0]
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET available_at="
+            "datetime('now','-1 second') WHERE wake_id=?",
+            (exhausted,),
+        )
+        self.con.commit()
+        self.fail_wake_turn(exhausted, error_code="HARNESS_ROUTE_MISMATCH")
+        self.assertEqual(
+            (),
+            self.lifecycle.reconcile_unread_pickup(
+                self.sprint_id,
+                trigger="resume-adopt-second-failure",
+            ),
+        )
+        followup = self.send("resume-adopt-pending")
+        adopted_wake = int(followup.wake_id)
+        wake_count = int(
+            self.con.execute("SELECT COUNT(*) FROM sprint_wake_outbox").fetchone()[0]
+        )
+
+        receipt = self.coordinator().resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="adopt the paused receiver backlog",
+        )
+
+        self.assertEqual((adopted_wake,), receipt.requeued_wake_ids)
+        self.assertEqual(
+            wake_count,
+            self.con.execute("SELECT COUNT(*) FROM sprint_wake_outbox").fetchone()[0],
+        )
+        self.assertEqual(
+            (
+                f"sprint-resume:{self.sprint_id}:pickup-episode:{exhausted}",
+                "pending",
+                2,
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT w.idempotency_key,w.state,COUNT(wm.message_id) "
+                    "FROM sprint_wake_outbox w JOIN sprint_wake_messages wm "
+                    "USING (wake_id) WHERE w.wake_id=? GROUP BY w.wake_id",
+                    (adopted_wake,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            [(message.message_id, adopted_wake), (followup.message_id, adopted_wake)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT message_id,wake_id FROM sprint_wake_messages "
+                    "WHERE message_id IN (?,?) ORDER BY message_id",
+                    (message.message_id, followup.message_id),
+                )
+            ],
         )
 
     def test_resume_repairs_delivered_unread_assignment_once(self):
@@ -1735,6 +2123,73 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                 ).fetchone()
             ),
         )
+
+    def test_startup_converts_legacy_generic_recovery_stall_to_atomic_pause(self):
+        message = self.send("legacy-generic-recovery-stall")
+        original = int(message.wake_id)
+        self.fail_wake_turn(original, error_code="HARNESS_ROUTE_MISMATCH")
+        generic_recovery = self.lifecycle.reconcile_unread_pickup(
+            self.sprint_id,
+            trigger="legacy-current-floor-first-failure",
+        )[0]
+        self.assertEqual(
+            f"sprint-recovery:{self.sprint_id}:delivered-unread:{original}",
+            self.con.execute(
+                "SELECT idempotency_key FROM sprint_wake_outbox WHERE wake_id=?",
+                (generic_recovery,),
+            ).fetchone()[0],
+        )
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET available_at="
+            "datetime('now','-1 second') WHERE wake_id=?",
+            (generic_recovery,),
+        )
+        self.con.commit()
+        self.fail_wake_turn(
+            generic_recovery,
+            error_code="HARNESS_SESSION_DISCOVERY_FAILED",
+        )
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+
+        coordinator = self.coordinator()
+        self.assertEqual("armed", coordinator.recover_on_startup(self.sprint_id))
+
+        self.assertEqual(
+            (
+                "paused",
+                None,
+                generic_recovery,
+                "wake_pickup_failed",
+                "HARNESS_SESSION_DISCOVERY_FAILED",
+                1,
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT s.lifecycle,m.read_at,wm.wake_id,"
+                    "json_extract(r.body,'$.reason'),"
+                    "json_extract(r.body,'$.detail.error_code'),"
+                    "(SELECT COUNT(*) FROM sprint_events e "
+                    "WHERE e.sprint_id=s.sprint_id "
+                    "AND e.event_type='wake.pickup_exhausted') "
+                    "FROM sprints s JOIN wake_message m "
+                    "ON m.message_id=? JOIN sprint_wake_messages wm "
+                    "USING (message_id) JOIN sprint_reports r "
+                    "ON r.sprint_id=s.sprint_id "
+                    "WHERE s.sprint_id=? AND r.report_kind='pause' "
+                    "ORDER BY r.report_id DESC LIMIT 1",
+                    (message.message_id, self.sprint_id),
+                ).fetchone()
+            ),
+        )
+        before_repeat = self.con.total_changes
+        self.assertEqual("paused", coordinator.recover_on_startup(self.sprint_id))
+        self.assertEqual(before_repeat, self.con.total_changes)
 
     def test_resume_projects_observed_merge_before_releasing_downstream(self):
         registered = self.register()


### PR DESCRIPTION
## Summary

- generalize authorized resume reset from contention-only to all pickup exhaustion reasons
- preserve terminal pickup evidence while moving only unread messages to one fresh/adopted receiver wake
- start a new bounded pickup episode after repair and keep delivery-time declared-type resolution intact
- cover current-floor legacy generic recovery stalls and the busy-chain/non-busy terminal entry variant

## Verification

- RED: focused regression failed because resume immediately reconciled the old terminal wake and returned `changed=False`
- focused recovery suite: 34 passed
- full `./sc test`: 1953 passed, 1 skipped
- `./sc verify`: linked worktree refusal per #769; canonical isolated-clone substitution passed on exact pushed head `d7e5eb35811f8c397927f69e84cb31234dd0e353`

## Notes

- no schema migration or direct state rewrite
- no changes to Sprint runtime pulse orchestration, monitor/board visibility, route resolution, or conversation adapters
- filed unrelated cross-file test-state leakage as #1060; canonical full suite and isolated live-proof file are green
