### PR TITLE
fix(sprint): reactivate reopened PR subscriptions

### DIFF
--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3924,6 +3924,15 @@ sc sprint register-pr --sprint <id> --repository <owner/name> \
   --pr <number> --work-unit <id>
 ```
 
+If GitHub closed this registered PR externally and you reopened, rebased, and
+pushed the same PR, replay the exact `register-pr` command above. The replay
+keeps the registered PR and ownership unchanged while taking one fresh watcher
+snapshot; `created: false` is the expected registration receipt. Confirm that
+write and stop. The refreshed observation arrives as the native PR-fact wake;
+on its green Re-enter, retry the blocked `request-review` with its original
+stable key. Do not register a replacement PR or ask the Planner to bypass the
+observed-green gate.
+
 When no local implementation action remains, stop and await the native PR-fact
 wake. Use Sprint-native wakes for coordination. Do not start a recurring shell
 loop, scheduled job, manual watcher daemon, or external PR watcher to track the

--- a/.super-coder/migrations/0197_reseed_reopened_pr_resubscription.sql
+++ b/.super-coder/migrations/0197_reseed_reopened_pr_resubscription.sql
@@ -1,11 +1,15 @@
----
-name: sprint_dev
-description: Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge only after live authorization, and record judgment without overlapping edits.
-category: workflow
-common: false
----
+-- 0197 — reseed Developer guidance for reopened registered PR resubscription.
+-- Converge existing installs after making exact register-pr replay refresh the watcher.
 
-# sprint_dev — own one editing lane
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_dev',
+  'Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge only after live authorization, and record judgment without overlapping edits.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_dev — own one editing lane
 
 Use for an actionable work-unit assignment in an armed Sprint. Marking that
 Sprint message read is acceptance and starts work immediately. If you cannot
@@ -45,10 +49,10 @@ Sprint or work-unit state.
 Read the assignment, expected output, bound spec revision, dependencies,
 assigned Reviewer, repository/worktree, merge grant, and prior judgments. One
 Developer shell may own one active work unit in the Sprint. Do not start a
-second editing lane or edit another shell's worktree.
+second editing lane or edit another shell''s worktree.
 
 If the requirement is ambiguous, choose the shippable reading within your
-unit's scope, record the choice and rationale, and continue. Escalate changes to
+unit''s scope, record the choice and rationale, and continue. Escalate changes to
 the unit boundary, interfaces another unit consumes, deliverable cuts, or scope
 growth to the Planner.
 
@@ -114,7 +118,7 @@ that decision.
 Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
 report drafts, and Dev scratch proof) go to the gitignored
 `shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR'd in the work repo; a review-notes commit is a finding.
+PR''d in the work repo; a review-notes commit is a finding.
 
 DB rows stay the durable record: judgments via `record-review`, report bodies in
 `sprint_reports`, and decisions in the durable relay. Files in the Sprint
@@ -126,7 +130,7 @@ Sync the assigned repository, work on a feature branch, match the surrounding
 code, and implement the smallest complete change. Keep external calls outside
 database transactions. Preserve durable identities and append-only evidence.
 
-Verification must exercise the unit's independent stage gate and realistic
+Verification must exercise the unit''s independent stage gate and realistic
 failure paths. A local exploratory number is not merge evidence. Record real CI
 failures, anomalous infrastructure failures, retries, review friction, and
 known departures for the final report.
@@ -275,5 +279,13 @@ Stop when the unit is merged and reported, declined, awaiting Planner/FnB
 recovery, returned to review, or paused awaiting a native PR-fact or verdict
 wake. For normal review and merge handoffs, the
 ordered procedures above place inbox handling before the typed handoff and make
-that handoff the turn's last action. Ask the Planner for later work only after
-the current editing lane is terminal.
+that handoff the turn''s last action. Ask the Planner for later work only after
+the current editing lane is terminal.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -928,7 +928,7 @@ class SprintPRWatcher:
         pr_number: int,
         work_unit_ids: Iterable[int],
     ) -> RegistrationReceipt:
-        """Register, then take the required initial snapshot after commit."""
+        """Register or resubscribe, then snapshot the current PR after commit."""
         receipt = self.registration.register(
             sprint_id,
             owner_shell_id=owner_shell_id,
@@ -942,7 +942,7 @@ class SprintPRWatcher:
             "WHERE subscription.sprint_registered_pr_id=?",
             (receipt.registered_pr_id,),
         ).fetchone()
-        if receipt.created and row is not None:
+        if row is not None:
             self._observe_rows((row,), "registration", ignore_backoff=True)
         notify_commit()
         return receipt

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -90,7 +90,8 @@
     ".super-coder/migrations/0192_reseed_sprint_pr_recovery.sql",
     ".super-coder/migrations/0194_sprint_scoped_reply_waits.sql",
     ".super-coder/migrations/0195_reseed_sprint_progress_carriers.sql",
-    ".super-coder/migrations/0196_sprint_wake_recovery_provenance.sql"
+    ".super-coder/migrations/0196_sprint_wake_recovery_provenance.sql",
+    ".super-coder/migrations/0197_reseed_reopened_pr_resubscription.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -281,8 +281,8 @@ class RegistrationTest(SprintPRWatcherCase):
         self.assertTrue(first.created)
         self.assertFalse(second.created)
         self.assertEqual(first.registered_pr_id, second.registered_pr_id)
