### PR TITLE
feat: verify fork harnesses during model refresh

### DIFF
--- a/.super-coder/api/model_catalog.py
+++ b/.super-coder/api/model_catalog.py
@@ -38,6 +38,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import toml_compat
+import harness_versions
 from conversation_adapters.opencode import (
     connected_models as opencode_connected_models,
 )
@@ -71,7 +72,7 @@ CLAUDE_ALIASES = ["fable", "opus", "sonnet", "haiku"]
 # Bump when the response/cache shape changes — a cached payload from another
 # version is ignored (treated as no cache) instead of being served to a
 # client that expects the new shape.
-PAYLOAD_VERSION = 4
+PAYLOAD_VERSION = 5
 
 # provider APIs, keyed by harness: (env var, url, header builder). Responses
 # are the OpenAI-style {"data": [{"id": ...}, ...]} shape on all three.
@@ -391,6 +392,128 @@ def persist_routes(con, payload: dict) -> None:
     con.commit()
 
 
+def _requires_high_effort(harness: str) -> bool:
+    """Match run.py: high is implicit only when the adapter transports it."""
+    try:
+        cfg = json.loads((ADAPTERS / harness / "adapter.json").read_text())
+    except Exception:  # noqa: BLE001
+        return False
+    return bool(((cfg.get("headless") or {}).get("effort")))
+
+
+def _default_route_verification(con, harnesses: dict[str, dict]) -> list[dict]:
+    """Validate every configured flavor route against this fork's live rows."""
+    defaults = []
+    for configured in con.execute(
+        "SELECT flavor,harness,model,is_default FROM flavor_defaults "
+        "ORDER BY flavor,harness"
+    ):
+        flavor = configured["flavor"]
+        harness = configured["harness"]
+        model = configured["model"]
+        status = harnesses.get(harness) or {}
+        harness_error = status.get("error")
+        if status.get("version") is None:
+            harness_error = harness_error or "HARNESS_UNAVAILABLE"
+
+        route = None
+        if model is not None:
+            found = con.execute(
+                "SELECT availability,headless_supported,"
+                "high_effort_supported,stale,last_error FROM model_routes "
+                "WHERE harness=? AND selector=?",
+                (harness, model),
+            ).fetchone()
+            route = dict(found) if found is not None else None
+
+        runnable: bool | None = False
+        if harness_error:
+            state = "harness-error"
+            reason = harness_error
+        elif model is None:
+            state = "harness-default"
+            runnable = None
+            reason = "model selected by harness at launch"
+        elif route is None:
+            state = "route-missing"
+            reason = "exact model route was not discovered locally"
+        elif route["stale"]:
+            state = "route-stale"
+            reason = route["last_error"] or "last-known route is stale"
+        elif route["availability"] != "available":
+            state = "route-unavailable"
+            reason = f"route is {route['availability']}, not locally available"
+        elif not route["headless_supported"]:
+            state = "headless-unsupported"
+            reason = "harness has no headless launch seam"
+        elif _requires_high_effort(harness) and not route["high_effort_supported"]:
+            state = "effort-unsupported"
+            reason = "default high-effort route was not locally verified"
+        else:
+            state = "runnable"
+            runnable = True
+            reason = None
+
+        defaults.append({
+            "flavor": flavor,
+            "harness": harness,
+            "model": model,
+            "is_default": bool(configured["is_default"]),
+            "state": state,
+            "runnable": runnable,
+            "reason": reason,
+        })
+    return defaults
+
+
+def runtime_verification(con, *, env=os.environ,
+                         harness_probe=harness_versions.compatibility_status) -> dict:
+    """Fork-local harness and configured-route evidence for one refresh."""
+    checked_at = datetime.now(timezone.utc).isoformat()
+    report = {
+        "checked_at": checked_at,
+        "runtime": "sandbox" if env.get("SC_SANDBOX") else "host",
+        "harnesses": {},
+        "defaults": [],
+        "summary": {
+            "harnesses_checked": 0,
+            "harnesses_ready": 0,
+            "exact_routes": 0,
+            "exact_routes_runnable": 0,
+            "harness_defaults": 0,
+        },
+    }
+    try:
+        harnesses = harness_probe()
+    except Exception as exc:  # noqa: BLE001
+        report["error"] = str(exc)
+        return report
+
+    report["harnesses"] = harnesses
+    report["summary"]["harnesses_checked"] = len(harnesses)
+    report["summary"]["harnesses_ready"] = sum(
+        1 for status in harnesses.values()
+        if status.get("version") is not None and not status.get("error")
+    )
+    try:
+        defaults = _default_route_verification(con, harnesses)
+    except Exception as exc:  # noqa: BLE001
+        report["route_error"] = str(exc)
+        return report
+
+    report["defaults"] = defaults
+    report["summary"]["exact_routes"] = sum(
+        1 for route in defaults if route["model"] is not None
+    )
+    report["summary"]["exact_routes_runnable"] = sum(
+        1 for route in defaults if route["runnable"] is True
+    )
+    report["summary"]["harness_defaults"] = sum(
+        1 for route in defaults if route["state"] == "harness-default"
+    )
+    return report
+
+
 def _served(payload: dict, con=None) -> dict:
     if con is not None:
         persist_routes(con, payload)
