### PR TITLE
Show context tokens on model messages

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -14,6 +14,7 @@ import hashlib
 import http.client
 import io
 import json
+import math
 import re
 import sys
 import time
@@ -1851,10 +1852,15 @@ def _transcript_projection(
                         "code": "MALFORMED_EVENT_PAYLOAD",
                     })
                 continue
+            projected_payload = _project_event_payload(
+                row["event_type"],
+                payload,
+                secrets,
+            )
             events.append({
                 "sequence": sequence,
                 "event_type": row["event_type"],
-                "payload": _redact_event_value(payload, secrets),
+                "payload": projected_payload,
                 "message_id": row["message_id"],
                 "run_id": row["run_id"],
                 "created_at": row["created_at"],
@@ -1868,6 +1874,8 @@ def _transcript_projection(
             and event["message_id"] is not None
         }
         segments_by_run: dict[int, dict[int, list[dict]]] = {}
+        context_tokens_by_run: dict[int, dict[int, int]] = {}
+        latest_assistant_anchor_by_run: dict[int, int] = {}
         evidence_count_by_run: dict[int, int] = {}
         activities = []
         boundary_types = {
@@ -1898,6 +1906,17 @@ def _transcript_projection(
                     anchor,
                     [],
                 ).append(event)
+                latest_assistant_anchor_by_run[int(run_id)] = anchor
+            elif event["event_type"] == "usage" and run_id is not None:
+                context_tokens = event["payload"].get("context_tokens")
+                assistant_anchor = latest_assistant_anchor_by_run.get(int(run_id))
+                if isinstance(context_tokens, int) and not isinstance(
+                    context_tokens,
+                    bool,
+                ) and assistant_anchor is not None:
+                    context_tokens_by_run.setdefault(int(run_id), {})[
+                        assistant_anchor
+                    ] = context_tokens
             elif event["event_type"] in activity_types:
                 activities.append(event)
 
@@ -1963,6 +1982,10 @@ def _transcript_projection(
                         "segment_anchor_sequence": anchor,
                         "first_sequence": deltas[0]["sequence"],
                         "last_sequence": deltas[-1]["sequence"],
+                        "context_tokens": context_tokens_by_run.get(
+                            run_id,
+                            {},
+                        ).get(anchor),
                         "text_truncated": False,
                     })
 
@@ -2206,12 +2229,60 @@ def _redact_event_value(value, secrets: tuple[str, ...]):
     return value
 
 
+def _token_count(value) -> int | None:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+        or int(value) != value
+    ):
+        return None
+    return int(value)
+
+
+def _usage_context_tokens(payload: dict) -> int | None:
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        return None
+    for key in ("totalTokens", "total_tokens", "total"):
+        total = _token_count(tokens.get(key))
+        if total is not None:
+            return total
+    fields = (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+    )
+    values = [_token_count(tokens.get(key)) for key in fields]
+    present = [value for value in values if value is not None]
+    return sum(present) if present else None
+
+
+def _project_event_payload(
+    event_type: str,
+    payload: dict,
+    secrets: tuple[str, ...],
+) -> dict:
+    projected = _redact_event_value(payload, secrets)
+    if event_type != "usage":
+        return projected
+    context_tokens = _usage_context_tokens(projected)
+    if context_tokens is not None:
+        projected["context_tokens"] = context_tokens
+    return projected
+
+
 def _event_projection(row, secrets: tuple[str, ...]) -> dict:
+    payload = json.loads(row["payload"])
     return {
         "sequence": int(row["sequence"]),
         "event_type": row["event_type"],
         "payload_version": int(row["payload_version"]),
-        "payload": _redact_event_value(json.loads(row["payload"]), secrets),
+        "payload": _project_event_payload(row["event_type"], payload, secrets),
         "message_id": row["message_id"],
         "run_id": row["run_id"],
         "created_at": row["created_at"],

--- a/.super-coder/scripts/conversation_adapters/codex.py
+++ b/.super-coder/scripts/conversation_adapters/codex.py
@@ -505,10 +505,13 @@ class CodexAdapter(ConversationAdapter):
             "thread/tokenUsage/updated",
             "turn/tokenUsage/updated",
         }:
+            token_usage = params.get("tokenUsage")
+            last = token_usage.get("last") if isinstance(token_usage, dict) else None
+            source = last if isinstance(last, dict) else params
             usage = {
                 key: value
-                for key, value in params.items()
-                if isinstance(value, (int, float))
+                for key, value in source.items()
+                if isinstance(value, (int, float)) and not isinstance(value, bool)
             }
             return [
                 NormalizedEvent("usage", {"tokens": usage}, method)

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2874,7 +2874,28 @@ async function chatCloseForSwitch(conversation) {
   }
 }
 
-function chatBubble(kind, body, meta = "", conversation = null, createdAt = "") {
+function chatContextTokenLabel(value) {
+  const tokens = Number(value);
+  return Number.isSafeInteger(tokens) && tokens >= 0 ? `${fmt(tokens)} tok` : "";
+}
+
+function chatUpdateContextTokens(node, value) {
+  const text = chatContextTokenLabel(value);
+  let label = node.querySelector(".chat-context-tokens");
+  if (!text) {
+    if (label) label.remove();
+    return;
+  }
+  if (!label) {
+    label = el("div", { className: "chat-context-tokens" });
+    node.append(label);
+  }
+  label.textContent = text;
+}
+
+function chatBubble(
+  kind, body, meta = "", conversation = null, createdAt = "", contextTokens = null,
+) {
   const bubble = el("article", { className: `chat-bubble chat-${kind}` });
   const header = el("div", { className: "chat-bubble-head" },
     el("div", { className: "chat-who" },
@@ -2893,6 +2914,11 @@ function chatBubble(kind, body, meta = "", conversation = null, createdAt = "") 
   if (kind === "assistant") content.classList.add("chat-assistant-body");
   bubble.append(content);
   if (meta) bubble.append(el("div", { className: "chat-meta" }, meta));
+  if (kind === "assistant") {
+    const tokenLabel = chatContextTokenLabel(contextTokens);
+    if (tokenLabel)
+      bubble.append(el("div", { className: "chat-context-tokens" }, tokenLabel));
+  }
   return bubble;
 }
 
@@ -3749,6 +3775,7 @@ function chatTranscriptItemNode(item, conversation, retry) {
     item.kind === "user" ? item.state || "" : "",
     conversation,
     item.created_at,
+    item.context_tokens,
   );
   if (item.kind === "user" && item.state === "failed") {
     const button = el("button", {
@@ -3767,6 +3794,7 @@ function chatUpdateTranscriptNode(node, item, retry) {
     const body = node.querySelector(".chat-assistant-body");
     const rendered = mdBlock(item.text || "");
     body.replaceChildren(...rendered.childNodes);
+    chatUpdateContextTokens(node, item.context_tokens);
     return;
   }
   if (item.kind !== "user") return;
@@ -4374,6 +4402,7 @@ async function chatRenderOpen(
           segment_anchor_sequence: anchor,
           first_sequence: sequence,
           last_sequence: sequence,
+          context_tokens: null,
           text_truncated: false,
         };
         transcriptState.items.set(itemId, assistant);
@@ -4382,6 +4411,16 @@ async function chatRenderOpen(
       assistant.text += event.payload?.text || "";
       assistant.last_sequence = sequence;
       transcriptState.dirty.add(itemId);
+    } else if (type === "usage") {
+      const runId = event.run_id;
+      const assistant = [...transcriptState.order].reverse()
+        .map((itemId) => transcriptState.items.get(itemId))
+        .find((item) => item?.kind === "assistant" && item.run_id === runId);
+      const contextTokens = Number(event.payload?.context_tokens);
+      if (assistant && Number.isSafeInteger(contextTokens) && contextTokens >= 0) {
+        assistant.context_tokens = contextTokens;
+        transcriptState.dirty.add(assistant.item_id);
+      }
     } else if ([
       "permission.requested",
       "input.requested",

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -468,6 +468,10 @@ body.interface-view main {
 .chat-bubble .md > :first-child { margin-top: 0; }
 .chat-bubble .md > :last-child { margin-bottom: 0; }
 .chat-meta { color: var(--dim); font-size: .64rem; margin-top: .35rem; }
+.chat-context-tokens {
+  color: var(--dim); font-size: .64rem; margin-top: .35rem; text-align: right;
+  font-variant-numeric: tabular-nums;
+}
 .chat-retry {
   margin-top: .4rem; background: transparent; color: var(--accent);
   border: 0; padding: 0; cursor: pointer; font: inherit; font-size: .72rem;

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -624,6 +624,24 @@ class FakeCodexRpc:
                     },
                 },
                 {
+                    "method": "thread/tokenUsage/updated",
+                    "params": {
+                        "threadId": self.session_ref,
+                        "turnId": self.run_ref,
+                        "tokenUsage": {
+                            "last": {
+                                "inputTokens": 12000,
+                                "cachedInputTokens": 9000,
+                                "outputTokens": 345,
+                                "reasoningOutputTokens": 200,
+                                "totalTokens": 12345,
+                            },
+                            "total": {"totalTokens": 98765},
+                            "modelContextWindow": 258400,
+                        },
+                    },
+                },
+                {
                     "method": "turn/completed",
                     "params": {
                         "threadId": self.session_ref,
@@ -2233,6 +2251,20 @@ class ConversationAdapterTest(unittest.TestCase):
             "permission.requested",
             [event.type for event in events],
         )
+        usage = next(event for event in events if event.type == "usage")
+        self.assertEqual(
+            usage.payload,
+            {
+                "tokens": {
+                    "inputTokens": 12000,
+                    "cachedInputTokens": 9000,
+                    "outputTokens": 345,
+                    "reasoningOutputTokens": 200,
+                    "totalTokens": 12345,
+                }
+            },
+        )
+        self.assertNotIn("98765", repr(usage.payload))
         resumed = adapter.resume(turn.session_ref, self.context, "again")
         self.assertIn("thread/resume", [method for method, _ in rpc.requests])
         rpc.read_status = "inProgress"

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -2070,6 +2070,48 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
                 source_rows,
             )
 
+    def test_transcript_attaches_exact_context_tokens_to_assistant_only(self) -> None:
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=701,
+                state="closed",
+            )
+            _message_id, _run_id, _through = self.seed_segmented_trace(
+                con,
+                conversation_id=conversation_id,
+                events=(
+                    ("assistant.delta", {"text": "answer"}),
+                    ("tool.started", {"tool_ref": "tool-1", "name": "Shell"}),
+                    (
+                        "usage",
+                        {
+                            "tokens": {
+                                "input_tokens": 10000,
+                                "output_tokens": 345,
+                                "cache_read_tokens": 2000,
+                                "cache_write_tokens": 0,
+                            }
+                        },
+                    ),
+                ),
+            )
+            con.commit()
+
+        status, _, transcript = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/transcript",
+        )
+
+        self.assertEqual(status, 200, transcript)
+        self.assertEqual(len(transcript["items"]), 2)
+        user, assistant = transcript["items"]
+        self.assertEqual(user["kind"], "user")
+        self.assertNotIn("context_tokens", user)
+        self.assertEqual(assistant["kind"], "assistant")
+        self.assertEqual(assistant["text"], "answer")
+        self.assertEqual(assistant["context_tokens"], 12345)
+
     def test_segmented_plain_prose_keeps_one_stable_anchor_zero_item(self) -> None:
         self.assert_historical_segment_trace("plain_prose")
 

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -328,6 +328,8 @@ def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():
     assert "if (reconcilePromise" in keyed
     assert "`run:${runId}:assistant:${anchor}`" in keyed
     assert "assistant.text += event.payload?.text || \"\"" in keyed
+    assert 'type === "usage"' in keyed
+    assert "assistant.context_tokens = contextTokens" in keyed
     assert "transcriptState.throughSequence" in keyed
     assert "/events?after=${afterSequence}" in interface
     assert "/transcript`" in keyed
@@ -532,7 +534,7 @@ def test_message_bubbles_show_local_creation_time_and_omit_invalid_values():
         APP.index("function chatShellLabel")
     ]
     bubble = APP[
-        APP.index("function chatBubble"):
+        APP.index("function chatContextTokenLabel"):
         APP.index("function chatTranscriptAtBottom")
     ]
     script = r"""
@@ -540,14 +542,18 @@ process.env.TZ = "UTC";
 function el(tag, props = {}, ...children) {
   return {
     tag, ...props, children,
+    classList: { add() {} },
     append(...items) { this.children.push(...items); },
   };
 }
 function mdBlock(body) { return el("div", { className: "md" }, body); }
 function chatShellLabel() { return "Shell"; }
+const fmt = (value) => value.toLocaleString("en-US");
 """ + helper + bubble + r"""
 const createdAt = "2026-08-06T06:17:00+02:00";
 const user = chatBubble("user", "hello", "completed", null, createdAt);
+const userWithTokens = chatBubble("user", "hello", "", null, createdAt, 12345);
+const assistant = chatBubble("assistant", "hello", "", null, createdAt, 12345);
 const activity = chatBubble("activity", "working");
 console.log(JSON.stringify({
   valid: chatMessageTimeLabel(createdAt),
@@ -562,6 +568,12 @@ console.log(JSON.stringify({
     time: user.children[0].children[1].children[0],
   },
   activityHeaderItems: activity.children[0].children.length,
+  assistantToken: {
+    className: assistant.children.at(-1).className,
+    text: assistant.children.at(-1).children[0],
+  },
+  userHasToken: userWithTokens.children.some(
+    (child) => child.className === "chat-context-tokens"),
 }));
 """
     assert run_js(script) == {
@@ -577,6 +589,11 @@ console.log(JSON.stringify({
             "time": "04:17",
         },
         "activityHeaderItems": 1,
+        "assistantToken": {
+            "className": "chat-context-tokens",
+            "text": "12,345 tok",
+        },
+        "userHasToken": False,
     }
     transcript_item = APP[
         APP.index("function chatTranscriptItemNode"):
@@ -918,6 +935,7 @@ def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
         ".chat-transcript",
         ".chat-bubble.chat-user",
         ".chat-bubble.chat-assistant",
+        ".chat-context-tokens",
         ".chat-composer",
         ".chat-jump-latest",
         ".chat-jump-latest[hidden]",


### PR DESCRIPTION
## Summary
- derive exact current context-token counts from native harness usage events
- attach counts to restored and live assistant transcript messages only
- render a compact, right-aligned `nn,nnn tok` footer and keep user messages unlabelled

## Verification
- `uv run --with pytest pytest -q tests/test_conversation_adapters.py tests/test_conversation_api.py tests/test_conversation_ui.py`
- `uv run --with pytest pytest tests/ -q` (2234 passed, 1 skipped, 1186 subtests)
- `node --check .super-coder/ui/app.js`
- `python3 -m py_compile .super-coder/api/conversation_routes.py .super-coder/scripts/conversation_adapters/codex.py`