### PR TITLE
fix(sprint): reconcile aborted PR ownership

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2496,6 +2496,28 @@ class Handler(BaseHTTPRequestHandler):
                     "registered_pr_id": receipt.registered_pr_id,
                     "created": receipt.created,
                 })
+            if path == "/_sc/sprint/reconcile-pr":
+                receipt = sprint_pr_watcher.SprintPRWatcher(
+                    con, repo_root=REPO_ROOT
+                ).reconcile_aborted_registration(
+                    sprint_id,
+                    actor=self._sprint_actor(con, sprint_id, shell_id),
+                    repository=body.get("repository") or "",
+                    pr_number=self._sprint_integer(body, "pr_number"),
+                    work_unit_id=self._sprint_integer(body, "work_unit_id"),
+                    reason=body.get("reason") or "",
+                )
+                return self._send(200, {
+                    "registered_pr_id": receipt.registered_pr_id,
+                    "changed": receipt.changed,
+                    "from_sprint_id": receipt.from_sprint_id,
+                    "normalized_state": receipt.normalized_state,
+                    "head_sha": receipt.head_sha,
+                    "merge_sha": receipt.merge_sha,
+                    "completed_work_unit_ids": list(
+                        receipt.completed_work_unit_ids
+                    ),
+                })
             if path == "/_sc/sprint/pause":
                 receipt = sprint_recovery.SprintRecoveryCoordinator(
                     con, repo_root=REPO_ROOT

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -200,21 +200,22 @@ An exhausted recovery wake is bounded manual-recovery evidence, not a retry
 loop. Preserve the unread message and failed wake, involve FnB, and do not create
 recursive fallbacks. Drift informs; it never silently blocks resume.
 
-PR ownership inherited from an aborted Sprint is an FnB repair boundary, not a
-Planner action. Keep the replacement Sprint paused and surface the exact old
-and new ownership. An authenticated FnB/admin shell may reconcile that identity:
+PR ownership inherited from an aborted Sprint is an originating-Planner repair
+boundary. Keep the replacement Sprint paused and establish the exact old and
+new ownership. The originating Planner may reconcile that identity; the FnB
+retains the same operation as a board-level override:
 
 ```text
 sc sprint reconcile-pr --sprint <replacement-id> --repository <owner/repo> \
-  --pr <number> --work-unit <replacement-unit-id> --reason <override-reason>
+  --pr <number> --work-unit <replacement-unit-id> --reason <recovery-reason>
 ```
 
-The command refuses a live source Sprint or target Sprint, non-code or already
-owned target unit, and a closed unmerged PR. It records the old and new owners
-plus the live GitHub head. If the PR is already merged, it also records the
-merge commit and completes the replacement unit as an explicit FnB override.
-Treat the receipt as recovery evidence; wait for a separate Reviewer decision
-before resuming. A Planner must never run this command under Planner authority.
+The command refuses a live source Sprint or target Sprint, a non-originating
+Planner, a non-code or already owned target unit, and a closed unmerged PR. It
+records the old and new owners plus the live GitHub head and acting authority.
+If the PR is already merged, it also records the merge commit and completes the
+replacement unit as explicit recovery evidence. Treat the receipt as recovery
+evidence; wait for a separate Reviewer decision before resuming.
 
 ### Cancel or re-plan
 

--- a/.super-coder/migrations/0192_reseed_sprint_pr_recovery.sql
+++ b/.super-coder/migrations/0192_reseed_sprint_pr_recovery.sql
@@ -1,11 +1,15 @@
----
-name: sprint_pln
-description: Run an armed Sprints v2 collaboration loop as Planner — dispatch ready lanes and execute Reviewer decisions through durable re-plan, pause, cancel, resume, and close protocols.
-category: workflow
-common: false
----
+-- 0192 — reseed FnB Sprint PR ownership recovery guidance.
+-- Converge existing installs after adding the authenticated reconcile-pr surface.
 
-# sprint_pln — govern the armed Sprint
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch ready lanes and execute Reviewer decisions through durable re-plan, pause, cancel, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
 
 Use as the originating Planner after `sprint_prep` arms the Sprint. The system
 captures deterministic facts; the Reviewer decides and documents, and the
@@ -149,7 +153,7 @@ unavailable while paused.
 Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
 report drafts, and Dev scratch proof) go to the gitignored
 `shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR'd in the work repo; a review-notes commit is a finding.
+PR''d in the work repo; a review-notes commit is a finding.
 
 DB rows stay the durable record: judgments via `record-review`, report bodies in
 `sprint_reports`, and decisions in the durable relay. Files in the Sprint
@@ -254,7 +258,7 @@ sc mem task add "<task-title>" --feature <feature-id> \
   --desc "<task-description>"
 ```
 
-Create the requested bound work units from those task ids, wiring the Reviewer's
+Create the requested bound work units from those task ids, wiring the Reviewer''s
 waves and dependencies directly:
 
 ```text
@@ -304,12 +308,12 @@ it is terminal and deletes nothing.
 
 Planner → Developer assignments and Developer → Reviewer review requests use
 Force-new delivery; Developer/Reviewer → Planner results are Re-enter. Forced
-delivery waits for the prior live turn's natural boundary; runtime delivery
+delivery waits for the prior live turn''s natural boundary; runtime delivery
 owns the rest. These are delivery guarantees, not a parent/child chat topology.
 The Planner receives no PR-event wakes; Developer-owned subscriptions carry
 red, green, and externally closed facts directly to the owning Developer.
 
-Never dispatch the next wave from a merge-observation turn. The Developer's
+Never dispatch the next wave from a merge-observation turn. The Developer''s
 merged-work handoff wake is the only normal next-wave dispatch trigger. On that
 wake, complete the turn in this exact order:
 
@@ -332,4 +336,12 @@ sc sprint dispatch --sprint <id>
 On a clean completion receipt, verify the named Sprint is terminal and record
 the bounded receipt; run no close command. The Planner does not author a second
 report, accept an actionable handoff, or wait for another actor to finish the
-Sprint.
+Sprint.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/migrations/0192_reseed_sprint_pr_recovery.sql
+++ b/.super-coder/migrations/0192_reseed_sprint_pr_recovery.sql
@@ -1,4 +1,4 @@
--- 0192 — reseed FnB Sprint PR ownership recovery guidance.
+-- 0192 — reseed Planner Sprint PR ownership recovery guidance.
 -- Converge existing installs after adding the authenticated reconcile-pr surface.
 
 BEGIN;
@@ -204,21 +204,22 @@ An exhausted recovery wake is bounded manual-recovery evidence, not a retry
 loop. Preserve the unread message and failed wake, involve FnB, and do not create
 recursive fallbacks. Drift informs; it never silently blocks resume.
 
-PR ownership inherited from an aborted Sprint is an FnB repair boundary, not a
-Planner action. Keep the replacement Sprint paused and surface the exact old
-and new ownership. An authenticated FnB/admin shell may reconcile that identity:
+PR ownership inherited from an aborted Sprint is an originating-Planner repair
+boundary. Keep the replacement Sprint paused and establish the exact old and
+new ownership. The originating Planner may reconcile that identity; the FnB
+retains the same operation as a board-level override:
 
 ```text
 sc sprint reconcile-pr --sprint <replacement-id> --repository <owner/repo> \
