### PR TITLE
fix: do not hard-lock actions on newer harness releases

### DIFF
--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -126,12 +126,17 @@ def checked_probe_result(
             "HARNESS_VERSION_UNSUPPORTED",
             f"{harness} {version} is older than required {minimum}",
         )
-    if version_tuple(version) >= version_tuple(maximum):
-        raise AdapterError(
-            "HARNESS_VERSION_UNSUPPORTED",
-            f"{harness} {version} is outside supported range "
-            f"[{minimum}, {maximum})",
-        )
+    # The minimum is a capability floor: older releases are known not to
+    # satisfy this adapter contract.  The maximum is only the edge of the
+    # tested envelope.  Vendor releases newer than that envelope must stay
+    # visible without globally locking otherwise valid engine actions; actual
+    # protocol incompatibilities still fail at the operation that observes
+    # them.
+    compatibility_status = (
+        "newer-unverified"
+        if version_tuple(version) >= version_tuple(maximum)
+        else ("verified" if version == verified else "supported")
+    )
     return ProbeResult(
         harness=harness,
         version=version,
@@ -139,7 +144,7 @@ def checked_probe_result(
         capabilities=capabilities,
         maximum_version_exclusive=maximum,
         verified_version=verified,
-        compatibility=("verified" if version == verified else "supported"),
+        compatibility=compatibility_status,
     )
 
 

--- a/.super-coder/scripts/harness_versions.py
+++ b/.super-coder/scripts/harness_versions.py
@@ -127,6 +127,12 @@ def main(argv: list[str]) -> int:
         compatibility = status["compatibility"]
         if status["error"]:
             detail = f"{version or '—'} · {status['error']}"
+        elif version and compatibility == "newer-unverified":
+            detail = (
+                f"{version} · {compatibility} · tested "
+                f"[{status['minimum_version']}, "
+                f"{status['maximum_version_exclusive']})"
+            )
         elif version and compatibility:
             detail = (
                 f"{version} · {compatibility} · supported "

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -667,7 +667,7 @@ class ConversationAdapterTest(unittest.TestCase):
         self.linked_vm.stop()
         self.temp.cleanup()
 
-    def test_declared_compatibility_ranges_enforce_closed_open_boundaries(self) -> None:
+    def test_declared_compatibility_ranges_enforce_floor_and_flag_newer(self) -> None:
         cases = {
             "claude": ("2.1.219", "2.1.220", "2.1.222", "2.2.0"),
             "codex": ("0.144.999", "0.145.0", "0.146.1", "0.147.0"),
@@ -696,11 +696,10 @@ class ConversationAdapterTest(unittest.TestCase):
                     rf"{harness} {re.escape(below)} is older than required {re.escape(lower)}",
                 ):
                     adapter._probe_result(below)
-                with self.assertRaisesRegex(
-                    AdapterError,
-                    rf"{harness} {re.escape(upper)} is outside supported range",
-                ):
-                    adapter._probe_result(upper)
+                upper_result = adapter._probe_result(upper)
+                self.assertEqual(upper_result.version, upper)
+                self.assertEqual(upper_result.compatibility, "newer-unverified")
+                self.assertEqual(upper_result.maximum_version_exclusive, upper)
 
     def test_verified_probe_result_names_missing_manifest_keys(self) -> None:
         adapter, _native = self.build("claude")

--- a/tests/test_harness_versions.py
+++ b/tests/test_harness_versions.py
@@ -51,6 +51,27 @@ def test_runtime_binary_version_is_checked_against_adapter_range() -> None:
         }
 
 
+def test_newer_runtime_is_reported_without_becoming_an_error() -> None:
+    with (
+        mock.patch.object(harness_versions, "HARNESSES", ("codex",)),
+        mock.patch.object(
+            harness_versions,
+            "probe",
+            return_value="codex-cli 0.147.0",
+        ),
+    ):
+        assert harness_versions.compatibility_status() == {
+            "codex": {
+                "version": "0.147.0",
+                "compatibility": "newer-unverified",
+                "minimum_version": "0.145.0",
+                "maximum_version_exclusive": "0.147.0",
+                "verified_version": "0.145.0",
+                "error": None,
+            }
+        }
+
+
 def test_text_status_couples_host_provenance_and_compatibility() -> None:
     output = io.StringIO()
     with (
@@ -63,6 +84,28 @@ def test_text_status_couples_host_provenance_and_compatibility() -> None:
     assert output.getvalue().splitlines() == [
         "  runtime:   host",
         "  codex     0.145.0 · verified · supported [0.145.0, 0.147.0)",
+    ]
+
+
+def test_text_status_marks_newer_runtime_as_unverified() -> None:
+    status = {
+        "codex": {
+            **STATUS["codex"],
+            "version": "0.147.0",
+            "compatibility": "newer-unverified",
+        }
+    }
+    output = io.StringIO()
+    with (
+        mock.patch.object(harness_versions, "compatibility_status", return_value=status),
+        mock.patch.dict(os.environ, {}, clear=True),
+        redirect_stdout(output),
+    ):
+        assert harness_versions.main([]) == 0
+
+    assert output.getvalue().splitlines() == [
+        "  runtime:   host",
+        "  codex     0.147.0 · newer-unverified · tested [0.145.0, 0.147.0)",
     ]
 
 

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -23,6 +23,7 @@ import sprint_domain
 import sprint_message_delivery as delivery
 import sprint_runtime
 from conversation_adapters import AdapterError
+from conversation_adapters.base import AdapterCapabilities, checked_probe_result
 
 
 def apply_schema(con: sqlite3.Connection) -> None:
@@ -290,13 +291,58 @@ class DispatchGateTest(SprintWorkDispatchCase):
         self.assertIsInstance(caught.exception, sprint_domain.SprintPreflightError)
         self.assert_arm_left_no_writes()
 
-    def test_arm_rejects_out_of_range_harness_before_any_write(self) -> None:
+    def test_arm_allows_newer_unverified_harness(self) -> None:
+        self.create_unit(developer=1)
+        observed: list[tuple[str, str]] = []
+        capabilities = AdapterCapabilities(
+            exact_session_resume=True,
+            structured_streaming=True,
+            interruption=True,
+            interactive_permission_response=True,
+            server_backed=True,
+            session_inspection=True,
+        )
+        manifest = {
+            "conversation": {
+                "minimum_cli_version": "1.0.0",
+                "maximum_cli_version_exclusive": "2.0.0",
+                "verified_cli_version": "1.5.0",
+            }
+        }
+
+        def newer(harness: str):
+            result = checked_probe_result(
+                harness=harness,
+                manifest=manifest,
+                capabilities=capabilities,
+                version="2.0.0",
+            )
+            observed.append((harness, result.compatibility))
+            return result
+
+        sprint_domain.SprintLifecycleStore(
+            self.con, probe_harness=newer
+        ).arm(self.sprint_id, 3)
+
+        self.assertEqual(
+            [("codex", "newer-unverified"), ("kimi", "newer-unverified")],
+            observed,
+        )
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+
+    def test_arm_rejects_too_old_harness_before_any_write(self) -> None:
         self.create_unit(developer=1)
 
-        def unsupported(harness: str):
+        def too_old(harness: str):
             raise AdapterError(
                 "HARNESS_VERSION_UNSUPPORTED",
-                f"{harness} 99.0.0 is outside supported range [1.0.0, 2.0.0)",
+                f"{harness} 0.9.0 is older than required 1.0.0",
             )
 
         with self.assertRaisesRegex(
@@ -304,7 +350,7 @@ class DispatchGateTest(SprintWorkDispatchCase):
             "HARNESS_VERSION_UNSUPPORTED",
         ) as caught:
             sprint_domain.SprintLifecycleStore(
-                self.con, probe_harness=unsupported
+                self.con, probe_harness=too_old
             ).arm(self.sprint_id, 3)
 
         self.assertIsInstance(caught.exception, sprint_domain.SprintPreflightError)


### PR DESCRIPTION
Fixes #1110

## Change
- keep minimum CLI versions as hard capability floors
- classify versions at or above the tested ceiling as `newer-unverified` instead of raising `HARNESS_VERSION_UNSUPPORTED`
- surface the unverified/tested-range distinction in `harness-status`
- cover adapter classification, runtime status, Sprint arm success, and the still-blocking too-old path

Actual host verification confirms Codex 0.147.0 still exposes the required app-server stdio transport and now probes as `newer-unverified` without blocking Sprint arm. Real missing-binary/protocol failures still fail at their observation point.

## Verification
- `77 passed, 25 subtests passed` across `test_conversation_adapters.py`, `test_harness_versions.py`, and `test_sprint_work_dispatch.py`
- live `adapter_for("codex").probe()` against codex-cli 0.147.0
- `git diff --check`