### PR TITLE
feat(sprint): expose runtime and pickup health

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2601,23 +2601,7 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, {"wake_ids": released})
             if path == "/_sc/sprint/monitor":
                 self._require_sprint_planner(con, sprint_id, shell_id)
-                sprint_domain.SprintLifecycleStore(con).reconcile_unread_pickup(
-                    sprint_id,
-                    trigger="monitor",
-                )
-                outcomes = sprint_liveness.SprintLivenessMonitor(con).evaluate(
-                    sprint_id
-                )
-                return self._send(200, {
-                    "outcomes": [
-                        {
-                            "message_id": outcome.message_id,
-                            "action": outcome.action,
-                            "silence_episode": outcome.silence_episode,
-                        }
-                        for outcome in outcomes
-                    ]
-                })
+                return self._send(200, sprint_monitor_response(con, sprint_id))
             if path == "/_sc/sprint/conformance":
                 findings = body.get("findings")
                 if not isinstance(findings, list):
@@ -4322,8 +4306,45 @@ def start_runtime_services() -> None:
         launch_preparer=conversation_launch.ConversationLaunchPreparer(DB_PATH),
     )
     conversation_reaper.start_service(DB_PATH, native_interrupt=broker.interrupt)
-    sprint_runtime.start_service(DB_PATH)
+    runtime = sprint_runtime.start_service(DB_PATH)
+    if not runtime.wait_ready():
+        runtime.stop()
+        raise RuntimeError(
+            "Sprint runtime did not complete its first successful cycle"
+        )
+    if not runtime.is_alive():
+        runtime.stop()
+        raise RuntimeError("Sprint runtime died during startup")
     sprint_pr_watcher.start_service(DB_PATH, repo_root=REPO_ROOT)
+
+
+def sprint_monitor_response(
+    con: sqlite3.Connection,
+    sprint_id: int,
+) -> dict[str, object]:
+    """Run one idempotent pickup/liveness evaluation without wake delivery."""
+    requeued = sprint_domain.SprintLifecycleStore(con).reconcile_unread_pickup(
+        sprint_id,
+        trigger="monitor",
+    )
+    outcomes = sprint_liveness.SprintLivenessMonitor(con).evaluate(sprint_id)
+    return {
+        "outcomes": [
+            {
+                "message_id": outcome.message_id,
+                "action": outcome.action,
+                "silence_episode": outcome.silence_episode,
+            }
+            for outcome in outcomes
+        ],
+        "pickup": sprint_board.pickup_projection(
+            con,
+            sprint_id,
+            requeued_wake_ids=requeued,
+            include_exhausted=False,
+        ),
+        "runtime": sprint_runtime.runtime_status(con),
+    }
 
 
 def main(argv):
@@ -4389,7 +4410,10 @@ def main(argv):
         finally:
             conversation_reaper.stop_service()
 
-    print(f"super-coder review layer → http://127.0.0.1:{port}  (bind {bind}, DB: {DB_PATH.name})")
+    print(
+        f"super-coder review layer starting on 127.0.0.1:{port} "
+        f"(bind {bind}, DB: {DB_PATH.name})"
+    )
     try:
         asyncio.run(_serve())
     except KeyboardInterrupt:

