### PR TITLE
fix(ui): timestamp chat messages and align rail status

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2601,6 +2601,22 @@ function chatStartedLabel(conversation) {
   }).format(started);
 }
 
+function chatMessageTimeLabel(createdAt) {
+  if (!createdAt) return "";
+  const raw = String(createdAt);
+  const normalized = raw.replace(" ", "T");
+  const timestamp = /(?:Z|[+-]\d\d:\d\d)$/.test(normalized)
+    ? normalized
+    : `${normalized}Z`;
+  const created = new Date(timestamp);
+  if (Number.isNaN(created.getTime())) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(created);
+}
+
 function chatShellLabel(conversation) {
   const shell = conversation?.shell || {};
   return [shell.display_name, shell.shortname].filter(Boolean).join(" | ") || "Shell";
@@ -2775,12 +2791,19 @@ async function chatCloseForSwitch(conversation) {
   }
 }
 
-function chatBubble(kind, body, meta = "", conversation = null) {
+function chatBubble(kind, body, meta = "", conversation = null, createdAt = "") {
   const bubble = el("article", { className: `chat-bubble chat-${kind}` });
-  bubble.append(el("div", { className: "chat-who" },
-    kind === "user" ? "You"
-      : kind === "assistant" ? chatShellLabel(conversation)
-      : "Activity"));
+  const header = el("div", { className: "chat-bubble-head" },
+    el("div", { className: "chat-who" },
+      kind === "user" ? "You"
+        : kind === "assistant" ? chatShellLabel(conversation)
+        : "Activity"));
+  const time = chatMessageTimeLabel(createdAt);
+  if (time) header.append(el("time", {
+    className: "chat-message-time",
+    dateTime: String(createdAt),
+  }, time));
+  bubble.append(header);
   const content = kind === "activity"
     ? el("div", { className: "chat-activity-text" }, body)
     : mdBlock(body);
@@ -3642,6 +3665,7 @@ function chatTranscriptItemNode(item, conversation, retry) {
     item.text || "",
     item.kind === "user" ? item.state || "" : "",
     conversation,
+    item.created_at,
   );
   if (item.kind === "user" && item.state === "failed") {
     const button = el("button", {
@@ -4513,7 +4537,7 @@ async function renderInterface(root) {
       };
     }
     const status = el("span", { className: "chat-shell-status" });
-    chatPaintShellStatus(status, badge, mail, wake);
+    chatPaintShellStatus(status, mail, badge, wake);
     shellStatusItems.set(item.shell_id, { row: shellRow, status, badge, mail });
     shellRow.append(status);
     rail.append(shellRow);
@@ -4525,7 +4549,7 @@ async function renderInterface(root) {
       if (!target) continue;
       const wake = chatWakePendingIndicator(next);
       target.row.classList.toggle("has-wake", Boolean(wake));
-      chatPaintShellStatus(target.status, target.badge, target.mail, wake);
+      chatPaintShellStatus(target.status, target.mail, target.badge, wake);
     }
   };
   const refreshWakeIndicators = async () => {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -426,10 +426,15 @@ body.interface-view main {
   align-self: flex-start; display: inline-flex; align-items: baseline;
   margin-left: .8rem; color: var(--accent); font-size: .78rem;
 }
-.chat-who {
-  color: var(--dim); font-size: calc(.62rem + 1px); text-transform: uppercase;
-  letter-spacing: .12em; margin-bottom: .22rem;
+.chat-bubble-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: .8rem; margin-bottom: .22rem;
 }
+.chat-who, .chat-message-time {
+  color: var(--dim); font-size: calc(.62rem + 1px); text-transform: uppercase;
+  letter-spacing: .12em;
+}
+.chat-message-time { font-variant-numeric: tabular-nums; white-space: nowrap; }
 .chat-bubble .md > :first-child { margin-top: 0; }
 .chat-bubble .md > :last-child { margin-bottom: 0; }
 .chat-meta { color: var(--dim); font-size: .64rem; margin-top: .35rem; }

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -101,8 +101,12 @@ def test_shell_card_orders_left_identity_and_right_status_cluster():
     status = interface[interface.index('const status = el("span"'):
                        interface.index("rail.append(shellRow)")]
     assert 'className: "chat-shell-status"' in status
-    assert "chatPaintShellStatus(status, badge, mail, wake)" in status
+    assert "chatPaintShellStatus(status, mail, badge, wake)" in status
     assert "shellStatusItems.set" in status
+    assert (
+        "chatPaintShellStatus(target.status, target.mail, target.badge, wake)"
+        in interface
+    )
 
     status_style = STYLE[STYLE.index(".chat-shell-status {"):
                          STYLE.index(".chat-sprint-badge {")]
@@ -433,6 +437,65 @@ def test_conversation_identity_uses_shell_context_and_neutral_user_label():
     assert 'className: "chat-history-context"' in interface
     assert 'className: "chat-shell-shortname"' in interface
     assert "chatPaintShellState(button, openByShell.get(item.shell_id))" in interface
+
+
+def test_message_bubbles_show_local_creation_time_and_omit_invalid_values():
+    helper = APP[
+        APP.index("function chatMessageTimeLabel"):
+        APP.index("function chatShellLabel")
+    ]
+    bubble = APP[
+        APP.index("function chatBubble"):
+        APP.index("function chatTranscriptAtBottom")
+    ]
+    script = r"""
+process.env.TZ = "UTC";
+function el(tag, props = {}, ...children) {
+  return {
+    tag, ...props, children,
+    append(...items) { this.children.push(...items); },
+  };
+}
+function mdBlock(body) { return el("div", { className: "md" }, body); }
+function chatShellLabel() { return "Shell"; }
+""" + helper + bubble + r"""
+const createdAt = "2026-08-06T06:17:00+02:00";
+const user = chatBubble("user", "hello", "completed", null, createdAt);
+const activity = chatBubble("activity", "working");
+console.log(JSON.stringify({
+  valid: chatMessageTimeLabel(createdAt),
+  missing: chatMessageTimeLabel(null),
+  invalid: chatMessageTimeLabel("not-a-time"),
+  header: {
+    className: user.children[0].className,
+    who: user.children[0].children[0].children[0],
+    timeTag: user.children[0].children[1].tag,
+    timeClass: user.children[0].children[1].className,
+    dateTime: user.children[0].children[1].dateTime,
+    time: user.children[0].children[1].children[0],
+  },
+  activityHeaderItems: activity.children[0].children.length,
+}));
+"""
+    assert run_js(script) == {
+        "valid": "04:17",
+        "missing": "",
+        "invalid": "",
+        "header": {
+            "className": "chat-bubble-head",
+            "who": "You",
+            "timeTag": "time",
+            "timeClass": "chat-message-time",
+            "dateTime": "2026-08-06T06:17:00+02:00",
+            "time": "04:17",
+        },
+        "activityHeaderItems": 1,
+    }
+    transcript_item = APP[
+        APP.index("function chatTranscriptItemNode"):
+        APP.index("function chatUpdateTranscriptNode")
+    ]
+    assert "item.created_at" in transcript_item
 
 
 def test_shell_rail_mail_badge_only_renders_for_unread_messages():


### PR DESCRIPTION
Summary
- show each user and assistant message creation time in the bubble header using local 24-hour time
- omit missing or malformed timestamps and leave activity rows unchanged
- order unread mail before the Sprint badge, including wake-indicator refreshes

Trade-off
- reuse the transcript projection created_at values in the browser; no API or schema expansion

Verification
- node --check .super-coder/ui/app.js
- .venv/bin/ruff check tests/test_conversation_ui.py
- ./sc test (1993 passed, 1 skipped)