### PR TITLE
feat(sprint): support live Planner replanning

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1977,6 +1977,28 @@ class Handler(BaseHTTPRequestHandler):
             raise ValueError(f"{name} must be a positive integer")
         return value
 
+    @staticmethod
+    def _sprint_nonnegative_integer(body: dict, name: str) -> int:
+        value = body.get(name)
+        if isinstance(value, bool):
+            raise ValueError(f"{name} must be a non-negative integer")
+        try:
+            value = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be a non-negative integer") from exc
+        if value < 0:
+            raise ValueError(f"{name} must be a non-negative integer")
+        return value
+
+    @staticmethod
+    def _sprint_optional_text(body: dict, name: str) -> str | None:
+        value = body.get(name)
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError(f"{name} must be a string")
+        return value
+
     @classmethod
     def _sprint_integer_list(cls, body: dict, name: str) -> list[int]:
         values = body.get(name)
@@ -2413,19 +2435,63 @@ class Handler(BaseHTTPRequestHandler):
                     sprint_id,
                     self._sprint_integer(body, "work_unit_id"),
                     planner_shell_id,
-                    assigned_shell_id=self._sprint_integer(
-                        body, "assigned_shell_id"
+                    assigned_shell_id=(
+                        self._sprint_integer(body, "assigned_shell_id")
+                        if body.get("assigned_shell_id") is not None
+                        else None
                     ),
-                    reviewer_shell_id=self._sprint_integer(
-                        body, "reviewer_shell_id"
+                    reviewer_shell_id=(
+                        self._sprint_integer(body, "reviewer_shell_id")
+                        if body.get("reviewer_shell_id") is not None
+                        else None
                     ),
-                    planned_wave=int(body.get("planned_wave", 0)),
+                    title=self._sprint_optional_text(body, "title"),
+                    expected_output=self._sprint_optional_text(
+                        body, "expected_output"
+                    ),
+                    task_ids=(
+                        self._sprint_integer_list(body, "task_ids")
+                        if "task_ids" in body
+                        else None
+                    ),
+                    planned_wave=(
+                        self._sprint_nonnegative_integer(body, "planned_wave")
+                        if body.get("planned_wave") is not None
+                        else None
+                    ),
                     dependency_ids=(
-                        self._sprint_integer_list(body, "dependency_ids")
-                        if body.get("dependency_ids")
-                        else ()
+                        self._sprint_optional_integer_list(body, "dependency_ids")
+                        if "dependency_ids" in body
+                        else None
                     ),
-                    output_kind=body.get("output_kind"),
+                    output_kind=self._sprint_optional_text(body, "output_kind"),
+                )
+                return self._send(200, {"changed": changed})
+            if path == "/_sc/sprint/recall-unit":
+                planner_shell_id = self._sprint_planner_proxy(
+                    con, sprint_id, shell_id
+                )
+                changed = sprint_domain.SprintWorkUnitStore(con).recall(
+                    sprint_id,
+                    self._sprint_integer(body, "work_unit_id"),
+                    planner_shell_id,
+                    reason=self._sprint_optional_text(body, "reason") or "",
+                )
+                return self._send(200, {"changed": changed})
+            if path == "/_sc/sprint/reroute-participant":
+                planner_shell_id = self._sprint_planner_proxy(
+                    con, sprint_id, shell_id
+                )
+                changed = sprint_domain.SprintParticipantStore(con).reroute(
+                    sprint_id,
+                    planner_shell_id,
+                    participant_shell_id=self._sprint_integer(
+                        body, "participant_shell_id"
+                    ),
+                    harness=self._sprint_optional_text(body, "harness") or "",
+                    model=self._sprint_optional_text(body, "model"),
+                    effort=self._sprint_optional_text(body, "effort"),
+                    route=self._sprint_optional_text(body, "route"),
                 )
                 return self._send(200, {"changed": changed})
             if path == "/_sc/sprint/complete-unit":

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sprint_pln
-description: Run an armed Sprints v2 collaboration loop as Planner — dispatch ready lanes and execute Reviewer decisions through durable re-plan, pause, cancel, resume, and close protocols.
+description: Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.
 category: workflow
 common: false
 ---
@@ -37,10 +37,13 @@ Load `sprint_pln` on every entry. Do not turn entry routing into a polling loop.
 
 The armed runtime owns scheduled dispatch and unread wake recovery. The
 registered-PR watcher owns subscription observation. React to their durable
-facts; use the Planner turn for dispatch and exact execution of durable Reviewer
-decisions. The Reviewer owns pause, cancel, and conclude decisions plus the
-conformance and final Sprint reports. The Planner owns control transitions;
-clean conformance approval performs its own atomic terminal transition.
+facts; use the Planner turn for dispatch, plan structure, and exact execution of
+durable Reviewer decisions. The Reviewer owns review and conformance judgment
+plus the conformance and final Sprint reports. The Planner owns the plan and its
+control transitions: it may modify, repeat, recall, reassign, or reroute work on
+its own operational judgment, and it executes Reviewer decisions that cross
+those same boundaries. Clean conformance approval performs its own atomic
+terminal transition.
 
 Assignments and review requests use Force-new delivery. Planner-bound results
 use Re-enter. Neither displaces a live turn; delivery waits for its natural
@@ -76,8 +79,10 @@ not change Sprint or work-unit state.
 ## Running loop
 
 - Keep dependencies as the only hard sequence. When reality requires a re-plan,
-  give the Reviewer the current projection and evidence, then execute the exact
-  decision it returns; never rewrite completed history.
+  restructure the current projection under Planner authority and record why.
+  Ask the Reviewer when the change depends on review or conformance judgment;
+  do not outsource ordinary assignment, capacity, or route judgment. Never
+  rewrite completed history.
 - Let Developers own their PRs through green, review, correction, and merge.
   Let Reviewers own verdicts and Sprint decisions. Do not proxy routine
   handoffs or substitute Planner judgment for a Reviewer decision.
@@ -164,12 +169,13 @@ DB rows stay the durable record: judgments via `record-review`, report bodies in
 `sprint_reports`, and decisions in the durable relay. Files in the Sprint
 artifact directory are working material only.
 
-## Reviewer decision actions
+## Reviewer decisions and Planner actions
 
-Pause, cancel, re-enter, and abort are Reviewer decisions and Planner actions.
-A valid control decision arrives as a durable Reviewer → Planner Re-enter
-message and names the decision, evidence, target ids, reason, and exact
-requested transition. Resolve every required-reply control decision through its
+Review, conformance, re-enter, and abort judgments remain Reviewer decisions.
+Planner independently owns operational plan structure, including pause-safe
+recall, cancellation of unreleased scope, reassignment, repeated task lanes,
+and participant route changes. When an action does arrive as a durable Reviewer
+→ Planner Re-enter decision, resolve every required-reply decision through its
 original message before acting. Complete this order without reordering:
 
 1. Re-run `sc sprint inbox --sprint <id>`, verify the decision came from the
@@ -211,20 +217,22 @@ stop at that decision boundary.
 
 ### Pause or resume
 
-On a Reviewer pause decision, transition durably, stop external Sprint services,
-persist interrupt intent, preserve every partial artifact, and retain the
-Reviewer judgment and evidence for recovery:
+Pause on a Reviewer decision or when Planner needs a safe restructuring window.
+Transition durably, stop external Sprint services, persist interrupt intent,
+preserve every partial artifact, and retain the governing judgment and evidence
+for recovery:
 
 ```text
-sc sprint pause --sprint <id> --reason <reviewer-decision-reason>
+sc sprint pause --sprint <id> --reason <decision-or-restructure-reason>
 ```
 
-Resume only on a later Reviewer decision or an FnB override. Reconcile native
-runs, unread messages, pending wakes, work units, registered PRs, capacity, and
-spec drift, then act with the supplied reason:
+Resume after the requested recovery/restructure is fully recorded, or on a
+later Reviewer decision or FnB override. Reconcile native runs, unread messages,
+pending wakes, work units, registered PRs, capacity, and spec drift, then act
+with the supplied reason:
 
 ```text
-sc sprint resume --sprint <id> [--reason <reviewer-reconciliation-decision>]
+sc sprint resume --sprint <id> [--reason <validated-reconciliation-reason>]
 ```
 
 An exhausted recovery wake is bounded manual-recovery evidence, not a retry
@@ -248,37 +256,85 @@ If the PR is already merged, it also records the merge commit and completes the
 replacement unit as explicit recovery evidence. Treat the receipt as recovery
 evidence; wait for a separate Reviewer decision before resuming.
 
-### Cancel or re-plan
+### Modify, recall, repeat, reassign, or reroute
 
-A Reviewer cancel decision must name one unreleased work unit and its retained
-terminal reason. Execute exactly that cancellation:
+Planner may cancel one unreleased work unit with its retained terminal reason.
+When cancellation executes a Reviewer decision, preserve that decision id in
+the reason and evidence:
 
 ```text
-sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reviewer-decision-reason>
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <cancellation-reason>
 ```
 
-For a Reviewer re-plan decision, apply its complete projection; never infer
-omitted fields or alter a released or completed lane:
+Edit any subset of an unreleased lane directly. Omitted fields retain their
+current values; `--clear-dependencies` is the explicit empty dependency set:
 
 ```text
 sc sprint replan-unit --sprint <id> --work-unit <id> \
-  --developer-shell <id> --reviewer-shell <id> --wave <n> \
-  [--depends-on <work-unit-id>] [--output-kind code|report-only|no-code]
+  [--developer-shell <id>] [--reviewer-shell <id>] [--title <title>] \
+  [--expected-output-file <path>] [--task <task-id>] [--wave <n>] \
+  [--depends-on <work-unit-id> | --clear-dependencies] \
+  [--output-kind code|report-only|no-code]
 ```
 
-If a Developer or Reviewer declines, preserve the reason and ask the Reviewer
-for the replacement routing decision before issuing a fresh assignment.
+Do not edit a released lane in place. To change an accepted or pending
+assignment, first pause so dispatch cannot race the edit, recall the unmerged
+lane, replan it, then resume:
+
+```text
+sc sprint pause --sprint <id> --reason <restructure-reason>
+sc sprint recall-unit --sprint <id> --work-unit <id> \
+  --reason <why-the-old-assignment-is-obsolete>
+sc sprint replan-unit --sprint <id> --work-unit <id> <changed-fields>
+sc sprint resume --sprint <id> --reason <validated-replan-reason>
+```
+
+Recall preserves the old accepted/declined message and event history, returns
+only an unmerged lane to `planned`, and refuses completed, cancelled, or
+PR-bound work. For a PR-bound lane, leave it intact and plan a replacement or
+use the supported PR-ownership recovery path; never force the projection back.
+Resume dispatches a fresh assignment generation.
+
+The same governing spec task may deliberately appear in more than one work
+unit. Use this for conformance reruns, repeat verification, or replacement work
+whose scope is still governed by the original task. Do not create a duplicate
+spec task merely to satisfy lane membership. Each work unit still lists a task
+at most once.
+
+To change which model will receive future assignments or reviews, pause first
+when the Sprint is armed, clear the participant's released expectation through
+recall or completion, then replace its exact route:
+
+```text
+sc sprint reroute-participant --sprint <id> --participant-shell <id> \
+  --harness <harness> [--model <model>] [--effort <effort>] \
+  [--route <display-route>]
+```
+
+Prepared Sprints may reroute before arm. Armed Sprints must pause; Developer
+routes reject any released lane and Reviewer routes reject an in-review lane.
+The engine validates the new route before writing it. Existing chats and runs
+stay immutable history; the next Force-new assignment or review request rotates
+onto the replacement route. Only already-declared participants can be selected
+or rerouted.
+
+If a Developer or Reviewer declines, preserve the reason and choose the
+replacement assignment or route from current capacity before issuing a fresh
+assignment. Ask the Reviewer only when that choice changes review or
+conformance judgment.
 
 ### Re-enter after conformance
 
-A Reviewer `re-enter` decision names the in-Sprint findings, the tasks to add
-to the governing spec document with title and description, and the suggested
+A Reviewer `re-enter` decision names the in-Sprint findings, the governing
+tasks (existing ids when scope is unchanged; new title and description when
+scope is new), and the suggested
 unit grouping, waves, dependencies, routing, and capacity rationale. The
 Reviewer should identify independent lanes, expected review overlap, and useful
 reserve. Preserve that projection; do not silently absorb extra scope, maximize
 shell occupancy, or turn post-Sprint findings into delivery work.
 
-Cut every named task against the governing spec document:
+Reuse an existing task id when the decision repeats or repairs that exact
+governing scope. Cut a new task only for genuinely new scope:
 
 ```text
 sc mem task add "<task-title>" --feature <feature-id> \
@@ -297,10 +353,11 @@ sc sprint plan-unit --sprint <id> \
   [--output-kind code|report-only|no-code]
 ```
 
-After every named task is bound, confirm the requested routes are available and
-the dependency graph and capacity plan match the decision. If they do not, send
-the concrete conflict back to the Reviewer rather than silently re-routing.
-Then release the new ready lanes with `sc sprint dispatch --sprint <id>`. When
+After every named task is bound, confirm the routes are available and the
+dependency graph and capacity plan match the decision. Planner may reassign or
+reroute for operational capacity; send the concrete conflict back to the
+Reviewer when that adaptation changes the Reviewer's scope or conformance
+judgment. Then release the new ready lanes with `sc sprint dispatch --sprint <id>`. When
 the added work reaches terminal disposition, the engine sends the Reviewer the
 next delivery-terminal wake; the Planner does not initiate the next conformance
 pass.

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sprint_rev
-description: Review Sprints v2 work and whole-Sprint conformance — own pause, cancel, and conclude decisions, author the conformance and Sprint reports, and direct Planner actions through durable messages.
+description: Review Sprints v2 work and whole-Sprint conformance — own review, re-enter, abort, and conclude judgments, author the conformance and Sprint reports, and direct safety actions through durable messages.
 category: workflow
 common: false
 ---
@@ -10,8 +10,9 @@ common: false
 Use in one of two modes: a work-unit PR review during the loop, or the final
 whole-Sprint conformance pass. Pre-declaration QAQC is a third entry condition,
 before a Sprint exists. The evidence differs; independence does not. The
-Reviewer decides and documents; the Planner acts. The FnB retains the
-board-level override established by decision #46.
+Reviewer decides and documents review and conformance judgments; the Planner
+owns operational plan structure and acts on control transitions. The FnB
+retains the board-level override established by decision #46.
 
 Use the simplest path supported by current durable state. Treat independence,
 authority, lifecycle preconditions, durable writes, and typed handoffs as hard
@@ -79,7 +80,7 @@ sc sprint send --sprint <id> --to <shortname> --body-file <path> \
 
 Use `--intent blocker` instead when the unit cannot advance. Ask the Planner for
 durable state or action-feasibility facts without delegating Reviewer judgment.
-A cross-unit, closeout, pause, replan, re-enter, cancel, or abort ruling is a
+A cross-unit review, closeout, re-enter, abort, or safety ruling is a
 Sprint-level decision:
 
 ```text
@@ -113,10 +114,10 @@ successfully and confirms the durable write and wake.
 If a command is rejected or transport fails, the verdict or handoff is
 incomplete. Correct and retry when safe. If the relay itself fails, surface the
 attempted command, evidence, impact, and recommendation to FnB; do not invent an
-alternate protocol. A Reviewer decides whether the condition warrants
-continuing, re-planning, pausing, cancellation, or conclusion; the Planner
-executes the durable decision. Record a live FnB override as FnB authority, not
-Reviewer judgment.
+alternate protocol. A Reviewer decides whether review or conformance evidence
+warrants changes requested, re-entry, abort, or conclusion; the Planner
+independently decides ordinary operational replanning and executes control
+transitions. Record a live FnB override as FnB authority, not Reviewer judgment.
 
 ## Sprint artifact paths
 
@@ -129,32 +130,36 @@ DB rows stay the durable record: judgments via `record-review`, report bodies in
 `sprint_reports`, and decisions in the durable relay. Files in the Sprint
 artifact directory are working material only.
 
-## Control and conclude decisions
+## Conformance decisions and Planner controls
 
-The Reviewer owns all pause, cancel, and conclude decisions and recommendations.
-The Planner owns control actions; clean conformance approval atomically performs
-its own close. Base a decision on durable Sprint state,
+The Reviewer owns review, re-enter, abort, and conclude judgments. The Planner
+independently owns operational plan structure: pausing for safe edits, recalling
+unreleased work, modifying or repeating task lanes, reassigning work, changing
+participant routes, cancelling unreleased scope, and resuming after validation.
+A clean conformance approval atomically performs its own close. Base a Reviewer
+judgment on durable Sprint state,
 the exact bound revisions, current work/PR facts, progress-carrier evidence, and any
 ratified judgment; ambiguous silence is not enough to corrupt a disposition.
 
-Send pause, resume, replan, re-enter, cancel, and abort decisions through the
+Send re-enter, abort, or safety-critical control recommendations through the
 durable `send` surface above. A clean conclude instead runs the atomic
 `record-conformance` close below. Every Reviewer → Planner route is Re-enter.
 The Reviewer-authored body must name:
 
-- `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, or `abort`;
+- `decision`: `re-enter`, `abort`, or the exact safety-critical recommendation;
 - the evidence and rationale owned by the Reviewer;
 - exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
 - any immediate safety impact that the FnB must see.
 
-The Planner marks the message handled, verifies the assigned Reviewer, and
-executes exactly that control transition. The clean completion receipt is
-informational because the Sprint is already terminal. The Reviewer never runs
-the standalone pause, replan, cancel, resume, complete, or abort action; its
-clean `record-conformance` command owns the narrow automatic close. If a control
-action is rejected, inspect the returned durable state and issue
-a new decision only when the evidence supports one; never ask the Planner to
-improvise around a precondition.
+The Planner marks the message handled, verifies the assigned Reviewer, and acts
+on the judgment without surrendering its separate authority over the concrete
+plan. The clean completion receipt is informational because the Sprint is
+already terminal. The Reviewer never runs the standalone pause, replan, recall,
+reroute, cancel, resume, complete, or abort action; its clean
+`record-conformance` command owns the narrow automatic close. If a requested
+action is rejected, inspect the returned durable state and issue a revised
+judgment only when the evidence supports one; never ask the Planner to improvise
+around a precondition.
 
 The FnB board-level override from decision #46 is unaffected. A live FnB
 instruction can direct or supersede any decision; preserve it as a distinct

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -4160,7 +4160,7 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'sprint_pln',
-  'Run an armed Sprints v2 collaboration loop as Planner — dispatch ready lanes and execute Reviewer decisions through durable re-plan, pause, cancel, resume, and close protocols.',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.',
   'workflow',
   NULL,
   0,
@@ -4196,10 +4196,13 @@ Load `sprint_pln` on every entry. Do not turn entry routing into a polling loop.
 
 The armed runtime owns scheduled dispatch and unread wake recovery. The
 registered-PR watcher owns subscription observation. React to their durable
-facts; use the Planner turn for dispatch and exact execution of durable Reviewer
-decisions. The Reviewer owns pause, cancel, and conclude decisions plus the
-conformance and final Sprint reports. The Planner owns control transitions;
-clean conformance approval performs its own atomic terminal transition.
+facts; use the Planner turn for dispatch, plan structure, and exact execution of
+durable Reviewer decisions. The Reviewer owns review and conformance judgment
+plus the conformance and final Sprint reports. The Planner owns the plan and its
+control transitions: it may modify, repeat, recall, reassign, or reroute work on
+its own operational judgment, and it executes Reviewer decisions that cross
+those same boundaries. Clean conformance approval performs its own atomic
+terminal transition.
 
 Assignments and review requests use Force-new delivery. Planner-bound results
 use Re-enter. Neither displaces a live turn; delivery waits for its natural
@@ -4235,8 +4238,10 @@ not change Sprint or work-unit state.
 ## Running loop
 
 - Keep dependencies as the only hard sequence. When reality requires a re-plan,
-  give the Reviewer the current projection and evidence, then execute the exact
-  decision it returns; never rewrite completed history.
+  restructure the current projection under Planner authority and record why.
+  Ask the Reviewer when the change depends on review or conformance judgment;
+  do not outsource ordinary assignment, capacity, or route judgment. Never
+  rewrite completed history.
 - Let Developers own their PRs through green, review, correction, and merge.
   Let Reviewers own verdicts and Sprint decisions. Do not proxy routine
   handoffs or substitute Planner judgment for a Reviewer decision.
@@ -4323,12 +4328,13 @@ DB rows stay the durable record: judgments via `record-review`, report bodies in
 `sprint_reports`, and decisions in the durable relay. Files in the Sprint
 artifact directory are working material only.
 
-## Reviewer decision actions
+## Reviewer decisions and Planner actions
 
-Pause, cancel, re-enter, and abort are Reviewer decisions and Planner actions.
-A valid control decision arrives as a durable Reviewer → Planner Re-enter
-message and names the decision, evidence, target ids, reason, and exact
-requested transition. Resolve every required-reply control decision through its
+Review, conformance, re-enter, and abort judgments remain Reviewer decisions.
+Planner independently owns operational plan structure, including pause-safe
+recall, cancellation of unreleased scope, reassignment, repeated task lanes,
+and participant route changes. When an action does arrive as a durable Reviewer
+→ Planner Re-enter decision, resolve every required-reply decision through its
 original message before acting. Complete this order without reordering:
 
 1. Re-run `sc sprint inbox --sprint <id>`, verify the decision came from the
@@ -4370,20 +4376,22 @@ stop at that decision boundary.
 
 ### Pause or resume
 
-On a Reviewer pause decision, transition durably, stop external Sprint services,
-persist interrupt intent, preserve every partial artifact, and retain the
-Reviewer judgment and evidence for recovery:
+Pause on a Reviewer decision or when Planner needs a safe restructuring window.
+Transition durably, stop external Sprint services, persist interrupt intent,
+preserve every partial artifact, and retain the governing judgment and evidence
+for recovery:
 
 ```text
-sc sprint pause --sprint <id> --reason <reviewer-decision-reason>
+sc sprint pause --sprint <id> --reason <decision-or-restructure-reason>
 ```
 
-Resume only on a later Reviewer decision or an FnB override. Reconcile native
-runs, unread messages, pending wakes, work units, registered PRs, capacity, and
-spec drift, then act with the supplied reason:
+Resume after the requested recovery/restructure is fully recorded, or on a
+later Reviewer decision or FnB override. Reconcile native runs, unread messages,
+pending wakes, work units, registered PRs, capacity, and spec drift, then act
+with the supplied reason:
 
 ```text
-sc sprint resume --sprint <id> [--reason <reviewer-reconciliation-decision>]
+sc sprint resume --sprint <id> [--reason <validated-reconciliation-reason>]
 ```
 
 An exhausted recovery wake is bounded manual-recovery evidence, not a retry
@@ -4407,37 +4415,85 @@ If the PR is already merged, it also records the merge commit and completes the
 replacement unit as explicit recovery evidence. Treat the receipt as recovery
 evidence; wait for a separate Reviewer decision before resuming.
 
-### Cancel or re-plan
+### Modify, recall, repeat, reassign, or reroute
 
-A Reviewer cancel decision must name one unreleased work unit and its retained
-terminal reason. Execute exactly that cancellation:
+Planner may cancel one unreleased work unit with its retained terminal reason.
+When cancellation executes a Reviewer decision, preserve that decision id in
+the reason and evidence:
 
 ```text
-sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reviewer-decision-reason>
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <cancellation-reason>
 ```
 
-For a Reviewer re-plan decision, apply its complete projection; never infer
-omitted fields or alter a released or completed lane:
+Edit any subset of an unreleased lane directly. Omitted fields retain their
+current values; `--clear-dependencies` is the explicit empty dependency set:
 
 ```text
 sc sprint replan-unit --sprint <id> --work-unit <id> \
-  --developer-shell <id> --reviewer-shell <id> --wave <n> \
-  [--depends-on <work-unit-id>] [--output-kind code|report-only|no-code]
+  [--developer-shell <id>] [--reviewer-shell <id>] [--title <title>] \
+  [--expected-output-file <path>] [--task <task-id>] [--wave <n>] \
+  [--depends-on <work-unit-id> | --clear-dependencies] \
+  [--output-kind code|report-only|no-code]
 ```
 
-If a Developer or Reviewer declines, preserve the reason and ask the Reviewer
-for the replacement routing decision before issuing a fresh assignment.
+Do not edit a released lane in place. To change an accepted or pending
+assignment, first pause so dispatch cannot race the edit, recall the unmerged
+lane, replan it, then resume:
+
+```text
+sc sprint pause --sprint <id> --reason <restructure-reason>
+sc sprint recall-unit --sprint <id> --work-unit <id> \
+  --reason <why-the-old-assignment-is-obsolete>
+sc sprint replan-unit --sprint <id> --work-unit <id> <changed-fields>
+sc sprint resume --sprint <id> --reason <validated-replan-reason>
+```
+
+Recall preserves the old accepted/declined message and event history, returns
+only an unmerged lane to `planned`, and refuses completed, cancelled, or
+PR-bound work. For a PR-bound lane, leave it intact and plan a replacement or
+use the supported PR-ownership recovery path; never force the projection back.
+Resume dispatches a fresh assignment generation.
+
+The same governing spec task may deliberately appear in more than one work
+unit. Use this for conformance reruns, repeat verification, or replacement work
+whose scope is still governed by the original task. Do not create a duplicate
+spec task merely to satisfy lane membership. Each work unit still lists a task
+at most once.
+
+To change which model will receive future assignments or reviews, pause first
+when the Sprint is armed, clear the participant''s released expectation through
+recall or completion, then replace its exact route:
+
+```text
+sc sprint reroute-participant --sprint <id> --participant-shell <id> \
+  --harness <harness> [--model <model>] [--effort <effort>] \
+  [--route <display-route>]
+```
+
+Prepared Sprints may reroute before arm. Armed Sprints must pause; Developer
+routes reject any released lane and Reviewer routes reject an in-review lane.
+The engine validates the new route before writing it. Existing chats and runs
+stay immutable history; the next Force-new assignment or review request rotates
+onto the replacement route. Only already-declared participants can be selected
+or rerouted.
+
+If a Developer or Reviewer declines, preserve the reason and choose the
+replacement assignment or route from current capacity before issuing a fresh
+assignment. Ask the Reviewer only when that choice changes review or
+conformance judgment.
 
 ### Re-enter after conformance
 
-A Reviewer `re-enter` decision names the in-Sprint findings, the tasks to add
-to the governing spec document with title and description, and the suggested
+A Reviewer `re-enter` decision names the in-Sprint findings, the governing
+tasks (existing ids when scope is unchanged; new title and description when
+scope is new), and the suggested
 unit grouping, waves, dependencies, routing, and capacity rationale. The
 Reviewer should identify independent lanes, expected review overlap, and useful
 reserve. Preserve that projection; do not silently absorb extra scope, maximize
 shell occupancy, or turn post-Sprint findings into delivery work.
 
-Cut every named task against the governing spec document:
+Reuse an existing task id when the decision repeats or repairs that exact
+governing scope. Cut a new task only for genuinely new scope:
 
 ```text
 sc mem task add "<task-title>" --feature <feature-id> \
@@ -4456,10 +4512,11 @@ sc sprint plan-unit --sprint <id> \
   [--output-kind code|report-only|no-code]
 ```
 
-After every named task is bound, confirm the requested routes are available and
-the dependency graph and capacity plan match the decision. If they do not, send
-the concrete conflict back to the Reviewer rather than silently re-routing.
-Then release the new ready lanes with `sc sprint dispatch --sprint <id>`. When
+After every named task is bound, confirm the routes are available and the
+dependency graph and capacity plan match the decision. Planner may reassign or
+reroute for operational capacity; send the concrete conflict back to the
+Reviewer when that adaptation changes the Reviewer''s scope or conformance
+judgment. Then release the new ready lanes with `sc sprint dispatch --sprint <id>`. When
 the added work reaches terminal disposition, the engine sends the Reviewer the
 next delivery-terminal wake; the Planner does not initiate the next conformance
 pass.
@@ -4721,7 +4778,7 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'sprint_rev',
-  'Review Sprints v2 work and whole-Sprint conformance — own pause, cancel, and conclude decisions, author the conformance and Sprint reports, and direct Planner actions through durable messages.',
+  'Review Sprints v2 work and whole-Sprint conformance — own review, re-enter, abort, and conclude judgments, author the conformance and Sprint reports, and direct safety actions through durable messages.',
   'workflow',
   NULL,
   0,
@@ -4730,8 +4787,9 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
 Use in one of two modes: a work-unit PR review during the loop, or the final
 whole-Sprint conformance pass. Pre-declaration QAQC is a third entry condition,
 before a Sprint exists. The evidence differs; independence does not. The
-Reviewer decides and documents; the Planner acts. The FnB retains the
-board-level override established by decision #46.
+Reviewer decides and documents review and conformance judgments; the Planner
+owns operational plan structure and acts on control transitions. The FnB
+retains the board-level override established by decision #46.
 
 Use the simplest path supported by current durable state. Treat independence,
 authority, lifecycle preconditions, durable writes, and typed handoffs as hard
@@ -4799,7 +4857,7 @@ sc sprint send --sprint <id> --to <shortname> --body-file <path> \
 
 Use `--intent blocker` instead when the unit cannot advance. Ask the Planner for
 durable state or action-feasibility facts without delegating Reviewer judgment.
-A cross-unit, closeout, pause, replan, re-enter, cancel, or abort ruling is a
+A cross-unit review, closeout, re-enter, abort, or safety ruling is a
 Sprint-level decision:
 
 ```text
@@ -4833,10 +4891,10 @@ successfully and confirms the durable write and wake.
 If a command is rejected or transport fails, the verdict or handoff is
 incomplete. Correct and retry when safe. If the relay itself fails, surface the
 attempted command, evidence, impact, and recommendation to FnB; do not invent an
-alternate protocol. A Reviewer decides whether the condition warrants
-continuing, re-planning, pausing, cancellation, or conclusion; the Planner
-executes the durable decision. Record a live FnB override as FnB authority, not
-Reviewer judgment.
+alternate protocol. A Reviewer decides whether review or conformance evidence
+warrants changes requested, re-entry, abort, or conclusion; the Planner
+independently decides ordinary operational replanning and executes control
+transitions. Record a live FnB override as FnB authority, not Reviewer judgment.
 
 ## Sprint artifact paths
 
@@ -4849,32 +4907,36 @@ DB rows stay the durable record: judgments via `record-review`, report bodies in
 `sprint_reports`, and decisions in the durable relay. Files in the Sprint
 artifact directory are working material only.
 
-## Control and conclude decisions
+## Conformance decisions and Planner controls
 
-The Reviewer owns all pause, cancel, and conclude decisions and recommendations.
-The Planner owns control actions; clean conformance approval atomically performs
-its own close. Base a decision on durable Sprint state,
+The Reviewer owns review, re-enter, abort, and conclude judgments. The Planner
+independently owns operational plan structure: pausing for safe edits, recalling
+unreleased work, modifying or repeating task lanes, reassigning work, changing
+participant routes, cancelling unreleased scope, and resuming after validation.
+A clean conformance approval atomically performs its own close. Base a Reviewer
+judgment on durable Sprint state,
 the exact bound revisions, current work/PR facts, progress-carrier evidence, and any
 ratified judgment; ambiguous silence is not enough to corrupt a disposition.
 
-Send pause, resume, replan, re-enter, cancel, and abort decisions through the
+Send re-enter, abort, or safety-critical control recommendations through the
 durable `send` surface above. A clean conclude instead runs the atomic
 `record-conformance` close below. Every Reviewer → Planner route is Re-enter.
 The Reviewer-authored body must name:
 
-- `decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, or `abort`;
+- `decision`: `re-enter`, `abort`, or the exact safety-critical recommendation;
 - the evidence and rationale owned by the Reviewer;
 - exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
 - any immediate safety impact that the FnB must see.
 
-The Planner marks the message handled, verifies the assigned Reviewer, and
-executes exactly that control transition. The clean completion receipt is
-informational because the Sprint is already terminal. The Reviewer never runs
-the standalone pause, replan, cancel, resume, complete, or abort action; its
-clean `record-conformance` command owns the narrow automatic close. If a control
-action is rejected, inspect the returned durable state and issue
-a new decision only when the evidence supports one; never ask the Planner to
-improvise around a precondition.
+The Planner marks the message handled, verifies the assigned Reviewer, and acts
+on the judgment without surrendering its separate authority over the concrete
+plan. The clean completion receipt is informational because the Sprint is
+already terminal. The Reviewer never runs the standalone pause, replan, recall,
+reroute, cancel, resume, complete, or abort action; its clean
+`record-conformance` command owns the narrow automatic close. If a requested
+action is rejected, inspect the returned durable state and issue a revised
+judgment only when the evidence supports one; never ask the Planner to improvise
+around a precondition.
 
 The FnB board-level override from decision #46 is unaffected. A live FnB
 instruction can direct or supersede any decision; preserve it as a distinct

--- a/.super-coder/migrations/0199_sprint_live_replanning.sql
+++ b/.super-coder/migrations/0199_sprint_live_replanning.sql
@@ -1,0 +1,33 @@
+-- 0199 — permit deliberate governing-task reuse across Sprint work units.
+--
+-- A task remains unique inside one work unit through the composite primary
+-- key.  Removing the global UNIQUE(task_id) constraint lets a later
+-- conformance/recovery lane repeat the same governing task without inventing
+-- duplicate product scope.
+
+-- migrate: foreign-keys-off
+PRAGMA foreign_keys=OFF;
+
+BEGIN;
+
+ALTER TABLE sprint_work_unit_tasks
+  RENAME TO _sprint_work_unit_tasks_one_lane;
+
+CREATE TABLE sprint_work_unit_tasks (
+    sprint_id    INTEGER NOT NULL REFERENCES sprints(sprint_id),
+    work_unit_id INTEGER NOT NULL,
+    task_id      INTEGER NOT NULL REFERENCES spec_tasks(task_id),
+    PRIMARY KEY (sprint_id, work_unit_id, task_id),
+    FOREIGN KEY (sprint_id, work_unit_id)
+      REFERENCES sprint_work_units(sprint_id, work_unit_id)
+);
+
+INSERT INTO sprint_work_unit_tasks (sprint_id,work_unit_id,task_id)
+SELECT sprint_id,work_unit_id,task_id
+FROM _sprint_work_unit_tasks_one_lane;
+
+DROP TABLE _sprint_work_unit_tasks_one_lane;
+
+COMMIT;
+
+PRAGMA foreign_keys=ON;

--- a/.super-coder/migrations/0200_reseed_sprint_live_replanning.sql
+++ b/.super-coder/migrations/0200_reseed_sprint_live_replanning.sql
@@ -1,0 +1,856 @@
+-- 0200 — reseed Planner and Reviewer guidance for live Sprint restructuring.
+-- Existing installs receive task reuse, recall/reassignment, route-change, and authority procedure.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
+
+Use as the originating Planner after `sprint_prep` arms the Sprint. The system
+captures deterministic facts; the Reviewer decides and documents, and the
+Planner acts. Execute Reviewer decisions without taking over their judgment or
+report authorship. The FnB retains the board-level override established by
+decision #46.
+
+Use the simplest path supported by current durable state. Treat authority,
+lifecycle preconditions, durable writes, and typed handoffs as hard boundaries;
+use judgment for investigation and execution within them. Repeat a read only
+when later activity could have changed it or the next command requires live
+revalidation.
+
+## Route the entry
+
+Classify the entry before reading an inbox:
+
+- For a Sprint-scoped control decision, merged-work handoff, question, blocker,
+  or other relay message, inspect the Sprint inbox once and handle that message.
+- For the self-contained engine-wide clean-completion receipt, inspect the
+  receipt and terminal Sprint state directly. It is informational: do not run
+  the Sprint inbox, accept it, or issue a close command.
+- For a live FnB instruction, act under the board-level override and name that
+  authority in the durable evidence.
+
+Load `sprint_pln` on every entry. Do not turn entry routing into a polling loop.
+
+## Start from durable state
+
+The armed runtime owns scheduled dispatch and unread wake recovery. The
+registered-PR watcher owns subscription observation. React to their durable
+facts; use the Planner turn for dispatch, plan structure, and exact execution of
+durable Reviewer decisions. The Reviewer owns review and conformance judgment
+plus the conformance and final Sprint reports. The Planner owns the plan and its
+control transitions: it may modify, repeat, recall, reassign, or reroute work on
+its own operational judgment, and it executes Reviewer decisions that cross
+those same boundaries. Clean conformance approval performs its own atomic
+terminal transition.
+
+Assignments and review requests use Force-new delivery. Planner-bound results
+use Re-enter. Neither displaces a live turn; delivery waits for its natural
+boundary, and the runtime owns bundling, rotation, recovery, and coordinate
+mode. Stop after a successful typed handoff so delivery can proceed cleanly.
+
+Start with the durable trigger, then read only the lifecycle, work-unit,
+dependency, route, PR, expectation, or anomaly facts needed for the current
+decision. Viewing a participant conversation is observation, not activity;
+never manufacture progress from browser presence.
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Release every dependency-ready lane through the production surface:
+
+```text
+sc sprint dispatch --sprint <id>
+```
+
+The returned ids are wake identities. Work-unit disposition and messages are
+the authoritative release facts. Dispatch is safe to repeat: occupied Developer
+lanes and stable assignment generations prevent double booking.
+
+Accept or decline only when the inbox item is actionable. After acting on an
+informational question, answer, blocker, or evidence message, run `accept` for
+that message. For informational messages it only marks the message read; it does
+not change Sprint or work-unit state.
+
+## Running loop
+
+- Keep dependencies as the only hard sequence. When reality requires a re-plan,
+  restructure the current projection under Planner authority and record why.
+  Ask the Reviewer when the change depends on review or conformance judgment;
+  do not outsource ordinary assignment, capacity, or route judgment. Never
+  rewrite completed history.
+- Let Developers own their PRs through green, review, correction, and merge.
+  Let Reviewers own verdicts and Sprint decisions. Do not proxy routine
+  handoffs or substitute Planner judgment for a Reviewer decision.
+- Consume passive system facts without waking yourself into every transition.
+  Route a decision boundary to the Reviewer; act when its Re-enter decision
+  message arrives.
+- Record the Reviewer decision identity, the exact action taken, and the action
+  receipt. Do not rewrite its rationale as Planner-authored judgment evidence.
+- A mid-Sprint spec edit is allowed only by the owning Planner or FnB. Record
+  the prior and new exact revision hashes. When acting as Planner, require a
+  durable Reviewer decision before the edit. The running Sprint remains bound
+  to its approved revision unless that decision explicitly says otherwise.
+
+Use Sprint-native wakes for coordination. Do not start a recurring shell loop,
+scheduled job, manual participant boot, or external PR watcher to track Sprint
+state. When a watcher-dependent gate has stalled, use the bounded read once:
+
+```text
+sc sprint watcher-state --sprint <id>
+```
+
+It distinguishes a stale or never-started watcher from red, pending, or absent
+PR observation and includes the newest bounded poll failures. Do not repeat it
+as a polling loop; act on the evidence, then return control to native delivery.
+
+## Questions, answers, blockers, and failures
+
+Put one concrete question, answer, decision, blocker, or useful context item in
+a short body file. Declare the message intent and whether the required reply
+belongs to one work unit or the whole Sprint.
+
+A question or blocker about one lane requires a reply and names that unit:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` instead for a blocked lane. A cross-unit, closeout, or
+external-authority ruling is a Sprint-level decision:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Answer the stored sender through the original message. The server inherits its
+unit or Sprint scope; never add `--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Confirm the reply write, then mark the handled incoming message read with
+`accept`. For a blocker, include evidence, impact, and the exact action needed.
+Continue safe independent governance, but stop at a decision boundary when an
+answer is required. Unread recovery owns re-waking; do not send duplicate
+reminders.
+
+Choose one stable key for the intended recipient, exact body, intent, reply
+linkage, and scope. Reuse it only when retrying that same write; use a new key
+when any of those fields changes.
+Keep the body near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. A handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake.
+
+If a command is rejected or transport fails, the handoff is incomplete. Correct
+and retry when safe. If the relay itself fails, surface the attempted command
+and durable evidence to FnB; do not invent an alternate protocol. Relay a
+Developer integrity concern to the Reviewer with its evidence, impact, and
+recommendation. Send needed context before pausing because the Sprint relay is
+unavailable while paused.
+
+## Sprint artifact paths
+
+Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
+report drafts, and Dev scratch proof) go to the gitignored
+`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
+PR''d in the work repo; a review-notes commit is a finding.
+
+DB rows stay the durable record: judgments via `record-review`, report bodies in
+`sprint_reports`, and decisions in the durable relay. Files in the Sprint
+artifact directory are working material only.
+
+## Reviewer decisions and Planner actions
+
+Review, conformance, re-enter, and abort judgments remain Reviewer decisions.
+Planner independently owns operational plan structure, including pause-safe
+recall, cancellation of unreleased scope, reassignment, repeated task lanes,
+and participant route changes. When an action does arrive as a durable Reviewer
+→ Planner Re-enter decision, resolve every required-reply decision through its
+original message before acting. Complete this order without reordering:
+
+1. Re-run `sc sprint inbox --sprint <id>`, verify the decision came from the
+   assigned Reviewer, and retain its message id.
+2. Put a short acknowledgement of the exact requested transition in a body
+   file, then send the linked reply:
+
+```text
+sc sprint send --sprint <id> --to <reviewer-shortname> --body-file <path> \
+  --intent information --reply-to <decision-message-id> \
+  --key <stable-control-reply-key>
+```
+
+3. Require the reply command to confirm its durable message and wake. Retry the
+   same command and key if it fails or does not confirm both.
+4. Mark the original decision accepted and require a successful receipt:
+
+```text
+sc sprint accept --sprint <id> --message <decision-message-id>
+```
+
+5. Only after acceptance confirms, execute the requested transition without
+   re-adjudicating the decision. The linked reply must precede any pause or
+   abort that makes the Sprint relay unavailable.
+
+Record the decision message id, reply receipt, acceptance receipt, and action
+receipt together. Clean conformance instead closes atomically and sends an
+informational engine-wide completion receipt; it requires no linked reply or
+Sprint inbox acceptance.
+
+The FnB board-level override from decision #46 is unaffected: a live FnB
+instruction may direct or supersede any action. Name that override in the
+evidence instead of attributing it to the Reviewer.
+
+If a requested action fails a lifecycle, authority, or disposition precondition,
+do not substitute a different action. Send the refusal and current durable state
+back to the Reviewer (or surface it directly to FnB for an FnB override), then
+stop at that decision boundary.
+
+### Pause or resume
+
+Pause on a Reviewer decision or when Planner needs a safe restructuring window.
+Transition durably, stop external Sprint services, persist interrupt intent,
+preserve every partial artifact, and retain the governing judgment and evidence
+for recovery:
+
+```text
+sc sprint pause --sprint <id> --reason <decision-or-restructure-reason>
+```
+
+Resume after the requested recovery/restructure is fully recorded, or on a
+later Reviewer decision or FnB override. Reconcile native runs, unread messages,
+pending wakes, work units, registered PRs, capacity, and spec drift, then act
+with the supplied reason:
+
+```text
+sc sprint resume --sprint <id> [--reason <validated-reconciliation-reason>]
+```
+
+An exhausted recovery wake is bounded manual-recovery evidence, not a retry
+loop. Preserve the unread message and failed wake, involve FnB, and do not create
+recursive fallbacks. Drift informs; it never silently blocks resume.
+
+PR ownership inherited from an aborted Sprint is an originating-Planner repair
+boundary. Keep the replacement Sprint paused and establish the exact old and
+new ownership. The originating Planner may reconcile that identity; the FnB
+retains the same operation as a board-level override:
+
+```text
+sc sprint reconcile-pr --sprint <replacement-id> --repository <owner/repo> \
+  --pr <number> --work-unit <replacement-unit-id> --reason <recovery-reason>
+```
+
+The command refuses a live source Sprint or target Sprint, a non-originating
+Planner, a non-code or already owned target unit, and a closed unmerged PR. It
+records the old and new owners plus the live GitHub head and acting authority.
+If the PR is already merged, it also records the merge commit and completes the
+replacement unit as explicit recovery evidence. Treat the receipt as recovery
+evidence; wait for a separate Reviewer decision before resuming.
+
+### Modify, recall, repeat, reassign, or reroute
+
+Planner may cancel one unreleased work unit with its retained terminal reason.
+When cancellation executes a Reviewer decision, preserve that decision id in
+the reason and evidence:
+
+```text
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <cancellation-reason>
+```
+
+Edit any subset of an unreleased lane directly. Omitted fields retain their
+current values; `--clear-dependencies` is the explicit empty dependency set:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  [--developer-shell <id>] [--reviewer-shell <id>] [--title <title>] \
+  [--expected-output-file <path>] [--task <task-id>] [--wave <n>] \
+  [--depends-on <work-unit-id> | --clear-dependencies] \
+  [--output-kind code|report-only|no-code]
+```
+
+Do not edit a released lane in place. To change an accepted or pending
+assignment, first pause so dispatch cannot race the edit, recall the unmerged
+lane, replan it, then resume:
+
+```text
+sc sprint pause --sprint <id> --reason <restructure-reason>
+sc sprint recall-unit --sprint <id> --work-unit <id> \
+  --reason <why-the-old-assignment-is-obsolete>
+sc sprint replan-unit --sprint <id> --work-unit <id> <changed-fields>
+sc sprint resume --sprint <id> --reason <validated-replan-reason>
+```
+
+Recall preserves the old accepted/declined message and event history, returns
+only an unmerged lane to `planned`, and refuses completed, cancelled, or
+PR-bound work. For a PR-bound lane, leave it intact and plan a replacement or
+use the supported PR-ownership recovery path; never force the projection back.
+Resume dispatches a fresh assignment generation.
+
+The same governing spec task may deliberately appear in more than one work
+unit. Use this for conformance reruns, repeat verification, or replacement work
+whose scope is still governed by the original task. Do not create a duplicate
+spec task merely to satisfy lane membership. Each work unit still lists a task
+at most once.
+
+To change which model will receive future assignments or reviews, pause first
+when the Sprint is armed, clear the participant''s released expectation through
+recall or completion, then replace its exact route:
+
+```text
+sc sprint reroute-participant --sprint <id> --participant-shell <id> \
+  --harness <harness> [--model <model>] [--effort <effort>] \
+  [--route <display-route>]
+```
+
+Prepared Sprints may reroute before arm. Armed Sprints must pause; Developer
+routes reject any released lane and Reviewer routes reject an in-review lane.
+The engine validates the new route before writing it. Existing chats and runs
+stay immutable history; the next Force-new assignment or review request rotates
+onto the replacement route. Only already-declared participants can be selected
+or rerouted.
+
+If a Developer or Reviewer declines, preserve the reason and choose the
+replacement assignment or route from current capacity before issuing a fresh
+assignment. Ask the Reviewer only when that choice changes review or
+conformance judgment.
+
+### Re-enter after conformance
+
+A Reviewer `re-enter` decision names the in-Sprint findings, the governing
+tasks (existing ids when scope is unchanged; new title and description when
+scope is new), and the suggested
+unit grouping, waves, dependencies, routing, and capacity rationale. The
+Reviewer should identify independent lanes, expected review overlap, and useful
+reserve. Preserve that projection; do not silently absorb extra scope, maximize
+shell occupancy, or turn post-Sprint findings into delivery work.
+
+Reuse an existing task id when the decision repeats or repairs that exact
+governing scope. Cut a new task only for genuinely new scope:
+
+```text
+sc mem task add "<task-title>" --feature <feature-id> \
+  --doc <governing-spec-document-id> --seq <next-seq> \
+  --desc "<task-description>"
+```
+
+Create the requested bound work units from those task ids, wiring the Reviewer''s
+waves and dependencies directly:
+
+```text
+sc sprint plan-unit --sprint <id> \
+  --developer-shell <id> --reviewer-shell <id> --title <title> \
+  --expected-output-file <path> --task <task-id> \
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>] \
+  [--output-kind code|report-only|no-code]
+```
+
+After every named task is bound, confirm the routes are available and the
+dependency graph and capacity plan match the decision. Planner may reassign or
+reroute for operational capacity; send the concrete conflict back to the
+Reviewer when that adaptation changes the Reviewer''s scope or conformance
+judgment. Then release the new ready lanes with `sc sprint dispatch --sprint <id>`. When
+the added work reaches terminal disposition, the engine sends the Reviewer the
+next delivery-terminal wake; the Planner does not initiate the next conformance
+pass.
+
+### Conclude or abort
+
+The Reviewer decides when the Sprint is done. A clean `record-conformance`
+command atomically stores conformance, follow-ups, the Reviewer-authored final
+report, completed lifecycle, and an informational engine-wide Planner receipt.
+When that Re-enter arrives, confirm the receipt names the expected Sprint,
+reports, outcome, and completed state. Do not run `complete`; closure is already
+durable and the notification is informational because closure is already
+terminal.
+Successful completion also closes every other active participant chat
+immutably linked to that Sprint. The originating Planner and report-authoring
+Reviewer remain open. Do not manually close peer chats as a second closeout
+action. Pause, abort, re-entry, failed conformance, and rejected fallback
+completion retain their existing no-cleanup behavior.
+
+Do not run `compile-report` by default, synthesize the final report, or
+editorialize the Reviewer body. The Reviewer compiles its own evidence. A
+Planner compile remains a valid FnB-directed fallback:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Do not wait for or request a conclude action message after the completion receipt.
+Abort is likewise an action taken only on a Reviewer decision or FnB override;
+it is terminal and deletes nothing.
+
+## Handoffs and stop
+
+Planner → Developer assignments and Developer → Reviewer review requests use
+Force-new delivery; Developer/Reviewer → Planner results are Re-enter. Forced
+delivery waits for the prior live turn''s natural boundary; runtime delivery
+owns the rest. These are delivery guarantees, not a parent/child chat topology.
+The Planner receives no PR-event wakes; Developer-owned subscriptions carry
+red, green, and externally closed facts directly to the owning Developer.
+
+Never dispatch the next wave from a merge-observation turn. The Developer''s
+merged-work handoff wake is the only normal next-wave dispatch trigger. On that
+wake, complete the turn in this exact order:
+
+1. Run `sc sprint inbox --sprint <id>` and inspect the durable merged-work
+   handoff plus current work-unit and dependency state.
+2. Act on every earlier informational item and mark each handled item read with
+   `accept`, including the Developer handoff.
+3. Finish all reconciliation, judgment recording, and other Planner
+   bookkeeping. No work remains after this step.
+4. As the literal final action of the turn, release dependency-ready lanes:
+
+```text
+sc sprint dispatch --sprint <id>
+```
+
+5. When the command confirms the durable assignment writes and New wakes, stop
+   immediately. Run no trailing command. Empty dispatch is still the final
+   action for that handoff turn; investigate only on a later durable wake.
+
+On a clean completion receipt, verify the named Sprint is terminal and record
+the bounded receipt; run no close command. The Planner does not author a second
+report, accept an actionable handoff, or wait for another actor to finish the
+Sprint.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_rev',
+  'Review Sprints v2 work and whole-Sprint conformance — own review, re-enter, abort, and conclude judgments, author the conformance and Sprint reports, and direct safety actions through durable messages.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_rev — independent review and conformance
+
+Use in one of two modes: a work-unit PR review during the loop, or the final
+whole-Sprint conformance pass. Pre-declaration QAQC is a third entry condition,
+before a Sprint exists. The evidence differs; independence does not. The
+Reviewer decides and documents review and conformance judgments; the Planner
+owns operational plan structure and acts on control transitions. The FnB
+retains the board-level override established by decision #46.
+
+Use the simplest path supported by current durable state. Treat independence,
+authority, lifecycle preconditions, durable writes, and typed handoffs as hard
+boundaries; use judgment for investigation and review within them. Repeat a
+read only when later activity could have changed it or the next command
+requires live revalidation.
+
+## Route the entry
+
+Classify the entry before reading an inbox:
+
+- Pre-declaration QAQC begins from an explicit Planner or FnB request through
+  the ordinary shell-to-shell channel. Read and sign the exact current spec
+  body directly; there is no Sprint id or Sprint inbox to inspect yet.
+- A work-unit review request or delivery-terminal notification is Sprint-scoped.
+  Inspect the Sprint inbox once and accept the actionable request before work.
+- For a live FnB instruction, preserve its board-level authority distinctly and
+  inspect only the durable state needed for an independent decision.
+
+Record pre-declaration QAQC through the authenticated surface:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
+
+Once a Sprint is armed, review and conformance entries arrive through durable
+wakes. Load `sprint_rev` on every entry, then use the Sprint inbox for the
+Sprint-scoped cases above:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+```
+
+Decline an actionable request you cannot take, with a concrete reason:
+
+```text
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Use `accept` or `decline` for actionable work. After acting on an informational
+question, answer, blocker, or context message, run `accept` for that message.
+For informational messages it only marks the message read; it does not change
+Sprint or work-unit state.
+
+Review requests use Force-new delivery. Reviewer verdicts to Developers and
+decisions to Planners use Re-enter. Neither displaces a live turn; delivery
+waits for its natural boundary, and the runtime owns bundling, rotation, and
+recovery. Stop after a successful typed handoff. Reviewers never receive
+PR-event subscription wakes.
+
+## Questions, answers, blockers, and failures
+
+Put one concrete question, answer, blocker, or useful context item in a short
+body file. Declare the message intent and whether the required reply belongs to
+one work unit or the whole Sprint. Ask the Developer for missing PR evidence
+with a unit-scoped question:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` instead when the unit cannot advance. Ask the Planner for
+durable state or action-feasibility facts without delegating Reviewer judgment.
+A cross-unit review, closeout, re-enter, abort, or safety ruling is a
+Sprint-level decision:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Answer the stored sender through the original message. The server inherits its
+unit or Sprint scope; never add `--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Confirm the reply write, then mark the handled incoming message read with
+`accept`. A blocker or integrity concern is evidence for your decision. If
+action is needed, send the Planner the decision, impact, exact action, and
+recommendation. Continue safe independent review, but stop at the decision
+boundary when missing facts prevent an honest decision. Unread recovery owns
+re-waking; do not send duplicate reminders.
+
+Choose one stable key for the intended recipient, exact body, intent, reply
+linkage, and scope. Reuse it only when retrying that same write; use a new key
+when any of those fields changes.
+
+Keep the body near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. A handoff is complete only when the Sprint command exits
+successfully and confirms the durable write and wake.
+
+If a command is rejected or transport fails, the verdict or handoff is
+incomplete. Correct and retry when safe. If the relay itself fails, surface the
+attempted command, evidence, impact, and recommendation to FnB; do not invent an
+alternate protocol. A Reviewer decides whether review or conformance evidence
+warrants changes requested, re-entry, abort, or conclusion; the Planner
+independently decides ordinary operational replanning and executes control
+transitions. Record a live FnB override as FnB authority, not Reviewer judgment.
+
+## Sprint artifact paths
+
+Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
+report drafts, and Dev scratch proof) go to the gitignored
+`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
+PR''d in the work repo; a review-notes commit is a finding.
+
+DB rows stay the durable record: judgments via `record-review`, report bodies in
+`sprint_reports`, and decisions in the durable relay. Files in the Sprint
+artifact directory are working material only.
+
+## Conformance decisions and Planner controls
+
+The Reviewer owns review, re-enter, abort, and conclude judgments. The Planner
+independently owns operational plan structure: pausing for safe edits, recalling
+unreleased work, modifying or repeating task lanes, reassigning work, changing
+participant routes, cancelling unreleased scope, and resuming after validation.
+A clean conformance approval atomically performs its own close. Base a Reviewer
+judgment on durable Sprint state,
+the exact bound revisions, current work/PR facts, progress-carrier evidence, and any
+ratified judgment; ambiguous silence is not enough to corrupt a disposition.
+
+Send re-enter, abort, or safety-critical control recommendations through the
+durable `send` surface above. A clean conclude instead runs the atomic
+`record-conformance` close below. Every Reviewer → Planner route is Re-enter.
+The Reviewer-authored body must name:
+
+- `decision`: `re-enter`, `abort`, or the exact safety-critical recommendation;
+- the evidence and rationale owned by the Reviewer;
+- exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
+- any immediate safety impact that the FnB must see.
+
+The Planner marks the message handled, verifies the assigned Reviewer, and acts
+on the judgment without surrendering its separate authority over the concrete
+plan. The clean completion receipt is informational because the Sprint is
+already terminal. The Reviewer never runs the standalone pause, replan, recall,
+reroute, cancel, resume, complete, or abort action; its clean
+`record-conformance` command owns the narrow automatic close. If a requested
+action is rejected, inspect the returned durable state and issue a revised
+judgment only when the evidence supports one; never ask the Planner to improvise
+around a precondition.
+
+The FnB board-level override from decision #46 is unaffected. A live FnB
+instruction can direct or supersede any decision; preserve it as a distinct
+authority record.
+
+## Severity rubric
+
+This skill owns severity. The governing spec intentionally does not.
+
+- **Critical** — active security/authority violation, destructive corruption,
+  or a condition that makes continued operation unsafe.
+- **Major** — wrong behavior, data loss, broken invariant, material spec
+  violation, or a loop/recovery path that can silently wedge delivery.
+- **Medium** — a concrete correctness or recovery gap likely to bite normal
+  use soon, including missing negative enforcement or an unreliable handoff.
+- **Low** — bounded cleanup, clarity, test depth, or resilience improvement that
+  does not make the delivered behavior wrong now.
+
+During a work-unit review, Critical/Major/Medium block approval; Low is a
+report note. During close-out conformance, severity does not decide timing: the
+Reviewer judges whether each finding requires in-Sprint patching or is an
+acceptable post-Sprint follow-up.
+
+## Work-unit review
+
+Accept the actionable review request and retain that exact message id as the
+identity of this review round. Its readiness body must be only the bare
+locator: submitting or resubmitting intent, PR URL, registered Sprint PR id,
+exact head SHA, and work-unit id. Treat scope narrative, verification evidence,
+judgment rationale, or review-focus steering in that body as a protocol defect;
+do not use it to frame the review. Neither party writes PR comments or
+annotations, and the PR body contains only the work-unit id and spec reference.
+
+Bind every inspection and the eventual verdict to the accepted request''s
+message id, registered PR, work unit, and exact head. Another request in the
+same delivery, another unit assigned to this Reviewer, or role activity in a
+different conversation does not belong to this round. Accept and review each
+request explicitly; never infer a review lane from Reviewer identity alone.
+
+Review the exact bound spec revision and the full diff at the request''s exact
+head, then inspect checks, tests, relevant runtime evidence, and ratified
+judgments. Each round is clean: no prior Developer evidence or prose is input,
+and prior findings are cleared only when the code at the new head proves they
+are cleared. Review code quality, edge cases/failure paths, and spec
+conformance. Trace the real path; do not trust names or PR prose.
+
+### Red-check doctrine
+
+Accepted-red is not a legal review outcome. A departure that leaves checks
+failing is never acceptable: do not note the failure and approve anyway. The
+review handoff remains green-only, without exception or waiver.
+
+`Note it and pass anyway` is the acceptance-shaped anti-pattern. In the
+dos-arch incident, a Reviewer accepted known-failing tests as a scoped
+departure and created a deadlock: the green-only handoff gate could never pass.
+Decision #93 records why this no-waiver rule exists.
+
+When failing checks are within the lane''s ratified scope, record
+`changes_requested` so the Developer fixes them and re-establishes green. When
+the failures are outside that scope, name the blocking failures in the finding
+and send the Planner a `replan` decision through the control protocol. The
+Planner must either widen the lane explicitly or cut a follow-up work unit; the
+current lane remains unapproved until the resulting work is green.
+
+Read resolved closure evidence through the authenticated memory surface; no SQL
+or mutation is needed. Use the exact form for a cited flag and the scoped form
+to audit every resolved flag attached to the feature:
+
+```text
+sc mem get flags <flag-id>
+sc mem get flags --feature <feature-id> --resolved
+```
+
+Findings must state:
+
+- severity and concise title;
+- violated behavior or invariant;
+- exact code/evidence location;
+- a reproducible consequence; and
+- the fix boundary, without prescribing unnecessary architecture.
+
+Complete a unit verdict in this exact order:
+
+1. Finish the review, findings, and verdict body; no inspection remains after
+   this step.
+2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+3. Run `wc -m < <path>`; keep the verdict near 6,000 characters and below the
+   8,000-character hard maximum.
+4. As the literal final action of the turn, record the typed verdict through
+   the authenticated surface:
+
+```text
+sc sprint record-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --verdict changes_requested --body-file <path> --key <stable-key>
+```
+
+5. When the command confirms the durable write and Developer wake, stop
+   immediately. Run no trailing command.
+
+Use `approved` only when no Critical/Major/Medium finding remains. The engine
+checks that the request was accepted and still binds to the reviewed head,
+records judgment evidence and sends a Re-enter wake to the Developer. Do not
+message around this surface;
+an unrecorded verdict cannot unlock merge.
+
+## Delivery-terminal closeout
+
+The `sprint.delivery_terminal` notification is the entry signal for
+whole-Sprint conformance. Retain that exact notification message id and its
+delivered wake as the closeout entry identity; another Reviewer turn or an old
+terminal notification does not carry this episode. On that wake, inspect the
+inbox, lifecycle, and current work-unit state first. If the lifecycle is already
+`completed` or `aborted`, mark the informational notification handled with
+`accept` and stop. If any non-terminal unit is visible, the wake is stale: mark
+it handled with `accept`, exit, and await the next episode''s delivery-terminal
+wake. Only an armed Sprint whose units are all terminal enters conformance.
+
+Compile the bounded evidence packet first and do so yourself, then judge
+integrated `main` against every governing bound revision, exact recorded
+mid-Sprint revision fact, and ratified judgment:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Increase the bound only when truncation counters show the default omitted
+needed evidence; 200 is the maximum. The packet supplies facts, not judgment.
+If every work unit was cancelled and nothing shipped, the honest decision is
+`abort`, not `conclude`.
+
+After classifying the requirements, choose exactly one branch:
+
+- **In-Sprint patching required.** Do not run `record-conformance`. Send the
+  Planner a durable `re-enter` decision naming every blocking finding; each
+  spec task to cut against the governing spec document, with title and
+  description; and the suggested unit grouping, waves, dependencies,
+  Developer/Reviewer routing, and capacity rationale. Identify independent
+  lanes, expected review overlap, useful reserve, and why additional capacity
+  would or would not shorten the critical path. The durable decision is the
+  failed-pass record.
+  After three re-entry episodes in one Sprint, escalate the non-convergence to
+  FnB instead of starting another patch round.
+- **Clean or post-Sprint-only findings.** Prepare the conformance report,
+  findings, final Sprint report, reason, and outcome. Submit them through the
+  atomic `record-conformance` protocol below: the engine commits the evidence,
+  completed lifecycle, informational Planner receipt, and wake together. Do not
+  send a separate conclude message.
+
+## Whole-Sprint conformance
+
+Review the integrated system, not unit diffs. Classify each requirement as:
+
+- `as-specced`;
+- `deviated-intentionally` with its ratified judgment;
+- `deviated-silently`; or
+- `unimplemented`.
+
+The last two are findings. Include spec document id and work-unit id when known.
+For the clean or post-Sprint-only branch, write the conformance report and a
+JSON findings array:
+
+```json
+[
+  {
+    "severity": "Major",
+    "title": "Integrated seam diverges",
+    "body": "Evidence and consequence.",
+    "spec_document_id": 46,
+    "work_unit_id": 9
+  }
+]
+```
+
+Keep the conformance report and each finding body at about 6,000 characters or
+fewer; 8,000 is the hard maximum for each. Run `wc -m < <report>` and length-check
+each finding body before submission.
+
+Before recording conformance, author the final Sprint report. Name the Reviewer
+as its author and answer:
+
+1. Which exact scope and revisions governed?
+2. What shipped, through which work units and PRs?
+3. Which Reviewer judgments and ratified deviations shaped the result?
+4. What failed, retried, paused, recovered, or remained anomalous?
+5. What did conformance conclude?
+6. Which follow-ups or unresolved items require FnB disposition?
+7. Where is the complete evidence?
+
+Keep the final report at about 6,000 characters or fewer and below the 8,000
+hard maximum; run `wc -m < <report>`. Do not smooth discrepancies into a
+success narrative. Keep the final report below 8,000 characters, then choose
+the exact completion reason, terminal outcome, and stable completion key. The
+engine stores the final report unchanged and generates the Planner receipt from
+the committed report and follow-up identities.
+
+Record the clean branch as one atomic final write:
+
+```text
+sc sprint record-conformance \
+  --sprint <id> --body-file <report> --findings-file <json> \
+  --final-report-file <final-report> --reason <reason> --outcome <outcome> \
+  --key <stable-pass-key>
+```
+
+The receipt must name the conformance report id, final report id, follow-up ids,
+completed state, Planner message id, and Planner wake id. This creates
+append-only evidence, pending follow-ups, terminal lifecycle, and one
+informational engine-wide Planner Re-enter in the same transaction. Never
+record conformance first and then close around it; send no conclude message.
+On that successful commit, the engine also closes every other active chat
+immutably linked to the Sprint. The originating Planner and this
+report-authoring Reviewer remain open. Do not manually close peer chats as an
+extra closeout step. Pause, abort, re-entry, failed conformance, and rejected
+fallback completion keep their existing no-cleanup behavior.
+Never reopen an editing
+lane after recording; the re-enter branch defers the report until added scope
+reaches terminal disposition and a fresh delivery-terminal wake starts the next
+episode. Surface any immediate safety risk to FnB.
+
+## Stop
+
+For unit review, follow the ordered verdict procedure above: inbox handling and
+all evidence work precede `record-review`; the durable verdict is the literal
+last action, then the Reviewer stops.
+
+For the clean or post-Sprint-only branch, require both reports, findings,
+reason, and outcome to replay idempotently. For the re-enter or abort branch,
+confirm that the decision body carries the complete evidence and exact
+requested action. Then complete this final handoff order:
+
+1. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
+   mark every handled informational message read with `accept`.
+2. Confirm every Reviewer-authored artifact and decision body is final and
+   below its 8,000-character hard maximum.
+3. For a clean conclude, run the atomic `record-conformance` command above as
+   the literal final action. When it confirms completed state and all receipt
+   identities, stop immediately; the Planner is already notified.
+4. For re-enter or abort, deliver the decision to the Planner as the literal
+   final action:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level \
+  --key <stable-decision-handoff-key>
+```
+
+5. When the command confirms the durable write and Planner wake, stop
+   immediately. Run no trailing command until another native wake arrives.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -99,12 +99,18 @@ _EVENT_FIELDS = {
         }
     ),
     "work_unit.replanned": frozenset({"work_unit_id", "before", "after"}),