--- a/.super-coder/api/transport.py
+++ b/.super-coder/api/transport.py
@@ -207,9 +207,10 @@ async def serve(host: str, port: int, http_handler, ws_handler,
     bound port after start for callers that passed port=0 — via `log` line and
     the Transport object; this coroutine simply runs until shutdown.
 
-    ``on_started`` runs only after the socket bind succeeds. Background workers
-    that can cause external side effects belong behind that boundary: a second
-    process must lose the bind race before it can dispatch work.
+    ``on_started`` runs only after the socket bind succeeds and before the
+    listening service is advertised. Background workers that can cause external
+    side effects belong behind that boundary: a second process must lose the
+    bind race before it can dispatch work, and failed readiness must stay quiet.
     """
     transport = Transport(
         host,
@@ -221,9 +222,9 @@ async def serve(host: str, port: int, http_handler, ws_handler,
     )
     await transport.start()
     try:
-        log(f"transport: listening on {host}:{transport.port}")
         if on_started is not None:
             on_started()
+        log(f"transport: listening on {host}:{transport.port}")
         await asyncio.Event().wait()
     finally:
         await transport.stop()

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -13,6 +13,8 @@ import sqlite3
 from collections import defaultdict
 from typing import Any
 
+import sprint_runtime
+
 LIFECYCLES = frozenset({"prepared", "armed", "paused", "completed", "aborted"})
 UNIT_COLUMNS = {
     "completed": "done",
@@ -26,6 +28,18 @@ UNIT_COLUMNS = {
     "blocked": "blocked",
 }
 _REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_PICKUP_PAUSE_REASONS = frozenset(
+    {
+        "wake_pickup_unknown",
+        "wake_pickup_failed",
+        "wake_pickup_unread",
+        "wake_pickup_evidence_invalid",
+    }
+)
+_RECOVERY_INSTRUCTION = (
+    "Inspect the pause report, repair the named route or service, then use an "
+    "authorized resume."
+)
 
 # Payloads are internal evidence.  Only fields with an explicit browser use
 # are projected; an unknown event remains visible with an empty detail object.
@@ -205,6 +219,81 @@ class ProjectionError(ValueError):
         super().__init__(message)
 
 
+def pickup_projection(
+    con: sqlite3.Connection,
+    sprint_id: int,
+    *,
+    requeued_wake_ids: tuple[int, ...] = (),
+    include_current_requeue: bool = False,
+    include_exhausted: bool = True,
+) -> dict[str, Any]:
+    """Project monitor action or the board's current bounded pickup state."""
+    sprint = con.execute(
+        "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+        (sprint_id,),
+    ).fetchone()
+    if sprint is None:
+        raise ProjectionError(404, "sprint_not_found", "Sprint not found")
+    pause_reason = None
+    exhausted = None
+    if str(sprint["lifecycle"]) == "paused":
+        paused = con.execute(
+            "SELECT json_extract(payload,'$.reason') reason "
+            "FROM sprint_events WHERE sprint_id=? "
+            "AND event_type='lifecycle.paused' ORDER BY event_id DESC LIMIT 1",
+            (sprint_id,),
+        ).fetchone()
+        candidate = str(paused["reason"]) if paused and paused["reason"] else None
+        if candidate in _PICKUP_PAUSE_REASONS:
+            pause_reason = candidate
+            event = con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='wake.pickup_exhausted' "
+                "ORDER BY event_id DESC LIMIT 1",
+                (sprint_id,),
+            ).fetchone()
+            if event is not None:
+                try:
+                    payload = json.loads(event["payload"])
+                except (TypeError, ValueError):
+                    payload = {}
+                allowed = _EVENT_FIELDS["wake.pickup_exhausted"]
+                exhausted = {
+                    key: payload[key]
+                    for key in allowed
+                    if key in payload
+                }
+                exhausted["recovery_instruction"] = _RECOVERY_INSTRUCTION
+
+    current_requeues = tuple(sorted(set(requeued_wake_ids)))
+    if include_current_requeue and pause_reason is None and not current_requeues:
+        current_requeues = tuple(
+            int(row[0])
+            for row in con.execute(
+                "SELECT DISTINCT CAST(json_extract(e.payload,'$.replacement_wake_id') "
+                "AS INTEGER) replacement_wake_id FROM sprint_events e "
+                "JOIN sprint_wake_outbox w ON w.wake_id=CAST("
+                "json_extract(e.payload,'$.replacement_wake_id') AS INTEGER) "
+                "WHERE e.sprint_id=? AND e.event_type='wake.requeued' "
+                "AND w.state IN ('pending','delivering') "
+                "AND EXISTS (SELECT 1 FROM sprint_wake_messages wm "
+                "JOIN wake_message m ON m.message_id=wm.message_id "
+                "WHERE wm.wake_id=w.wake_id AND m.read_at IS NULL) "
+                "ORDER BY replacement_wake_id LIMIT 100",
+                (sprint_id,),
+            )
+        )
+    action = "paused" if pause_reason else "requeued" if current_requeues else "none"
+    result = {
+        "action": action,
+        "requeued_wake_ids": list(current_requeues),
+        "pause_reason": pause_reason,
+    }
+    if include_exhausted and exhausted is not None:
+        result["exhausted"] = exhausted
+    return result
+
+
 def _cursor_encode(kind: str, values: list[Any]) -> str:
     raw = json.dumps(
         {"v": 1, "kind": kind, "values": values},
@@ -381,6 +470,40 @@ class SprintBoardProjection:
         ).fetchone()
         if sprint is None:
             raise ProjectionError(404, "sprint_not_found", "Sprint not found")
+
+        runtime = sprint_runtime.runtime_status(self.con)
+        pickup = pickup_projection(
+            self.con,
+            sprint_id,
+            include_current_requeue=True,
+        )
+        exhausted = pickup.get("exhausted")
+        exhausted_unit_id = (
+            int(exhausted["work_unit_id"])
+            if exhausted and exhausted.get("work_unit_id") is not None
+            else None
+        )
+        unavailable_delivery: dict[int, dict[str, Any]] = {}
+        if runtime["state"] != "live":
+            for row in self.con.execute(
+                "SELECT m.work_unit_id,w.wake_id,w.attempt_count "
+                "FROM sprint_wake_outbox w "
+                "JOIN sprint_wake_messages wm ON wm.wake_id=w.wake_id "
+                "JOIN wake_message m ON m.message_id=wm.message_id "
+                "WHERE m.sprint_id=? AND m.work_unit_id IS NOT NULL "
+                "AND m.read_at IS NULL AND w.state='pending' "
+                "AND w.attempt_count=0 ORDER BY w.wake_id",
+                (sprint_id,),
+            ):
+                unavailable_delivery.setdefault(
+                    int(row["work_unit_id"]),
+                    {
+                        "state": "runtime_unavailable",
+                        "runtime_state": runtime["state"],
+                        "wake_id": int(row["wake_id"]),
+                        "attempt_count": int(row["attempt_count"]),
+                    },
+                )
 
         specs = [
             {
@@ -578,6 +701,16 @@ class SprintBoardProjection:
                     "dependent_ids": dependents[unit_id],
                     "pull_requests": prs[unit_id],
                     "messages": messages[unit_id],
+                    **(
+                        {"pickup": exhausted}
+                        if unit_id == exhausted_unit_id
+                        else {}
+                    ),
+                    **(
+                        {"delivery": unavailable_delivery[unit_id]}
+                        if unit_id in unavailable_delivery
+                        else {}
+                    ),
                 }
             )
 
@@ -612,6 +745,8 @@ class SprintBoardProjection:
             "work_units": units,
             "dependencies": dependencies,
             "column_counts": counts,
