### PR TITLE
Omit missing context token counts

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2875,8 +2875,7 @@ async function chatCloseForSwitch(conversation) {
 }
 
 function chatContextTokenLabel(value) {
-  const tokens = Number(value);
-  return Number.isSafeInteger(tokens) && tokens >= 0 ? `${fmt(tokens)} tok` : "";
+  return Number.isSafeInteger(value) && value >= 0 ? `${fmt(value)} tok` : "";
 }
 
 function chatUpdateContextTokens(node, value) {
@@ -4416,7 +4415,7 @@ async function chatRenderOpen(
       const assistant = [...transcriptState.order].reverse()
         .map((itemId) => transcriptState.items.get(itemId))
         .find((item) => item?.kind === "assistant" && item.run_id === runId);
-      const contextTokens = Number(event.payload?.context_tokens);
+      const contextTokens = event.payload?.context_tokens;
       if (assistant && Number.isSafeInteger(contextTokens) && contextTokens >= 0) {
         assistant.context_tokens = contextTokens;
         transcriptState.dirty.add(assistant.item_id);

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -554,6 +554,7 @@ const createdAt = "2026-08-06T06:17:00+02:00";
 const user = chatBubble("user", "hello", "completed", null, createdAt);
 const userWithTokens = chatBubble("user", "hello", "", null, createdAt, 12345);
 const assistant = chatBubble("assistant", "hello", "", null, createdAt, 12345);
+const assistantWithoutTokens = chatBubble("assistant", "hello", "", null, createdAt);
 const activity = chatBubble("activity", "working");
 console.log(JSON.stringify({
   valid: chatMessageTimeLabel(createdAt),
@@ -573,6 +574,8 @@ console.log(JSON.stringify({
     text: assistant.children.at(-1).children[0],
   },
   userHasToken: userWithTokens.children.some(
+    (child) => child.className === "chat-context-tokens"),
+  assistantWithoutTokensHasToken: assistantWithoutTokens.children.some(
     (child) => child.className === "chat-context-tokens"),
 }));
 """
@@ -594,6 +597,7 @@ console.log(JSON.stringify({
             "text": "12,345 tok",
         },
         "userHasToken": False,
+        "assistantWithoutTokensHasToken": False,
     }
     transcript_item = APP[
         APP.index("function chatTranscriptItemNode"):


### PR DESCRIPTION
## Cause
JavaScript coerced a missing `context_tokens` value with `Number(null)`, producing a valid numeric zero and rendering `0 tok` on every assistant message without stored usage.

## Fix
- accept only native non-negative integer counts; do not coerce null or malformed values
- cover an assistant message with no usage reading and assert that it has no token footer

Historical Codex messages whose usage was never stored remain unlabelled; messages with usage continue to show the exact count.

## Verification
- `uv run --with pytest pytest -q tests/test_conversation_ui.py` (35 passed)
- `node --check .super-coder/ui/app.js`
- `git diff --check`