+    "work_unit.recalled": frozenset(
+        {"work_unit_id", "before", "after", "assignment_message_ids", "reason"}
+    ),
     "work_unit.ready": frozenset({"work_unit_id", "message_id", "wake_id"}),
     "work_unit.accepted": frozenset({"work_unit_id", "message_id"}),
     "work_unit.completed": frozenset(
         {"work_unit_id", "result", "output_kind", "source", "transition_key"}
     ),
     "work_unit.cancelled": frozenset({"work_unit_id", "reason"}),
+    "participant.route_changed": frozenset(
+        {"participant_id", "shell_id", "role", "before", "after"}
+    ),
     "review.requested": frozenset(
         {
             "work_unit_id",

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -98,19 +98,61 @@ def cmd_plan_unit(args: argparse.Namespace) -> int:
 
 
 def cmd_replan_unit(args: argparse.Namespace) -> int:
+    payload = {
+        "sprint_id": args.sprint,
+        "work_unit_id": args.work_unit,
+    }
+    optional = {
+        "assigned_shell_id": args.developer_shell,
+        "reviewer_shell_id": args.reviewer_shell,
+        "title": args.title,
+        "expected_output": (
+            _text(args.expected_output_file, "expected output")
+            if args.expected_output_file
+            else None
+        ),
+        "task_ids": _integer_list(args.task) if args.task is not None else None,
+        "planned_wave": args.wave,
+        "output_kind": (
+            args.output_kind.replace("-", "_") if args.output_kind else None
+        ),
+    }
+    payload.update({key: value for key, value in optional.items() if value is not None})
+    if args.clear_dependencies:
+        payload["dependency_ids"] = []
+    elif args.depends_on is not None:
+        payload["dependency_ids"] = _integer_list(args.depends_on)
+    result = _post("/_sc/sprint/replan-unit", payload, idempotent=True)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_recall_unit(args: argparse.Namespace) -> int:
     result = _post(
-        "/_sc/sprint/replan-unit",
+        "/_sc/sprint/recall-unit",
         {
             "sprint_id": args.sprint,
             "work_unit_id": args.work_unit,
-            "assigned_shell_id": args.developer_shell,
-            "reviewer_shell_id": args.reviewer_shell,
-            "planned_wave": args.wave,
-            "dependency_ids": _integer_list(args.depends_on),
-            "output_kind": (
-                args.output_kind.replace("-", "_") if args.output_kind else None
-            ),
+            "reason": args.reason,
         },
+        idempotent=True,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_reroute_participant(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/reroute-participant",
+        {
+            "sprint_id": args.sprint,
+            "participant_shell_id": args.participant_shell,
+            "harness": args.harness,
+            "model": args.model,
+            "effort": args.effort,
+            "route": args.route,
+        },
+        idempotent=True,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
@@ -453,18 +495,44 @@ def build_parser() -> argparse.ArgumentParser:
     plan.set_defaults(fn=cmd_plan_unit)
 
     replan = sub.add_parser(
-        "replan-unit", help="Planner revises one still-planned editing lane"
+        "replan-unit", help="Planner revises any fields on one planned lane"
     )
     replan.add_argument("--sprint", type=int, required=True)
     replan.add_argument("--work-unit", type=int, required=True)
-    replan.add_argument("--developer-shell", type=int, required=True)
-    replan.add_argument("--reviewer-shell", type=int, required=True)
-    replan.add_argument("--wave", type=int, default=0)
-    replan.add_argument("--depends-on", type=int, action="append")
+    replan.add_argument("--developer-shell", type=int)
+    replan.add_argument("--reviewer-shell", type=int)
+    replan.add_argument("--title")
+    replan.add_argument("--expected-output-file")
+    replan.add_argument("--task", type=int, action="append")
+    replan.add_argument("--wave", type=int)
+    dependencies = replan.add_mutually_exclusive_group()
+    dependencies.add_argument("--depends-on", type=int, action="append")
+    dependencies.add_argument("--clear-dependencies", action="store_true")
     replan.add_argument(
         "--output-kind", choices=("code", "report-only", "no-code")
     )
     replan.set_defaults(fn=cmd_replan_unit)
+
+    recall = sub.add_parser(
+        "recall-unit",
+        help="Planner returns one paused unmerged lane to the editable plan",
+    )
+    recall.add_argument("--sprint", type=int, required=True)
+    recall.add_argument("--work-unit", type=int, required=True)
+    recall.add_argument("--reason", required=True)
+    recall.set_defaults(fn=cmd_recall_unit)
+
+    reroute = sub.add_parser(
+        "reroute-participant",
+        help="Planner changes a Developer or Reviewer route for future wakes",
+    )
+    reroute.add_argument("--sprint", type=int, required=True)
+    reroute.add_argument("--participant-shell", type=int, required=True)
+    reroute.add_argument("--harness", required=True)
+    reroute.add_argument("--model")
+    reroute.add_argument("--effort")
+    reroute.add_argument("--route")
+    reroute.set_defaults(fn=cmd_reroute_participant)
 
     arm = sub.add_parser("arm", help="Planner atomically arms an eligible plan")
     arm.add_argument("--sprint", type=int, required=True)

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -2648,6 +2648,186 @@ class SprintLifecycleStore:
         )
 
 
+class SprintParticipantStore:
+    """Planner-owned participant route selection for future Sprint wakes."""
+
+    def __init__(
+        self,
+        con: sqlite3.Connection,
+        *,
+        probe_harness: Callable[[str], ProbeResult] | None = None,
+    ) -> None:
+        self.con = con
+        self.con.row_factory = sqlite3.Row
+        self.probe_harness = probe_harness or (
+            lambda harness: adapter_for(harness).probe()
+        )
+
+    def reroute(
+        self,
+        sprint_id: int,
+        planner_shell_id: int,
+        *,
+        participant_shell_id: int,
+        harness: str,
+        model: str | None,
+        effort: str | None,
+        route: str | None = None,
+    ) -> bool:
+        """Validate and replace one idle Developer/Reviewer launch selection."""
+        harness = harness.strip()
+        if not harness:
+            raise ValueError("participant harness is required")
+        if model is not None:
+            model = model.strip()
+            if not model:
+                raise ValueError("participant model must be non-empty when supplied")
+        if effort is not None:
+            effort = effort.strip()
+            if not effort:
+                raise ValueError("participant effort must be non-empty when supplied")
+        if route is not None:
+            route = route.strip()
+            if not route:
+                raise ValueError("participant display route must be non-empty")
+
+        lifecycle, _ = SprintWorkUnitStore(self.con)._require_planner(
+            sprint_id, planner_shell_id
+        )
+        if lifecycle not in {"prepared", "paused"}:
+            raise SprintInvariantError(
+                "participant routes may change only while a Sprint is prepared or paused"
+            )
+        participant = self._participant(sprint_id, participant_shell_id)
+        if participant["role"] not in {"developer", "reviewer"}:
+            raise SprintInvariantError(
+                "only Developer or Reviewer participant routes may be changed"
+            )
+        try:
+            prepared = sprint_participant_chats.prepare_participant_route(
+                self.con,
+                sprint_id=sprint_id,
+                participant_id=int(participant["participant_id"]),
+                harness=harness,
+                model=model,
+                effort=effort,
+            )
+        except sprint_participant_chats.SprintConversationError as exc:
+            raise SprintPreflightError(str(exc)) from exc
+        try:
+            self.probe_harness(prepared.harness)
+        except AdapterError as exc:
+            raise SprintPreflightError(str(exc)) from exc
+
+        before = self._projection(participant)
+        after = {
+            "harness": prepared.harness,
+            "model": prepared.model,
+            "effort": prepared.effort,
+            "route": route if route is not None else participant["route"],
+        }
+        if before == after:
+            return False
+
+        with db_driver.write_transaction(self.con, "sprint.participant.reroute"):
+            lifecycle, _ = SprintWorkUnitStore(self.con)._require_planner(
+                sprint_id, planner_shell_id
+            )
+            if lifecycle not in {"prepared", "paused"}:
+                raise SprintInvariantError(
+                    "participant routes may change only while a Sprint is prepared or paused"
+                )
+            current = self._participant(sprint_id, participant_shell_id)
+            if self._projection(current) != before:
+                raise SprintInvariantError(
+                    "participant route changed during preflight; retry reroute"
+                )
+            self._require_idle_projection(current, lifecycle)
+            self.con.execute(
+                "UPDATE sprint_participants SET harness=?,model=?,effort=?,route=?,"
+                "updated_at=datetime('now') WHERE participant_id=?",
+                (
+                    after["harness"],
+                    after["model"],
+                    after["effort"],
+                    after["route"],
+                    current["participant_id"],
+                ),
+            )
+            self.con.execute(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+                "VALUES (?,'participant.route_changed','planner',?,?)",
+                (
+                    sprint_id,
+                    planner_shell_id,
+                    json.dumps(
+                        {
+                            "participant_id": int(current["participant_id"]),
+                            "shell_id": participant_shell_id,
+                            "role": str(current["role"]),
+                            "before": before,
+                            "after": after,
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+        return True
+
+    def _participant(self, sprint_id: int, shell_id: int) -> sqlite3.Row:
+        row = self.con.execute(
+            "SELECT participant_id,sprint_id,shell_id,role,harness,model,effort,route "
+            "FROM sprint_participants WHERE sprint_id=? AND shell_id=?",
+            (sprint_id, shell_id),
+        ).fetchone()
+        if row is None:
+            raise SprintInvariantError(
+                f"shell {shell_id} is not a participant in this Sprint"
+            )
+        return row
+
+    def _require_idle_projection(
+        self,
+        participant: sqlite3.Row,
+        lifecycle: str,
+    ) -> None:
+        if lifecycle == "prepared":
+            return
+        sprint_id = int(participant["sprint_id"])
+        shell_id = int(participant["shell_id"])
+        if participant["role"] == "developer":
+            active = self.con.execute(
+                "SELECT work_unit_id,disposition FROM sprint_work_units "
+                "WHERE sprint_id=? AND assigned_shell_id=? AND disposition IN "
+                "('ready','active','in_review','fixing','merge_ready') "
+                "ORDER BY work_unit_id LIMIT 1",
+                (sprint_id, shell_id),
+            ).fetchone()
+        else:
+            active = self.con.execute(
+                "SELECT work_unit_id,disposition FROM sprint_work_units "
+                "WHERE sprint_id=? AND reviewer_shell_id=? "
+                "AND disposition='in_review' ORDER BY work_unit_id LIMIT 1",
+                (sprint_id, shell_id),
+            ).fetchone()
+        if active is not None:
+            raise SprintInvariantError(
+                f"participant route still owns released work unit "
+                f"{int(active['work_unit_id'])} ({active['disposition']}); "
+                "recall or finish that expectation first"
+            )
+
+    @staticmethod
+    def _projection(participant: sqlite3.Row) -> dict:
+        return {
+            "harness": str(participant["harness"]),
+            "model": participant["model"],
+            "effort": participant["effort"],
+            "route": participant["route"],
+        }
+
+
 class SprintWorkUnitStore:
     """Planner-owned work-unit planning and dependency-aware dispatch."""
 
@@ -2736,38 +2916,79 @@ class SprintWorkUnitStore:
         work_unit_id: int,
         planner_shell_id: int,
         *,
-        assigned_shell_id: int,
-        reviewer_shell_id: int,
-        planned_wave: int,
-        dependency_ids: Iterable[int],
+        assigned_shell_id: int | None = None,
+        reviewer_shell_id: int | None = None,
+        title: str | None = None,
+        expected_output: str | None = None,
+        task_ids: Iterable[int] | None = None,
+        planned_wave: int | None = None,
+        dependency_ids: Iterable[int] | None = None,
         output_kind: str | None = None,
     ) -> bool:
         """Replace the editable plan projection and append its before/after fact."""
-        if planned_wave < 0:
+        if planned_wave is not None and planned_wave < 0:
             raise ValueError("planned wave must be non-negative")
-        dependencies = tuple(
-            dict.fromkeys(int(unit_id) for unit_id in dependency_ids)
-        )
         with db_driver.write_transaction(self.con, "sprint.work_unit.replan"):
             self._require_planner(sprint_id, planner_shell_id)
             unit = self._unit(sprint_id, work_unit_id)
             if unit["disposition"] != "planned":
                 raise SprintInvariantError(
-                    "only planned work units may be replanned; return assigned "
-                    "work to the ready pool first"
+                    "only planned work units may be replanned; pause and recall "
+                    "released work first"
                 )
+            before = self._plan_projection(unit)
+            assigned_shell_id = (
+                int(unit["assigned_shell_id"])
+                if assigned_shell_id is None
+                else assigned_shell_id
+            )
+            reviewer_shell_id = (
+                int(unit["reviewer_shell_id"])
+                if reviewer_shell_id is None
+                else reviewer_shell_id
+            )
+            title = str(unit["title"]) if title is None else title.strip()
+            expected_output = (
+                str(unit["expected_output"])
+                if expected_output is None
+                else expected_output.strip()
+            )
+            if not title or not expected_output:
+                raise ValueError("work unit title and expected output are required")
+            tasks = (
+                tuple(before["task_ids"])
+                if task_ids is None
+                else tuple(dict.fromkeys(int(task_id) for task_id in task_ids))
+            )
+            if task_ids is not None and not tasks:
+                raise SprintInvariantError("work units require at least one spec task")
+            dependencies = (
+                tuple(before["dependency_ids"])
+                if dependency_ids is None
+                else tuple(
+                    dict.fromkeys(int(unit_id) for unit_id in dependency_ids)
+                )
+            )
+            planned_wave = (
+                int(unit["planned_wave"])
+                if planned_wave is None
+                else planned_wave
+            )
             self._require_participant(sprint_id, assigned_shell_id, "developer")
             self._require_participant(sprint_id, reviewer_shell_id, "reviewer")
+            self._require_tasks(sprint_id, tasks)
             if output_kind is None:
                 output_kind = str(unit["output_kind"])
             if output_kind not in WORK_UNIT_OUTPUT_KINDS:
                 raise ValueError(
                     "work-unit output kind must be code, report_only, or no_code"
                 )
-            before = self._plan_projection(unit)
             after = {
                 "assigned_shell_id": assigned_shell_id,
                 "reviewer_shell_id": reviewer_shell_id,
+                "title": title,
+                "expected_output": expected_output,
+                "task_ids": sorted(tasks),
                 "planned_wave": planned_wave,
                 "output_kind": output_kind,
                 "dependency_ids": sorted(dependencies),
@@ -2776,17 +2997,31 @@ class SprintWorkUnitStore:
                 return False
             self.con.execute(
                 "UPDATE sprint_work_units SET assigned_shell_id=?,"
-                "reviewer_shell_id=?,planned_wave=?,output_kind=?,"
+                "reviewer_shell_id=?,title=?,expected_output=?,planned_wave=?,"
+                "output_kind=?,"
                 "updated_at=datetime('now') "
                 "WHERE work_unit_id=?",
                 (
                     assigned_shell_id,
                     reviewer_shell_id,
+                    title,
+                    expected_output,
                     planned_wave,
                     output_kind,
                     work_unit_id,
                 ),
             )
+            if before["task_ids"] != after["task_ids"]:
+                self.con.execute(
+                    "DELETE FROM sprint_work_unit_tasks "
+                    "WHERE sprint_id=? AND work_unit_id=?",
+                    (sprint_id, work_unit_id),
+                )
+                self.con.executemany(
+                    "INSERT INTO sprint_work_unit_tasks "
+                    "(sprint_id,work_unit_id,task_id) VALUES (?,?,?)",
+                    ((sprint_id, work_unit_id, task_id) for task_id in tasks),
+                )
             self._replace_dependencies(sprint_id, work_unit_id, dependencies)
             self._event(
                 sprint_id,
@@ -2796,6 +3031,75 @@ class SprintWorkUnitStore:
                     "work_unit_id": work_unit_id,
                     "before": before,
                     "after": after,
+                },
+            )
+        return True
+
+    def recall(
+        self,
+        sprint_id: int,
+        work_unit_id: int,
+        planner_shell_id: int,
+        *,
+        reason: str,
+    ) -> bool:
+        """Return one paused, unmerged lane to the editable plan projection."""
+        reason = reason.strip()
+        if not reason:
+            raise ValueError("work-unit recall reason is required")
+        if len(reason) > 8000:
+            raise ValueError(
+                f"work-unit recall reason is {len(reason)} characters; maximum is 8000"
+            )
+        with db_driver.write_transaction(self.con, "sprint.work_unit.recall"):
+            lifecycle, _ = self._require_planner(sprint_id, planner_shell_id)
+            if lifecycle != "paused":
+                raise SprintInvariantError(
+                    "work units may be recalled only while the Sprint is paused"
+                )
+            unit = self._unit(sprint_id, work_unit_id)
+            before = str(unit["disposition"])
+            if before == "planned":
+                return False
+            if before in {"completed", "cancelled"}:
+                raise SprintInvariantError("terminal work units cannot be recalled")
+            registered = self.con.execute(
+                "SELECT registered_pr_id FROM sprint_pr_work_units "
+                "WHERE sprint_id=? AND work_unit_id=? "
+                "ORDER BY registered_pr_id LIMIT 1",
+                (sprint_id, work_unit_id),
+            ).fetchone()
+            if registered is not None:
+                raise SprintInvariantError(
+                    f"work unit {work_unit_id} is bound to registered PR "
+                    f"{int(registered['registered_pr_id'])}; preserve that lane and "
+                    "plan a replacement instead"
+                )
+
+            from sprint_message_delivery import SprintMessageStore
+
+            message_ids = SprintMessageStore(
+                self.con
+            ).recall_work_assignment_in_transaction(
+                sprint_id,
+                work_unit_id,
+                reason,
+            )
+            self.con.execute(
+                "UPDATE sprint_work_units SET disposition='planned',"
+                "updated_at=datetime('now') WHERE work_unit_id=?",
+                (work_unit_id,),
+            )
+            self._event(
+                sprint_id,
+                "work_unit.recalled",
+                planner_shell_id,
+                {
+                    "work_unit_id": work_unit_id,
+                    "before": before,
+                    "after": "planned",
+                    "assignment_message_ids": list(message_ids),
+                    "reason": reason,
                 },
             )
         return True
@@ -3362,6 +3666,14 @@ class SprintWorkUnitStore:
         return row
 
     def _plan_projection(self, unit: sqlite3.Row) -> dict:
+        tasks = [
+            int(row[0])
+            for row in self.con.execute(
+                "SELECT task_id FROM sprint_work_unit_tasks "
+                "WHERE sprint_id=? AND work_unit_id=? ORDER BY task_id",
+                (unit["sprint_id"], unit["work_unit_id"]),
+            )
+        ]
         dependencies = [
             int(row[0])
             for row in self.con.execute(
@@ -3375,6 +3687,9 @@ class SprintWorkUnitStore:
         return {
             "assigned_shell_id": int(unit["assigned_shell_id"]),
             "reviewer_shell_id": int(unit["reviewer_shell_id"]),
+            "title": str(unit["title"]),
+            "expected_output": str(unit["expected_output"]),
+            "task_ids": tasks,
             "planned_wave": int(unit["planned_wave"]),
             "output_kind": str(unit["output_kind"]),
             "dependency_ids": dependencies,

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -835,6 +835,45 @@ class SprintMessageStore:
             raise KeyError(f"unknown wake message: {message_id}")
         self._cancel_resolved_wakes(message_id)
 
+    def recall_work_assignment_in_transaction(
+        self,
+        sprint_id: int,
+        work_unit_id: int,
+        reason: str,
+    ) -> tuple[int, ...]:
+        """Retire obsolete assignment pickup while preserving message history."""
+        if not self.con.in_transaction:
+            raise RuntimeError("assignment recall requires an active transaction")
+        rows = self.con.execute(
+            "SELECT message_id,disposition FROM wake_message "
+            "WHERE sprint_id=? AND work_unit_id=? "
+            "AND message_kind='work_assignment' "
+            "AND disposition IN ('pending','accepted') ORDER BY message_id",
+            (sprint_id, work_unit_id),
+        ).fetchall()
+        message_ids = tuple(int(row["message_id"]) for row in rows)
+        if not rows:
+            return ()
+
+        from sprint_liveness import SprintLivenessMonitor
+
+        monitor = SprintLivenessMonitor(self.con)
+        for row in rows:
+            message_id = int(row["message_id"])
+            if row["disposition"] == "pending":
+                self.con.execute(
+                    "UPDATE wake_message SET disposition='declined',"
+                    "read_at=COALESCE(read_at,datetime('now')),decline_reason=? "
+                    "WHERE message_id=? AND disposition='pending'",
+                    (f"Recalled by Planner: {reason}", message_id),
+                )
+                self._cancel_resolved_wakes(message_id)
+            monitor.resolve_in_transaction(
+                message_id,
+                f"work unit recalled by Planner: {reason}",
+            )
+        return message_ids
+
 
 class SprintWakeDeliveryService:
     """Lease wake intents and resolve their chat placement at delivery time."""

--- a/.super-coder/scripts/sprint_participant_chats.py
+++ b/.super-coder/scripts/sprint_participant_chats.py
@@ -238,6 +238,68 @@ def prepare_shell_wake_conversation(con, shell_id: int) -> PreparedShellWake:
     )
 
 
+def _prepare_participant_route(
+    row,
+    *,
+    harness: str,
+    model: str | None,
+    effort: str | None,
+) -> PreparedParticipantRoute:
+    adapter = _browser_adapter(harness)
+    try:
+        resolved = run_mod.resolve_headless_route(
+            harness=harness,
+            adapter=adapter,
+            flavor_model=row["flavor_model"],
+            model=model,
+            effort=effort,
+        )
+    except ValueError as exc:
+        raise SprintConversationError(str(exc)) from exc
+    worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
+    return PreparedParticipantRoute(
+        participant_id=int(row["participant_id"]),
+        shell_id=int(row["shell_id"]),
+        role=str(row["role"]),
+        shortname=str(row["shortname"]),
+        harness=resolved.harness,
+        provider=resolved.provider,
+        model=resolved.model,
+        effort=resolved.effort,
+        worktree=str(worktree.resolve(strict=False)),
+    )
+
+
+def prepare_participant_route(
+    con,
+    *,
+    sprint_id: int,
+    participant_id: int,
+    harness: str,
+    model: str | None,
+    effort: str | None,
+) -> PreparedParticipantRoute:
+    """Resolve one proposed participant route without mutating its Sprint."""
+    row = con.execute(
+        "SELECT p.participant_id,p.shell_id,p.role,p.harness,p.model,p.effort,"
+        "sh.shortname,sh.flavor,fd.model AS flavor_model "
+        "FROM sprint_participants p "
+        "JOIN shells sh ON sh.shell_id=p.shell_id "
+        "LEFT JOIN flavor_defaults fd "
+        "ON fd.flavor=sh.flavor AND fd.harness=? "
+        "WHERE p.sprint_id=? AND p.participant_id=?",
+        (harness, sprint_id, participant_id),
+    ).fetchone()
+    if row is None:
+        raise SprintConversationError("Sprint participant does not exist")
+    return _prepare_participant_route(
+        row,
+        harness=harness,
+        model=model,
+        effort=effort,
+    )
+
+
 def prepare_sprint_participant_routes(
     con,
     sprint_id: int,
@@ -255,35 +317,15 @@ def prepare_sprint_participant_routes(
         "p.participant_id",
         (sprint_id,),
     ).fetchall()
-    prepared: list[PreparedParticipantRoute] = []
-    for row in rows:
-        harness = str(row["harness"])
-        adapter = _browser_adapter(harness)
-        try:
-            resolved = run_mod.resolve_headless_route(
-                harness=harness,
-                adapter=adapter,
-                flavor_model=row["flavor_model"],
-                model=row["model"],
-                effort=row["effort"],
-            )
-        except ValueError as exc:
-            raise SprintConversationError(str(exc)) from exc
-        worktree = run_mod.shell_work_dir(row["shortname"], row["flavor"])
-        prepared.append(
-            PreparedParticipantRoute(
-                participant_id=int(row["participant_id"]),
-                shell_id=int(row["shell_id"]),
-                role=str(row["role"]),
-                shortname=str(row["shortname"]),
-                harness=resolved.harness,
-                provider=resolved.provider,
-                model=resolved.model,
-                effort=resolved.effort,
-                worktree=str(worktree.resolve(strict=False)),
-            )
+    return tuple(
+        _prepare_participant_route(
+            row,
+            harness=str(row["harness"]),
+            model=row["model"],
+            effort=row["effort"],
         )
-    return tuple(prepared)
+        for row in rows
+    )
 
 
 def create_shell_wake_conversation(

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -92,7 +92,9 @@
     ".super-coder/migrations/0195_reseed_sprint_progress_carriers.sql",
     ".super-coder/migrations/0196_sprint_wake_recovery_provenance.sql",
     ".super-coder/migrations/0197_reseed_reopened_pr_resubscription.sql",
-    ".super-coder/migrations/0198_reseed_engine_authored_review_handoff.sql"
+    ".super-coder/migrations/0198_reseed_engine_authored_review_handoff.sql",
+    ".super-coder/migrations/0199_sprint_live_replanning.sql",
+    ".super-coder/migrations/0200_reseed_sprint_live_replanning.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -927,6 +927,218 @@ class SprintCliApiTest(unittest.TestCase):
         finally:
             con.close()
 
+    def test_planner_repeats_recalls_reassigns_and_reroutes_live_work(self):
+        self.use_isolated_db()
+        feature_id, approval_id, task_id = self.seed_declaration("live-replan")
+        participants = self.write(
+            json.dumps(
+                [
+                    {"shell_id": 3, "role": "planner", "harness": "codex"},
+                    {"shell_id": 1, "role": "developer", "harness": "codex"},
+                    {
+                        "shell_id": 4,
+                        "role": "developer",
+                        "harness": "codex",
+                        "model": "old-model",
+                    },
+                    {"shell_id": 2, "role": "reviewer", "harness": "kimi"},
+                ]
+            )
+        )
+        sprint_id = self.run_cli(
+            TOKENS["planner"],
+            "declare",
+            "--feature",
+            str(feature_id),
+            "--spec-approval",
+            str(approval_id),
+            "--participants-file",
+            participants,
+            "--merge-grant",
+        )["sprint_id"]
+        first_unit = self.run_cli(
+            TOKENS["planner"],
+            "plan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--developer-shell",
+            "1",
+            "--reviewer-shell",
+            "2",
+            "--title",
+            "Original lane",
+            "--expected-output-file",
+            self.write("Original output"),
+            "--task",
+            str(task_id),
+        )["work_unit_id"]
+        repeated_unit = self.run_cli(
+            TOKENS["planner"],
+            "plan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--developer-shell",
+            "1",
+            "--reviewer-shell",
+            "2",
+            "--title",
+            "Repeat governing task",
+            "--expected-output-file",
+            self.write("Conformance rerun"),
+            "--task",
+            str(task_id),
+            "--depends-on",
+            str(first_unit),
+            "--output-kind",
+            "report-only",
+        )["work_unit_id"]
+        self.assertNotEqual(first_unit, repeated_unit)
+
+        self.run_cli(TOKENS["planner"], "arm", "--sprint", str(sprint_id))
+        con = sqlite3.connect(self.db)
+        try:
+            first_assignment_message = int(
+                con.execute(
+                    "SELECT message_id FROM wake_message WHERE sprint_id=? "
+                    "AND work_unit_id=? AND message_kind='work_assignment'",
+                    (sprint_id, first_unit),
+                ).fetchone()[0]
+            )
+        finally:
+            con.close()
+        self.deliver_message(first_assignment_message)
+        assignment = self.run_cli(
+            TOKENS["developer"], "inbox", "--sprint", str(sprint_id)
+        )["messages"][0]
+        self.run_cli(
+            TOKENS["developer"],
+            "accept",
+            "--sprint",
+            str(sprint_id),
+            "--message",
+            str(assignment["message_id"]),
+        )
+        self.run_cli(
+            TOKENS["planner"],
+            "pause",
+            "--sprint",
+            str(sprint_id),
+            "--reason",
+            "Planner is restructuring the live plan",
+        )
+        with self.assertRaisesRegex(SystemExit, "HTTP 403.*change the Sprint plan"):
+            self.run_cli(
+                TOKENS["developer"],
+                "recall-unit",
+                "--sprint",
+                str(sprint_id),
+                "--work-unit",
+                str(first_unit),
+                "--reason",
+                "unauthorized",
+            )
+        recalled = self.run_cli(
+            TOKENS["planner"],
+            "recall-unit",
+            "--sprint",
+            str(sprint_id),
+            "--work-unit",
+            str(first_unit),
+            "--reason",
+            "move work to replacement capacity",
+        )
+        self.assertTrue(recalled["changed"])
+        replanned = self.run_cli(
+            TOKENS["planner"],
+            "replan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--work-unit",
+            str(first_unit),
+            "--developer-shell",
+            "4",
+            "--title",
+            "Replacement lane",
+            "--expected-output-file",
+            self.write("Replacement output"),
+            "--task",
+            str(task_id),
+            "--wave",
+            "3",
+        )
+        self.assertTrue(replanned["changed"])
+        rerouted = self.run_cli(
+            TOKENS["planner"],
+            "reroute-participant",
+            "--sprint",
+            str(sprint_id),
+            "--participant-shell",
+            "4",
+            "--harness",
+            "codex",
+            "--model",
+            "replacement-model",
+            "--effort",
+            "medium",
+            "--route",
+            "codex/replacement-model",
+        )
+        self.assertTrue(rerouted["changed"])
+        resumed = self.run_cli(
+            TOKENS["planner"],
+            "resume",
+            "--sprint",
+            str(sprint_id),
+            "--reason",
+            "replacement plan validated",
+        )
+        self.assertTrue(resumed["changed"])
+        con = sqlite3.connect(self.db)
+        try:
+            replacement_message = int(
+                con.execute(
+                    "SELECT message_id FROM wake_message WHERE sprint_id=? "
+                    "AND work_unit_id=? AND message_kind='work_assignment' "
+                    "ORDER BY message_id DESC LIMIT 1",
+                    (sprint_id, first_unit),
+                ).fetchone()[0]
+            )
+        finally:
+            con.close()
+        self.deliver_message(replacement_message)
+        replacement_inbox = self.run_cli(
+            "dev2-token", "inbox", "--sprint", str(sprint_id)
+        )
+        self.assertEqual(first_unit, replacement_inbox["messages"][0]["work_unit_id"])
+
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                2,
+                con.execute(
+                    "SELECT COUNT(*) FROM sprint_work_unit_tasks WHERE task_id=?",
+                    (task_id,),
+                ).fetchone()[0],
+            )
+            self.assertEqual(
+                (4, "Replacement lane", 3),
+                con.execute(
+                    "SELECT assigned_shell_id,title,planned_wave "
+                    "FROM sprint_work_units WHERE work_unit_id=?",
+                    (first_unit,),
+                ).fetchone(),
+            )
+            self.assertEqual(
+                ("replacement-model", "medium", "codex/replacement-model"),
+                con.execute(
+                    "SELECT model,effort,route FROM sprint_participants "
+                    "WHERE sprint_id=? AND shell_id=4",
+                    (sprint_id,),
+                ).fetchone(),
+            )
+        finally:
+            con.close()
+
     def test_review_properties_never_change_authenticated_launch_eligibility(self):
         cases = (
             ("no-review", None, False, False, False),

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -31,6 +31,7 @@ FORCE_NEW_ROLE_SKILLS = {"sprint_dev", "sprint_pln", "sprint_rev"}
 POLISHED_SPRINT_SKILLS = set(SKILLS) - {"sprint_prep"}
 CHAT_CLEANUP_SKILLS = {"sprint_close", "sprint_pln", "sprint_rev"}
 PROGRESS_CARRIER_ROLE_SKILLS = {"sprint_dev", "sprint_pln", "sprint_rev"}
+LIVE_REPLAN_ROLE_SKILLS = {"sprint_pln", "sprint_rev"}
 
 ARTIFACT_PATH_RULE = """## Sprint artifact paths
 
@@ -781,6 +782,51 @@ class SprintSkillTest(unittest.TestCase):
         finally:
             con.close()
 
+    def test_live_replanning_reseed_matches_assets_and_replays_idempotently(self):
+        con = sqlite3.connect(":memory:")
+        try:
+            con.executescript((ENGINE / "schema.sql").read_text())
+            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name >= "0200_reseed_sprint_live_replanning.sql":
+                    break
+                con.executescript(migration.read_text())
+            placeholders = ",".join("?" for _ in LIVE_REPLAN_ROLE_SKILLS)
+            con.execute(
+                f"UPDATE skills SET description='stale',category='stale',"
+                f"command='stale',common=1,content='immutable sprint plan',"
+                f"is_deleted=1 WHERE name IN ({placeholders})",
+                tuple(sorted(LIVE_REPLAN_ROLE_SKILLS)),
+            )
+
+            migration = (
+                ENGINE / "migrations" / "0200_reseed_sprint_live_replanning.sql"
+            ).read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+
+            for name in sorted(LIVE_REPLAN_ROLE_SKILLS):
+                with self.subTest(name=name):
+                    parsed = seed_skills.parse_skill(ASSETS / name / "SKILL.md")
+                    rows = con.execute(
+                        "SELECT description,category,command,common,content,is_deleted "
+                        "FROM skills WHERE name=?",
+                        (name,),
+                    ).fetchall()
+                    self.assertEqual(1, len(rows))
+                    self.assertEqual(
+                        (
+                            parsed["description"],
+                            parsed["category"],
+                            parsed["command"],
+                            parsed["common"],
+                            parsed["content"],
+                            0,
+                        ),
+                        tuple(rows[0]),
+                    )
+        finally:
+            con.close()
+
     def test_progress_carrier_reseed_matches_assets_and_replays_idempotently(self):
         con = sqlite3.connect(":memory:")
         try:
@@ -992,6 +1038,8 @@ class SprintSkillTest(unittest.TestCase):
             "declare",
             "plan-unit",
             "replan-unit",
+            "recall-unit",
+            "reroute-participant",
             "arm",
             "inbox",
             "send",
@@ -1120,14 +1168,17 @@ class SprintSkillTest(unittest.TestCase):
         normalized_planner = " ".join(planner.lower().split())
         normalized_reviewer = " ".join(reviewer.lower().split())
 
-        self.assertIn("## Reviewer decision actions", planner)
+        self.assertIn("## Reviewer decisions and Planner actions", planner)
         self.assertIn(
-            "pause, cancel, re-enter, and abort are reviewer decisions",
+            "planner independently owns operational plan structure",
             normalized_planner,
         )
-        self.assertIn("planner actions", normalized_planner)
+        self.assertIn("pause-safe recall", normalized_planner)
+        self.assertIn("repeated task lanes", normalized_planner)
         for command in (
             "sc sprint pause --sprint <id>",
+            "sc sprint recall-unit --sprint <id>",
+            "sc sprint reroute-participant --sprint <id>",
             "sc sprint cancel-unit --sprint <id>",
         ):
             self.assertIn(command, planner)
@@ -1136,15 +1187,20 @@ class SprintSkillTest(unittest.TestCase):
         self.assertIn("do not run `complete`", normalized_planner)
         self.assertNotIn("you decide scope, sequencing, and recovery", normalized_planner)
 
-        self.assertIn("## Control and conclude decisions", reviewer)
+        self.assertIn("## Conformance decisions and Planner controls", reviewer)
         self.assertIn(
-            "owns all pause, cancel, and conclude decisions", normalized_reviewer
+            "planner independently owns operational plan structure",
+            normalized_reviewer,
+        )
+        self.assertIn(
+            "reviewer owns review, re-enter, abort, and conclude",
+            normalized_reviewer,
         )
         self.assertIn("author the final Sprint report", reviewer)
         self.assertIn("sc sprint record-conformance", reviewer)
         self.assertIn("sc sprint compile-report", reviewer)
         self.assertIn(
-            "`decision`: `pause`, `resume`, `replan`, `re-enter`, `cancel`, or `abort`",
+            "`decision`: `re-enter`, `abort`, or the exact safety-critical recommendation",
             reviewer,
         )
         self.assertNotIn("`cancel`, `conclude`", reviewer)
@@ -1159,7 +1215,7 @@ class SprintSkillTest(unittest.TestCase):
     def test_planner_control_decisions_reply_before_accept_and_action(self):
         planner = (ASSETS / "sprint_pln" / "SKILL.md").read_text()
         control = planner[
-            planner.index("## Reviewer decision actions"):
+            planner.index("## Reviewer decisions and Planner actions"):
             planner.index("The FnB board-level override")
         ]
 
@@ -1219,7 +1275,7 @@ class SprintSkillTest(unittest.TestCase):
         planner = bodies["sprint_pln"]
         self.assertIn("outside an armed Sprint", developer)
         self.assertIn("Reviewer decides", developer)
-        self.assertIn("replan, cancel", reviewer)
+        self.assertIn("recalling unreleased work", " ".join(reviewer.split()))
         self.assertIn("Compile the bounded evidence packet first", reviewer)
         self.assertIn("Developer-owned subscriptions", planner)
 
@@ -1358,7 +1414,7 @@ class SprintSkillTest(unittest.TestCase):
         )
         planner = " ".join(bodies["sprint_pln"].split())
         self.assertIn("dependency graph and capacity plan match the decision", planner)
-        self.assertIn("rather than silently re-routing", planner)
+        self.assertIn("Planner may reassign or reroute for operational capacity", planner)
         for fact in ("scheduled dispatch", "unread wake recovery"):
             self.assertIn(fact, planner)
         self.assertIn("registered-PR watcher owns subscription observation", planner)

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -20,11 +20,13 @@ MIGRATIONS = ENGINE / "migrations"
 FOUNDATION = MIGRATIONS / "0146_sprint_v2_domain.sql"
 GENERATION_MIGRATION = MIGRATIONS / "0155_sprint_conversation_generations.sql"
 OPTIONAL_QAQC_MIGRATION = MIGRATIONS / "0185_optional_sprint_qaqc.sql"
+LIVE_REPLAN_MIGRATION = MIGRATIONS / "0199_sprint_live_replanning.sql"
 
 sys.path.insert(0, str(ENGINE / "scripts"))
 import db_driver  # noqa: E402
 import migrate  # noqa: E402
 import sprint_domain  # noqa: E402
+import sprint_message_delivery  # noqa: E402
 
 
 def apply_schema(con: sqlite3.Connection, *, through: str | None = None) -> None:
@@ -214,6 +216,70 @@ class MigrationAndShapeTest(SprintDomainCase):
                 ),
             )
             self.assertEqual(2, con.execute("SELECT COUNT(*) FROM sprint_specs").fetchone()[0])
+            self.assertEqual([], con.execute("PRAGMA foreign_key_check").fetchall())
+
+    def test_live_replanning_migration_preserves_and_repeats_task_binding(self) -> None:
+        with closing(sqlite3.connect(":memory:")) as con:
+            con.row_factory = sqlite3.Row
+            apply_schema(con, through="0198_reseed_engine_authored_review_handoff.sql")
+            sprint_id, document_id, _, _ = self._seed_prechange_binding(con)
+            con.execute(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (1,'Developer','DEV1','dev','prompt',1)"
+            )
+            feature_id = int(
+                con.execute(
+                    "SELECT feature_id FROM sprints WHERE sprint_id=?", (sprint_id,)
+                ).fetchone()[0]
+            )
+            task_id = int(
+                con.execute(
+                    "INSERT INTO spec_tasks (feature_id,document_id,seq,title) "
+                    "VALUES (?,?,1,'Repeat governing task')",
+                    (feature_id, document_id),
+                ).lastrowid
+            )
+            unit_ids = [
+                int(
+                    con.execute(
+                        "INSERT INTO sprint_work_units "
+                        "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                        "expected_output) VALUES (?,1,2,?,?)",
+                        (sprint_id, f"Lane {number}", f"Output {number}"),
+                    ).lastrowid
+                )
+                for number in (1, 2)
+            ]
+            con.execute(
+                "INSERT INTO sprint_work_unit_tasks "
+                "(sprint_id,work_unit_id,task_id) VALUES (?,?,?)",
+                (sprint_id, unit_ids[0], task_id),
+            )
+
+            con.executescript(LIVE_REPLAN_MIGRATION.read_text())
+            con.execute(
+                "INSERT INTO sprint_work_unit_tasks "
+                "(sprint_id,work_unit_id,task_id) VALUES (?,?,?)",
+                (sprint_id, unit_ids[1], task_id),
+            )
+
+            self.assertEqual(
+                [(unit_ids[0], task_id), (unit_ids[1], task_id)],
+                [
+                    tuple(row)
+                    for row in con.execute(
+                        "SELECT work_unit_id,task_id FROM sprint_work_unit_tasks "
+                        "ORDER BY work_unit_id"
+                    )
+                ],
+            )
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute(
+                    "INSERT INTO sprint_work_unit_tasks "
+                    "(sprint_id,work_unit_id,task_id) VALUES (?,?,?)",
+                    (sprint_id, unit_ids[1], task_id),
+                )
             self.assertEqual([], con.execute("PRAGMA foreign_key_check").fetchall())
 
     def test_optional_qaqc_migration_failure_rolls_back_original_table(self) -> None:
@@ -572,6 +638,219 @@ class SpecApprovalTest(SprintDomainCase):
                 "SELECT lifecycle FROM sprints WHERE sprint_id=?", (sprint_id,)
             ).fetchone()[0],
         )
+
+
+class LiveReplanningTest(SprintDomainCase):
+    def test_paused_recall_reassign_and_reroute_dispatches_fresh_generation(self) -> None:
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (5,'Developer 2','DEV2','dev','prompt',1)"
+        )
+        sprint_id, work_unit_id = self.create_sprint()
+        document_id = int(
+            self.con.execute(
+                "SELECT document_id FROM sprint_specs WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()[0]
+        )
+        feature_id = int(
+            self.con.execute(
+                "SELECT feature_id FROM sprints WHERE sprint_id=?", (sprint_id,)
+            ).fetchone()[0]
+        )
+        task_id = int(
+            self.con.execute(
+                "INSERT INTO spec_tasks (feature_id,document_id,seq,title) "
+                "VALUES (?,?,1,'Governing task')",
+                (feature_id, document_id),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_work_unit_tasks "
+            "(sprint_id,work_unit_id,task_id) VALUES (?,?,?)",
+            (sprint_id, work_unit_id, task_id),
+        )
+        self.con.execute(
+            "INSERT INTO sprint_participants "
+            "(sprint_id,shell_id,role,harness,model,effort) "
+            "VALUES (?,5,'developer','codex','old-model','high')",
+            (sprint_id,),
+        )
+        self.con.commit()
+
+        assignment_wake = self.store.arm(sprint_id, 3)[0]
+        assignment_message = int(
+            self.con.execute(
+                "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",
+                (assignment_wake,),
+            ).fetchone()[0]
+        )
+        self.con.execute(
+            "UPDATE wake_message SET delivered_at=datetime('now') WHERE message_id=?",
+            (assignment_message,),
+        )
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET state='delivered',"
+            "delivered_at=datetime('now') WHERE wake_id=?",
+            (assignment_wake,),
+        )
+        self.con.commit()
+        sprint_message_delivery.SprintMessageStore(self.con).mark_read(
+            assignment_message, 1, sprint_id=sprint_id
+        )
+        self.store.pause(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="Planner is restructuring assignments",
+        )
+
+        units = sprint_domain.SprintWorkUnitStore(self.con)
+        self.assertTrue(
+            units.recall(
+                sprint_id,
+                work_unit_id,
+                3,
+                reason="move the lane to available capacity",
+            )
+        )
+        self.assertTrue(
+            units.replan(
+                sprint_id,
+                work_unit_id,
+                3,
+                assigned_shell_id=5,
+                title="Reassigned foundation",
+                expected_output="Ship through the replacement route",
+                task_ids=(task_id,),
+                planned_wave=4,
+            )
+        )
+        participant_id = int(
+            self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=5",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+        prepared = sprint_domain.sprint_participant_chats.PreparedParticipantRoute(
+            participant_id=participant_id,
+            shell_id=5,
+            role="developer",
+            shortname="DEV2",
+            harness="codex",
+            provider="openai",
+            model="replacement-model",
+            effort="medium",
+            worktree="/tmp/dev2",
+        )
+        with mock.patch.object(
+            sprint_domain.sprint_participant_chats,
+            "prepare_participant_route",
+            return_value=prepared,
+        ):
+            changed = sprint_domain.SprintParticipantStore(
+                self.con, probe_harness=lambda _harness: None
+            ).reroute(
+                sprint_id,
+                3,
+                participant_shell_id=5,
+                harness="codex",
+                model="replacement-model",
+                effort="medium",
+                route="codex/replacement-model",
+            )
+        self.assertTrue(changed)
+
+        receipt = self.store.resume(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="replan is complete",
+        )
+
+        self.assertEqual(1, len(receipt.dispatched_wake_ids))
+        recall_event = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='work_unit.recalled'",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual("planned", recall_event["after"])
+        self.assertEqual(
+            "accepted",
+            self.con.execute(
+                "SELECT disposition FROM wake_message WHERE message_id=?",
+                (assignment_message,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            (5, "Reassigned foundation", 4),
+            tuple(
+                self.con.execute(
+                    "SELECT assigned_shell_id,title,planned_wave "
+                    "FROM sprint_work_units WHERE work_unit_id=?",
+                    (work_unit_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            ("replacement-model", "medium", "codex/replacement-model"),
+            tuple(
+                self.con.execute(
+                    "SELECT model,effort,route FROM sprint_participants "
+                    "WHERE participant_id=?",
+                    (participant_id,),
+                ).fetchone()
+            ),
+        )
+        fresh = self.con.execute(
+            "SELECT receiver_shell_id,idempotency_key FROM wake_message "
+            "WHERE work_unit_id=? AND message_kind='work_assignment' "
+            "ORDER BY message_id DESC LIMIT 1",
+            (work_unit_id,),
+        ).fetchone()
+        self.assertEqual(5, fresh["receiver_shell_id"])
+        self.assertTrue(str(fresh["idempotency_key"]).endswith(":assignment:2"))
+
+    def test_recall_rejects_armed_and_registered_pr_lanes(self) -> None:
+        sprint_id, work_unit_id = self.create_sprint()
+        self.store.arm(sprint_id, 3)
+        units = sprint_domain.SprintWorkUnitStore(self.con)
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "only while the Sprint is paused"
+        ):
+            units.recall(sprint_id, work_unit_id, 3, reason="too early")
+
+        self.store.pause(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="inspect lane",
+        )
+        owner = int(
+            self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=1",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+        registered_pr_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_registered_prs "
+                "(sprint_id,owner_participant_id,repository,pr_number) "
+                "VALUES (?,?,'acme/repo',99)",
+                (sprint_id, owner),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_pr_work_units "
+            "(sprint_id,registered_pr_id,work_unit_id) VALUES (?,?,?)",
+            (sprint_id, registered_pr_id, work_unit_id),
+        )
+        self.con.commit()
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "preserve that lane"
+        ):
+            units.recall(sprint_id, work_unit_id, 3, reason="unsafe rewind")
 
 
 class LifecycleTest(SprintDomainCase):

--- a/tests/test_sprint_work_dispatch.py
+++ b/tests/test_sprint_work_dispatch.py
@@ -808,9 +808,12 @@ class DispatchGateTest(SprintWorkDispatchCase):
             {
                 "assigned_shell_id": 4,
                 "reviewer_shell_id": 2,
-            "planned_wave": 1,
-            "output_kind": "code",
-            "dependency_ids": [upstream],
+                "title": "Target",
+                "expected_output": "Output 2",
+                "task_ids": [2],
+                "planned_wave": 1,
+                "output_kind": "code",
+                "dependency_ids": [upstream],
             },
             payload["before"],
         )
@@ -818,9 +821,12 @@ class DispatchGateTest(SprintWorkDispatchCase):
             {
                 "assigned_shell_id": 4,
                 "reviewer_shell_id": 5,
-            "planned_wave": 7,
-            "output_kind": "code",
-            "dependency_ids": [],
+                "title": "Target",
+                "expected_output": "Output 2",
+                "task_ids": [2],
+                "planned_wave": 7,
+                "output_kind": "code",
+                "dependency_ids": [],
             },
             payload["after"],
         )


### PR DESCRIPTION
Closes #1142

## Summary

- allow one governing spec task to be deliberately repeated across multiple Sprint work units
- add Planner-only pause-safe recall, full planned-lane editing, reassignment, and participant model/harness/effort rerouting
- preserve accepted message, event, conversation, and run history while future assignment generations use the replacement route
- teach sprint_pln the live restructuring procedure and align sprint_rev with Planner ownership of operational plan structure
- project the new recall and route-change audit events on the Sprint board

## Safety boundaries

- released work can only be recalled while the Sprint is paused
- completed, cancelled, and PR-bound work cannot be recalled
- participant routes can change only while prepared or paused and only after released expectations are cleared
- rerouting affects future Force-new assignments or reviews; existing chats remain immutable history

## Verification

- 432 Sprint tests pass
- 36 migration, rebuild, removal-manifest, and snapshot tests pass
- focused API/CLI/domain/skill suite passes (90 tests)
- render-check passes
- clean-clone verify regression passes
- direct verify safely refuses linked worktrees under existing issue #769; no live state was touched
- diff check and Python E9 syntax lint pass