+            "runtime": runtime,
+            "pickup": pickup,
             "feed_counts": {
                 "events": int(feed_counts["event_count"]),
                 "summaries": int(feed_counts["judgment_count"])

--- a/.super-coder/scripts/sprint_runtime.py
+++ b/.super-coder/scripts/sprint_runtime.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import threading
 from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +25,46 @@ from sprint_liveness import SprintLivenessMonitor
 from sprint_message_delivery import SprintWakeDeliveryService
 
 DEFAULT_PULSE_SECONDS = 5.0
+RUNTIME_DAEMON_NAME = "sprint-runtime"
+# A runtime is stale after three missed recorded pulse intervals.  The
+# threshold follows the durable interval rather than assuming the default.
+RUNTIME_STALE_INTERVALS = 3
+
+
+def _parse_stamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def runtime_status(
+    con: sqlite3.Connection,
+    *,
+    now: datetime | None = None,
+) -> dict[str, str | int | float | None]:
+    """Project live/stale/missing state from the durable runtime heartbeat."""
+    heartbeat = con.execute(
+        "SELECT beat_at,interval_s FROM daemon_heartbeats WHERE name=?",
+        (RUNTIME_DAEMON_NAME,),
+    ).fetchone()
+    if heartbeat is None:
+        return {
+            "state": "missing",
+            "beat_at": None,
+            "interval_seconds": int(DEFAULT_PULSE_SECONDS),
+        }
+    beat_at = str(heartbeat["beat_at"])
+    interval = float(heartbeat["interval_s"])
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    age = (current - _parse_stamp(beat_at)).total_seconds()
+    state = "live" if age <= RUNTIME_STALE_INTERVALS * interval else "stale"
+    interval_value: int | float = int(interval) if interval.is_integer() else interval
+    return {
+        "state": state,
+        "beat_at": beat_at,
+        "interval_seconds": interval_value,
+    }
 
 
 def _request_hash(prompt: str) -> str:
@@ -177,6 +218,7 @@ class SprintRuntimeService(threading.Thread):
         )
         self._stop_event = threading.Event()
         self._started_once = threading.Event()
+        self._ready = threading.Event()
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -184,17 +226,49 @@ class SprintRuntimeService(threading.Thread):
     def wait_started(self, timeout: float = 5.0) -> bool:
         return self._started_once.wait(timeout)
 
+    def wait_ready(self, timeout: float = 5.0) -> bool:
+        """Wait until the first complete successful cycle is durable."""
+        return self._ready.wait(timeout)
+
     def pulse_once(self, *, startup: bool = False) -> bool:
         con = db_driver.connect(self.db_path)
         try:
-            monitored = activity_monitor.ActivityMonitor(
-                con, config=self.activity_config
-            ).tick()
-            switch = self._switch(con)
-            serviced = switch.recover_on_startup() if startup else switch.tick()
-            return self._deliver_wakes(con) or serviced or monitored.changed
+            return self._pulse(con, startup=startup)
         finally:
             con.close()
+
+    def _pulse(self, con: sqlite3.Connection, *, startup: bool) -> bool:
+        monitored = activity_monitor.ActivityMonitor(
+            con, config=self.activity_config
+        ).tick()
+        switch = self._switch(con)
+        serviced = switch.recover_on_startup() if startup else switch.tick()
+        delivered = self._deliver_wakes(con)
+        self._record_heartbeat(con)
+        return delivered or serviced or monitored.changed
+
+    def _record_heartbeat(self, con: sqlite3.Connection) -> None:
+        prior = con.execute(
+            "SELECT beat_at FROM daemon_heartbeats WHERE name=?",
+            (RUNTIME_DAEMON_NAME,),
+        ).fetchone()
+        floor = str(prior[0]) if prior is not None else None
+        stamp = str(
+            con.execute(
+                "SELECT CASE WHEN ? IS NOT NULL "
+                "AND ?>=strftime('%Y-%m-%d %H:%M:%f','now') "
+                "THEN strftime('%Y-%m-%d %H:%M:%f',?,'+0.001 seconds') "
+                "ELSE strftime('%Y-%m-%d %H:%M:%f','now') END",
+                (floor, floor, floor),
+            ).fetchone()[0]
+        )
+        with db_driver.write_transaction(con, "sprint.runtime.heartbeat"):
+            con.execute(
+                "INSERT INTO daemon_heartbeats (name,beat_at,interval_s) "
+                "VALUES (?,?,?) ON CONFLICT(name) DO UPDATE SET "
+                "beat_at=excluded.beat_at,interval_s=excluded.interval_s",
+                (RUNTIME_DAEMON_NAME, stamp, self.pulse_seconds),
+            )
 
     def _switch(self, con: sqlite3.Connection) -> ArmedServiceSwitch:
         lifecycle = SprintLifecycleStore(con)
@@ -228,27 +302,29 @@ class SprintRuntimeService(threading.Thread):
         return delivered
 
     def run(self) -> None:  # pragma: no cover - loop tested through pulse_once
-        con = db_driver.connect(self.db_path)
         try:
-            switch = self._switch(con)
-            monitor = activity_monitor.ActivityMonitor(con, config=self.activity_config)
+            con = db_driver.connect(self.db_path)
             try:
-                monitor.tick()
-                switch.recover_on_startup()
-                self._deliver_wakes(con)
-            except Exception as exc:  # noqa: BLE001 - service faults stay visible
-                print(f"sprint-runtime: startup error ({exc})", flush=True)
-            self._started_once.set()
-            while not self._stop_event.wait(self.pulse_seconds):
+                self._started_once.set()
+                if self._stop_event.is_set():
+                    return
                 try:
-                    monitor.tick()
-                    switch.tick()
-                    self._deliver_wakes(con)
-                except Exception as exc:  # noqa: BLE001 - keep inspection alive
-                    print(f"sprint-runtime: pulse error ({exc})", flush=True)
+                    self._pulse(con, startup=True)
+                except Exception as exc:  # noqa: BLE001 - startup must fail closed
+                    print(f"sprint-runtime: startup error ({exc})", flush=True)
+                    return
+                self._ready.set()
+                while not self._stop_event.wait(self.pulse_seconds):
+                    try:
+                        self._pulse(con, startup=False)
+                    except Exception as exc:  # noqa: BLE001 - keep inspection alive
+                        print(f"sprint-runtime: pulse error ({exc})", flush=True)
+            except Exception as exc:  # noqa: BLE001 - service faults stay visible
+                print(f"sprint-runtime: service error ({exc})", flush=True)
+            finally:
+                con.close()
         finally:
             self._started_once.set()