-  --pr <number> --work-unit <replacement-unit-id> --reason <override-reason>
+  --pr <number> --work-unit <replacement-unit-id> --reason <recovery-reason>
 ```
 
-The command refuses a live source Sprint or target Sprint, non-code or already
-owned target unit, and a closed unmerged PR. It records the old and new owners
-plus the live GitHub head. If the PR is already merged, it also records the
-merge commit and completes the replacement unit as an explicit FnB override.
-Treat the receipt as recovery evidence; wait for a separate Reviewer decision
-before resuming. A Planner must never run this command under Planner authority.
+The command refuses a live source Sprint or target Sprint, a non-originating
+Planner, a non-code or already owned target unit, and a closed unmerged PR. It
+records the old and new owners plus the live GitHub head and acting authority.
+If the PR is already merged, it also records the merge commit and completes the
+replacement unit as explicit recovery evidence. Treat the receipt as recovery
+evidence; wait for a separate Reviewer decision before resuming.
 
 ### Cancel or re-plan
 

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -190,6 +190,21 @@ _EVENT_FIELDS = {
     "pr.registered": frozenset(
         {"registered_pr_id", "repository", "pr_number", "work_unit_ids"}
     ),
+    "pr.registration_reconciled": frozenset(
+        {
+            "from_sprint_id",
+            "from_work_unit_ids",
+            "head_sha",
+            "merge_sha",
+            "normalized_state",
+            "pr_number",
+            "reason",
+            "registered_pr_id",
+            "repository",
+            "to_sprint_id",
+            "to_work_unit_id",
+        }
+    ),
     "pr.transition": frozenset(
         {"registered_pr_id", "transition_id", "normalized_state"}
     ),

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -207,6 +207,22 @@ def cmd_register_pr(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_reconcile_pr(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/reconcile-pr",
+        {
+            "sprint_id": args.sprint,
+            "repository": args.repository,
+            "pr_number": args.pr,
+            "work_unit_id": args.work_unit,
+            "reason": args.reason,
+        },
+        idempotent=True,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
 def cmd_pause(args: argparse.Namespace) -> int:
     result = _post(
         "/_sc/sprint/pause",
@@ -503,6 +519,17 @@ def build_parser() -> argparse.ArgumentParser:
     register.add_argument("--pr", type=int, required=True)
     register.add_argument("--work-unit", type=int, required=True)
     register.set_defaults(fn=cmd_register_pr)
+
+    reconcile = sub.add_parser(
+        "reconcile-pr",
+        help="FnB repairs PR ownership inherited from an aborted Sprint",
+    )
+    reconcile.add_argument("--sprint", type=int, required=True)
+    reconcile.add_argument("--repository", required=True)
+    reconcile.add_argument("--pr", type=int, required=True)
+    reconcile.add_argument("--work-unit", type=int, required=True)
+    reconcile.add_argument("--reason", required=True)
+    reconcile.set_defaults(fn=cmd_reconcile_pr)
 
     pause = sub.add_parser("pause", help="Participant or FnB pauses for integrity")
     pause.add_argument("--sprint", type=int, required=True)

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -522,7 +522,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     reconcile = sub.add_parser(
         "reconcile-pr",
-        help="FnB repairs PR ownership inherited from an aborted Sprint",
+        help="Planner repairs PR ownership inherited from an aborted Sprint",
     )
     reconcile.add_argument("--sprint", type=int, required=True)
     reconcile.add_argument("--repository", required=True)

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -28,7 +28,7 @@ from github_pull_requests import (
     GitHubReadError,
     PullRequest,
 )
-from sprint_domain import SprintInvariantError
+from sprint_domain import LifecycleActor, SprintAuthorityError, SprintInvariantError
 from sprint_message_delivery import SprintMessageStore
 from sprint_review_loop import SprintReviewLoopStore
 
@@ -287,6 +287,17 @@ class RegistrationReceipt:
 
 
 @dataclass(frozen=True)
+class RegistrationReconciliationReceipt:
+    registered_pr_id: int
+    changed: bool
+    from_sprint_id: int
+    normalized_state: str
+    head_sha: str
+    merge_sha: str | None
+    completed_work_unit_ids: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
 class SubscriptionReceipt:
     subscription_id: int
     created: bool
@@ -519,6 +530,323 @@ class SprintPRRegistrationStore:
             notify_commit()
         return RegistrationReceipt(registered_pr_id, True)
 
+    def reconcile_aborted_registration(
+        self,
+        sprint_id: int,
+        *,
+        actor: LifecycleActor,
+        repository: str,
+        pr_number: int,
+        work_unit_id: int,
+        reason: str,
+        pull_request: PullRequest,
+        notify_service: bool = True,
+    ) -> RegistrationReconciliationReceipt:
+        """Move one PR from an aborted Sprint, preserving explicit FnB evidence."""
+        if actor.kind != "fnb" or actor.shell_id is None:
+            raise SprintAuthorityError("only FnB may reconcile Sprint PR ownership")
+        repository = repository.strip().lower()
+        if not _REPOSITORY.fullmatch(repository):
+            raise ValueError("repository must be owner/name")
+        if not isinstance(pr_number, int) or pr_number < 1:
+            raise ValueError("PR number must be a positive integer")
+        if not isinstance(work_unit_id, int) or work_unit_id < 1:
+            raise ValueError("work-unit ID must be a positive integer")
+        reason = reason.strip()
+        if not reason:
+            raise ValueError("reconciliation reason is empty")
+        if len(reason) > 2000:
+            raise ValueError("reconciliation reason exceeds 2000 characters")
+        if pull_request.number != pr_number:
+            raise GitHubReadError("GitHub returned a different PR identity")
+        state = normalize_state(pull_request)
+
+        completed: tuple[int, ...] = ()
+        with db_driver.write_transaction(self.con, "sprint.pr.reconcile"):
+            caller = self.con.execute(
+                "SELECT flavor FROM shells WHERE shell_id=? "
+                "AND COALESCE(is_deleted,0)=0",
+                (actor.shell_id,),
+            ).fetchone()
+            if caller is None or caller["flavor"] != "admin":
+                raise SprintAuthorityError(
+                    "only an authenticated FnB shell may reconcile Sprint PR ownership"
+                )
+            target_sprint = self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                (sprint_id,),
+            ).fetchone()
+            if target_sprint is None:
+                raise KeyError(f"unknown Sprint: {sprint_id}")
+            if target_sprint["lifecycle"] != "paused":
+                raise SprintInvariantError(
+                    "PR ownership reconciliation requires a paused target Sprint"
+                )
+            target = self.con.execute(
+                "SELECT u.disposition,u.output_kind,u.assigned_shell_id,"
+                "p.participant_id FROM sprint_work_units u "
+                "JOIN sprint_participants p ON p.sprint_id=u.sprint_id "
+                "AND p.shell_id=u.assigned_shell_id AND p.role='developer' "
+                "WHERE u.sprint_id=? AND u.work_unit_id=?",
+                (sprint_id, work_unit_id),
+            ).fetchone()
+            if target is None:
+                raise SprintInvariantError(
+                    "reconciliation target must be a Developer-owned work unit"
+                )
+            if target["output_kind"] != "code":
+                raise SprintInvariantError(
+                    "PR ownership reconciliation requires a code work unit"
+                )
+
+            existing = self.con.execute(
+                "SELECT pr.registered_pr_id,pr.sprint_id,pr.owner_participant_id,"
+                "s.lifecycle,p.shell_id AS owner_shell_id "
+                "FROM sprint_registered_prs pr "
+                "JOIN sprints s ON s.sprint_id=pr.sprint_id "
+                "JOIN sprint_participants p "
+                "ON p.participant_id=pr.owner_participant_id "
+                "WHERE pr.repository=? AND pr.pr_number=?",
+                (repository, pr_number),
+            ).fetchone()
+            if existing is None:
+                raise SprintInvariantError(
+                    "PR ownership reconciliation requires an existing registration"
+                )
+            registered_pr_id = int(existing["registered_pr_id"])
+            old_unit_ids = tuple(
+                int(row[0])
+                for row in self.con.execute(
+                    "SELECT work_unit_id FROM sprint_pr_work_units "
+                    "WHERE registered_pr_id=? ORDER BY work_unit_id",
+                    (registered_pr_id,),
+                )
+            )
+            exact = (
+                int(existing["sprint_id"]) == sprint_id
+                and int(existing["owner_participant_id"])
+                == int(target["participant_id"])
+                and old_unit_ids == (work_unit_id,)
+            )
+            if exact:
+                durable = self.con.execute(
+                    "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                    "AND event_type='pr.registration_reconciled' "
+                    "AND json_extract(payload,'$.registered_pr_id')=? "
+                    "AND json_extract(payload,'$.to_work_unit_id')=? "
+                    "ORDER BY event_id DESC LIMIT 1",
+                    (sprint_id, registered_pr_id, work_unit_id),
+                ).fetchone()
+                if durable is None:
+                    raise SprintInvariantError(
+                        "PR is already owned by the target without a recovery receipt"
+                    )
+                durable_payload = json.loads(durable["payload"])
+                durable_state = str(durable_payload["normalized_state"])
+                completed = (
+                    (work_unit_id,)
+                    if target["disposition"] == "completed"
+                    and durable_state == "merged"
+                    else ()
+                )
+                return RegistrationReconciliationReceipt(
+                    registered_pr_id,
+                    False,
+                    int(durable_payload["from_sprint_id"]),
+                    durable_state,
+                    str(durable_payload["head_sha"]),
+                    (
+                        str(durable_payload["merge_sha"])
+                        if durable_payload["merge_sha"] is not None
+                        else None
+                    ),
+                    completed,
+                )
+            if state == "closed":
+                raise SprintInvariantError(
+                    "closed unmerged PR ownership cannot be reconciled"
+                )
+            if not pull_request.head_sha:
+                raise SprintInvariantError(
+                    "PR ownership reconciliation requires an exact head"
+                )
+            if state == "merged" and not pull_request.merge_sha:
+                raise SprintInvariantError(
+                    "merged PR reconciliation requires exact head and merge commit"
+                )
+            if existing["lifecycle"] != "aborted":
+                raise SprintInvariantError(
+                    "PR ownership may be reconciled only from an aborted Sprint"
+                )
+            if target["disposition"] != "active":
+                raise SprintInvariantError(
+                    "PR ownership reconciliation requires an active target work unit"
+                )
+            target_registration = self.con.execute(
+                "SELECT registered_pr_id FROM sprint_pr_work_units "
+                "WHERE sprint_id=? AND work_unit_id=?",
+                (sprint_id, work_unit_id),
+            ).fetchone()
+            if target_registration is not None:
+                raise SprintInvariantError(
+                    "reconciliation target work unit already has a registered PR"
+                )
+
+            prior_sprint_id = int(existing["sprint_id"])
+            self.con.execute(
+                "DELETE FROM sprint_pr_work_units WHERE registered_pr_id=?",
+                (registered_pr_id,),
+            )
+            self.con.execute(
+                "UPDATE sprint_registered_prs SET sprint_id=?,owner_participant_id=? "
+                "WHERE registered_pr_id=?",
+                (sprint_id, target["participant_id"], registered_pr_id),
+            )
+            self.con.execute(
+                "INSERT INTO sprint_pr_work_units "
+                "(sprint_id,registered_pr_id,work_unit_id) VALUES (?,?,?)",
+                (sprint_id, registered_pr_id, work_unit_id),
+            )
+            subscription = self.con.execute(
+                "SELECT subscription_id FROM pr_subscriptions "
+                "WHERE repository=? AND pr_number=?",
+                (repository, pr_number),
+            ).fetchone()
+            if subscription is None:
+                subscription_id = PRSubscriptionStore(self.con).subscribe(
+                    owner_shell_id=int(target["assigned_shell_id"]),
+                    repository=repository,
+                    pr_number=pr_number,
+                    sprint_registered_pr_id=registered_pr_id,
+                ).subscription_id
+            else:
+                subscription_id = int(subscription["subscription_id"])
+                self.con.execute(
+                    "UPDATE pr_subscriptions SET owner_shell_id=?,"
+                    "sprint_registered_pr_id=?,updated_at=datetime('now') "
+                    "WHERE subscription_id=?",
+                    (
+                        target["assigned_shell_id"],
+                        registered_pr_id,
+                        subscription_id,
+                    ),
+                )
+
+            transition_key: str | None = None
+            if state == "merged":
+                transition_key = hashlib.sha256(
+                    (
+                        f"reconcile:{registered_pr_id}:{prior_sprint_id}:"
+                        f"{sprint_id}:{work_unit_id}:{pull_request.head_sha}:"
+                        f"{pull_request.merge_sha}"
+                    ).encode()
+                ).hexdigest()
+                evidence = json.dumps(
+                    {
+                        "base_ref": pull_request.base_ref,
+                        "base_sha": pull_request.base_sha,
+                        "checks": pull_request.checks,
+                        "checks_failed": pull_request.checks_failed,
+                        "head_ref": pull_request.head_ref,
+                        "merge_sha": pull_request.merge_sha,
+                        "review_decision": pull_request.review_decision,
+                        "state": pull_request.state,
+                        "title": pull_request.title,
+                        "trigger": "fnb_reconciliation",
+                        "url": pull_request.url,
+                    },
+                    sort_keys=True,
+                )
+                self.con.execute(
+                    "INSERT INTO pr_subscription_transitions "
+                    "(subscription_id,normalized_state,transition_key,"
+                    "observed_head_sha,evidence) VALUES (?,?,?,?,?)",
+                    (
+                        subscription_id,
+                        state,
+                        transition_key,
+                        pull_request.head_sha,
+                        evidence,
+                    ),
+                )
+                self.con.execute(
+                    "INSERT INTO sprint_pr_transitions "
+                    "(registered_pr_id,normalized_state,transition_key,"
+                    "observed_head_sha,evidence) VALUES (?,?,?,?,?)",
+                    (
+                        registered_pr_id,
+                        state,
+                        transition_key,
+                        pull_request.head_sha,
+                        evidence,
+                    ),
+                )
+                self.con.execute(
+                    "UPDATE sprint_work_units SET disposition='completed',"
+                    "completed_at=datetime('now'),updated_at=datetime('now') "
+                    "WHERE work_unit_id=?",
+                    (work_unit_id,),
+                )
+                completed = (work_unit_id,)
+
+            payload = json.dumps(
+                {
+                    "from_sprint_id": prior_sprint_id,
+                    "from_work_unit_ids": old_unit_ids,
+                    "head_sha": pull_request.head_sha,
+                    "merge_sha": pull_request.merge_sha,
+                    "normalized_state": state,
+                    "pr_number": pr_number,
+                    "reason": reason,
+                    "registered_pr_id": registered_pr_id,
+                    "repository": repository,
+                    "to_sprint_id": sprint_id,
+                    "to_work_unit_id": work_unit_id,
+                },
+                sort_keys=True,
+            )
+            self.con.executemany(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+                "VALUES (?,'pr.registration_reconciled','fnb',?,?)",
+                (
+                    (prior_sprint_id, actor.shell_id, payload),
+                    (sprint_id, actor.shell_id, payload),
+                ),
+            )
+            if completed:
+                self.con.execute(
+                    "INSERT INTO sprint_events "
+                    "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+                    "VALUES (?,'work_unit.completed','fnb',?,?)",
+                    (
+                        sprint_id,
+                        actor.shell_id,
+                        json.dumps(
+                            {
+                                "head_sha": pull_request.head_sha,
+                                "merge_sha": pull_request.merge_sha,
+                                "registered_pr_id": registered_pr_id,
+                                "source": "fnb.pr_recovery_override",
+                                "transition_key": transition_key,
+                                "work_unit_id": work_unit_id,
+                            },
+                            sort_keys=True,
+                        ),
+                    ),
+                )
+        if notify_service:
+            notify_commit()
+        return RegistrationReconciliationReceipt(
+            registered_pr_id,
+            True,
+            prior_sprint_id,
+            state,
+            str(pull_request.head_sha),
+            pull_request.merge_sha,
+            completed,
+        )
+
 
 class SprintPRWatcher:
     """Observe every active PR subscription, regardless of Sprint state."""
@@ -597,6 +925,54 @@ class SprintPRWatcher:
         ).fetchone()
         if receipt.created and row is not None:
             self._observe_rows((row,), "registration", ignore_backoff=True)
+        notify_commit()
+        return receipt
+
+    def reconcile_aborted_registration(
+        self,
+        sprint_id: int,
+        *,
+        actor: LifecycleActor,
+        repository: str,
+        pr_number: int,
+        work_unit_id: int,
+        reason: str,
+    ) -> RegistrationReconciliationReceipt:
+        """Read GitHub, then perform the bounded FnB ownership repair."""
+        caller = self.con.execute(
+            "SELECT flavor FROM shells WHERE shell_id=? "
+            "AND COALESCE(is_deleted,0)=0",
+            (actor.shell_id,),
+        ).fetchone()
+        if (
+            actor.kind != "fnb"
+            or actor.shell_id is None
+            or caller is None
+            or caller["flavor"] != "admin"
+        ):
+            raise SprintAuthorityError(
+                "only an authenticated FnB shell may reconcile Sprint PR ownership"
+            )
+        normalized_repository = repository.strip().lower()
+        if not _REPOSITORY.fullmatch(normalized_repository):
+            raise ValueError("repository must be owner/name")
+        live = self.reader_factory(normalized_repository).get(pr_number)
+        receipt = self.registration.reconcile_aborted_registration(
+            sprint_id,
+            actor=actor,
+            repository=normalized_repository,
+            pr_number=pr_number,
+            work_unit_id=work_unit_id,
+            reason=reason,
+            pull_request=live,
+            notify_service=False,
+        )
+        row = self.con.execute(
+            "SELECT * FROM pr_subscriptions WHERE sprint_registered_pr_id=?",
+            (receipt.registered_pr_id,),
+        ).fetchone()
+        if receipt.changed and row is not None:
+            self._observe_rows((row,), "reconciliation", ignore_backoff=True)
         notify_commit()
         return receipt
 

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -542,9 +542,12 @@ class SprintPRRegistrationStore:
         pull_request: PullRequest,
         notify_service: bool = True,
     ) -> RegistrationReconciliationReceipt:
-        """Move one PR from an aborted Sprint, preserving explicit FnB evidence."""
-        if actor.kind != "fnb" or actor.shell_id is None:
-            raise SprintAuthorityError("only FnB may reconcile Sprint PR ownership")
+        """Move one PR from an aborted Sprint, preserving actor provenance."""
+        if actor.shell_id is None:
+            raise SprintAuthorityError(
+                "only the originating Planner or authenticated FnB may reconcile "
+                "Sprint PR ownership"
+            )
         repository = repository.strip().lower()
         if not _REPOSITORY.fullmatch(repository):
             raise ValueError("repository must be owner/name")
@@ -563,14 +566,25 @@ class SprintPRRegistrationStore:
 
         completed: tuple[int, ...] = ()
         with db_driver.write_transaction(self.con, "sprint.pr.reconcile"):
-            caller = self.con.execute(
-                "SELECT flavor FROM shells WHERE shell_id=? "
-                "AND COALESCE(is_deleted,0)=0",
-                (actor.shell_id,),
+            authority = self.con.execute(
+                "SELECT sp.originating_planner_shell_id,caller.flavor "
+                "FROM sprints sp LEFT JOIN shells caller ON caller.shell_id=? "
+                "AND COALESCE(caller.is_deleted,0)=0 WHERE sp.sprint_id=?",
+                (actor.shell_id, sprint_id),
             ).fetchone()
-            if caller is None or caller["flavor"] != "admin":
+            if authority is None:
+                raise KeyError(f"unknown Sprint: {sprint_id}")
+            is_fnb = actor.kind == "fnb" and authority["flavor"] == "admin"
+            is_planner = (
+                actor.kind == "planner"
+                and int(authority["originating_planner_shell_id"])
+                == actor.shell_id
+                and authority["flavor"] is not None
+            )
+            if not is_fnb and not is_planner:
                 raise SprintAuthorityError(
-                    "only an authenticated FnB shell may reconcile Sprint PR ownership"
+                    "only the originating Planner or authenticated FnB may reconcile "
+                    "Sprint PR ownership"
                 )
             target_sprint = self.con.execute(
                 "SELECT lifecycle FROM sprints WHERE sprint_id=?",
@@ -752,7 +766,7 @@ class SprintPRRegistrationStore:
                         "review_decision": pull_request.review_decision,
                         "state": pull_request.state,
                         "title": pull_request.title,
-                        "trigger": "fnb_reconciliation",
+                        "trigger": f"{actor.kind}_reconciliation",
                         "url": pull_request.url,
                     },
                     sort_keys=True,
@@ -808,26 +822,31 @@ class SprintPRRegistrationStore:
             self.con.executemany(
                 "INSERT INTO sprint_events "
                 "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
-                "VALUES (?,'pr.registration_reconciled','fnb',?,?)",
+                "VALUES (?,'pr.registration_reconciled',?,?,?)",
                 (
-                    (prior_sprint_id, actor.shell_id, payload),
-                    (sprint_id, actor.shell_id, payload),
+                    (prior_sprint_id, actor.kind, actor.shell_id, payload),
+                    (sprint_id, actor.kind, actor.shell_id, payload),
                 ),
             )
             if completed:
                 self.con.execute(
                     "INSERT INTO sprint_events "
                     "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
-                    "VALUES (?,'work_unit.completed','fnb',?,?)",
+                    "VALUES (?,'work_unit.completed',?,?,?)",
                     (
                         sprint_id,
+                        actor.kind,
                         actor.shell_id,
                         json.dumps(
                             {
                                 "head_sha": pull_request.head_sha,
                                 "merge_sha": pull_request.merge_sha,
                                 "registered_pr_id": registered_pr_id,
-                                "source": "fnb.pr_recovery_override",
+                                "source": (
+                                    "fnb.pr_recovery_override"
+                                    if actor.kind == "fnb"
+                                    else "planner.pr_recovery"
+                                ),
                                 "transition_key": transition_key,
                                 "work_unit_id": work_unit_id,
                             },
@@ -938,20 +957,26 @@ class SprintPRWatcher:
         work_unit_id: int,
         reason: str,
     ) -> RegistrationReconciliationReceipt:
-        """Read GitHub, then perform the bounded FnB ownership repair."""
-        caller = self.con.execute(
-            "SELECT flavor FROM shells WHERE shell_id=? "
-            "AND COALESCE(is_deleted,0)=0",
-            (actor.shell_id,),
+        """Read GitHub, then perform the bounded ownership repair."""
+        authority = self.con.execute(
+            "SELECT sp.originating_planner_shell_id,caller.flavor "
+            "FROM sprints sp LEFT JOIN shells caller ON caller.shell_id=? "
+            "AND COALESCE(caller.is_deleted,0)=0 WHERE sp.sprint_id=?",
+            (actor.shell_id, sprint_id),
         ).fetchone()
-        if (
-            actor.kind != "fnb"
-            or actor.shell_id is None
-            or caller is None
-            or caller["flavor"] != "admin"
-        ):
+        if authority is None:
+            raise KeyError(f"unknown Sprint: {sprint_id}")
+        is_fnb = actor.kind == "fnb" and authority["flavor"] == "admin"
+        is_planner = (
+            actor.kind == "planner"
+            and actor.shell_id is not None
+            and int(authority["originating_planner_shell_id"]) == actor.shell_id
+            and authority["flavor"] is not None
+        )
+        if not is_fnb and not is_planner:
             raise SprintAuthorityError(
-                "only an authenticated FnB shell may reconcile Sprint PR ownership"
+                "only the originating Planner or authenticated FnB may reconcile "
+                "Sprint PR ownership"
             )
         normalized_repository = repository.strip().lower()
         if not _REPOSITORY.fullmatch(normalized_repository):

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -86,7 +86,8 @@
     ".super-coder/migrations/0185_optional_sprint_qaqc.sql",
     ".super-coder/migrations/0186_admin_singleton.sql",
     ".super-coder/migrations/0189_reseed_spec_scope_audience.sql",
-    ".super-coder/migrations/0191_reseed_target_aware_dev_kit.sql"
+    ".super-coder/migrations/0191_reseed_target_aware_dev_kit.sql",
+    ".super-coder/migrations/0192_reseed_sprint_pr_recovery.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_devkit_declaration.py
+++ b/tests/test_devkit_declaration.py
@@ -640,11 +640,15 @@ class DevKitReseedConformanceTest(unittest.TestCase):
         )
         self.assertEqual(local, ("local", "fork", None, 0, "bespoke body", 0))
 
-    def test_reseed_is_last_in_the_ordered_chain(self):
+    def test_later_migrations_do_not_override_the_terminal_reseed(self):
         migrations = sorted(
             (ROOT / ".super-coder" / "migrations").glob("[0-9][0-9][0-9][0-9]_*.sql")
         )
-        self.assertEqual(migrations[-1], DEVKIT_RESEED)
+        later = migrations[migrations.index(DEVKIT_RESEED) + 1 :]
+        self.assertTrue(later)
+        for migration in later:
+            with self.subTest(migration=migration.name):
+                self.assertNotIn("  'dev_kit',", migration.read_text())
 
 
 class DispatcherHelpTest(unittest.TestCase):

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -27,6 +27,7 @@ import server
 import sprint_cli
 import sprint_domain
 import sprint_message_delivery
+import sprint_pr_watcher
 from github_pull_requests import PullRequest
 from test_sprint_v2_domain import apply_schema
 
@@ -53,6 +54,7 @@ class SprintCliDispatcherTest(unittest.TestCase):
         self.assertIn("record-qaqc", completed.stdout)
         self.assertIn("compile-report", completed.stdout)
         self.assertIn("watcher-state", completed.stdout)
+        self.assertIn("reconcile-pr", completed.stdout)
 
 
 class Reader:
@@ -296,6 +298,63 @@ class SprintCliApiTest(unittest.TestCase):
         self.assertEqual((1, None, None, "re-enter"), message[:4])
         self.assertIn("number=85", message[4])
         self.assertIn("event=green", message[4])
+
+    def test_reconcile_pr_is_fnb_only_and_projects_the_durable_receipt(self):
+        argv = (
+            "reconcile-pr",
+            "--sprint",
+            str(self.sprint_id),
+            "--repository",
+            "Acme/Repo",
+            "--pr",
+            "42",
+            "--work-unit",
+            str(self.unit_id),
+            "--reason",
+            "repair aborted Sprint ownership",
+        )
+        with mock.patch.object(
+            server.sprint_pr_watcher,
+            "GitHubPullRequestReader",
+            return_value=Reader(),
+        ), self.assertRaisesRegex(SystemExit, "HTTP 403.*only .*FnB"):
+            self.run_cli(TOKENS["developer"], *argv)
+
+        expected = sprint_pr_watcher.RegistrationReconciliationReceipt(
+            self.registered_pr_id,
+            True,
+            9,
+            "merged",
+            "a" * 40,
+            "b" * 40,
+            (self.unit_id,),
+        )
+        with mock.patch.object(
+            server.sprint_pr_watcher.SprintPRWatcher,
+            "reconcile_aborted_registration",
+            return_value=expected,
+        ) as reconcile:
+            response = self.run_cli(TOKENS["admin"], *argv)
+
+        self.assertEqual(
+            {
+                "changed": True,
+                "completed_work_unit_ids": [self.unit_id],
+                "from_sprint_id": 9,
+                "head_sha": "a" * 40,
+                "merge_sha": "b" * 40,
+                "normalized_state": "merged",
+                "registered_pr_id": self.registered_pr_id,
+            },
+            response,
+        )
+        call = reconcile.call_args
+        self.assertEqual(self.sprint_id, call.args[0])
+        self.assertEqual("fnb", call.kwargs["actor"].kind)
+        self.assertEqual(5, call.kwargs["actor"].shell_id)
+        self.assertEqual("Acme/Repo", call.kwargs["repository"])
+        self.assertEqual(42, call.kwargs["pr_number"])
+        self.assertEqual(self.unit_id, call.kwargs["work_unit_id"])
 
     def deliver_message(self, message_id: int) -> None:
         # The delivery worker is out of frame in these surface tests: stamp

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -299,7 +299,7 @@ class SprintCliApiTest(unittest.TestCase):
         self.assertIn("number=85", message[4])
         self.assertIn("event=green", message[4])
 
-    def test_reconcile_pr_is_fnb_only_and_projects_the_durable_receipt(self):
+    def test_reconcile_pr_allows_originating_planner_and_projects_receipt(self):
         argv = (
             "reconcile-pr",
             "--sprint",
@@ -317,7 +317,7 @@ class SprintCliApiTest(unittest.TestCase):
             server.sprint_pr_watcher,
             "GitHubPullRequestReader",
             return_value=Reader(),
-        ), self.assertRaisesRegex(SystemExit, "HTTP 403.*only .*FnB"):
+        ), self.assertRaisesRegex(SystemExit, "HTTP 403.*originating Planner"):
             self.run_cli(TOKENS["developer"], *argv)
 
         expected = sprint_pr_watcher.RegistrationReconciliationReceipt(
@@ -334,7 +334,7 @@ class SprintCliApiTest(unittest.TestCase):
             "reconcile_aborted_registration",
             return_value=expected,
         ) as reconcile:
-            response = self.run_cli(TOKENS["admin"], *argv)
+            response = self.run_cli(TOKENS["planner"], *argv)
 
         self.assertEqual(
             {
@@ -350,8 +350,8 @@ class SprintCliApiTest(unittest.TestCase):
         )
         call = reconcile.call_args
         self.assertEqual(self.sprint_id, call.args[0])
-        self.assertEqual("fnb", call.kwargs["actor"].kind)
-        self.assertEqual(5, call.kwargs["actor"].shell_id)
+        self.assertEqual("planner", call.kwargs["actor"].kind)
+        self.assertEqual(3, call.kwargs["actor"].shell_id)
         self.assertEqual("Acme/Repo", call.kwargs["repository"])
         self.assertEqual(42, call.kwargs["pr_number"])
         self.assertEqual(self.unit_id, call.kwargs["work_unit_id"])

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -452,6 +452,309 @@ class RegistrationTest(SprintPRWatcherCase):
         )
 
 
+class RegistrationRecoveryTest(SprintPRWatcherCase):
+    def _prepare_replacement(
+        self, *, abort_source: bool = True, pause: bool = True
+    ) -> tuple[int, int]:
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (4,'FnB','FNB','admin','prompt',1)"
+        )
+        source_spec = self.con.execute(
+            "SELECT document_id,bound_revision_sha256,approval_id "
+            "FROM sprint_specs WHERE sprint_id=?",
+            (self.sprint_id,),
+        ).fetchone()
+        feature_id = int(
+            self.con.execute(
+                "SELECT feature_id FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        target_sprint_id = int(
+            self.con.execute(
+                "INSERT INTO sprints "
+                "(feature_id,originating_planner_shell_id,merge_grant_enabled) "
+                "VALUES (?,3,1)",
+                (feature_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_specs "
+            "(sprint_id,document_id,bound_revision_sha256,approval_id) "
+            "VALUES (?,?,?,?)",
+            (target_sprint_id, *tuple(source_spec)),
+        )
+        self.con.executemany(
+            "INSERT INTO sprint_participants "
+            "(sprint_id,shell_id,role,harness) VALUES (?,?,?,?)",
+            (
+                (target_sprint_id, 3, "planner", "codex"),
+                (target_sprint_id, 1, "developer", "codex"),
+                (target_sprint_id, 2, "reviewer", "codex"),
+            ),
+        )
+        target_unit_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output) VALUES (?,1,2,'Replacement','Ship it')",
+                (target_sprint_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+        lifecycle = sprint_domain.SprintLifecycleStore(
+            self.con, probe_harness=lambda _harness: None
+        )
+        if abort_source:
+            lifecycle.abort(
+                self.sprint_id,
+                sprint_domain.LifecycleActor("fnb", 4),
+                reason="replace the failed Sprint",
+                terminal_outcome="recovered elsewhere",
+            )
+        else:
+            lifecycle.transition(
+                self.sprint_id,
+                "paused",
+                sprint_domain.LifecycleActor("participant", 1),
+                reason="source remains recoverable",
+            )
+        lifecycle.arm(target_sprint_id, 3)
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='active' "
+            "WHERE work_unit_id=?",
+            (target_unit_id,),
+        )
+        self.con.commit()
+        if pause:
+            lifecycle.transition(
+                target_sprint_id,
+                "paused",
+                sprint_domain.LifecycleActor("participant", 1),
+                reason="await ownership repair",
+            )
+        return target_sprint_id, target_unit_id
+
+    def test_fnb_reconciles_merged_pr_from_aborted_sprint_atomically(self):
+        self.reader.current = pull_request(state="MERGED", checks="SUCCESS", checks_failed=False)
+        original = self.register()
+        target_sprint_id, target_unit_id = self._prepare_replacement()
+
+        receipt = self.watcher.reconcile_aborted_registration(
+            target_sprint_id,
+            actor=sprint_domain.LifecycleActor("fnb", 4),
+            repository="Acme/Repo",
+            pr_number=42,
+            work_unit_id=target_unit_id,
+            reason="FnB merged the preserved replacement implementation",
+        )
+        self.reader.current = pull_request(
+            state="CLOSED", checks=None, checks_failed=False
+        )
+        replay = self.watcher.reconcile_aborted_registration(
+            target_sprint_id,
+            actor=sprint_domain.LifecycleActor("fnb", 4),
+            repository="acme/repo",
+            pr_number=42,
+            work_unit_id=target_unit_id,
+            reason="FnB merged the preserved replacement implementation",
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertFalse(replay.changed)
+        self.assertEqual(original.registered_pr_id, receipt.registered_pr_id)
+        self.assertEqual(self.sprint_id, receipt.from_sprint_id)
+        self.assertEqual("merged", receipt.normalized_state)
+        self.assertEqual("a" * 40, receipt.head_sha)
+        self.assertEqual("b" * 40, receipt.merge_sha)
+        self.assertEqual((target_unit_id,), receipt.completed_work_unit_ids)
+        self.assertEqual(receipt, replace(replay, changed=True))
+        target_participant_id = int(
+            self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=1 AND role='developer'",
+                (target_sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual(
+            (target_sprint_id, target_participant_id, "acme/repo", 42),
+            tuple(
+                self.con.execute(
+                    "SELECT sprint_id,owner_participant_id,repository,pr_number "
+                    "FROM sprint_registered_prs WHERE registered_pr_id=?",
+                    (receipt.registered_pr_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            [(target_sprint_id, receipt.registered_pr_id, target_unit_id)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT sprint_id,registered_pr_id,work_unit_id "
+                    "FROM sprint_pr_work_units"
+                )
+            ],
+        )
+        self.assertEqual(
+            (1, receipt.registered_pr_id),
+            tuple(
+                self.con.execute(
+                    "SELECT owner_shell_id,sprint_registered_pr_id "
+                    "FROM pr_subscriptions WHERE repository='acme/repo' AND pr_number=42"
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            "completed",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (target_unit_id,),
+            ).fetchone()[0],
+        )
+        events = self.con.execute(
+            "SELECT sprint_id,actor_kind,actor_shell_id,payload FROM sprint_events "
+            "WHERE event_type='pr.registration_reconciled' ORDER BY event_id"
+        ).fetchall()
+        self.assertEqual(2, len(events))
+        self.assertEqual({self.sprint_id, target_sprint_id}, {int(row[0]) for row in events})
+        for event in events:
+            payload = json.loads(event["payload"])
+            self.assertEqual("fnb", event["actor_kind"])
+            self.assertEqual(4, event["actor_shell_id"])
+            self.assertEqual(self.sprint_id, payload["from_sprint_id"])
+            self.assertEqual(target_sprint_id, payload["to_sprint_id"])
+            self.assertEqual([self.unit_id], payload["from_work_unit_ids"])
+            self.assertEqual(target_unit_id, payload["to_work_unit_id"])
+            self.assertEqual("a" * 40, payload["head_sha"])
+            self.assertEqual("b" * 40, payload["merge_sha"])
+        self.assertEqual(
+            2,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='pr.registration_reconciled'"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='work_unit.completed' "
+                "AND json_extract(payload,'$.source')='fnb.pr_recovery_override'",
+                (target_sprint_id,),
+            ).fetchone()[0],
+        )
+
+    def test_fnb_rebinds_open_pr_without_completing_the_target_unit(self):
+        original = self.register()
+        target_sprint_id, target_unit_id = self._prepare_replacement()
+
+        receipt = self.watcher.reconcile_aborted_registration(
+            target_sprint_id,
+            actor=sprint_domain.LifecycleActor("fnb", 4),
+            repository="acme/repo",
+            pr_number=42,
+            work_unit_id=target_unit_id,
+            reason="continue the preserved PR through normal review",
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual(original.registered_pr_id, receipt.registered_pr_id)
+        self.assertEqual(self.sprint_id, receipt.from_sprint_id)
+        self.assertEqual("red", receipt.normalized_state)
+        self.assertEqual("a" * 40, receipt.head_sha)
+        self.assertIsNone(receipt.merge_sha)
+        self.assertEqual((), receipt.completed_work_unit_ids)
+        self.assertEqual(
+            (target_sprint_id, target_unit_id, "active"),
+            tuple(
+                self.con.execute(
+                    "SELECT link.sprint_id,link.work_unit_id,unit.disposition "
+                    "FROM sprint_pr_work_units link JOIN sprint_work_units unit "
+                    "ON unit.work_unit_id=link.work_unit_id "
+                    "WHERE link.registered_pr_id=?",
+                    (receipt.registered_pr_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='work_unit.completed'",
+                (target_sprint_id,),
+            ).fetchone()[0],
+        )
+
+    def test_reconciliation_requires_the_target_sprint_to_be_paused(self):
+        original = self.register()
+        target_sprint_id, target_unit_id = self._prepare_replacement(pause=False)
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "paused target Sprint"
+        ):
+            self.watcher.reconcile_aborted_registration(
+                target_sprint_id,
+                actor=sprint_domain.LifecycleActor("fnb", 4),
+                repository="acme/repo",
+                pr_number=42,
+                work_unit_id=target_unit_id,
+                reason="unsafe live repair",
+            )
+
+        self.assertEqual(
+            self.sprint_id,
+            self.con.execute(
+                "SELECT sprint_id FROM sprint_registered_prs WHERE registered_pr_id=?",
+                (original.registered_pr_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='pr.registration_reconciled'"
+            ).fetchone()[0],
+        )
+
+    def test_reconciliation_rejects_non_fnb_and_non_aborted_ownership_without_changes(self):
+        original = self.register()
+        target_sprint_id, target_unit_id = self._prepare_replacement(
+            abort_source=False
+        )
+
+        for actor, message in (
+            (sprint_domain.LifecycleActor("planner", 3), "only .*FnB"),
+            (sprint_domain.LifecycleActor("fnb", 4), "aborted Sprint"),
+        ):
+            with self.assertRaisesRegex(sprint_domain.SprintLifecycleError, message):
+                self.watcher.reconcile_aborted_registration(
+                    target_sprint_id,
+                    actor=actor,
+                    repository="acme/repo",
+                    pr_number=42,
+                    work_unit_id=target_unit_id,
+                    reason="attempted repair",
+                )
+
+        self.assertEqual(
+            self.sprint_id,
+            self.con.execute(
+                "SELECT sprint_id FROM sprint_registered_prs WHERE registered_pr_id=?",
+                (original.registered_pr_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='pr.registration_reconciled'"
+            ).fetchone()[0],
+        )
+
+
 class TransitionRoutingTest(SprintPRWatcherCase):
     def test_queued_checkrun_stays_pending_without_green_owner_wake(self):
         raw = {

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -537,29 +537,29 @@ class RegistrationRecoveryTest(SprintPRWatcherCase):
             )
         return target_sprint_id, target_unit_id
 
-    def test_fnb_reconciles_merged_pr_from_aborted_sprint_atomically(self):
+    def test_originating_planner_reconciles_merged_pr_atomically(self):
         self.reader.current = pull_request(state="MERGED", checks="SUCCESS", checks_failed=False)
         original = self.register()
         target_sprint_id, target_unit_id = self._prepare_replacement()
 
         receipt = self.watcher.reconcile_aborted_registration(
             target_sprint_id,
-            actor=sprint_domain.LifecycleActor("fnb", 4),
+            actor=sprint_domain.LifecycleActor("planner", 3),
             repository="Acme/Repo",
             pr_number=42,
             work_unit_id=target_unit_id,
-            reason="FnB merged the preserved replacement implementation",
+            reason="preserve the merged replacement implementation",
         )
         self.reader.current = pull_request(
             state="CLOSED", checks=None, checks_failed=False
         )
         replay = self.watcher.reconcile_aborted_registration(
             target_sprint_id,
-            actor=sprint_domain.LifecycleActor("fnb", 4),
+            actor=sprint_domain.LifecycleActor("planner", 3),
             repository="acme/repo",
             pr_number=42,
             work_unit_id=target_unit_id,
-            reason="FnB merged the preserved replacement implementation",
+            reason="preserve the merged replacement implementation",
         )
 
         self.assertTrue(receipt.changed)
@@ -622,8 +622,8 @@ class RegistrationRecoveryTest(SprintPRWatcherCase):
         self.assertEqual({self.sprint_id, target_sprint_id}, {int(row[0]) for row in events})
         for event in events:
             payload = json.loads(event["payload"])
-            self.assertEqual("fnb", event["actor_kind"])
-            self.assertEqual(4, event["actor_shell_id"])
+            self.assertEqual("planner", event["actor_kind"])
+            self.assertEqual(3, event["actor_shell_id"])
             self.assertEqual(self.sprint_id, payload["from_sprint_id"])
             self.assertEqual(target_sprint_id, payload["to_sprint_id"])
             self.assertEqual([self.unit_id], payload["from_work_unit_ids"])
@@ -642,7 +642,7 @@ class RegistrationRecoveryTest(SprintPRWatcherCase):
             self.con.execute(
                 "SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
                 "AND event_type='work_unit.completed' "
-                "AND json_extract(payload,'$.source')='fnb.pr_recovery_override'",
+                "AND json_extract(payload,'$.source')='planner.pr_recovery'",
                 (target_sprint_id,),
             ).fetchone()[0],
         )
@@ -719,14 +719,17 @@ class RegistrationRecoveryTest(SprintPRWatcherCase):
             ).fetchone()[0],
         )
 
-    def test_reconciliation_rejects_non_fnb_and_non_aborted_ownership_without_changes(self):
+    def test_reconciliation_rejects_non_owner_and_live_source_without_changes(self):
         original = self.register()
         target_sprint_id, target_unit_id = self._prepare_replacement(
             abort_source=False
         )
 
         for actor, message in (
-            (sprint_domain.LifecycleActor("planner", 3), "only .*FnB"),
+            (
+                sprint_domain.LifecycleActor("planner", 2),
+                "only the originating Planner",
+            ),
             (sprint_domain.LifecycleActor("fnb", 4), "aborted Sprint"),
         ):
             with self.assertRaisesRegex(sprint_domain.SprintLifecycleError, message):
@@ -739,6 +742,7 @@ class RegistrationRecoveryTest(SprintPRWatcherCase):
                     reason="attempted repair",
                 )
 
+        self.assertEqual([42, 42], self.reader.get_calls)
         self.assertEqual(
             self.sprint_id,
             self.con.execute(

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -814,6 +814,16 @@ class SprintSkillTest(unittest.TestCase):
         self.assertIn("completes the Sprint", normalized_close)
         self.assertIn("informational Planner receipt", normalized_close)
 
+    def test_originating_planner_owns_pr_reconciliation(self):
+        planner = " ".join(
+            (ASSETS / "sprint_pln" / "SKILL.md").read_text().split()
+        )
+
+        self.assertIn("originating Planner may reconcile that identity", planner)
+        self.assertIn("refuses a live source Sprint or target Sprint", planner)
+        self.assertIn("a non-originating Planner", planner)
+        self.assertIn("separate Reviewer decision before resuming", planner)
+
     def test_skills_use_only_the_shipped_shell_command_surface(self):
         expected = {
             "record-qaqc",

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -592,6 +592,11 @@ class SprintSkillTest(unittest.TestCase):
             ).read_text()
             con.executescript(migration)
             con.executescript(migration)
+            for later_migration in sorted(
+                (ENGINE / "migrations").glob("*.sql")
+            ):
+                if later_migration.name > "0190_reseed_successful_sprint_chat_cleanup.sql":
+                    con.executescript(later_migration.read_text())
 
             for name in sorted(CHAT_CLEANUP_SKILLS):
                 with self.subTest(name=name):
@@ -626,6 +631,45 @@ class SprintSkillTest(unittest.TestCase):
                         "FROM skills WHERE name='sprint_dev'"
                     ).fetchone()
                 ),
+            )
+        finally:
+            con.close()
+
+    def test_pr_recovery_reseed_matches_asset_and_replays_idempotently(self):
+        con = sqlite3.connect(":memory:")
+        try:
+            con.executescript((ENGINE / "schema.sql").read_text())
+            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name >= "0192_reseed_sprint_pr_recovery.sql":
+                    break
+                con.executescript(migration.read_text())
+            con.execute(
+                "UPDATE skills SET description='stale',category='stale',"
+                "command='stale',common=1,content='no recovery surface',"
+                "is_deleted=1 WHERE name='sprint_pln'"
+            )
+
+            migration = (
+                ENGINE / "migrations" / "0192_reseed_sprint_pr_recovery.sql"
+            ).read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+
+            parsed = seed_skills.parse_skill(ASSETS / "sprint_pln" / "SKILL.md")
+            row = con.execute(
+                "SELECT description,category,command,common,content,is_deleted "
+                "FROM skills WHERE name='sprint_pln'"
+            ).fetchone()
+            self.assertEqual(
+                (
+                    parsed["description"],
+                    parsed["category"],
+                    parsed["command"],
+                    parsed["common"],
+                    parsed["content"],
+                    0,
+                ),
+                tuple(row),
             )
         finally:
             con.close()
@@ -784,6 +828,7 @@ class SprintSkillTest(unittest.TestCase):
             "complete-unit",
             "cancel-unit",
             "register-pr",
+            "reconcile-pr",
             "pause",
             "resume",
             "complete",


### PR DESCRIPTION
## Outcome

Adds a guarded recovery path that lets the originating Planner recover a PR identity stranded on an aborted Sprint without weakening normal Sprint registration or review invariants. FnB retains the same operation as a board-level override.

sc sprint reconcile-pr can rebind the existing registration to an active code unit in a paused replacement Sprint after verifying the live GitHub PR head and state. For an already-merged PR, the same atomic transition records the merge identity and closes the replacement unit with explicit recovery evidence; an open PR returns to the normal typed review path. Replays are idempotent. Durable events attribute the action to the actual Planner or FnB actor.

Guardrails require the target Sprint originating Planner or an authenticated FnB actor, an aborted source Sprint, a paused target Sprint, a Developer-owned active code unit, no competing target registration, and exact repository/PR facts. Normal register-pr remains strict, and a separate Reviewer decision is required before resume.

The planner skill and its migration-backed installed copy make reconciliation part of the Planner recovery role.

## Verification

- 2153 passed, 1069 subtests passed — canonical full suite
- 396 passed, 191 subtests passed — Sprint suite
- git diff --check
- Python bytecode compilation for changed modules

Fixes #1115