@@ -437,7 +560,8 @@ def _with_live_opencode(payload: dict, provider_models) -> dict:
 
 def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
             run=subprocess.run, con=None,
-            opencode_provider=opencode_connected_models) -> dict:
+            opencode_provider=opencode_connected_models,
+            harness_probe=harness_versions.compatibility_status) -> dict:
     """The cached-with-fallbacks entry point the API serves.
 
     fresh cache → serve it; miss/stale/refresh → live sweep, cache the result;
@@ -451,17 +575,44 @@ def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
         fresh = build(fetch, env, run)
     except Exception as e:  # noqa: BLE001
         if cached:
-            return _served(_with_live_opencode(
+            response = _served(_with_live_opencode(
                 {**cached, "stale": True, "error": str(e)},
                 opencode_provider,
             ), con)
-        return _served(_with_live_opencode(
-            {"v": PAYLOAD_VERSION, "fetched_at": None,
-             "sources": ["static"], "stale": True,
-             "error": str(e), "harnesses": _floor()},
-            opencode_provider,
+            if refresh and con is not None:
+                verification = runtime_verification(
+                    con, env=env, harness_probe=harness_probe
+                )
+                response["verification"] = verification
+                CACHE.write_text(json.dumps(
+                    {**cached, "verification": verification}, indent=1
+                ) + "\n")
+            return response
+        fallback = {
+            "v": PAYLOAD_VERSION, "fetched_at": None,
+            "sources": ["static"], "stale": True,
+            "error": str(e), "harnesses": _floor(),
+        }
+        response = _served(_with_live_opencode(
+            fallback, opencode_provider,
         ), con)
+        if refresh and con is not None:
+            verification = runtime_verification(
+                con, env=env, harness_probe=harness_probe
+            )
+            fallback["verification"] = verification
+            response["verification"] = verification
+            CACHE.parent.mkdir(parents=True, exist_ok=True)
+            CACHE.write_text(json.dumps(fallback, indent=1) + "\n")
+        return response
+    response = _served(_with_live_opencode(
+        {**fresh, "stale": False}, opencode_provider), con)
+    if refresh and con is not None:
+        verification = runtime_verification(
+            con, env=env, harness_probe=harness_probe
+        )
+        fresh["verification"] = verification
+        response["verification"] = verification
     CACHE.parent.mkdir(parents=True, exist_ok=True)
     CACHE.write_text(json.dumps(fresh, indent=1) + "\n")
-    return _served(_with_live_opencode(
-        {**fresh, "stale": False}, opencode_provider), con)
+    return response

--- a/.super-coder/scripts/harness_versions.py
+++ b/.super-coder/scripts/harness_versions.py
@@ -69,7 +69,7 @@ def compatibility_status() -> dict[str, dict[str, str | None]]:
                 "minimum_version": None,
                 "maximum_version_exclusive": None,
                 "verified_version": None,
-                "error": None,
+                "error": None if raw_version else "HARNESS_UNAVAILABLE",
             }
             continue
         if version is None:

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -543,22 +543,36 @@ function dmModelPicker(harness, cat, row, save) {
   return { current, input, results };
 }
 
-async function renderDefaultModels(root, s) {
+async function renderDefaultModels(root, s, catalogOverride = null) {
   root.textContent = "";
   let fd;
   try { fd = await api("/flavor-defaults"); }
   catch (e) { root.append(el("div", { className: "vpanel" }, "flavor-defaults error: " + e.message)); return; }
   let cat = { harnesses: {}, sources: [], fetched_at: null, stale: true };
-  try { cat = await api("/models"); } catch { /* picker shows Harness default only */ }
+  if (catalogOverride) cat = catalogOverride;
+  else try { cat = await api("/models"); } catch { /* picker shows Harness default only */ }
 
   const head = el("div", { className: "viewer-head" }, microlabel("Default Models"));
-  const refresh = el("button", { className: "act", type: "button", textContent: "↻ Refresh models" });
+  const refresh = el("button", { className: "act", type: "button", textContent: "↻ Refresh & verify" });
   refresh.onclick = async () => {
     refresh.disabled = true;
-    setStatus("refreshing model catalog…");
-    try { await api("/models?refresh=1"); setStatus("model catalog refreshed"); }
-    catch (e) { toast("catalog refresh error: " + e.message); setStatus("catalog refresh failed"); }
-    renderDefaultModels(root, s);
+    setStatus("refreshing model catalog and harnesses…");
+    let refreshed = null;
+    try {
+      refreshed = await api("/models?refresh=1");
+      const verification = refreshed.verification || {};
+      const warnings = refreshed.stale || verification.error || verification.route_error
+        || Object.values(verification.harnesses || {}).some(
+          (status) => status.error || status.compatibility === "newer-unverified")
+        || (verification.defaults || []).some((route) => route.runnable === false);
+      setStatus(warnings
+        ? "refresh complete — review verification warnings"
+        : "model catalog and harnesses verified");
+    } catch (e) {
+      toast("catalog refresh error: " + e.message);
+      setStatus("catalog and harness verification failed");
+    }
+    await renderDefaultModels(root, s, refreshed);
   };
   head.append(refresh);
   root.append(head);
@@ -566,6 +580,50 @@ async function renderDefaultModels(root, s) {
   root.append(el("div", { className: "dm-meta" },
     `catalog: ${(cat.sources || []).join(" + ") || "none"} · as of ${when}`
     + (cat.stale ? " (stale — live refresh failed)" : "")));
+
+  const verification = cat.verification;
+  if (!verification) {
+    root.append(el("div", { className: "dm-meta" },
+      "harnesses: not verified — use Refresh & verify on this fork"));
+  } else {
+    const panel = el("div", { className: "vpanel dm-verify" });
+    panel.append(el("div", { className: "acc-group" }, "Fork verification"));
+    const checked = verification.checked_at
+      ? new Date(verification.checked_at).toLocaleString() : "unknown";
+    panel.append(el("div", { className: "dm-meta dm-verify-meta" },
+      `${verification.runtime || "runtime"} · checked ${checked}`));
+    const harnessOrder = [...new Set([
+      ...(fd.harnesses || []), ...Object.keys(verification.harnesses || {}),
+    ])];
+    for (const harness of harnessOrder) {
+      const status = (verification.harnesses || {})[harness] || {};
+      const verdict = status.error || status.compatibility
+        || (status.version ? "detected" : "not checked");
+      const stateClass = status.error ? "dm-verify-bad"
+        : status.compatibility === "newer-unverified" ? "dm-verify-warn"
+          : "dm-verify-ok";
+      panel.append(el("div", { className: "dm-verify-row" },
+        el("span", { className: "dm-harness" }, harness),
+        el("span", { className: "dm-current" }, status.version || "not installed"),
+        el("span", { className: `dm-verify-state ${stateClass}` }, verdict)));
+    }
+    const summary = verification.summary || {};
+    panel.append(el("div", { className: "dm-meta dm-verify-summary" },
+      `harnesses: ${summary.harnesses_ready || 0}/${summary.harnesses_checked || 0} ready`
+      + ` · exact defaults: ${summary.exact_routes_runnable || 0}/${summary.exact_routes || 0} runnable`
+      + ` · harness-selected: ${summary.harness_defaults || 0}`));
+    if (verification.error || verification.route_error) {
+      panel.append(el("div", { className: "dm-verify-failure" },
+        verification.error || verification.route_error));
+    }
+    for (const route of (verification.defaults || []).filter(
+      (candidate) => candidate.runnable === false)) {
+      panel.append(el("div", { className: "dm-verify-failure" },
+        `${route.flavor} · ${route.harness} · ${route.model || "Harness default"}`
+        + ` — ${route.reason || route.state}`));
+    }
+    root.append(panel);
+  }
 
   // App-wide config: flavors in a stable alphabetical order (no shell-scoped
   // emphasis — the shell header above is inert on this tab), one card per

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -1067,6 +1067,20 @@ a { color: var(--accent); }
 .subbar-inert { opacity: .85; pointer-events: none; }
 .dm-card + .dm-card { margin-top: 5px; }
 .dm-meta { padding: .1rem .2rem .4rem; font-size: 11px; color: var(--dim); }
+.dm-verify { margin-bottom: 5px; }
+.dm-verify-meta { padding: .45rem 1.1rem .25rem; }
+.dm-verify-row {
+  display: grid; grid-template-columns: 100px minmax(8rem, 1fr) minmax(8rem, auto);
+  align-items: center; gap: .7rem; padding: .35rem 1.1rem;
+  border-top: 1px solid var(--line-soft);
+}
+.dm-verify-state { font: 11px/1.4 ui-monospace, "Cascadia Mono", "Menlo", monospace;
+  text-align: right; }
+.dm-verify-ok { color: var(--ok); }
+.dm-verify-warn, .dm-verify-bad, .dm-verify-failure { color: var(--warn); }
+.dm-verify-summary { padding: .45rem 1.1rem; border-top: 1px solid var(--line-soft); }
+.dm-verify-failure { padding: .25rem 1.1rem; font-size: 11px; }
+.dm-verify-failure:last-child { padding-bottom: .55rem; }
 .dm-row {
   display: grid; grid-template-columns: 24px 100px minmax(8rem, 22rem) 1fr;
   align-items: center; gap: .7rem; padding: .4rem 1.1rem;

--- a/tests/test_harness_versions.py
+++ b/tests/test_harness_versions.py
@@ -72,6 +72,23 @@ def test_newer_runtime_is_reported_without_becoming_an_error() -> None:
         }
 
 
+def test_missing_non_conversation_harness_is_reported_unavailable() -> None:
+    with (
+        mock.patch.object(harness_versions, "HARNESSES", ("vibe",)),
+        mock.patch.object(harness_versions, "probe", return_value=None),
+    ):
+        assert harness_versions.compatibility_status() == {
+            "vibe": {
+                "version": None,
+                "compatibility": None,
+                "minimum_version": None,
+                "maximum_version_exclusive": None,
+                "verified_version": None,
+                "error": "HARNESS_UNAVAILABLE",
+            }
+        }
+
+
 def test_text_status_couples_host_provenance_and_compatibility() -> None:
     output = io.StringIO()
     with (

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -3,9 +3,10 @@
 
 The catalog is layered and best-effort: models.dev (keyless, all five
 harnesses) → provider APIs (only with env keys) → OpenCode's connected-provider
-projection → cache → static floor. Payload v4 retains family metadata:
+projection → cache → static floor. Payload v5 retains family metadata
 (newest-first; claude families with a CLI alias resolve `latest` to the
-alias) plus the flat `models` list for sub-version search. These tests pin
+alias), the flat `models` list for sub-version search, and fork-local harness
+and configured-route verification. These tests pin
 that contract: harness→provider mapping and opencode prefixing, family
 grouping/alias resolution, opportunistic merges that never fail the sweep,
 stale-cache-on-failure, version-mismatched caches ignored, and the floor
@@ -265,6 +266,255 @@ class RoutePersistenceTest(unittest.TestCase):
         got = routes_cli.resolve(self.con, "kimi", "kimi-code/legacy")
         self.assertFalse(got["ok"])
         self.assertIn("high-effort", got["error"])
+
+
+class RuntimeVerificationTest(unittest.TestCase):
+    def setUp(self):
+        self.con = sqlite3.connect(":memory:")
+        self.con.row_factory = sqlite3.Row
+        self.addCleanup(self.con.close)
+        self.con.executescript((
+            ROOT / ".super-coder" / "migrations" / "0075_model_routes.sql"
+        ).read_text())
+        self.con.execute(
+            "CREATE TABLE flavor_defaults ("
+            "flavor TEXT NOT NULL,harness TEXT NOT NULL,model TEXT,"
+            "is_default INTEGER NOT NULL DEFAULT 0,"
+            "PRIMARY KEY (flavor,harness))"
+        )
+
+    @staticmethod
+    def harnesses():
+        base = {
+            "minimum_version": "1.0.0",
+            "maximum_version_exclusive": "2.0.0",
+            "verified_version": "1.5.0",
+        }
+        return {
+            "codex": {
+                **base, "version": "2.0.0",
+                "compatibility": "newer-unverified", "error": None,
+            },
+            "claude": {
+                **base, "version": "1.5.0",
+                "compatibility": "verified", "error": None,
+            },
+            "opencode": {
+                **base, "version": "1.6.0",
+                "compatibility": "supported", "error": None,
+            },
+            "vibe": {
+                "version": None, "compatibility": None,
+                "minimum_version": None,
+                "maximum_version_exclusive": None,
+                "verified_version": None,
+                "error": "HARNESS_UNAVAILABLE",
+            },
+        }
+
+    def insert_default(self, flavor, harness, model, is_default=0):
+        self.con.execute(
+            "INSERT INTO flavor_defaults (flavor,harness,model,is_default) "
+            "VALUES (?,?,?,?)",
+            (flavor, harness, model, is_default),
+        )
+
+    def test_report_combines_harness_compatibility_and_exact_route_evidence(self):
+        self.insert_default("dev", "codex", "gpt-ready", 1)
+        self.insert_default("planner", "codex", "gpt-missing", 1)
+        self.insert_default("reviewer", "claude", None, 1)
+        self.insert_default("cartographer", "opencode", "openai/local", 1)
+        self.insert_default("dev", "vibe", "vibe-model")
+        mc.persist_routes(self.con, {
+            "fetched_at": "2026-08-09T00:00:00+00:00",
+            "stale": False,
+            "harnesses": {
+                "codex": {"models": [mc._entry(
+                    "gpt-ready", source="codex-cache",
+                    availability="available", supported_efforts=["high"]
+                )]},
+                "opencode": {"models": [mc._entry(
+                    "openai/local", source="opencode-provider-api",
+                    availability="available"
+                )]},
+            },
+        })
+
+        report = mc.runtime_verification(
+            self.con, env={"SC_SANDBOX": "1"}, harness_probe=self.harnesses
+        )
+
+        self.assertEqual(report["runtime"], "sandbox")
+        self.assertEqual(report["harnesses"]["codex"]["compatibility"],
+                         "newer-unverified")
+        self.assertEqual(report["summary"], {
+            "harnesses_checked": 4,
+            "harnesses_ready": 3,
+            "exact_routes": 4,
+            "exact_routes_runnable": 2,
+            "harness_defaults": 1,
+        })
+        by_key = {
+            (row["flavor"], row["harness"]): row
+            for row in report["defaults"]
+        }
+        self.assertEqual(by_key[("dev", "codex")], {
+            "flavor": "dev", "harness": "codex", "model": "gpt-ready",
+            "is_default": True, "state": "runnable", "runnable": True,
+            "reason": None,
+        })
+        self.assertEqual(by_key[("planner", "codex")]["state"],
+                         "route-missing")
+        self.assertFalse(by_key[("planner", "codex")]["runnable"])
+        self.assertEqual(by_key[("reviewer", "claude")]["state"],
+                         "harness-default")
+        self.assertIsNone(by_key[("reviewer", "claude")]["runnable"])
+        self.assertEqual(by_key[("cartographer", "opencode")]["state"],
+                         "runnable")
+        self.assertTrue(by_key[("cartographer", "opencode")]["runnable"])
+        self.assertEqual(by_key[("dev", "vibe")]["reason"],
+                         "HARNESS_UNAVAILABLE")
+        self.assertFalse(by_key[("dev", "vibe")]["runnable"])
+
+    def test_probe_failure_is_visible_without_skipping_the_response(self):
+        def fail_probe():
+            raise RuntimeError("probe transport failed")
+
+        report = mc.runtime_verification(
+            self.con, env={}, harness_probe=fail_probe
+        )
+
+        self.assertEqual(report["runtime"], "host")
+        self.assertEqual(report["error"], "probe transport failed")
+        self.assertEqual(report["harnesses"], {})
+        self.assertEqual(report["defaults"], [])
+        self.assertEqual(report["summary"], {
+            "harnesses_checked": 0,
+            "harnesses_ready": 0,
+            "exact_routes": 0,
+            "exact_routes_runnable": 0,
+            "harness_defaults": 0,
+        })
+
+    def test_non_runnable_route_states_keep_exact_failure_reasons(self):
+        self.insert_default("dev", "codex", "gpt-stale")
+        self.insert_default("planner", "claude", "opus-advisory")
+        self.insert_default("reviewer", "vibe", "vibe-local")
+        self.insert_default("cartographer", "kimi", "kimi-low")
+        mc.persist_routes(self.con, {
+            "fetched_at": "2026-08-09T00:00:00+00:00",
+            "stale": False,
+            "harnesses": {
+                "codex": {"models": [mc._entry(
+                    "gpt-stale", availability="available",
+                    supported_efforts=["high"]
+                )]},
+                "claude": {"models": [mc._entry(
+                    "opus-advisory", availability="advisory",
+                    supported_efforts=["high"]
+                )]},
+                "vibe": {"models": [mc._entry(
+                    "vibe-local", availability="available"
+                )]},
+                "kimi": {"models": [mc._entry(
+                    "kimi-low", availability="available",
+                    supported_efforts=["low"]
+                )]},
+            },
+        })
+        self.con.execute(
+            "UPDATE model_routes SET stale=1,last_error='catalog offline' "
+            "WHERE harness='codex' AND selector='gpt-stale'"
+        )
+        statuses = self.harnesses()
+        statuses["vibe"] = {
+            "version": "vibe 1.0.0", "compatibility": None,
+            "minimum_version": None, "maximum_version_exclusive": None,
+            "verified_version": None, "error": None,
+        }
+        statuses["kimi"] = {
+            **statuses["claude"], "version": "1.6.0",
+            "compatibility": "supported",
+        }
+
+        report = mc.runtime_verification(
+            self.con, env={}, harness_probe=lambda: statuses
+        )
+
+        by_harness = {row["harness"]: row for row in report["defaults"]}
+        self.assertEqual(
+            (by_harness["codex"]["state"], by_harness["codex"]["reason"]),
+            ("route-stale", "catalog offline"),
+        )
+        self.assertEqual(
+            (by_harness["claude"]["state"], by_harness["claude"]["reason"]),
+            ("route-unavailable", "route is advisory, not locally available"),
+        )
+        self.assertEqual(
+            (by_harness["vibe"]["state"], by_harness["vibe"]["reason"]),
+            ("headless-unsupported", "harness has no headless launch seam"),
+        )
+        self.assertEqual(
+            (by_harness["kimi"]["state"], by_harness["kimi"]["reason"]),
+            ("effort-unsupported",
+             "default high-effort route was not locally verified"),
+        )
+        self.assertTrue(all(
+            row["runnable"] is False for row in report["defaults"]
+        ))
+
+    def test_explicit_refresh_caches_verification_for_later_gui_reads(self):
+        self.insert_default("dev", "codex", "gpt-5.5", 1)
+        with tempfile.TemporaryDirectory() as tmp:
+            old_cache = mc.CACHE
+            mc.CACHE = Path(tmp) / "model_catalog.json"
+            self.addCleanup(lambda: setattr(mc, "CACHE", old_cache))
+            probe = mock.Mock(return_value=self.harnesses())
+            with mock.patch.object(mc.shutil, "which", return_value=None):
+                first = mc.catalog(
+                    refresh=True, fetch=fetch_ok, env={}, run=None, con=self.con,
+                    opencode_provider=lambda: [], harness_probe=probe,
+                )
+                second = mc.catalog(
+                    fetch=fetch_down, env={}, run=None, con=self.con,
+                    opencode_provider=lambda: [],
+                    harness_probe=mock.Mock(
+                        side_effect=AssertionError("reprobed")
+                    ),
+                )
+
+        probe.assert_called_once_with()
+        self.assertEqual(first["verification"]["summary"]["exact_routes"], 1)
+        self.assertEqual(
+            first["verification"]["summary"]["exact_routes_runnable"], 0
+        )
+        self.assertEqual(second["verification"], first["verification"])
+        self.assertFalse(second["stale"])
+
+    def test_failed_first_refresh_still_persists_fork_verification(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old_cache = mc.CACHE
+            mc.CACHE = Path(tmp) / "model_catalog.json"
+            self.addCleanup(lambda: setattr(mc, "CACHE", old_cache))
+            with mock.patch.object(mc.shutil, "which", return_value=None):
+                got = mc.catalog(
+                    refresh=True, fetch=fetch_down, env={}, run=None,
+                    con=self.con, opencode_provider=lambda: [],
+                    harness_probe=self.harnesses,
+                )
+            cached = json.loads(mc.CACHE.read_text())
+
+        self.assertTrue(got["stale"])
+        self.assertEqual(got["sources"], ["static"])
+        self.assertEqual(got["verification"]["summary"], {
+            "harnesses_checked": 4,
+            "harnesses_ready": 3,
+            "exact_routes": 0,
+            "exact_routes_runnable": 0,
+            "harness_defaults": 0,
+        })
+        self.assertEqual(cached["verification"], got["verification"])
+        self.assertIsNone(cached["fetched_at"])
 
 
 class RouteCliConnectionTest(unittest.TestCase):

--- a/tests/test_shells_ui_contract.py
+++ b/tests/test_shells_ui_contract.py
@@ -17,6 +17,8 @@ SHELL_STATE = APP[APP.index("let selectedShell ="):
                   APP.index("// Rough token estimator")]
 SHELL_RENDER = APP[APP.index("async function renderShells(root)"):
                    APP.index("// Default Models — the flavor_defaults")]
+DEFAULT_MODELS = APP[APP.index("async function renderDefaultModels(root, s,"):
+                     APP.index("// Harness — the shell's surfaces")]
 ROUTER_AT = APP.index("function routeFromHash()")
 ROUTER = APP[ROUTER_AT:
              APP.index('document.querySelectorAll("nav button").forEach',
@@ -333,3 +335,100 @@ const tick = () => new Promise((resolve) => setImmediate(resolve));
     assert "second role" in result["text"]
     assert "Code-01" not in result["text"]
     assert "first role" not in result["text"]
+
+
+def test_model_refresh_verifies_and_renders_fork_local_harness_evidence():
+    script = r"""
+class FakeElement {
+  constructor(tag) {
+    this.tagName = tag;
+    this.nodeType = 1;
+    this.children = [];
+    this.className = "";
+    this._text = "";
+    this.disabled = false;
+  }
+  append(...nodes) { this.children.push(...nodes); }
+  set textContent(value) { this._text = String(value ?? ""); this.children = []; }
+  get textContent() {
+    return this._text + this.children.map(
+      (child) => typeof child === "string" ? child : child.textContent
+    ).join("");
+  }
+}
+globalThis.document = {
+  createElement: (tag) => new FakeElement(tag),
+  createTextNode: (text) => ({ nodeType: 3, textContent: String(text ?? "") }),
+};
+const el = (tag, props = {}, ...kids) => {
+  const node = Object.assign(new FakeElement(tag), props);
+  for (const kid of kids)
+    node.append(kid?.nodeType ? kid : document.createTextNode(kid ?? ""));
+  return node;
+};
+const catalog = {
+  harnesses: {}, sources: ["models.dev", "codex-cache"],
+  fetched_at: "2026-08-09T18:00:00+00:00", stale: false,
+  verification: {
+    checked_at: "2026-08-09T18:01:00+00:00", runtime: "sandbox",
+    harnesses: {
+      codex: {
+        version: "0.147.0", compatibility: "newer-unverified", error: null,
+      },
+      vibe: { version: null, compatibility: null, error: "HARNESS_UNAVAILABLE" },
+    },
+    defaults: [{
+      flavor: "planner", harness: "vibe", model: "vibe-model",
+      runnable: false, state: "harness-error", reason: "HARNESS_UNAVAILABLE",
+    }],
+    summary: {
+      harnesses_ready: 1, harnesses_checked: 2,
+      exact_routes_runnable: 1, exact_routes: 2, harness_defaults: 0,
+    },
+  },
+};
+const requests = [];
+async function api(path) {
+  requests.push(path);
+  if (path === "/flavor-defaults")
+    return { flavors: {}, harnesses: ["codex", "vibe"] };
+  if (path === "/models" || path === "/models?refresh=1") return catalog;
+  throw new Error("unexpected API call: " + path);
+}
+const statuses = [];
+function setStatus(value) { statuses.push(value); }
+function toast() {}
+const microlabel = (text) => el("span", {}, text);
+function all(root, predicate, found = []) {
+  if (predicate(root)) found.push(root);
+  for (const child of root.children || [])
+    if (child?.nodeType === 1) all(child, predicate, found);
+  return found;
+}
+""" + DEFAULT_MODELS + r"""
+(async () => {
+  const root = new FakeElement("div");
+  await renderDefaultModels(root, {});
+  const button = all(root, (node) => node.tagName === "button")[0];
+  await button.onclick();
+  console.log(JSON.stringify({ text: root.textContent, requests, statuses }));
+})().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});
+"""
+    result = run_js(script)
+    assert result["requests"] == [
+        "/flavor-defaults", "/models", "/models?refresh=1",
+        "/flavor-defaults",
+    ]
+    assert result["statuses"] == [
+        "refreshing model catalog and harnesses…",
+        "refresh complete — review verification warnings",
+    ]
+    assert "Refresh & verify" in result["text"]
+    assert "Fork verification" in result["text"]
+    assert "codex0.147.0newer-unverified" in result["text"]
+    assert "vibenot installedHARNESS_UNAVAILABLE" in result["text"]
+    assert "exact defaults: 1/2 runnable" in result["text"]
+    assert "planner · vibe · vibe-model — HARNESS_UNAVAILABLE" in result["text"]


### PR DESCRIPTION
## Summary

Follow-up to #1111.

- make the GUI's explicit model refresh refetch the catalogue and probe every local harness
- verify each configured default route against the refreshed catalogue and the harness's real headless/effort capabilities
- cache and display the verification evidence, including when the catalogue network refresh fails
- surface missing, outdated, unavailable, stale, or unsupported routes without hard-locking actions
- treat newer-than-tested harnesses as warnings rather than failures

The refresh intentionally does not launch live model turns: those consume quota and create sessions. It verifies the local catalogue, installed harnesses, and exact configured routes entirely on the fork.

## Verification

- 186 tests passed, 220 subtests passed
- focused model refresh/harness/UI contract suite passed
- live host harness probe passed (Claude, Codex, OpenCode, Vibe, Kimi)
- Ruff fatal-error checks passed
- Python and JavaScript syntax checks passed
- `git diff --check` passed