-            con.close()
 
 
 _SERVICE_LOCK = threading.Lock()

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -5391,6 +5391,15 @@ function sprintWorkUnitCard(unit, snapshot) {
       el("span", {}, pr ? `PR #${pr.pr_number} · ${pr.normalized_state || "registered"}` : "No PR")));
   if (unit.disposition === "cancelled") card.append(
     el("div", { className: "sprint-cancelled-note" }, "Cancelled — not completed"));
+  if (unit.pickup) card.append(
+    el("div", { className: "workflow-recovery-note" },
+      `Pickup exhausted · ${unit.pickup.error_code} · ${unit.pickup.role} ${unit.pickup.shell} · `,
+      `message ${unit.pickup.message_id} · wake ${unit.pickup.wake_id} · `,
+      `attempt ${unit.pickup.attempt_count}`));
+  if (unit.delivery?.state === "runtime_unavailable") card.append(
+    el("div", { className: "workflow-health-note" },
+      `Runtime ${unit.delivery.runtime_state} — wake ${unit.delivery.wake_id} has `,
+      `${unit.delivery.attempt_count} delivery attempts`));
   card.onclick = () => openSprintUnitModal(unit, snapshot);
   return card;
 }
@@ -5476,6 +5485,20 @@ function sprintBoardNode(snapshot) {
     sprintActionButtons(sprint));
   if (sprint.terminal_outcome) header.append(
     el("div", { className: "sprint-terminal-outcome" }, `Outcome: ${sprint.terminal_outcome}`));
+  if (snapshot.runtime?.state !== "live") {
+    const runtime = snapshot.runtime || {state: "missing", beat_at: null, interval_seconds: 5};
+    header.append(el("div", { className: "workflow-health-alert" },
+      `Runtime ${runtime.state}`,
+      runtime.beat_at ? ` · last beat ${sprintTimestamp(runtime.beat_at)}` : " · no successful cycle recorded",
+      ` · interval ${runtime.interval_seconds}s`));
+  }
+  const exhausted = snapshot.pickup?.exhausted;
+  if (exhausted) header.append(el("div", { className: "workflow-recovery-alert" },
+    el("strong", {}, `Pickup exhausted · ${exhausted.error_code}`),
+    el("span", {}, `${exhausted.role} ${exhausted.shell} · U${exhausted.work_unit_id} · `,
+      `message ${exhausted.message_id} · wake ${exhausted.wake_id} · `,
+      `attempt ${exhausted.attempt_count}`),
+    el("span", {}, exhausted.recovery_instruction)));
 
   const scroll = el("div", { className: "sprint-board-scroll" });
   const canvas = el("div", { className: "sprint-board-canvas" });

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -98,6 +98,13 @@ main { padding: 1.2rem; flex: 1 0 auto; min-height: 0; }
 .sprint-header-context, .sprint-header-times { margin-top: .45rem; font-size: .76rem; color: var(--dim); }
 .sprint-spec-links { display: inline-flex; gap: .45rem; }
 .sprint-terminal-outcome { grid-column: 1 / -1; margin-top: .7rem; padding-top: .6rem; border-top: 1px solid var(--line); }
+.workflow-health-alert, .workflow-recovery-alert {
+  grid-column: 1 / -1; margin-top: .7rem; padding: .55rem .65rem;
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--line));
+  background: color-mix(in srgb, var(--warn) 8%, var(--panel));
+  border-radius: 7px; color: var(--warn); font-size: .76rem;
+}
+.workflow-recovery-alert { display: grid; gap: .25rem; }
 .sprint-actions { grid-area: actions; align-self: start; display: flex; justify-content: flex-end; gap: .5rem; margin-top: .45rem; }
 .sprint-stale-notice { display: flex; align-items: center; justify-content: space-between; gap: .75rem; margin-bottom: .65rem; padding: .55rem .7rem; color: var(--warn); border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--line)); background: color-mix(in srgb, var(--warn) 8%, var(--panel)); border-radius: 7px; }
 .sprint-board-scroll { overflow-x: auto; padding: .9rem 1rem 1rem; border-top: 1px solid var(--line); background: var(--bg); }
@@ -115,6 +122,10 @@ main { padding: 1.2rem; flex: 1 0 auto; min-height: 0; }
 .sprint-unit-meta, .sprint-unit-foot { display: flex; align-items: center; justify-content: space-between; gap: .5rem; }
 .sprint-unit-people, .sprint-unit-deps, .sprint-unit-foot { font-size: .7rem; color: var(--dim); }
 .sprint-cancelled-note { color: var(--warn); font-size: .7rem; }
+.workflow-recovery-note, .workflow-health-note {
+  color: var(--warn); font-size: .7rem; padding-top: .35rem;
+  border-top: 1px solid color-mix(in srgb, var(--warn) 30%, var(--line));
+}
 .sprint-wires { position: absolute; inset: 0; z-index: 1; pointer-events: none; overflow: visible; }
 .sprint-wire { fill: none; stroke: color-mix(in srgb, var(--accent) 22%, transparent); stroke-width: 1.5; }
 .sprint-wire-focus .sprint-wire { opacity: .18; }