-        self.assertEqual([42], self.reader.get_calls)
-        self.assertEqual(["acme/repo"], self.repositories)
+        self.assertEqual([42, 42], self.reader.get_calls)
+        self.assertEqual(["acme/repo", "acme/repo"], self.repositories)
         self.assertEqual(
             [("acme/repo", 42)],
             [
@@ -320,6 +320,44 @@ class RegistrationTest(SprintPRWatcherCase):
                     "FROM sprint_pr_transitions"
                 )
             ],
+        )
+
+    def test_exact_registration_replay_reactivates_a_reopened_subscription(self):
+        self.reader.current = pull_request(
+            state="CLOSED", checks=None, checks_failed=False
+        )
+        first = self.register()
+        self.assertFalse(self.watcher.poll_once())
+
+        reopened_head = "d" * 40
+        self.reader.current = pull_request(
+            checks="SUCCESS",
+            checks_failed=False,
+            head_sha=reopened_head,
+        )
+        replay = self.register()
+
+        self.assertFalse(replay.created)
+        self.assertEqual(first.registered_pr_id, replay.registered_pr_id)
+        self.assertEqual([42, 42], self.reader.get_calls)
+        self.assertEqual(
+            [("closed", "a" * 40), ("green", reopened_head)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT normalized_state,observed_head_sha "
+                    "FROM sprint_pr_transitions ORDER BY transition_id"
+                )
+            ],
+        )
+
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual([42, 42, 42], self.reader.get_calls)
+        self.assertEqual(
+            2,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_pr_transitions"
+            ).fetchone()[0],
         )
 
     def test_registration_without_checks_records_one_diagnostic_event(self):

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -683,6 +683,53 @@ class SprintSkillTest(unittest.TestCase):
         finally:
             con.close()
 
+    def test_reopened_pr_reseed_matches_asset_and_replays_idempotently(self):
+        con = sqlite3.connect(":memory:")
+        try:
+            con.executescript((ENGINE / "schema.sql").read_text())
+            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name >= "0197_reseed_reopened_pr_resubscription.sql":
+                    break
+                con.executescript(migration.read_text())
+            con.execute(
+                "UPDATE skills SET description='stale',category='stale',"
+                "command='stale',common=1,content='no resubscription guidance',"
+                "is_deleted=1 WHERE name='sprint_dev'"
+            )
+
+            migration = (
+                ENGINE
+                / "migrations"
+                / "0197_reseed_reopened_pr_resubscription.sql"
+            ).read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+            self.assertIn(
+                "replay the exact `register-pr` command",
+                con.execute(
+                    "SELECT content FROM skills WHERE name='sprint_dev'"
+                ).fetchone()[0],
+            )
+
+            parsed = seed_skills.parse_skill(ASSETS / "sprint_dev" / "SKILL.md")
+            row = con.execute(
+                "SELECT description,category,command,common,content,is_deleted "
+                "FROM skills WHERE name='sprint_dev'"
+            ).fetchone()
+            self.assertEqual(
+                (
+                    parsed["description"],
+                    parsed["category"],
+                    parsed["command"],
+                    parsed["common"],
+                    parsed["content"],
+                    0,
+                ),
+                tuple(row),
+            )
+        finally:
+            con.close()
+
     def test_progress_carrier_reseed_matches_assets_and_replays_idempotently(self):
         con = sqlite3.connect(":memory:")
         try:
@@ -706,6 +753,11 @@ class SprintSkillTest(unittest.TestCase):
             ).read_text()
             con.executescript(migration)
             con.executescript(migration)
+            for later_migration in sorted(
+                (ENGINE / "migrations").glob("*.sql")
+            ):
+                if later_migration.name > "0195_reseed_sprint_progress_carriers.sql":
+                    con.executescript(later_migration.read_text())
 
             for name in sorted(PROGRESS_CARRIER_ROLE_SKILLS):
                 with self.subTest(name=name):
@@ -1259,6 +1311,9 @@ class SprintSkillTest(unittest.TestCase):
         self.assertNotIn("sc sprint monitor", bodies["sprint_pln"])
         self.assertIn(
             "After `register-pr` succeeds", bodies["sprint_dev"]
+        )
+        self.assertIn(
+            "replay the exact `register-pr` command", bodies["sprint_dev"]
         )
         self.assertIn(
             "stop and await the native verdict wake", bodies["sprint_dev"]


### PR DESCRIPTION
Closes #1127.

## Summary

- take a fresh watcher snapshot when the owning Developer replays an exact existing `register-pr`
- preserve registered PR identity, ownership, observed-green review gate, and terminal-subscription quiescence
- document the stop-and-wait recovery sequence in `sprint_dev` and converge it through migration 0197
- cover closed old head → reopened green new head, unchanged-state deduplication, pulse reactivation, and migration replay

## Verification

- `python -m pytest -q tests/test_sprint_pr_watcher.py tests/test_sprint_cli.py tests/test_sprint_skills.py` — 100 passed, 94 subtests passed
- `python -m pytest -q` — 2206 passed, 1088 subtests passed
- `./sc map` — 1600 files mapped
- `./sc render-check` — passed
- `git diff --check` — passed
- `./sc verify` — safely refused from the linked source worktree; known upstream gate defect #769 (reproduction added there)