--- a/tests/test_server_schema_guard.py
+++ b/tests/test_server_schema_guard.py
@@ -3,6 +3,7 @@
 non-loopback bind (spec #26)."""
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import io
 import os
@@ -38,6 +39,43 @@ def build_pre_acknowledgement_db(path: Path) -> None:
         con.commit()
     finally:
         con.close()
+
+
+class TransportReadinessTest(unittest.TestCase):
+    def test_failed_start_callback_is_never_advertised_as_listening(self):
+        events = []
+
+        class FakeTransport:
+            port = 8844
+
+            async def start(self):
+                events.append("bound")
+
+            async def stop(self):
+                events.append("stopped")
+
+        def fail_readiness():
+            events.append("readiness")
+            raise RuntimeError("runtime unavailable")
+
+        logs = []
+        with (
+            mock.patch.object(transport, "Transport", return_value=FakeTransport()),
+            self.assertRaisesRegex(RuntimeError, "runtime unavailable"),
+        ):
+            asyncio.run(
+                transport.serve(
+                    "127.0.0.1",
+                    8844,
+                    object(),
+                    object(),
+                    log=logs.append,
+                    on_started=fail_readiness,
+                )
+            )
+
+        self.assertEqual(["bound", "readiness", "stopped"], events)
+        self.assertEqual([], logs)
 
 
 class ServerSchemaGuardTest(unittest.TestCase):

--- a/tests/test_sprint_board_api.py
+++ b/tests/test_sprint_board_api.py
@@ -295,7 +295,9 @@ class SprintBoardApiCase(unittest.TestCase):
             "second_sprint_id": second,
             "third_sprint_id": third,
             "unit": unit_ids[2],
+            "ready_unit": unit_ids[7],
             "other_unit": unit_ids[0],
+            "developer_participant_id": participant_ids["developer"],
         }
 
     def connect(self) -> sqlite3.Connection:
@@ -368,6 +370,10 @@ class SprintBoardApiCase(unittest.TestCase):
         status, _, board = self.request("GET", f"/api/sprints/{self.ids['sprint_id']}")
         self.assertEqual(status, 200, board)
         self.assertEqual("Board feature", board["sprint"]["feature"]["title"])
+        self.assertEqual(
+            {"state": "missing", "beat_at": None, "interval_seconds": 5},
+            board["runtime"],
+        )
         self.assertEqual("Board spec", board["specs"][0]["title"])
         units = {row["work_unit_id"]: row for row in board["work_units"]}
         review = units[self.ids["unit"]]
@@ -379,6 +385,169 @@ class SprintBoardApiCase(unittest.TestCase):
         cancelled = next(row for row in units.values() if row["disposition"] == "cancelled")
         self.assertEqual("done", cancelled["column"])
         self.assertEqual("cancelled cleanly", cancelled["completion_result"])
+
+    def test_board_projects_stale_runtime_and_bounded_pickup_exhaustion(self):
+        exhausted = {
+            "sprint_id": self.ids["sprint_id"],
+            "participant_id": self.ids["developer_participant_id"],
+            "shell": "DEV1",
+            "role": "developer",
+            "work_unit_id": self.ids["unit"],
+            "message_id": 71,
+            "wake_id": 81,
+            "conversation_id": "cv_dead",
+            "run_state": "unknown",
+            "error_code": "HARNESS_SESSION_DISCOVERY_FAILED",
+            "failure_class": "native_unknown",
+            "attempt_count": 1,
+            "error_detail": "Traceback: private adapter detail",
+            "stack_trace": "private stack",
+        }
+        with self.connect() as con:
+            con.execute(
+                "INSERT INTO daemon_heartbeats (name,beat_at,interval_s) "
+                "VALUES ('sprint-runtime','2000-01-01 00:00:00',5)"
+            )
+            con.execute(
+                "UPDATE sprints SET lifecycle='paused',"
+                "paused_at='2026-08-01 14:00:00' WHERE sprint_id=?",
+                (self.ids["sprint_id"],),
+            )
+            con.executemany(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,payload,created_at) "
+                "VALUES (?,?,'system',?,'2026-08-01 14:00:00')",
+                (
+                    (
+                        self.ids["sprint_id"],
+                        "wake.pickup_exhausted",
+                        json.dumps(exhausted),
+                    ),
+                    (
+                        self.ids["sprint_id"],
+                        "lifecycle.paused",
+                        json.dumps({"from": "armed", "reason": "wake_pickup_unknown"}),
+                    ),
+                ),
+            )
+
+        status, _, board = self.request(
+            "GET", f"/api/sprints/{self.ids['sprint_id']}"
+        )
+        self.assertEqual(200, status, board)
+        self.assertEqual(
+            {
+                "state": "stale",
+                "beat_at": "2000-01-01 00:00:00",
+                "interval_seconds": 5,
+            },
+            board["runtime"],
+        )
+        self.assertEqual("paused", board["pickup"]["action"])
+        self.assertEqual("wake_pickup_unknown", board["pickup"]["pause_reason"])
+        self.assertEqual(
+            {
+                key: value
+                for key, value in exhausted.items()
+                if key not in {"error_detail", "stack_trace"}
+            },
+            {
+                key: value
+                for key, value in board["pickup"]["exhausted"].items()
+                if key != "recovery_instruction"
+            },
+        )
+        self.assertEqual(
+            "Inspect the pause report, repair the named route or service, "
+            "then use an authorized resume.",
+            board["pickup"]["exhausted"]["recovery_instruction"],
+        )
+        affected = next(
+            unit
+            for unit in board["work_units"]
+            if unit["work_unit_id"] == self.ids["unit"]
+        )
+        self.assertEqual(
+            "HARNESS_SESSION_DISCOVERY_FAILED",
+            affected["pickup"]["error_code"],
+        )
+        rendered = json.dumps(board)
+        self.assertNotIn("Traceback", rendered)
+        self.assertNotIn("private stack", rendered)
+
+        status, _, timeline = self.request(
+            "GET", f"/api/sprints/{self.ids['sprint_id']}/events?limit=100"
+        )
+        self.assertEqual(200, status, timeline)
+        event = next(
+            item
+            for item in timeline["items"]
+            if item["type"] == "wake.pickup_exhausted"
+        )
+        self.assertEqual(
+            "HARNESS_SESSION_DISCOVERY_FAILED",
+            event["details"]["error_code"],
+        )
+        self.assertNotIn("error_detail", event["details"])
+        self.assertNotIn("stack_trace", event["details"])
+
+    def test_stale_runtime_marks_zero_attempt_pending_wake_as_unhealthy(self):
+        with self.connect() as con:
+            con.execute(
+                "INSERT INTO daemon_heartbeats (name,beat_at,interval_s) "
+                "VALUES ('sprint-runtime','2000-01-01 00:00:00',5)"
+            )
+            wake_id = int(
+                con.execute(
+                    "INSERT INTO sprint_wake_outbox "
+                    "(sprint_id,participant_id,receiver_shell_id,idempotency_key) "
+                    "VALUES (?,?,3,'runtime-stale-zero-attempt')",
+                    (
+                        self.ids["sprint_id"],
+                        self.ids["developer_participant_id"],
+                    ),
+                ).lastrowid
+            )
+            message_id = int(
+                con.execute(
+                    "INSERT INTO wake_message "
+                    "(sprint_id,receiver_shell_id,to_participant_id,work_unit_id,"
+                    "message_kind,body,declared_type,actionable,disposition,"
+                    "idempotency_key) VALUES (?,?,?,?,'work_assignment',"
+                    "'pending assignment','new',1,'pending','runtime-stale-message')",
+                    (
+                        self.ids["sprint_id"],
+                        3,
+                        self.ids["developer_participant_id"],
+                        self.ids["ready_unit"],
+                    ),
+                ).lastrowid
+            )
+            con.execute(
+                "INSERT INTO sprint_wake_messages (sprint_id,wake_id,message_id) "
+                "VALUES (?,?,?)",
+                (self.ids["sprint_id"], wake_id, message_id),
+            )
+
+        status, _, board = self.request(
+            "GET", f"/api/sprints/{self.ids['sprint_id']}"
+        )
+        self.assertEqual(200, status, board)
+        ready = next(
+            unit
+            for unit in board["work_units"]
+            if unit["work_unit_id"] == self.ids["ready_unit"]
+        )
+        self.assertEqual("waiting", ready["column"])
+        self.assertEqual(
+            {
+                "state": "runtime_unavailable",
+                "runtime_state": "stale",
+                "wake_id": wake_id,
+                "attempt_count": 0,
+            },
+            ready["delivery"],
+        )
 
     def test_events_are_cursor_stable_and_never_return_unknown_payload_fields(self):
         status, _, first = self.request(

--- a/tests/test_sprint_board_ui.py
+++ b/tests/test_sprint_board_ui.py
@@ -268,6 +268,81 @@ console.log(JSON.stringify({
     assert result["focusParity"] is True
 
 
+def test_board_surfaces_runtime_failure_and_bounded_pickup_recovery_without_transcript():
+    harness = r"""
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag; this.nodeType = 1; this.children = []; this._text = "";
+    this.className = ""; this.dataset = {}; this.attributes = {}; this.isConnected = false;
+    this.scrollWidth = 1200; this.scrollHeight = 500;
+    this.classList = {toggle() {}};
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  replaceChildren(...nodes) { this.children = [...nodes]; this._text = ""; }
+  set textContent(value) { this._text = String(value ?? ""); this.children = []; }
+  get textContent() { return this._text + this.children.map(
+    (x) => typeof x === "string" ? x : (x.textContent || "")).join(""); }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  querySelectorAll() { return []; }
+  getBoundingClientRect() { return {left: 0, right: 100, top: 0, height: 50}; }
+}
+globalThis.document = {
+  hidden: false,
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({nodeType: 3, textContent: String(text ?? "")}),
+  createElementNS: (_ns, tag) => new FakeElement(tag),
+};
+globalThis.window = {addEventListener() {}, removeEventListener() {}};
+globalThis.requestAnimationFrame = () => {};
+globalThis.SVGNS = "svg";
+const el = (tag, props = {}, ...kids) => {
+  const node = Object.assign(new FakeElement(tag), props);
+  for (const kid of kids) node.append(kid?.nodeType ? kid : document.createTextNode(kid ?? ""));
+  return node;
+};
+function openModal() { return () => {}; }
+"""
+    script = harness + SPRINT_BLOCK + r"""
+const person = (shortname) => ({shell_id: 1, shortname, current_conversation_id: null});
+const recovery = {
+  sprint_id: 9, participant_id: 3, shell: "DEV1", role: "developer",
+  work_unit_id: 4, message_id: 71, wake_id: 81, conversation_id: "cv_dead",
+  run_state: "unknown", error_code: "HARNESS_SESSION_DISCOVERY_FAILED",
+  failure_class: "native_unknown", attempt_count: 1,
+  recovery_instruction: "Inspect the pause report, repair the named route or service, then use an authorized resume.",
+};
+const unit = {
+  work_unit_id: 4, title: "Pickup", expected_output: "Output", output_kind: "code",
+  completion_result: null, planned_wave: 1, disposition: "ready", column: "waiting",
+  created_at: "2026-08-01 10:00:00", updated_at: "2026-08-01 10:00:00",
+  completed_at: null, developer: person("DEV1"), reviewer: person("REV1"),
+  task_ids: [], tasks: [], prerequisite_ids: [], dependent_ids: [], pull_requests: [],
+  messages: [], pickup: recovery,
+  delivery: {state: "runtime_unavailable", runtime_state: "stale", wake_id: 81, attempt_count: 0},
+};
+const snapshot = {
+  sprint: {sprint_id: 9, feature: {feature_id: 31, title: "Board"},
+    planner: {shortname: "PLN1"}, lifecycle: "paused", created_at: "2026-08-01 10:00:00",
+    armed_at: "2026-08-01 10:01:00", paused_at: "2026-08-01 10:02:00",
+    completed_at: null, aborted_at: null, terminal_outcome: null},
+  specs: [], work_units: [unit], dependencies: [],
+  runtime: {state: "stale", beat_at: "2026-08-01 10:00:00", interval_seconds: 5},
+  pickup: {action: "paused", requeued_wake_ids: [], pause_reason: "wake_pickup_unknown", exhausted: recovery},
+};
+const root = sprintBoardNode(snapshot);
+console.log(JSON.stringify({text: root.textContent}));
+"""
+    text = run_js(script)["text"]
+    assert "Runtime stale" in text
+    assert "HARNESS_SESSION_DISCOVERY_FAILED" in text
+    assert "DEV1" in text and "developer" in text
+    assert "U4" in text and "message 71" in text and "wake 81" in text
+    assert "attempt 1" in text
+    assert "authorized resume" in text
+    assert "Runtime stale — wake 81 has 0 delivery attempts" in text
+    assert "Traceback" not in text
+
+
 def test_participant_conversation_link_uses_existing_interface_route():
     script = r"""
 class FakeElement { constructor(tag) { this.tagName = tag; this.nodeType = 1; } }

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -1395,6 +1395,18 @@ class SprintCliApiTest(unittest.TestCase):
             TOKENS["planner"], "monitor", "--sprint", str(self.sprint_id)
         )
         self.assertEqual([], monitor["outcomes"])
+        self.assertEqual(
+            {
+                "action": "none",
+                "requeued_wake_ids": [],
+                "pause_reason": None,
+            },
+            monitor["pickup"],
+        )
+        self.assertEqual(
+            {"state": "missing", "beat_at": None, "interval_seconds": 5},
+            monitor["runtime"],
+        )
 
         findings = self.write(
             json.dumps(

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -9,8 +9,10 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".super-coder" / "scripts"
-sys.path[:0] = [str(SCRIPTS), str(ROOT / "tests")]
+API = ROOT / ".super-coder" / "api"
+sys.path[:0] = [str(SCRIPTS), str(API), str(ROOT / "tests")]
 
+import server
 import sprint_domain
 import sprint_message_delivery
 import sprint_participant_chats
@@ -1069,6 +1071,101 @@ class SprintRecoveryCase(SprintPRWatcherCase):
                 "work_unit_id": self.unit_id,
             },
             exhausted,
+        )
+
+    def test_monitor_reports_pause_with_empty_liveness_outcomes(self):
+        message = self.send("monitor-unknown-first-turn")
+        original = int(message.wake_id)
+        self.fail_wake_turn(
+            original,
+            error_code="HARNESS_SESSION_DISCOVERY_FAILED",
+            run_state="unknown",
+        )
+
+        with mock.patch.object(
+            server.sprint_liveness.SprintLivenessMonitor,
+            "evaluate",
+            return_value=(),
+        ):
+            response = server.sprint_monitor_response(self.con, self.sprint_id)
+
+        self.assertEqual([], response["outcomes"])
+        self.assertEqual(
+            {
+                "action": "paused",
+                "requeued_wake_ids": [],
+                "pause_reason": "wake_pickup_unknown",
+            },
+            response["pickup"],
+        )
+        self.assertEqual("missing", response["runtime"]["state"])
+        self.assertEqual(None, response["runtime"]["beat_at"])
+        self.assertEqual(5, response["runtime"]["interval_seconds"])
+
+    def test_monitor_requeue_is_idempotent_and_never_delivers_a_second_copy(self):
+        message = self.send("monitor-requeue")
+        original = int(message.wake_id)
+        self.fail_wake_turn(original, error_code="HARNESS_ROUTE_MISMATCH")
+        self.con.execute(
+            "INSERT INTO daemon_heartbeats (name,beat_at,interval_s) "
+            "VALUES ('sprint-runtime','2000-01-01 00:00:00',5)"
+        )
+        self.con.commit()
+
+        with mock.patch.object(
+            server.sprint_liveness.SprintLivenessMonitor,
+            "evaluate",
+            return_value=(),
+        ):
+            first = server.sprint_monitor_response(self.con, self.sprint_id)
+            native_before = self.con.execute(
+                "SELECT COUNT(*) FROM conversation_messages"
+            ).fetchone()[0]
+            wakes_before = self.con.execute(
+                "SELECT COUNT(*) FROM sprint_wake_outbox"
+            ).fetchone()[0]
+            second = server.sprint_monitor_response(self.con, self.sprint_id)
+
+        replacement = first["pickup"]["requeued_wake_ids"]
+        self.assertEqual(1, len(replacement))
+        self.assertNotEqual(original, replacement[0])
+        self.assertEqual("requeued", first["pickup"]["action"])
+        self.assertEqual([], first["outcomes"])
+        self.assertEqual(
+            {
+                "state": "stale",
+                "beat_at": "2000-01-01 00:00:00",
+                "interval_seconds": 5,
+            },
+            first["runtime"],
+        )
+        self.assertEqual(
+            {
+                "action": "none",
+                "requeued_wake_ids": [],
+                "pause_reason": None,
+            },
+            second["pickup"],
+        )
+        self.assertEqual([], second["outcomes"])
+        self.assertEqual(
+            native_before,
+            self.con.execute(
+                "SELECT COUNT(*) FROM conversation_messages"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            wakes_before,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_wake_outbox"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            "pending",
+            self.con.execute(
+                "SELECT state FROM sprint_wake_outbox WHERE wake_id=?",
+                (replacement[0],),
+            ).fetchone()[0],
         )
 
     def test_non_busy_failed_turn_replaces_once_then_exhausts_atomically(self):

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -1112,6 +1112,69 @@ class DeliveryTerminalTest(SprintWorkDispatchCase):
 
 
 class ProductionPulseTest(SprintWorkDispatchCase):
+    def test_successful_pulses_advance_runtime_heartbeat_but_failure_does_not(self) -> None:
+        runtime = sprint_runtime.SprintRuntimeService(
+            self.db_path,
+            owner="heartbeat-runtime-test",
+        )
+
+        self.assertFalse(runtime.pulse_once())
+        first = self.con.execute(
+            "SELECT beat_at,interval_s FROM daemon_heartbeats "
+            "WHERE name='sprint-runtime'"
+        ).fetchone()
+        self.assertEqual(5, first["interval_s"])
+        self.assertEqual(
+            {
+                "state": "live",
+                "beat_at": first["beat_at"],
+                "interval_seconds": 5,
+            },
+            sprint_runtime.runtime_status(self.con),
+        )
+
+        with mock.patch.object(
+            runtime,
+            "_deliver_wakes",
+            side_effect=RuntimeError("injected delivery failure"),
+        ), self.assertRaisesRegex(RuntimeError, "injected delivery failure"):
+            runtime.pulse_once()
+
+        after_failure = self.con.execute(
+            "SELECT beat_at,interval_s FROM daemon_heartbeats "
+            "WHERE name='sprint-runtime'"
+        ).fetchone()
+        self.assertEqual(tuple(first), tuple(after_failure))
+
+        self.assertFalse(runtime.pulse_once())
+        after_success = self.con.execute(
+            "SELECT beat_at,interval_s FROM daemon_heartbeats "
+            "WHERE name='sprint-runtime'"
+        ).fetchone()
+        self.assertGreater(after_success["beat_at"], first["beat_at"])
+        self.assertEqual(5, after_success["interval_s"])
+
+    def test_initial_failing_pulse_does_not_create_runtime_heartbeat(self) -> None:
+        runtime = sprint_runtime.SprintRuntimeService(
+            self.db_path,
+            owner="initial-failure-runtime-test",
+        )
+
+        with mock.patch.object(
+            runtime,
+            "_deliver_wakes",
+            side_effect=RuntimeError("startup delivery failed"),
+        ), self.assertRaisesRegex(RuntimeError, "startup delivery failed"):
+            runtime.pulse_once(startup=True)
+
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM daemon_heartbeats "
+                "WHERE name='sprint-runtime'"
+            ).fetchone()[0],
+        )
+
     def test_armed_pulse_enqueues_every_parallel_ready_lane(self) -> None:
         first = self.create_unit(developer=1, wave=4)
         second = self.create_unit(developer=4, wave=0)
@@ -1300,6 +1363,9 @@ class ProductionPulseTest(SprintWorkDispatchCase):
         order: list[str] = []
         preparer = object()
         broker = mock.Mock()
+        runtime = mock.Mock()
+        runtime.wait_ready.return_value = True
+        runtime.is_alive.return_value = True
         with (
             mock.patch.object(
                 server.conversation_launch,
@@ -1321,12 +1387,19 @@ class ProductionPulseTest(SprintWorkDispatchCase):
             mock.patch.object(
                 server.sprint_runtime,
                 "start_service",
-                side_effect=lambda *_args, **_kwargs: order.append("sprint"),
+                side_effect=lambda *_args, **_kwargs: (
+                    order.append("sprint") or runtime
+                ),
             ) as sprint_start,
+            mock.patch.object(
+                server.sprint_pr_watcher,
+                "start_service",
+                side_effect=lambda *_args, **_kwargs: order.append("watcher"),
+            ) as watcher_start,
         ):
             server.start_runtime_services()
 
-        self.assertEqual(["broker", "reaper", "sprint"], order)
+        self.assertEqual(["broker", "reaper", "sprint", "watcher"], order)
         broker_start.assert_called_once_with(
             server.DB_PATH,
             launch_preparer=preparer,
@@ -1336,11 +1409,46 @@ class ProductionPulseTest(SprintWorkDispatchCase):
             native_interrupt=broker.interrupt,
         )
         sprint_start.assert_called_once_with(server.DB_PATH)
+        runtime.wait_ready.assert_called_once()
+        runtime.is_alive.assert_called_once_with()
+        watcher_start.assert_called_once_with(server.DB_PATH, repo_root=server.REPO_ROOT)
         self.assertIn(
             "on_started=start_runtime_services",
             inspect.getsource(server.main),
             "the combined startup function must remain the production callback",
         )
+
+    def test_server_startup_refuses_runtime_that_never_becomes_ready_or_dies(self) -> None:
+        for ready, alive, expected in (
+            (False, True, "did not complete its first successful cycle"),
+            (True, False, "died during startup"),
+        ):
+            with self.subTest(ready=ready, alive=alive):
+                runtime = mock.Mock()
+                runtime.wait_ready.return_value = ready
+                runtime.is_alive.return_value = alive
+                with (
+                    mock.patch.object(
+                        server.conversation_broker,
+                        "start_service",
+                        return_value=mock.Mock(interrupt=mock.Mock()),
+                    ),
+                    mock.patch.object(server.conversation_reaper, "start_service"),
+                    mock.patch.object(
+                        server.sprint_runtime,
+                        "start_service",
+                        return_value=runtime,
+                    ),
+                    mock.patch.object(
+                        server.sprint_pr_watcher,
+                        "start_service",
+                    ) as watcher_start,
+                    self.assertRaisesRegex(RuntimeError, expected),
+                ):
+                    server.start_runtime_services()
+
+                runtime.stop.assert_called_once_with()
+                watcher_start.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- persist sprint-runtime heartbeats only after complete successful pulse cycles and gate server readiness on the first successful cycle
- extend monitor and Sprint detail projections with runtime health plus bounded pickup recovery evidence
- surface stale/missing runtime and exhausted pickup state directly on the board without raw adapter traces

## Verification
- RED: 9 targeted failures before implementation (missing heartbeat/readiness/monitor/board/UI contracts); initial failed-cycle no-heartbeat control already passed
- focused: 123 passed, 176 subtests passed
- full: 1958 passed, 1 skipped via ./sc test
- ./sc verify: linked-worktree refusal per #769; canonical verify passed in isolated clone at exact pushed head 65d3af3cad41a29391a37810c9a9cd9932d48c10

Spec #116, task #345. Do not merge before PLN2/reviewer verdict.