### PR TITLE
Feature #41: context-efficient shell execution

### DIFF
--- a/.super-coder/assets/skills/spec/SKILL.md
+++ b/.super-coder/assets/skills/spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec
-description: Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step.
+description: Load before implementing any feature, spec, or roadmap item. Analyze viability, surface blockers, plan Preparation → implementation → Verification, and track spec_tasks/current_state across sessions.
 category: craft
 common: false
 ---

--- a/.super-coder/assets/skills/spec/SKILL.md
+++ b/.super-coder/assets/skills/spec/SKILL.md
@@ -1,266 +1,133 @@
 ---
 name: spec
-description: Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step. Load when starting, implementing, or building any feature, spec, or roadmap item — before writing code.
+description: Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step.
 category: craft
 common: false
 ---
 
 # spec — analyze and execute a spec
 
-Load at the start of any session that builds or implements a feature, whether
-or not the work is framed as a "spec". A spec governs the work -> this skill
-executes it; one should exist but doesn't -> the `docs` skill authors it first.
-Run **Analyze** before touching any code. Blockers / unclear items you can't
-resolve alone -> pause for the FnB.
+Load before implementing any feature/spec/roadmap item. A governing spec is
+missing -> use `docs` to author it first. Analyze before code; unresolved
+ambiguity goes to FnB, while hard blockers get flags. `<self>` = your shell id.
 
-`<self>` = your shell_id.
+## 1. Select the spec
 
----
+Never auto-pick the latest document. Read the complete selected body + task
+ledger:
 
-## Step 1: Load the spec
-
-A feature can hold several unfrozen specs at once (see the `docs` skill).
-NEVER auto-pick "the latest" — list the feature's open specs and choose the
-target explicitly:
-
-```
-# the feature's documents — pick an unfrozen spec (frozen=0) by id:
+```text
 sc mem get documents --feature <id>
-# load the chosen spec body:
 sc mem get documents --doc <doc_id>
-# the spec's task plan (empty = no plan yet):
 sc mem get tasks --doc <doc_id>
 ```
 
-`get documents --feature <id>` lists every spec/doc with `kind`, `seq`,
-`frozen`, `task_count`. Active spec = the unfrozen one with `task_count > 0`
-— resume it. `task_count = 0` = backlog; starting it (Step 3) makes it
-active. More than one open spec and the target unclear -> ask the FnB.
+The feature list includes `kind`, `seq`, `frozen`, and `task_count`. Resume the
+one unfrozen spec with tasks. An unfrozen zero-task spec is backlog; engaging it
+creates the plan below. Multiple plausible open specs -> ask FnB. Existing
+tasks -> skip planning and track the first unfinished one.
 
-Tasks already exist -> skip to **Step 4** (Track).
+## 2. Analyze before planning
 
-Read the entire spec body before going further. Do not skim.
+Return these findings before any code or task writes:
 
----
+| Check | Pass condition / action |
+|---|---|
+| Viability | Bounded, clear entry points, session-sized verification. Otherwise propose a verifiable slice. Missing done-condition = unclear. |
+| Current Posture | Preparation code/DB state matches the documented baseline. A mismatch stops for Planner/FnB; never redefine it silently. |
+| Scope | Every In Scope promise is planned; every Out of Scope item stays out. New/substantively revised specs contain both `## Current Posture` and `## Scope`; ambiguity stops. |
+| Anticipated User Activity | Plan stated roles, audience/reach, access, validation, recovery, authority, safety, process curation, and tenancy invariants. Older absence is allowed; ambiguity is not. |
+| Unclear item | Two plausible readings, missing target/interface, or unstated required knowledge -> ask FnB; do not flag a question they can answer. |
+| Blocker | Missing prerequisite/environment/external dependency -> open one High feature flag and stop at its boundary. |
 
-## Step 2: Analyze
-
-Surface all three before any planning or code:
-
-### Viability
-- Session-completable? Bounded + clear entry points = yes. Multiple layers /
-  migrations / unknown dependencies = no -> say so + propose a session-sized
-  slice.
-- No stated done-condition in the spec -> that is the first unclear item.
-
-### Current posture and scope
-Treat `## Current Posture` as the intended baseline and `## Scope` as the
-delivery boundary. Plan every **In Scope** promise and no **Out of Scope** item.
-If Preparation shows that documented posture and code disagree, stop and return
-the discrepancy to the Planner/FnB; do not silently redefine the baseline.
-
-New specs and substantively revised unfrozen specs must carry both sections
-(see `docs`). Frozen historical specs may predate them; absence there is not a
-blocker, but ambiguity still is.
-
-### Anticipated User Activity
-The spec's `## Anticipated User Activity` section is governing intent: its
-roles, per-surface audience posture, reach, process curation, safety hardening,
-and tenancy invariants shape the plan — access, validation, recovery, authority,
-and tenancy checks are planned tasks, not afterthoughts. Older specs predate the
-section; absence there is not a blocker.
-
-### Unclear items
-Anything you cannot act on without guessing:
-- Ambiguous between two interpretations
-- Missing a critical detail (which table? which endpoint? which component?)
-- Implies knowledge not stated in the spec
-
-List them and ask the FnB before writing the plan.
-
-### Blockers
-Hard stops — prior work not shipped, missing environment state, unresolved
-external dependency. Open one flag per blocker:
-
-```
-sc mem flag open "[Spec] <what is blocked> | Blocker for: <feature title>" --name SC-### --priority High --feature <feature_id>
+```text
+sc mem flag open "[Spec] <blocked fact> | Blocker for: <feature>" \
+  --name SC-### --priority High --feature <feature_id>
 ```
 
-NEVER open a flag for an unclear item resolvable by asking — ask first.
+## 3. Engage and plan
 
----
+Building this session moves `brainstorm|long_term|near_term` to `in_progress`;
+planning ahead moves it to `next`. Matching/later stages are no-ops. Reading
+for reference moves nothing, and unspec'd small fixes have no stage ceremony.
 
-## Step 3: Plan
-
-### Reconcile the stage first
-
-Planning a spec = engaging it to build, so the feature's `roadmap_status`
-(loaded in Step 1) must catch up to reality. Stages:
-`brainstorm · long_term · near_term · next · in_progress · shipped`.
-
-- At `brainstorm`/`long_term`/`near_term` + building this session ->
-  `sc mem roadmap status <feature_id> in_progress`
-- Planning ahead only (no build this session) -> move it to `next`.
-- Already at `in_progress` (or further) -> no-op; don't churn it.
-
-The transition fires because you *act on* the spec — reading one for
-reference moves nothing. No spec governing the work (quick UI fix, minor
-migration) -> skip all stage handling (see Stance).
-
-### Confirm the work-stream too
-
-Check the feature's work-stream (`roadmap.project_id` — the Flow-view
-grouping). Ungrouped -> assign now so the feature shows in a flow:
-
-```
-sc mem roadmap project <feature_id> <shortname>   # 'none' to clear
+```text
+sc mem roadmap status <feature_id> in_progress
 ```
 
-Stream obvious -> assign; ambiguous -> surface to the FnB; already assigned
--> no-op. Full create/assess procedure (new streams, new features) = the
-`docs` skill; this is only the engage-time confirmation.
+Confirm `roadmap.project_id`. Assign the obvious stream; ask FnB if ambiguous;
+leave an existing assignment unchanged:
 
-### Write the task plan
-
-Analysis clear + blockers resolved or accepted -> generate the task list.
-Always this shape:
-
-| seq | title | role |
-|---|---|---|
-| 0 | Preparation | Always first — read code paths, verify DB state, confirm entry points |
-| 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
-| N+1 | Verification | Always last — run tests, smoke-test against done-condition, check the build against the spec's Anticipated User Activity section, snapshot + render |
-
-Add one task per seq with `sc mem task add` — each write is live in the
-shared DB immediately:
-
-```
-sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
-sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
-sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
-sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test every In Scope promise and done-condition, check the build against Anticipated User Activity assurance, snapshot + render"
+```text
+sc mem roadmap project <feature_id> <shortname>
 ```
 
-Then set `current_state` — nothing done yet, next = Preparation:
+Create exactly: Preparation, independently verifiable implementation steps,
+then Verification. Each write is immediately durable:
 
+```text
+sc mem task add "Preparation" --feature <id> --doc <doc_id> --seq 0 \
+  --desc "Read code paths, verify DB state, confirm entry points"
+sc mem task add "<step>" --feature <id> --doc <doc_id> --seq <n> \
+  --desc "<independently verifiable outcome>"
+sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <last> \
+  --desc "Test every scope promise, done-condition, audience assurance, snapshot, and render"
+sc mem state "[<feature>] — last: —. next: Preparation."
 ```
-sc mem state "[<feature_title>] — last: —. next: Preparation."
-```
 
----
+No task plan = no implementation.
 
-## Step 4: Track session by session
+## 4. Execute one task at a time
 
-**Agents overlay:** this shell granted `agents` + FnB invoked `--agents` ->
-that skill's overlay replaces this step's one-task-at-a-time loop with
-adjudicated waves. Load it and apply it on top of this step.
+When FnB explicitly invoked `--agents`, load `agents`; its adjudicated waves
+overlay this loop. Otherwise:
 
-At each work session's start, load the plan:
-
-```
+```text
 sc mem get tasks --doc <doc_id>
-```
-
-Find the first `pending` task -> mark it in progress:
-
-```
 sc mem task start <task_id>
-```
-
-Work ONLY that task. When done:
-
-```
+# work and verify only this task
 sc mem task done <task_id>
 ```
 
-A planned task overtaken by a feature split or re-scope (its work moved to
-another feature/spec, never built here) is cancelled, not done:
+After completion, re-read the ledger. Set `current_state` to the highest done
+task + lowest pending task. Start the next only after the current task is
+verified and durably done. Work moved to another feature/spec is cancelled,
+never marked done or left pending under a shipped feature:
 
-```
+```text
 sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"
+sc mem state "[<feature>] — last: <last_done>. next: <next_up>."
 ```
 
-NEVER mark unbuilt work `done` and NEVER leave it `pending` under a shipped
-feature — the task ledger is how a planner answers "is this feature actually
-finished."
+The final Verification task runs focused/full gates, every In Scope
+done-condition, and the Anticipated User Activity contract. Unexpected reach,
+weakened hardening, or crossed tenancy is a failure. A large spec may stop
+after a verified task slice; leave later tasks pending and state the next one.
 
-Re-read the plan (`sc mem get tasks --doc <doc_id>`) and resolve from it:
-`last_done` = highest-`seq` `done` task; `next_up` = lowest-`seq` `pending`.
-Advance `current_state`:
+## 5. Ship and hand docs to Planner
 
+All tasks done + Verification green -> deliver:
+
+1. `sc mem roadmap status <feature_id> shipped`
+2. Open one Medium docs-pending feature flag.
+3. Message the planner: read shipped code, freeze the spec, write a `kind=doc`
+   document under the feature, then close the flag. Confirm the durable message.
+4. Tell FnB that code shipped and Planner owns freeze + docs. No planner shell ->
+   message nobody; tell FnB and leave the flag open.
+
+```text
+sc mem flag open "[Docs] <feature> shipped, doc pending | Blocker for: <feature> doc" \
+  --name SC-### --priority Medium --feature <feature_id>
 ```
-sc mem state "[<feature_title>] — last: <last_done>. next: <next_up>."
-```
 
-`next_up` NULL = all tasks done -> set current_state to reflect that.
+Do not freeze or author the shipped doc as Developer.
 
----
+## Scope change and stop rules
 
-## Step 5: Hand off on completion
+Small growth within the same intent -> revise the unfrozen spec with `docs`, add
+tasks, continue. A separate mental model -> stop and recommend a new feature +
+spec; never absorb it silently.
 
-Verification task passes (`next_up` NULL — the existing done-line) = feature
-delivered. As the dev: flip the horizon + hand the paperwork to the planner.
-Do NOT freeze the spec or write the doc — that's the planner (`docs` skill).
-
-1. **Flip the horizon to shipped:**
-   ```
-   sc mem roadmap status <feature_id> shipped
-   ```
-2. **Open a docs-pending flag + message the planner with full instructions.**
-   `shipped` + an open flag = the honest interim state; the message carries
-   everything the planner needs without digging:
-   ```
-   sc mem flag open "[Docs] <feature> shipped, doc pending | Blocker for: <feature> doc" --name SC-### --priority Medium --feature <feature_id>
-   sc mem message send <planner-shortname> "**[Docs pending] <feature_title> (feature <feature_id>)**
-
-   Spec <doc_id> shipped. Flag SC-### is open — your action required:
-
-   1. **Read the shipped code first.** Write the doc from what actually shipped, not from the spec. Drift happens and decisions get made in production — the spec captures the intent, the code is the truth.
-   2. Freeze the spec: \`sc mem doc freeze <doc_id>\`
-   3. Write the doc (\`kind='doc'\`) under feature <feature_id> (see the \`docs\` skill).
-   4. Close flag SC-### when the doc is live."
-   ```
-3. **Surface to the FnB:** "shipped; the planner needs to freeze the spec +
-   write the doc." The planner closes the flag when the doc lands.
-
-No planner-flavor shell in this fork -> message nobody; surface to the FnB
-directly and leave the docs-pending flag open for whoever picks up docs.
-
----
-
-## Watch for creep while you build
-
-Mid-build, the work crosses the spec's In Scope / Out of Scope boundary:
-
-- **Small growth** (same mental model, a few more tasks) -> the unfrozen spec
-  is living; edit it (`sc mem doc edit`) and carry on. No ceremony.
-- **A separate coherent intent** (a new mental-model boundary — the
-  granularity test in the `docs` skill) -> do NOT quietly absorb it.
-  Recommend a **new spec** to the FnB, authored by the planner against its
-  own feature. Significant creep = planning event, not dev improvisation.
-
----
-
-## Stance
-
-- **Analyze before acting.** Analysis finds the gap between what the spec
-  says and what the code does.
-- **One task at a time.** Start task N+1 only after task N is verified +
-  marked done.
-- **Verification is not optional.** It is the last task; skipping it makes
-  "done" meaningless.
-- **Scope and Anticipated User Activity are intent.** Verification checks every
-  In Scope promise and the audience/assurance contract — an Out of Scope
-  capability, reach beyond the stated roles, weakened hardening obligation, or
-  data crossing a tenancy line is a finding, not a nuance.
-- **Spec too large for one session** -> scope a slice at Preparation: cover
-  steps 1–K verifiable now, leave K+1–N pending. NEVER start work that can't
-  be verified before the session ends.
-- **current_state always reflects the plan.** Update after every task
-  completion — last done + next up. The next session resumes from it without
-  reading the full task list first.
-- **The stage tracks reality — spec'd work only.** Engaging a spec ->
-  `in_progress`; finishing -> `shipped`; already matching -> no-op, don't
-  churn. Work with no spec (quick UI tweaks, minor migrations) is exempt
-  entirely: no promotion, no handoff, no creep check. Stage discipline never
-  blocks small things.
+Stop for unresolved ambiguity/blocker, at the end of a verified session slice,
+or after the shipped/docs handoff. `current_state` must always point to the
+durable plan rather than reproduce its rationale.

--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -7,27 +7,21 @@ common: false
 
 # sprint_dev — own one editing lane
 
-Use for an actionable work-unit assignment in an armed Sprint. Marking that
-Sprint message read is acceptance and starts work immediately. If you cannot
-accept, decline with a concrete reason; never leave it unread and waking.
-
-Use the simplest path supported by current durable state. Treat ownership,
-lifecycle preconditions, durable writes, and typed handoffs as hard boundaries;
-use judgment for implementation and verification within them. Repeat a read
-only when later activity could have changed it or the next command requires
-live revalidation.
+Use for an actionable work-unit assignment in an armed Sprint. Use the simplest
+path supported by current durable state. Treat ownership, lifecycle
+preconditions, durable writes, and typed handoffs as hard boundaries; use
+judgment inside them. Repeat a read only when later activity could have changed
+it or the next command requires live revalidation.
 
 ## Route the entry
 
-Load `sprint_dev` on every entry, then classify the trigger:
+Load `sprint_dev` on every entry, then classify it:
 
-- For a Sprint assignment, verdict, question, blocker, or other relay message,
-  inspect the Sprint inbox once and handle the relevant message.
-- For a self-describing engine-wide PR fact, inspect that fact and the
-  registered PR directly. Do not manufacture a Sprint inbox item; perform the
-  once-only inbox check immediately before the next typed handoff.
-- For a live FnB instruction, preserve its authority distinctly and inspect
-  only the durable state needed to act safely.
+| Trigger | First read / action |
+|---|---|
+| Assignment, verdict, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; accept or handle the relevant message. |
+| Self-describing engine-wide PR fact | Inspect the fact + registered PR directly. Do not manufacture a Sprint inbox item; check the inbox once immediately before the next typed handoff. |
+| Live FnB instruction | Preserve its authority; read only durable state needed for safe action. |
 
 ```text
 sc sprint inbox --sprint <id>
@@ -35,35 +29,26 @@ sc sprint accept --sprint <id> --message <message-id>
 sc sprint decline --sprint <id> --message <message-id> --reason <reason>
 ```
 
-Use `accept` or `decline` for actionable work. After acting on an informational
-question, answer, blocker, or context message, run `accept` for that message.
-For informational messages it only marks the message read; it does not change
-Sprint or work-unit state.
+Accepting marks assignment ownership and starts work. Decline with a concrete
+reason when unable to accept. After handling an informational message, run
+`accept`; it marks the message read and does not change Sprint or work-unit
+state.
 
-## Orient and bound the lane
+Assignments and review requests use Force-new delivery; verdicts and PR-event
+wakes use Re-enter. Delivery waits for a natural boundary; the runtime owns
+bundling, rotation, and recovery. Stop after a successful typed handoff.
+
+## Bound the lane
 
 Read the assignment, expected output, bound spec revision, dependencies,
-assigned Reviewer, repository/worktree, merge grant, and prior judgments. One
-Developer shell may own one active work unit in the Sprint. Do not start a
-second editing lane or edit another shell's worktree.
+Reviewer, repository/worktree, merge grant, and prior judgments. Own at most one
+active work unit; never start a second editing lane or edit another shell's
+worktree. Resolve ambiguity with the shippable in-scope reading + recorded
+rationale. Ask the Planner before changing the unit boundary, shared interface,
+deliverable cut, priority, or scope.
 
-If the requirement is ambiguous, choose the shippable reading within your
-unit's scope, record the choice and rationale, and continue. Escalate changes to
-the unit boundary, interfaces another unit consumes, deliverable cuts, or scope
-growth to the Planner.
-
-Assignments use Force-new delivery; Reviewer verdicts and engine-wide PR facts
-use Re-enter. Neither displaces a live turn; delivery waits for its natural
-boundary, and the runtime owns bundling, rotation, and recovery. Stop after a
-successful typed handoff so the next delivery can proceed cleanly.
-
-## Questions, answers, blockers, and failures
-
-Put one concrete question, answer, blocker, or useful context item in a short
-body file. Declare the message intent and whether the required reply belongs to
-this work unit or the whole Sprint.
-
-A question or blocker about this lane requires a reply and names the work unit:
+Put one question, blocker, decision, answer, or useful context item in a short
+body file. Unit questions/blockers require a reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
@@ -71,149 +56,116 @@ sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --key <stable-key>
 ```
 
-Use `--intent blocker` instead for a blocked lane. A cross-unit, closeout, or
-external-authority ruling is a Sprint-level decision:
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level decisions:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent decision --requires-reply --sprint-level --key <stable-key>
 ```
 
-Answer the stored sender through the original message. The server inherits its
-unit or Sprint scope; never add `--work-unit` or `--sprint-level` to a reply:
+Reply through the original message; the server inherits its scope, so never add
+`--work-unit` or `--sprint-level` to a reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent information --reply-to <message-id> --key <stable-key>
 ```
 
-Ask the Planner about scope, priority, or cross-unit decisions and the Reviewer
-about review evidence. Confirm the reply write, then mark the handled incoming
-message read with `accept`. For a blocker or integrity concern, send the Planner
-evidence, impact, the exact action needed, and your recommendation. Continue
-safe independent work, but stop at a decision boundary when an answer is
-required. Unread recovery owns re-waking; do not send duplicate reminders.
+Ask the Reviewer about review evidence and the Planner about scope or
+cross-unit authority. Confirm the durable reply, then `accept` the incoming
+message. At a decision boundary, stop until the required answer arrives;
+unread recovery re-wakes, so send no duplicate reminder.
 
-Choose one stable key for the intended recipient, exact body, intent, reply
-linkage, and scope. Reuse it only when retrying that same write; use a new key
-when any of those fields changes.
+A stable key identifies recipient + exact body + intent + reply linkage +
+scope. Reuse it only for the same failed/ambiguous write; when any of those
+fields changes, use a new key. Keep bodies near 6,000 characters and below the
+8,000-character hard limit; run `wc -m < <path>`. A handoff completes only when
+the command exits successfully and confirms its durable message/state + wake.
+If a command is rejected or transport fails, correct and retry safely. If the
+relay itself fails, give FnB the attempted command, evidence, impact, and
+recommendation; invent no alternate protocol.
 
-Keep the body near 6,000 characters and below the 8,000 hard maximum; run
-`wc -m < <path>`. A handoff is complete only when the Sprint command exits
-successfully and confirms the durable write and wake.
+A Developer does not pause the Sprint. Report blocker or integrity evidence to
+the Planner, continue safe independent work, and stop at the unsafe boundary.
+The Reviewer decides continue/replan/pause; the Planner executes the decision.
 
-If a command is rejected or transport fails, the handoff is incomplete. Correct
-and retry when safe. If the relay itself fails, surface the attempted command,
-evidence, impact, and recommendation to FnB; do not invent an alternate
-protocol. A Developer does not pause the Sprint. The Reviewer decides whether
-the evidence warrants continuing, re-planning, or pausing; the Planner executes
-that decision.
-
-## Sprint artifact paths
-
-Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
-report drafts, and Dev scratch proof) go to the gitignored
-`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR'd in the work repo; a review-notes commit is a finding.
-
-DB rows stay the durable record: judgments via `record-review`, report bodies in
-`sprint_reports`, and decisions in the durable relay. Files in the Sprint
-artifact directory are working material only.
+Store scratch proof, diffs, evidence packets, review notes, and report drafts in
+gitignored `shared/sprints/sprint-<n>/`. Never commit or PR them. Durable
+judgments belong in `record-review`, reports in `sprint_reports`, and decisions
+in the relay.
 
 ## Build and verify
 
-Sync the assigned repository, work on a feature branch, match the surrounding
-code, and implement the smallest complete change. Keep external calls outside
-database transactions. Preserve durable identities and append-only evidence.
+Sync the assigned repository, branch, implement the smallest complete change,
+and exercise the unit's independent gate + realistic failures. Keep external
+calls outside DB transactions; preserve durable identities and append-only
+evidence. Record CI failures, infrastructure anomalies, retries, review
+friction, and known departures for closeout.
 
-Verification must exercise the unit's independent stage gate and realistic
-failure paths. A local exploratory number is not merge evidence. Record real CI
-failures, anomalous infrastructure failures, retries, review friction, and
-known departures for the final report.
-
-Immediately before a typed Developer handoff (`complete-unit`, `register-pr`,
-or `request-review`), re-run `sc sprint inbox --sprint <id>` once and act on
-anything new; a ruling may have arrived during the build. This is a once-only
-pre-handoff check. After the handoff confirms its durable write, stop without a
-further inbox pass. The reopened-PR recovery sequence below is the one
-exception: its single inbox check covers the exact registration replay and the
-immediately following review request, which remains the turn's final action.
+Immediately before `complete-unit`, `register-pr`, or `request-review`, re-run
+`sc sprint inbox --sprint <id>` once and act on new messages. After the typed
+handoff confirms its durable write, stop without another inbox pass. The
+reopened-PR route below is the sole exception.
 
 ## Report-only or no-code completion
 
-An explicitly planned report-only or no-code lane completes with its durable
-result instead of a PR. Code lanes cannot use this path; they complete only
-after merge authorization and observation.
-
-Keep the result at about 6,000 characters or fewer; 8,000 is the hard maximum.
-Run `wc -m < <path>` before submitting, then require a successful command and
-durable completion receipt.
+Only an explicitly planned report/no-code lane may finish without a PR. Keep
+the result near 6,000 characters and below 8,000; run `wc -m < <path>`, perform
+the pre-handoff inbox check, then require a durable completion receipt:
 
 ```text
 sc sprint complete-unit --sprint <id> --work-unit <id> \
   --result-file <path>
 ```
 
-Register the PR through the authoritative Sprint surface and retain ownership
-until it is green. After `register-pr` succeeds, the native registered-PR
-watcher creates an engine-wide subscription owned by your shell. It supplies
-self-describing red, green, and externally closed facts as Re-enter wakes even
-after chat rotation or outside an armed Sprint. On red, diagnose and fix the PR.
-On green, judge readiness rather than forwarding mechanically. Planner and
-Reviewer receive no PR-event wakes.
+Stop after success. A code lane continues through merge observation.
+
+## Register and observe the PR
 
 ```text
 sc sprint register-pr --sprint <id> --repository <owner/name> \
   --pr <number> --work-unit <id>
 ```
 
-If GitHub closed this registered PR externally and you reopened, rebased, and
-pushed the same PR, replay the exact `register-pr` command above. The replay
-keeps the registered PR and ownership unchanged while taking one fresh watcher
-snapshot; `created: false` is the expected registration receipt. Confirm that
-write, perform no second inbox pass, then immediately attempt the typed
-`request-review`; do not wait for a second PR-fact wake. An unchanged state at
-the same head is intentionally deduplicated, so that wake would not exist. The
-review gate consumes the fresh durable snapshot: green proceeds, while any
-other state returns the existing watcher diagnostic without a partial handoff.
-Reuse the original stable key only when retrying a request that never returned
-a durable receipt; a new review round uses a new key. Do not register a
-replacement PR or ask the Planner to bypass the observed-green gate.
+After `register-pr` succeeds, retain ownership through green. The native
+registered-PR watcher creates your engine-wide subscription and sends
+self-describing red/green/externally-closed PR-event wakes as Re-enter, even
+outside an armed Sprint. Fix red; judge green. Planner and Reviewer receive no
+PR-event wakes.
 
-Outside that reopened-PR recovery sequence, when no local implementation action
-remains, stop and await the native PR-fact wake. Use Sprint-native wakes for
-coordination. Do not start a recurring shell loop, scheduled job, manual
-watcher daemon, or external PR watcher to track the registered PR.
+If the same registered PR was externally closed, then reopened, rebased, and
+pushed, replay the exact `register-pr` command. Require `created: false`, which
+keeps identity/ownership and takes a fresh snapshot. Its one pre-handoff inbox
+check covers registration replay + the immediately following review request.
+Do not wait for a second PR-fact wake: immediately request review. Green
+proceeds; any other snapshot returns the watcher diagnostic without partial
+handoff. Never register a replacement PR or ask the Planner to bypass observed
+green.
 
-If a watcher-dependent gate has stalled, one bounded inspection is sanctioned:
+Otherwise, when no local action remains, stop for the native PR fact. Start no
+recurring loop, scheduled job, daemon, or external watcher. A stalled gate
+permits one bounded read, then stop or report its evidence:
 
 ```text
 sc sprint watcher-state --sprint <id>
 ```
 
-Run it once to distinguish a stale or never-started watcher from red, pending,
-or absent PR observation, then stop or return the evidence to the Planner. Do
-not repeat the read as a polling loop.
+Do not repeat this read as a polling loop.
 
-## Review handoff
+## Review handoff and correction
 
-Complete a review handoff in this exact order. Every review round uses
-Force-new delivery, so stop cleanly after the request confirms and let the
-Reviewer begin in a fresh chat with the full bundled request:
+Complete each round in order:
 
-1. Finish the readiness judgment and every local verification step.
-2. Perform the once-only typed-handoff inbox check above, act on newly arrived
-   messages, and mark every handled informational message read with `accept`.
-3. Choose `submit` for the first review round or `resubmit` after a
-   changes-requested verdict. The engine injects the PR URL, registered Sprint
-   PR id, exact durable green head SHA, and work-unit id into the Reviewer's
-   canonical bare one-line locator. Create no readiness file and include no
-   scope narrative,
-   verification evidence, judgment rationale, or review-focus steering. Put
-   only the work-unit id and spec reference in the PR body, and write no PR
-   comments or annotations.
-4. As the literal final action of the turn, send the typed handoff with one
-   stable retry key:
+1. Finish readiness judgment + local verification.
+2. Perform the once-only inbox check; handle and `accept` new messages.
+3. Use `submit` first or `resubmit` after changes requested. The engine injects
+   the PR URL, registered id, exact green head, and work-unit id into the
+   Reviewer's canonical bare one-line locator. Create no readiness file. Send
+   no scope narrative, verification evidence, rationale, or review-focus
+   steering. Put only the work-unit id and spec reference in the PR body; write
+   no PR comments or annotations.
+4. As the literal final action, run:
 
 ```text
 sc sprint request-review \
@@ -221,66 +173,51 @@ sc sprint request-review \
   --intent <submit|resubmit> --key <stable-key>
 ```
 
-5. When the command confirms the durable write and Reviewer wake, immediately
-   stop and await the native verdict wake. Run no trailing command.
+5. Require confirmation of the durable write + Reviewer wake; run no trailing
+   command and stop and await the native verdict wake.
 
-A changes-requested verdict returns as Re-enter to your registry chat. Apply
-every blocking finding, re-establish green, and hand back with a new stable
-review key and `--intent resubmit`. Do not narrate how prior findings were
-cleared; the Reviewer verifies that from the full diff at the engine-injected
-exact head. Record
-disagreements as judgment; the Reviewer owns scope/severity decisions and the
-Planner executes any resulting action.
+Changes requested returns by Re-enter. Apply every blocking finding,
+re-establish green, and resubmit with a new review-round key. Do not narrate
+cleared findings; the Reviewer verifies the full diff at the engine-injected
+head. Record disagreements as judgment. Reviewer owns scope/severity; Planner
+executes resulting action.
 
 ## Merge boundary
 
-Approval alone is stale evidence. Immediately before merge, ask the engine to
-re-read live GitHub state and revalidate the armed grant, ownership, work-unit
-state, approved head, and checks:
+Approval is stale evidence. Immediately before merge, re-read live GitHub,
+grant, ownership, unit state, approved head, and checks through:
 
 ```text
 sc sprint authorize-merge \
   --sprint <id> --registered-pr <registered-id>
 ```
 
-Merge only the exact repository, PR number, and head SHA returned. If the
-command refuses, do not work around it; wait for the watcher or return to the
-appropriate loop.
+Merge only the returned repository, PR, and head SHA. A refusal means wait for
+the watcher or re-enter the appropriate loop; never bypass it.
 
 ## Post-merge handoff
 
-After the exact authorized merge succeeds, complete close-out in this order:
+After the authorized merge:
 
-1. Clean the worktree and collect the merged PR identity, merge SHA, unit
-   result, verification evidence, and judgments in the handoff body file.
-2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
-   mark every handled informational message read with `accept`.
-3. Run `wc -m < <path>`; keep the report near 6,000 characters and below the
-   8,000-character hard maximum.
-4. As the literal final action of the turn, send the merged-work handoff to the
-   Planner:
+1. Clean the worktree; put merged PR + SHA, unit result, verification,
+   judgments, and departures in the handoff file.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle and `accept` new items.
+3. Run `wc -m < <path>`; keep the body near 6,000 characters and below 8,000.
+4. As the literal final action, send:
 
 ```text
 sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
   --intent handoff --key <stable-merged-handoff-key>
 ```
 
-5. When the command confirms the durable write and Planner wake, stop
-   immediately. Run no trailing Git, Sprint, inbox, cleanup, or status command.
-   Automatic merge observation records the durable PR transition; the Planner
-   uses this handoff wake to release the next wave.
+5. Require the durable message + Planner wake, then stop immediately. Run no trailing Git,
+   Sprint, inbox, cleanup, or status command. Automatic merge
+   observation records the PR transition; this handoff releases the next wave.
 
 ## Report and stop
 
 Report broken bases, destructive ambiguity, unavailable GitHub, untrustworthy
-runners, provider exhaustion, or an unrecoverable environment to the Planner
-with evidence, impact, and a recommendation. Stop at the unsafe boundary while
-the Reviewer decides whether to continue, re-plan, or pause and the Planner
-executes that decision.
-
-Stop when the unit is merged and reported, declined, awaiting Planner/FnB
-recovery, returned to review, or paused awaiting a native PR-fact or verdict
-wake. For normal review and merge handoffs, the
-ordered procedures above place inbox handling before the typed handoff and make
-that handoff the turn's last action. Ask the Planner for later work only after
-the current editing lane is terminal.
+runners, provider exhaustion, or unrecoverable environment with evidence,
+impact, and recommendation. Stop when merged + reported, declined, returned to
+review, paused for a native wake, or awaiting Planner/FnB recovery. Ask for
+later work only after this editing lane is terminal.

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -7,114 +7,75 @@ common: false
 
 # sprint_pln — govern the armed Sprint
 
-Use as the originating Planner after `sprint_prep` arms the Sprint. The system
-captures deterministic facts; the Reviewer decides and documents, and the
-Planner acts. Execute Reviewer decisions without taking over their judgment or
-report authorship. The FnB retains the board-level override established by
-decision #46.
+Use as originating Planner after `sprint_prep` arms a Sprint. System records
+facts; Reviewer owns review/conformance judgment + reports; Planner owns plan
+structure and executes control transitions. FnB retains board-level override
+under decision #46.
 
 Use the simplest path supported by current durable state. Treat authority,
-lifecycle preconditions, durable writes, and typed handoffs as hard boundaries;
-use judgment for investigation and execution within them. Repeat a read only
-when later activity could have changed it or the next command requires live
-revalidation.
+lifecycle preconditions, durable writes, and typed handoffs as hard boundaries.
+Repeat a read only when later activity could have changed it or the next command
+requires live revalidation.
 
 ## Route the entry
 
-Classify the entry before reading an inbox:
+Load `sprint_pln` on every entry, then classify:
 
-- For a Sprint-scoped control decision, merged-work handoff, question, blocker,
-  or other relay message, inspect the Sprint inbox once and handle that message.
-- For the self-contained engine-wide clean-completion receipt, inspect the
-  receipt and terminal Sprint state directly. It is informational: do not run
-  the Sprint inbox, accept it, or issue a close command.
-- For a live FnB instruction, act under the board-level override and name that
-  authority in the durable evidence.
+| Trigger | Route |
+|---|---|
+| Sprint decision, merged-work handoff, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; handle that message. |
+| Self-contained clean-completion receipt | Inspect receipt + terminal state directly; it is informational—do not run the Sprint inbox, accept it, or close again. |
+| Live FnB instruction | Act under board override; name FnB authority in durable evidence. |
 
-Load `sprint_pln` on every entry. Do not turn entry routing into a polling loop.
+Do not poll. Armed runtime owns scheduled dispatch + unread wake recovery;
+registered-PR watcher owns subscription observation. Developer-owned subscriptions send
+red/green/closed facts to Developers, never Planner.
 
-## Start from durable state
+Assignments/review requests use Force-new delivery; Planner-bound results use
+Re-enter. Delivery waits for a natural boundary; runtime owns bundling,
+rotation, recovery, and coordinate mode. Stop after a successful typed handoff.
 
-The armed runtime owns scheduled dispatch and unread wake recovery. The
-registered-PR watcher owns subscription observation. React to their durable
-facts; use the Planner turn for dispatch, plan structure, and exact execution of
-durable Reviewer decisions. The Reviewer owns review and conformance judgment
-plus the conformance and final Sprint reports. The Planner owns the plan and its
-control transitions: it may modify, repeat, recall, reassign, or reroute work on
-its own operational judgment, and it executes Reviewer decisions that cross
-those same boundaries. Clean conformance approval performs its own atomic
-terminal transition.
+## Durable running loop
 
-Assignments and review requests use Force-new delivery. Planner-bound results
-use Re-enter. Neither displaces a live turn; delivery waits for its natural
-boundary, and the runtime owns bundling, rotation, recovery, and coordinate
-mode. Stop after a successful typed handoff so delivery can proceed cleanly.
-
-Start with the durable trigger, then read only the lifecycle, work-unit,
-dependency, route, PR, expectation, or anomaly facts needed for the current
-decision. Viewing a participant conversation is observation, not activity;
-never manufacture progress from browser presence.
+Read only lifecycle, unit, dependency, route, PR, expectation, and anomaly
+facts required by the trigger. Browser presence is not progress.
 
 ```text
 sc sprint inbox --sprint <id>
 sc sprint accept --sprint <id> --message <message-id>
 sc sprint decline --sprint <id> --message <message-id> --reason <reason>
-```
-
-Release every dependency-ready lane through the production surface:
-
-```text
 sc sprint dispatch --sprint <id>
 ```
 
-The returned ids are wake identities. Work-unit disposition and messages are
-the authoritative release facts. Dispatch is safe to repeat: occupied Developer
-lanes and stable assignment generations prevent double booking.
+Dispatch every dependency-ready lane; returned ids are wake identities.
+Disposition + messages are release facts. Stable assignment generations and
+occupied lanes make dispatch repeat-safe.
 
-Accept or decline only when the inbox item is actionable. After acting on an
-informational question, answer, blocker, or evidence message, run `accept` for
-that message. For informational messages it only marks the message read; it does
-not change Sprint or work-unit state.
+Accept/decline only actionable items. After acting on an informational message,
+run `accept`; it marks the message read and does not change Sprint or work-unit
+state.
 
-## Running loop
-
-- Keep dependencies as the only hard sequence. When reality requires a re-plan,
-  restructure the current projection under Planner authority and record why.
-  Ask the Reviewer when the change depends on review or conformance judgment;
-  do not outsource ordinary assignment, capacity, or route judgment. Never
-  rewrite completed history.
-- Let Developers own their PRs through green, review, correction, and merge.
-  Let Reviewers own verdicts and Sprint decisions. Do not proxy routine
-  handoffs or substitute Planner judgment for a Reviewer decision.
-- Consume passive system facts without waking yourself into every transition.
-  Route a decision boundary to the Reviewer; act when its Re-enter decision
-  message arrives.
-- Record the Reviewer decision identity, the exact action taken, and the action
-  receipt. Do not rewrite its rationale as Planner-authored judgment evidence.
-- A mid-Sprint spec edit is allowed only by the owning Planner or FnB. Record
-  the prior and new exact revision hashes. When acting as Planner, require a
-  durable Reviewer decision before the edit. The running Sprint remains bound
-  to its approved revision unless that decision explicitly says otherwise.
-
-Use Sprint-native wakes for coordination. Do not start a recurring shell loop,
-scheduled job, manual participant boot, or external PR watcher to track Sprint
-state. When a watcher-dependent gate has stalled, use the bounded read once:
+- Keep dependencies as hard sequence; restructure current projection under
+  Planner authority, record why, and never rewrite completed history.
+- Developers own PR green/review/correction/merge. Reviewers own verdicts and
+  conformance. Do not proxy routine handoffs or judgments.
+- Record Reviewer decision id + exact action + receipt; never rewrite rationale
+  as Planner judgment.
+- Mid-Sprint spec edits require owning Planner/FnB + durable Reviewer decision.
+  Record old/new revision hashes; binding changes only when the decision says so.
+- Use native wakes. Start no recurring loop, scheduled job, manual participant
+  boot, or external watcher. One stalled-gate inspection is allowed:
 
 ```text
 sc sprint watcher-state --sprint <id>
 ```
 
-It distinguishes a stale or never-started watcher from red, pending, or absent
-PR observation and includes the newest bounded poll failures. Do not repeat it
-as a polling loop; act on the evidence, then return control to native delivery.
+Do not repeat this read as a polling loop. Act on its bounded watcher evidence,
+then return to native delivery.
 
-## Questions, answers, blockers, and failures
+## Relay contract
 
-Put one concrete question, answer, decision, blocker, or useful context item in
-a short body file. Declare the message intent and whether the required reply
-belongs to one work unit or the whole Sprint.
-
-A question or blocker about one lane requires a reply and names that unit:
+Unit question/blocker requiring reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
@@ -122,66 +83,49 @@ sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --key <stable-key>
 ```
 
-Use `--intent blocker` instead for a blocked lane. A cross-unit, closeout, or
-external-authority ruling is a Sprint-level decision:
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent decision --requires-reply --sprint-level --key <stable-key>
 ```
 
-Answer the stored sender through the original message. The server inherits its
-unit or Sprint scope; never add `--work-unit` or `--sprint-level` to a reply:
+Answer through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent information --reply-to <message-id> --key <stable-key>
 ```
 
-Confirm the reply write, then mark the handled incoming message read with
-`accept`. For a blocker, include evidence, impact, and the exact action needed.
-Continue safe independent governance, but stop at a decision boundary when an
-answer is required. Unread recovery owns re-waking; do not send duplicate
-reminders.
+Confirm reply, then `accept` incoming. A missing answer stops at the decision
+boundary; unread recovery re-wakes, so send no duplicate. Choose a stable key
+for recipient + body + intent + reply + scope; reuse it only for that identical
+write. When any of those fields changes, use a new key.
 
-Choose one stable key for the intended recipient, exact body, intent, reply
-linkage, and scope. Reuse it only when retrying that same write; use a new key
-when any of those fields changes.
-Keep the body near 6,000 characters and below the 8,000 hard maximum; run
-`wc -m < <path>`. A handoff is complete only when the Sprint command exits
-successfully and confirms the durable write and wake.
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. Handoff completes only when the command exits successfully
+and confirms durable write + wake. If a command is rejected or transport fails,
+correct/retry safely. If relay itself fails, give FnB attempted command +
+durable evidence; invent no alternate protocol. Relay Developer integrity
+evidence, impact, and recommendation to Reviewer. Send required context before
+pausing because paused Sprint relay is unavailable.
 
-If a command is rejected or transport fails, the handoff is incomplete. Correct
-and retry when safe. If the relay itself fails, surface the attempted command
-and durable evidence to FnB; do not invent an alternate protocol. Relay a
-Developer integrity concern to the Reviewer with its evidence, impact, and
-recommendation. Send needed context before pausing because the Sprint relay is
-unavailable while paused.
-
-## Sprint artifact paths
-
-Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
-report drafts, and Dev scratch proof) go to the gitignored
-`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR'd in the work repo; a review-notes commit is a finding.
-
-DB rows stay the durable record: judgments via `record-review`, report bodies in
-`sprint_reports`, and decisions in the durable relay. Files in the Sprint
-artifact directory are working material only.
+Keep scratch review notes, diffs, evidence, reports, and proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit/branch/PR them. Durable judgment,
+reports, and decisions belong in `record-review`, `sprint_reports`, and relay.
 
 ## Reviewer decisions and Planner actions
 
-Review, conformance, re-enter, and abort judgments remain Reviewer decisions.
-Planner independently owns operational plan structure, including pause-safe
-recall, cancellation of unreleased scope, reassignment, repeated task lanes,
-and participant route changes. When an action does arrive as a durable Reviewer
-→ Planner Re-enter decision, resolve every required-reply decision through its
-original message before acting. Complete this order without reordering:
+Review/conformance/re-enter/abort judgment remains Reviewer-owned. Planner
+independently owns operational plan structure: pause-safe recall, cancellation
+of unreleased scope, reassignment, repeated task lanes, and route changes.
 
-1. Re-run `sc sprint inbox --sprint <id>`, verify the decision came from the
-   assigned Reviewer, and retain its message id.
-2. Put a short acknowledgement of the exact requested transition in a body
-   file, then send the linked reply:
+For a required-reply Reviewer→Planner Re-enter decision, keep this order:
+
+1. Re-run `sc sprint inbox --sprint <id>`; verify assigned Reviewer + retain id.
+2. Send linked acknowledgement:
 
 ```text
 sc sprint send --sprint <id> --to <reviewer-shortname> --body-file <path> \
@@ -189,85 +133,68 @@ sc sprint send --sprint <id> --to <reviewer-shortname> --body-file <path> \
   --key <stable-control-reply-key>
 ```
 
-3. Require the reply command to confirm its durable message and wake. Retry the
-   same command and key if it fails or does not confirm both.
-4. Mark the original decision accepted and require a successful receipt:
+3. Require the reply command to confirm its durable message and wake; retry the
+   same command/key if ambiguous.
+4. Accept the decision:
 
 ```text
 sc sprint accept --sprint <id> --message <decision-message-id>
 ```
 
-5. Only after acceptance confirms, execute the requested transition without
-   re-adjudicating the decision. The linked reply must precede any pause or
+5. Only after acceptance, execute the requested transition without
+   re-adjudicating it. The linked reply must precede any pause or
    abort that makes the Sprint relay unavailable.
 
-Record the decision message id, reply receipt, acceptance receipt, and action
-receipt together. Clean conformance instead closes atomically and sends an
-informational engine-wide completion receipt; it requires no linked reply or
-Sprint inbox acceptance.
+Record decision id + reply, acceptance, and action receipts. Clean conformance
+closes atomically and sends informational receipt; no reply/accept is needed.
 
-The FnB board-level override from decision #46 is unaffected: a live FnB
-instruction may direct or supersede any action. Name that override in the
-evidence instead of attributing it to the Reviewer.
-
-If a requested action fails a lifecycle, authority, or disposition precondition,
-do not substitute a different action. Send the refusal and current durable state
-back to the Reviewer (or surface it directly to FnB for an FnB override), then
-stop at that decision boundary.
+The FnB board-level override from decision #46 remains distinct. If action
+fails lifecycle/authority/disposition precondition, send refusal + durable state
+to Reviewer (or FnB for override), substitute nothing, and stop.
 
 ### Pause or resume
 
-Pause on a Reviewer decision or when Planner needs a safe restructuring window.
-Transition durably, stop external Sprint services, persist interrupt intent,
-preserve every partial artifact, and retain the governing judgment and evidence
-for recovery:
+Pause for Reviewer decision or safe Planner restructuring; preserve partial
+artifacts, interrupt intent, judgment, and evidence:
 
 ```text
 sc sprint pause --sprint <id> --reason <decision-or-restructure-reason>
 ```
 
-Resume after the requested recovery/restructure is fully recorded, or on a
-later Reviewer decision or FnB override. Reconcile native runs, unread messages,
-pending wakes, work units, registered PRs, capacity, and spec drift, then act
-with the supplied reason:
+Resume only after recording recovery/restructure and reconciling native runs,
+unread messages, wakes, units, PRs, capacity, and spec drift:
 
 ```text
 sc sprint resume --sprint <id> [--reason <validated-reconciliation-reason>]
 ```
 
-An exhausted recovery wake is bounded manual-recovery evidence, not a retry
-loop. Preserve the unread message and failed wake, involve FnB, and do not create
-recursive fallbacks. Drift informs; it never silently blocks resume.
+Exhausted recovery wake = bounded manual evidence: preserve unread message +
+failed wake, involve FnB, create no recursive fallback. Drift informs but never
+silently blocks resume.
 
-PR ownership inherited from an aborted Sprint is an originating-Planner repair
-boundary. Keep the replacement Sprint paused and establish the exact old and
-new ownership. The originating Planner may reconcile that identity; the FnB
-retains the same operation as a board-level override:
+Aborted-Sprint PR ownership repair belongs to the originating Planner. Keep
+replacement Sprint paused; establish old/new identity. The originating Planner
+may reconcile that identity (FnB may override):
 
 ```text
 sc sprint reconcile-pr --sprint <replacement-id> --repository <owner/repo> \
   --pr <number> --work-unit <replacement-unit-id> --reason <recovery-reason>
 ```
 
-The command refuses a live source Sprint or target Sprint, a non-originating
-Planner, a non-code or already owned target unit, and a closed unmerged PR. It
-records the old and new owners plus the live GitHub head and acting authority.
-If the PR is already merged, it also records the merge commit and completes the
-replacement unit as explicit recovery evidence. Treat the receipt as recovery
-evidence; wait for a separate Reviewer decision before resuming.
+It refuses a live source Sprint or target Sprint, a non-originating Planner,
+invalid/owned target, and closed-unmerged PR. Receipt records owners, live head,
+authority, and merged completion when applicable. Require a separate Reviewer
+decision before resuming.
 
 ### Modify, recall, repeat, reassign, or reroute
 
-Planner may cancel one unreleased work unit with its retained terminal reason.
-When cancellation executes a Reviewer decision, preserve that decision id in
-the reason and evidence:
+Cancel unreleased scope with retained terminal reason/Reviewer id:
 
 ```text
-sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <cancellation-reason>
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reason>
 ```
 
-Edit any subset of an unreleased lane directly. Omitted fields retain their
-current values; `--clear-dependencies` is the explicit empty dependency set:
+Edit an unreleased lane; omitted fields stay, `--clear-dependencies` means none:
 
 ```text
 sc sprint replan-unit --sprint <id> --work-unit <id> \
@@ -277,33 +204,24 @@ sc sprint replan-unit --sprint <id> --work-unit <id> \
   [--output-kind code|report-only|no-code]
 ```
 
-Do not edit a released lane in place. To change an accepted or pending
-assignment, first pause so dispatch cannot race the edit, recall the unmerged
-lane, replan it, then resume:
+Never edit a released lane in place. Pause → recall unmerged lane → replan →
+resume:
 
 ```text
 sc sprint pause --sprint <id> --reason <restructure-reason>
-sc sprint recall-unit --sprint <id> --work-unit <id> \
-  --reason <why-the-old-assignment-is-obsolete>
+sc sprint recall-unit --sprint <id> --work-unit <id> --reason <obsolete-reason>
 sc sprint replan-unit --sprint <id> --work-unit <id> <changed-fields>
 sc sprint resume --sprint <id> --reason <validated-replan-reason>
 ```
 
-Recall preserves the old accepted/declined message and event history, returns
-only an unmerged lane to `planned`, and refuses completed, cancelled, or
-PR-bound work. For a PR-bound lane, leave it intact and plan a replacement or
-use the supported PR-ownership recovery path; never force the projection back.
-Resume dispatches a fresh assignment generation.
+Recall preserves message/event history, returns only unmerged work to planned,
+and refuses terminal/PR-bound work. PR-bound work stays; plan replacement or use
+reconciliation. Resume creates fresh assignment generation. One spec task may
+govern repeated verification/replacement lanes; each lane lists it once. Do not
+duplicate the spec task.
 
-The same governing spec task may deliberately appear in more than one work
-unit. Use this for conformance reruns, repeat verification, or replacement work
-whose scope is still governed by the original task. Do not create a duplicate
-spec task merely to satisfy lane membership. Each work unit still lists a task
-at most once.
-
-To change which model will receive future assignments or reviews, pause first
-when the Sprint is armed, clear the participant's released expectation through
-recall or completion, then replace its exact route:
+To change future assignment/review model, pause armed Sprint, clear released
+expectation, then validate + replace route:
 
 ```text
 sc sprint reroute-participant --sprint <id> --participant-shell <id> \
@@ -311,41 +229,24 @@ sc sprint reroute-participant --sprint <id> --participant-shell <id> \
   [--route <display-route>]
 ```
 
-Prepared Sprints may reroute before arm. Armed Sprints must pause; Developer
-routes reject any released lane and Reviewer routes reject an in-review lane.
-The engine validates the new route before writing it. Existing chats and runs
-stay immutable history; the next Force-new assignment or review request rotates
-onto the replacement route. Only already-declared participants can be selected
-or rerouted.
-
-If a Developer or Reviewer declines, preserve the reason and choose the
-replacement assignment or route from current capacity before issuing a fresh
-assignment. Ask the Reviewer only when that choice changes review or
-conformance judgment.
+Prepared Sprints may reroute directly. Armed Developer route rejects released
+lane; Reviewer route rejects in-review lane. Existing chats/runs remain history;
+next Force-new delivery uses replacement. Reroute declared participants only.
+On decline, preserve reason and choose replacement from current capacity; ask
+Reviewer only if review/conformance judgment changes.
 
 ### Re-enter after conformance
 
-A Reviewer `re-enter` decision names the in-Sprint findings, the governing
-tasks (existing ids when scope is unchanged; new title and description when
-scope is new), and the suggested
-unit grouping, waves, dependencies, routing, and capacity rationale. The
-Reviewer should identify independent lanes, expected review overlap, and useful
-reserve. Preserve that projection; do not silently absorb extra scope, maximize
-shell occupancy, or turn post-Sprint findings into delivery work.
-
-Reuse an existing task id when the decision repeats or repairs that exact
-governing scope. Cut a new task only for genuinely new scope:
+Reviewer decision names findings; governing tasks (existing for same scope,
+new title/description for new scope); and grouping, waves, dependencies,
+routing, capacity. Preserve it; do not absorb extra/post-Sprint scope or
+maximize occupancy.
 
 ```text
 sc mem task add "<task-title>" --feature <feature-id> \
   --doc <governing-spec-document-id> --seq <next-seq> \
   --desc "<task-description>"
-```
 
-Create the requested bound work units from those task ids, wiring the Reviewer's
-waves and dependencies directly:
-
-```text
 sc sprint plan-unit --sprint <id> \
   --developer-shell <id> --reviewer-shell <id> --title <title> \
   --expected-output-file <path> --task <task-id> \
@@ -353,73 +254,48 @@ sc sprint plan-unit --sprint <id> \
   [--output-kind code|report-only|no-code]
 ```
 
-After every named task is bound, confirm the routes are available and the
-dependency graph and capacity plan match the decision. Planner may reassign or
-reroute for operational capacity; send the concrete conflict back to the
-Reviewer when that adaptation changes the Reviewer's scope or conformance
-judgment. Then release the new ready lanes with `sc sprint dispatch --sprint <id>`. When
-the added work reaches terminal disposition, the engine sends the Reviewer the
-next delivery-terminal wake; the Planner does not initiate the next conformance
-pass.
+Reuse task for exact repair/repeat; add only genuinely new scope. Bind every
+task, then confirm routes + dependency graph and capacity plan match the
+decision. Planner may reassign or reroute for operational capacity; tell
+Reviewer if conflict changes scope/judgment. Release ready lanes with
+`sc sprint dispatch --sprint <id>`. Engine sends next delivery-terminal wake;
+Planner does not initiate conformance.
 
 ### Conclude or abort
 
-The Reviewer decides when the Sprint is done. A clean `record-conformance`
-command atomically stores conformance, follow-ups, the Reviewer-authored final
-report, completed lifecycle, and an informational engine-wide Planner receipt.
-When that Re-enter arrives, confirm the receipt names the expected Sprint,
-reports, outcome, and completed state. Do not run `complete`; closure is already
-durable and the notification is informational because closure is already
-terminal.
-Successful completion also closes every other active participant chat
-immutably linked to that Sprint. The originating Planner and report-authoring
-Reviewer remain open. Do not manually close peer chats as a second closeout
-action. Pause, abort, re-entry, failed conformance, and rejected fallback
-completion retain their existing no-cleanup behavior.
+The clean `record-conformance` command atomically stores conformance, follow-ups,
+Reviewer-authored final report, completion, and informational engine-wide
+Planner receipt. On Re-enter, verify Sprint/reports/outcome/completed state.
+Do not run `complete`; notification is informational because closure is already
+terminal. Planner does not author a second report. The originating Planner and
+report-authoring Reviewer remain open. Do not manually close peer chats. Pause,
+abort, re-entry, failed conformance, and rejected fallback retain no-cleanup
+behavior.
 
-Do not run `compile-report` by default, synthesize the final report, or
-editorialize the Reviewer body. The Reviewer compiles its own evidence. A
-Planner compile remains a valid FnB-directed fallback:
+Do not compile or editorialize by default; Reviewer owns evidence/report. Only
+FnB-directed fallback may run:
 
 ```text
 sc sprint compile-report --sprint <id> --limit 50 \
   > shared/sprints/sprint-<n>/evidence.json
 ```
 
-Do not wait for or request a conclude action message after the completion receipt.
-Abort is likewise an action taken only on a Reviewer decision or FnB override;
-it is terminal and deletes nothing.
+Abort only on Reviewer decision/FnB override; it is terminal and deletes
+nothing.
 
 ## Handoffs and stop
 
-Planner → Developer assignments and Developer → Reviewer review requests use
-Force-new delivery; Developer/Reviewer → Planner results are Re-enter. Forced
-delivery waits for the prior live turn's natural boundary; runtime delivery
-owns the rest. These are delivery guarantees, not a parent/child chat topology.
-The Planner receives no PR-event wakes; Developer-owned subscriptions carry
-red, green, and externally closed facts directly to the owning Developer.
+Planner receives no PR-event wakes. Never dispatch the next wave from merge
+observation. The merged-work handoff wake is the only normal next-wave dispatch trigger.
+On it:
 
-Never dispatch the next wave from a merge-observation turn. The Developer's
-merged-work handoff wake is the only normal next-wave dispatch trigger. On that
-wake, complete the turn in this exact order:
+1. Run `sc sprint inbox --sprint <id>`; inspect merged handoff + unit/dependency state.
+2. Handle earlier informational items and `accept` each, including handoff.
+3. Finish reconciliation and Planner bookkeeping; no work remains.
+4. As literal final action run `sc sprint dispatch --sprint <id>`.
+5. Require durable assignments + New wakes, then stop. Run no trailing command.
+   Empty dispatch remains final; investigate only on a later durable wake.
 
-1. Run `sc sprint inbox --sprint <id>` and inspect the durable merged-work
-   handoff plus current work-unit and dependency state.
-2. Act on every earlier informational item and mark each handled item read with
-   `accept`, including the Developer handoff.
-3. Finish all reconciliation, judgment recording, and other Planner
-   bookkeeping. No work remains after this step.
-4. As the literal final action of the turn, release dependency-ready lanes:
-
-```text
-sc sprint dispatch --sprint <id>
-```
-
-5. When the command confirms the durable assignment writes and New wakes, stop
-   immediately. Run no trailing command. Empty dispatch is still the final
-   action for that handoff turn; investigate only on a later durable wake.
-
-On a clean completion receipt, verify the named Sprint is terminal and record
-the bounded receipt; run no close command. The Planner does not author a second
-report, accept an actionable handoff, or wait for another actor to finish the
-Sprint.
+On a clean completion receipt, verify terminal Sprint + bounded receipt; run no
+close command. Planner does not author a second report, accept an actionable
+handoff, or wait for another actor to finish the Sprint.

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -7,70 +7,53 @@ common: false
 
 # sprint_rev — independent review and conformance
 
-Use in one of two modes: a work-unit PR review during the loop, or the final
-whole-Sprint conformance pass. Pre-declaration QAQC is a third entry condition,
-before a Sprint exists. The evidence differs; independence does not. The
-Reviewer decides and documents review and conformance judgments; the Planner
-owns operational plan structure and acts on control transitions. The FnB
-retains the board-level override established by decision #46.
+Use for pre-declaration QAQC, one work-unit review, or whole-Sprint
+conformance. The Reviewer decides review/conformance; the Planner owns
+operational plan structure + control execution. FnB retains the board-level
+override from decision #46.
 
 Use the simplest path supported by current durable state. Treat independence,
 authority, lifecycle preconditions, durable writes, and typed handoffs as hard
-boundaries; use judgment for investigation and review within them. Repeat a
-read only when later activity could have changed it or the next command
-requires live revalidation.
+boundaries. Repeat a read only when later activity could have changed it or the
+next command requires live revalidation.
 
 ## Route the entry
 
 Classify the entry before reading an inbox:
 
-- Pre-declaration QAQC begins from an explicit Planner or FnB request through
-  the ordinary shell-to-shell channel. Read and sign the exact current spec
-  body directly; there is no Sprint id or Sprint inbox to inspect yet.
-- A work-unit review request or delivery-terminal notification is Sprint-scoped.
-  Inspect the Sprint inbox once and accept the actionable request before work.
-- For a live FnB instruction, preserve its board-level authority distinctly and
-  inspect only the durable state needed for an independent decision.
+| Entry | Route |
+|---|---|
+| Explicit pre-declaration request | Read/sign the exact current spec directly; there is no Sprint id or Sprint inbox to inspect yet. |
+| Work-unit review / `sprint.delivery_terminal` | Inspect the Sprint inbox once; accept the actionable request. |
+| Live FnB instruction | Preserve board-level authority; read only durable state needed for independent judgment. |
 
-Record pre-declaration QAQC through the authenticated surface:
+QAQC precedes all Sprint inbox commands:
 
 ```text
 sc sprint record-qaqc --document <spec-document-id> \
   --verdict pass [--findings-document <document-id>]
 ```
 
-Once a Sprint is armed, review and conformance entries arrive through durable
-wakes. Load `sprint_rev` on every entry, then use the Sprint inbox for the
-Sprint-scoped cases above:
+For an armed Sprint, load `sprint_rev` on every entry:
 
 ```text
 sc sprint inbox --sprint <id>
 sc sprint accept --sprint <id> --message <message-id>
-```
-
-Decline an actionable request you cannot take, with a concrete reason:
-
-```text
 sc sprint decline --sprint <id> --message <message-id> --reason <reason>
 ```
 
-Use `accept` or `decline` for actionable work. After acting on an informational
-question, answer, blocker, or context message, run `accept` for that message.
-For informational messages it only marks the message read; it does not change
-Sprint or work-unit state.
+Decline actionable work only with a concrete reason. After handling an
+informational message, run `accept`; it marks the message read and does not
+change Sprint or work-unit state.
 
-Review requests use Force-new delivery. Reviewer verdicts to Developers and
-decisions to Planners use Re-enter. Neither displaces a live turn; delivery
-waits for its natural boundary, and the runtime owns bundling, rotation, and
-recovery. Stop after a successful typed handoff. Reviewers never receive
-PR-event subscription wakes.
+Review requests use Force-new delivery. Verdicts and Planner decisions use
+Re-enter. Delivery waits for a natural boundary; the runtime owns bundling,
+rotation, and recovery. Stop after a successful typed handoff. Reviewers never
+receive PR-event wakes.
 
-## Questions, answers, blockers, and failures
+## Relay contract and authority
 
-Put one concrete question, answer, blocker, or useful context item in a short
-body file. Declare the message intent and whether the required reply belongs to
-one work unit or the whole Sprint. Ask the Developer for missing PR evidence
-with a unit-scoped question:
+Ask the Developer for unit evidence with a unit-scoped question/blocker:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
@@ -78,179 +61,120 @@ sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --key <stable-key>
 ```
 
-Use `--intent blocker` instead when the unit cannot advance. Ask the Planner for
-durable state or action-feasibility facts without delegating Reviewer judgment.
-A cross-unit review, closeout, re-enter, abort, or safety ruling is a
-Sprint-level decision:
+Use `--intent blocker` when the unit cannot advance. Cross-unit, closeout,
+re-enter, abort, and safety rulings are Sprint-level decisions:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent decision --requires-reply --sprint-level --key <stable-key>
 ```
 
-Answer the stored sender through the original message. The server inherits its
-unit or Sprint scope; never add `--work-unit` or `--sprint-level` to a reply:
+Reply through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent information --reply-to <message-id> --key <stable-key>
 ```
 
-Confirm the reply write, then mark the handled incoming message read with
-`accept`. A blocker or integrity concern is evidence for your decision. If
-action is needed, send the Planner the decision, impact, exact action, and
-recommendation. Continue safe independent review, but stop at the decision
-boundary when missing facts prevent an honest decision. Unread recovery owns
-re-waking; do not send duplicate reminders.
+Confirm a reply, then `accept` its incoming message. Missing facts stop review
+at the decision boundary; unread recovery re-wakes, so send no duplicate.
+A stable key identifies recipient + exact body + intent + reply + scope. Reuse
+it only for the same failed/ambiguous write; when any of those fields changes,
+use a new key.
 
-Choose one stable key for the intended recipient, exact body, intent, reply
-linkage, and scope. Reuse it only when retrying that same write; use a new key
-when any of those fields changes.
-
-Keep the body near 6,000 characters and below the 8,000 hard maximum; run
-`wc -m < <path>`. A handoff is complete only when the Sprint command exits
-successfully and confirms the durable write and wake.
-
-If a command is rejected or transport fails, the verdict or handoff is
-incomplete. Correct and retry when safe. If the relay itself fails, surface the
-attempted command, evidence, impact, and recommendation to FnB; do not invent an
-alternate protocol. A Reviewer decides whether review or conformance evidence
-warrants changes requested, re-entry, abort, or conclusion; the Planner
-independently decides ordinary operational replanning and executes control
-transitions. Record a live FnB override as FnB authority, not Reviewer judgment.
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. A handoff completes only when the command exits successfully
+and confirms the durable write + wake. If a command is rejected or transport fails,
+the verdict/handoff is incomplete. Correct and retry safely. If the relay itself fails,
+give FnB the attempted command, evidence, impact, and recommendation; invent no
+alternate protocol.
 
 ## Sprint artifact paths
 
-Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
-report drafts, and Dev scratch proof) go to the gitignored
-`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR'd in the work repo; a review-notes commit is a finding.
-
-DB rows stay the durable record: judgments via `record-review`, report bodies in
-`sprint_reports`, and decisions in the durable relay. Files in the Sprint
-artifact directory are working material only.
+Keep review notes, diffs, evidence, reports, and scratch proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit, branch, or PR them. Durable records
+belong in `record-review`, `sprint_reports`, and the relay.
 
 ## Conformance decisions and Planner controls
 
-The Reviewer owns review, re-enter, abort, and conclude judgments. The Planner
-independently owns operational plan structure: pausing for safe edits, recalling
-unreleased work, modifying or repeating task lanes, reassigning work, changing
-participant routes, cancelling unreleased scope, and resuming after validation.
-A clean conformance approval atomically performs its own close. Base a Reviewer
-judgment on durable Sprint state,
-the exact bound revisions, current work/PR facts, progress-carrier evidence, and any
-ratified judgment; ambiguous silence is not enough to corrupt a disposition.
+Reviewer owns review, re-enter, abort, and conclude judgments. Planner
+independently owns operational plan structure: safe-edit pauses, recalling
+unreleased work, lane changes/repeats, assignment/routing, unreleased-scope
+cancellation, and validated resume. Reviewer never runs standalone pause,
+replan, recall, reroute, cancel, resume, complete, or abort actions; clean
+`record-conformance` alone performs its narrow atomic close.
 
-Send re-enter, abort, or safety-critical control recommendations through the
-durable `send` surface above. A clean conclude instead runs the atomic
-`record-conformance` close below. Every Reviewer → Planner route is Re-enter.
-The Reviewer-authored body must name:
+Base judgment on durable Sprint state, bound revisions, current work/PR facts,
+progress-carrier evidence, and ratified judgments. Every Reviewer→Planner route
+is Re-enter. A decision body names:
 
 - `decision`: `re-enter`, `abort`, or the exact safety-critical recommendation;
-- the evidence and rationale owned by the Reviewer;
-- exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
-- any immediate safety impact that the FnB must see.
+- Reviewer-owned evidence + rationale;
+- exact Sprint/unit ids, reason, outcome, and complete action arguments;
+- immediate safety impact for FnB.
 
-The Planner marks the message handled, verifies the assigned Reviewer, and acts
-on the judgment without surrendering its separate authority over the concrete
-plan. The clean completion receipt is informational because the Sprint is
-already terminal. The Reviewer never runs the standalone pause, replan, recall,
-reroute, cancel, resume, complete, or abort action; its clean
-`record-conformance` command owns the narrow automatic close. If a requested
-action is rejected, inspect the returned durable state and issue a revised
-judgment only when the evidence supports one; never ask the Planner to improvise
-around a precondition.
-
-The FnB board-level override from decision #46 is unaffected. A live FnB
-instruction can direct or supersede any decision; preserve it as a distinct
-authority record.
+Planner verifies Reviewer identity and executes the transition without
+surrendering plan authority. A rejected action requires a revised judgment
+supported by returned durable state, never an improvised bypass. A live FnB
+instruction supersedes as distinct FnB board-level override authority under
+decision #46.
 
 ## Severity rubric
 
-This skill owns severity. The governing spec intentionally does not.
-
 - **Critical** — active security/authority violation, destructive corruption,
-  or a condition that makes continued operation unsafe.
+  or unsafe continued operation.
 - **Major** — wrong behavior, data loss, broken invariant, material spec
-  violation, or a loop/recovery path that can silently wedge delivery.
-- **Medium** — a concrete correctness or recovery gap likely to bite normal
-  use soon, including missing negative enforcement or an unreliable handoff.
-- **Low** — bounded cleanup, clarity, test depth, or resilience improvement that
-  does not make the delivered behavior wrong now.
+  violation, or silently wedged delivery/recovery.
+- **Medium** — concrete normal-use correctness/recovery gap, missing negative
+  enforcement, or unreliable handoff.
+- **Low** — bounded cleanup, clarity, test-depth, or resilience improvement;
+  delivered behavior remains correct.
 
-During a work-unit review, Critical/Major/Medium block approval; Low is a
-report note. During close-out conformance, severity does not decide timing: the
-Reviewer judges whether each finding requires in-Sprint patching or is an
-acceptable post-Sprint follow-up.
+Critical/Major/Medium block unit approval; Low is a report note. At closeout,
+severity does not decide timing: Reviewer judges whether each finding requires in-Sprint patching
+or acceptable post-Sprint follow-up.
 
 ## Work-unit review
 
-Accept the actionable review request and retain that exact message id as the
-identity of this review round. Its readiness body must be only the bare
-locator: submitting or resubmitting intent, PR URL, registered Sprint PR id,
-exact head SHA, and work-unit id. Treat scope narrative, verification evidence,
-judgment rationale, or review-focus steering in that body as a protocol defect;
-do not use it to frame the review. Neither party writes PR comments or
-annotations, and the PR body contains only the work-unit id and spec reference.
+Accept the request and retain that exact message id. Its body is a bare locator:
+intent, PR URL, registered PR id, exact head, work-unit id. Scope narrative,
+verification, rationale, or focus steering is a protocol defect. PR comments
+and annotations are forbidden; PR body contains only unit id + spec reference.
 
-Bind every inspection and the eventual verdict to the accepted request's
-message id, registered PR, work unit, and exact head. Another request in the
-same delivery, another unit assigned to this Reviewer, or role activity in a
-different conversation does not belong to this round. Accept and review each
-request explicitly; never infer a review lane from Reviewer identity alone.
-
-Review the exact bound spec revision and the full diff at the request's exact
-head, then inspect checks, tests, relevant runtime evidence, and ratified
-judgments. Each round is clean: no prior Developer evidence or prose is input,
-and prior findings are cleared only when the code at the new head proves they
-are cleared. Review code quality, edge cases/failure paths, and spec
-conformance. Trace the real path; do not trust names or PR prose.
+Bind inspection/verdict to the accepted request's message id, registered PR,
+work unit, and exact head. Review each request explicitly. Read the exact spec
+revision + full diff at that head, then checks, tests, relevant runtime facts,
+and ratified judgments. Each round is clean: no prior Developer evidence or
+prose; prior findings clear only when the new head proves it. Trace code paths,
+failure cases, and spec behavior rather than names or PR prose.
 
 ### Red-check doctrine
 
 Accepted-red is not a legal review outcome. A departure that leaves checks
-failing is never acceptable: do not note the failure and approve anyway. The
-review handoff remains green-only, without exception or waiver.
+failing is never acceptable; the handoff remains green-only, without exception
+or waiver: do not note the failure and approve anyway.
 
-`Note it and pass anyway` is the acceptance-shaped anti-pattern. In the
-dos-arch incident, a Reviewer accepted known-failing tests as a scoped
-departure and created a deadlock: the green-only handoff gate could never pass.
-Decision #93 records why this no-waiver rule exists.
+- In-scope failure -> record `changes_requested` so the Developer fixes them and restores green.
+- Out-of-scope failure -> keep the lane unapproved and send the Planner a `replan`
+  decision naming the failures; Planner widens the lane or cuts follow-up work.
 
-When failing checks are within the lane's ratified scope, record
-`changes_requested` so the Developer fixes them and re-establishes green. When
-the failures are outside that scope, name the blocking failures in the finding
-and send the Planner a `replan` decision through the control protocol. The
-Planner must either widen the lane explicitly or cut a follow-up work unit; the
-current lane remains unapproved until the resulting work is green.
-
-Read resolved closure evidence through the authenticated memory surface; no SQL
-or mutation is needed. Use the exact form for a cited flag and the scoped form
-to audit every resolved flag attached to the feature:
+Read cited and feature-scoped resolved flag evidence through memory, never SQL:
 
 ```text
 sc mem get flags <flag-id>
 sc mem get flags --feature <feature-id> --resolved
 ```
 
-Findings must state:
-
-- severity and concise title;
-- violated behavior or invariant;
-- exact code/evidence location;
-- a reproducible consequence; and
-- the fix boundary, without prescribing unnecessary architecture.
+Each finding pins severity/title, violated invariant, exact location/evidence,
+reproducible consequence, and fix boundary without unnecessary architecture.
 
 Complete a unit verdict in this exact order:
 
-1. Finish the review, findings, and verdict body; no inspection remains after
-   this step.
-2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
-   mark every handled informational message read with `accept`.
-3. Run `wc -m < <path>`; keep the verdict near 6,000 characters and below the
-   8,000-character hard maximum.
-4. As the literal final action of the turn, record the typed verdict through
-   the authenticated surface:
+1. Finish every inspection, finding, and verdict body.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle + `accept` new items.
+3. Run `wc -m < <path>`; require near 6,000 and below 8,000 characters.
+4. As the literal final action, run:
 
 ```text
 sc sprint record-review \
@@ -258,107 +182,65 @@ sc sprint record-review \
   --verdict changes_requested --body-file <path> --key <stable-key>
 ```
 
-5. When the command confirms the durable write and Developer wake, stop
-   immediately. Run no trailing command.
+5. Require durable judgment evidence + Developer Re-enter wake. Run no trailing command;
+   stop.
 
-Use `approved` only when no Critical/Major/Medium finding remains. The engine
-checks that the request was accepted and still binds to the reviewed head,
-records judgment evidence and sends a Re-enter wake to the Developer. Do not
-message around this surface;
-an unrecorded verdict cannot unlock merge.
+Use `approved` only with no Critical/Major/Medium finding. Engine validation
+requires the accepted request and reviewed head. Do not message around the
+surface; an unrecorded verdict cannot unlock merge.
 
 ## Delivery-terminal closeout
 
-The `sprint.delivery_terminal` notification is the entry signal for
-whole-Sprint conformance. Retain that exact notification message id and its
-delivered wake as the closeout entry identity; another Reviewer turn or an old
-terminal notification does not carry this episode. On that wake, inspect the
-inbox, lifecycle, and current work-unit state first. If the lifecycle is already
-`completed` or `aborted`, mark the informational notification handled with
-`accept` and stop. If any non-terminal unit is visible, the wake is stale: mark
-it handled with `accept`, exit, and await the next episode's delivery-terminal
-wake. Only an armed Sprint whose units are all terminal enters conformance.
+Retain the exact notification message id + delivered wake as this closeout
+episode's identity. Inspect inbox, lifecycle, and units first:
 
-Compile the bounded evidence packet first and do so yourself, then judge
-integrated `main` against every governing bound revision, exact recorded
-mid-Sprint revision fact, and ratified judgment:
+- Already completed/aborted -> `accept` notification and stop.
+- If any non-terminal unit is visible, the wake is stale -> `accept`, stop, and
+  await a fresh delivery-terminal episode.
+- Only an armed Sprint whose units are all terminal enters conformance.
+
+Compile the bounded evidence packet first, yourself:
 
 ```text
 sc sprint compile-report --sprint <id> --limit 50 \
   > shared/sprints/sprint-<n>/evidence.json
 ```
 
-Increase the bound only when truncation counters show the default omitted
-needed evidence; 200 is the maximum. The packet supplies facts, not judgment.
-If every work unit was cancelled and nothing shipped, the honest decision is
-`abort`, not `conclude`.
+Increase only when truncation omitted needed evidence; maximum 200. Judge
+integrated `main` against every bound/current revision + ratified judgment. All
+units cancelled and nothing shipped -> `abort`, not `conclude`.
 
-After classifying the requirements, choose exactly one branch:
+Choose one branch:
 
-- **In-Sprint patching required.** Do not run `record-conformance`. Send the
-  Planner a durable `re-enter` decision naming every blocking finding; each
-  spec task to cut against the governing spec document, with title and
-  description; and the suggested unit grouping, waves, dependencies,
-  Developer/Reviewer routing, and capacity rationale. Identify independent
-  lanes, expected review overlap, useful reserve, and why additional capacity
-  would or would not shorten the critical path. The durable decision is the
-  failed-pass record.
-  After three re-entry episodes in one Sprint, escalate the non-convergence to
-  FnB instead of starting another patch round.
-- **Clean or post-Sprint-only findings.** Prepare the conformance report,
-  findings, final Sprint report, reason, and outcome. Submit them through the
-  atomic `record-conformance` protocol below: the engine commits the evidence,
-  completed lifecycle, informational Planner receipt, and wake together. Do not
-  send a separate conclude message.
+- **In-Sprint patching required.** Do not run `record-conformance`. Send Planner
+  a durable `re-enter` decision with every blocking finding; each spec task's
+  title and description; grouping, waves, dependencies, routing, and capacity
+  rationale. State independent lanes, expected review overlap, useful reserve,
+  and critical-path effect. After three re-entry episodes, escalate
+  non-convergence to FnB.
+- **Clean or post-Sprint-only findings.** Prepare conformance report, findings,
+  final report, reason, and outcome; submit the atomic close below. Send no
+  conclude message.
 
 ## Whole-Sprint conformance
 
-Review the integrated system, not unit diffs. Classify each requirement as:
+Review the integrated system, not unit diffs. Classify every requirement
+`as-specced`, `deviated-intentionally` with ratified judgment,
+`deviated-silently`, or `unimplemented`; the last two are findings. Include
+spec document + work-unit ids when known.
 
-- `as-specced`;
-- `deviated-intentionally` with its ratified judgment;
-- `deviated-silently`; or
-- `unimplemented`.
+For the clean branch, write a conformance report and JSON findings array with
+`severity`, `title`, `body`, `spec_document_id`, and `work_unit_id`. Keep the
+report and each body near 6,000 and below 8,000 characters; run
+`wc -m < <report>` and validate each body.
 
-The last two are findings. Include spec document id and work-unit id when known.
-For the clean or post-Sprint-only branch, write the conformance report and a
-JSON findings array:
+Before recording conformance, author the final Sprint report. Name Reviewer as
+author and cover governing scope/revisions, shipped units/PRs, judgments +
+ratified deviations, failures/retries/recovery/anomalies, conclusion,
+follow-ups, and evidence location. Keep it near 6,000 and below 8,000; preserve
+discrepancies.
 
-```json
-[
-  {
-    "severity": "Major",
-    "title": "Integrated seam diverges",
-    "body": "Evidence and consequence.",
-    "spec_document_id": 46,
-    "work_unit_id": 9
-  }
-]
-```
-
-Keep the conformance report and each finding body at about 6,000 characters or
-fewer; 8,000 is the hard maximum for each. Run `wc -m < <report>` and length-check
-each finding body before submission.
-
-Before recording conformance, author the final Sprint report. Name the Reviewer
-as its author and answer:
-
-1. Which exact scope and revisions governed?
-2. What shipped, through which work units and PRs?
-3. Which Reviewer judgments and ratified deviations shaped the result?
-4. What failed, retried, paused, recovered, or remained anomalous?
-5. What did conformance conclude?
-6. Which follow-ups or unresolved items require FnB disposition?
-7. Where is the complete evidence?
-
-Keep the final report at about 6,000 characters or fewer and below the 8,000
-hard maximum; run `wc -m < <report>`. Do not smooth discrepancies into a
-success narrative. Keep the final report below 8,000 characters, then choose
-the exact completion reason, terminal outcome, and stable completion key. The
-engine stores the final report unchanged and generates the Planner receipt from
-the committed report and follow-up identities.
-
-Record the clean branch as one atomic final write:
+Record one atomic final write:
 
 ```text
 sc sprint record-conformance \
@@ -367,41 +249,27 @@ sc sprint record-conformance \
   --key <stable-pass-key>
 ```
 
-The receipt must name the conformance report id, final report id, follow-up ids,
-completed state, Planner message id, and Planner wake id. This creates
-append-only evidence, pending follow-ups, terminal lifecycle, and one
-informational engine-wide Planner Re-enter in the same transaction. Never
-record conformance first and then close around it; send no conclude message.
-On that successful commit, the engine also closes every other active chat
-immutably linked to the Sprint. The originating Planner and this
-report-authoring Reviewer remain open. Do not manually close peer chats as an
-extra closeout step. Pause, abort, re-entry, failed conformance, and rejected
-fallback completion keep their existing no-cleanup behavior.
-Never reopen an editing
-lane after recording; the re-enter branch defers the report until added scope
-reaches terminal disposition and a fresh delivery-terminal wake starts the next
-episode. Surface any immediate safety risk to FnB.
+Require receipt: conformance report id, final report id, follow-up ids,
+completed state, Planner message id, and Planner wake id. The transaction adds
+append-only evidence, follow-ups, terminal state, and one informational engine-wide Planner Re-enter;
+send no conclude message. Successful conformance also closes other Sprint-linked
+chats while the originating Planner + report-authoring Reviewer stay open. Do
+not manually close peer chats. Pause, abort, re-entry, failed conformance, and
+rejected fallback retain no-cleanup behavior. Never reopen editing after recording; a re-enter defers
+reports until new scope is terminal and a fresh delivery-terminal wake arrives.
 
 ## Stop
 
-For unit review, follow the ordered verdict procedure above: inbox handling and
-all evidence work precede `record-review`; the durable verdict is the literal
-last action, then the Reviewer stops.
+Unit review ends with the ordered `record-review` write as the literal final
+action.
 
-For the clean or post-Sprint-only branch, require both reports, findings,
-reason, and outcome to replay idempotently. For the re-enter or abort branch,
-confirm that the decision body carries the complete evidence and exact
-requested action. Then complete this final handoff order:
+For closeout, first re-run `sc sprint inbox --sprint <id>`, handle + `accept`
+new messages, then confirm every artifact/body is final and below 8,000.
 
-1. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
-   mark every handled informational message read with `accept`.
-2. Confirm every Reviewer-authored artifact and decision body is final and
-   below its 8,000-character hard maximum.
-3. For a clean conclude, run the atomic `record-conformance` command above as
-   the literal final action. When it confirms completed state and all receipt
-   identities, stop immediately; the Planner is already notified.
-4. For re-enter or abort, deliver the decision to the Planner as the literal
-   final action:
+- Clean conclude -> run the atomic `record-conformance` command above as the
+  literal final action. When it confirms completed state and all receipt
+  identities, stop immediately; Planner is notified.
+- Re-enter/abort -> as literal final action send:
 
 ```text
 sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
@@ -409,5 +277,5 @@ sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
   --key <stable-decision-handoff-key>
 ```
 
-5. When the command confirms the durable write and Planner wake, stop
-   immediately. Run no trailing command until another native wake arrives.
+Require durable write + Planner wake, then stop immediately. Run no trailing
+command until another native wake.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3479,7 +3479,7 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'spec',
-  'Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step.',
+  'Load before implementing any feature, spec, or roadmap item. Analyze viability, surface blockers, plan Preparation → implementation → Verification, and track spec_tasks/current_state across sessions.',
   'craft',
   NULL,
   0,

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3479,269 +3479,136 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'spec',
-  'Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step. Load when starting, implementing, or building any feature, spec, or roadmap item — before writing code.',
+  'Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step.',
   'craft',
   NULL,
   0,
   '# spec — analyze and execute a spec
 
-Load at the start of any session that builds or implements a feature, whether
-or not the work is framed as a "spec". A spec governs the work -> this skill
-executes it; one should exist but doesn''t -> the `docs` skill authors it first.
-Run **Analyze** before touching any code. Blockers / unclear items you can''t
-resolve alone -> pause for the FnB.
+Load before implementing any feature/spec/roadmap item. A governing spec is
+missing -> use `docs` to author it first. Analyze before code; unresolved
+ambiguity goes to FnB, while hard blockers get flags. `<self>` = your shell id.
 
-`<self>` = your shell_id.
+## 1. Select the spec
 
----
+Never auto-pick the latest document. Read the complete selected body + task
+ledger:
 
-## Step 1: Load the spec
-
-A feature can hold several unfrozen specs at once (see the `docs` skill).
-NEVER auto-pick "the latest" — list the feature''s open specs and choose the
-target explicitly:
-
-```
-# the feature''s documents — pick an unfrozen spec (frozen=0) by id:
+```text
 sc mem get documents --feature <id>
-# load the chosen spec body:
 sc mem get documents --doc <doc_id>
-# the spec''s task plan (empty = no plan yet):
 sc mem get tasks --doc <doc_id>
 ```
 
-`get documents --feature <id>` lists every spec/doc with `kind`, `seq`,
-`frozen`, `task_count`. Active spec = the unfrozen one with `task_count > 0`
-— resume it. `task_count = 0` = backlog; starting it (Step 3) makes it
-active. More than one open spec and the target unclear -> ask the FnB.
+The feature list includes `kind`, `seq`, `frozen`, and `task_count`. Resume the
+one unfrozen spec with tasks. An unfrozen zero-task spec is backlog; engaging it
+creates the plan below. Multiple plausible open specs -> ask FnB. Existing
+tasks -> skip planning and track the first unfinished one.
 
-Tasks already exist -> skip to **Step 4** (Track).
+## 2. Analyze before planning
 
-Read the entire spec body before going further. Do not skim.
+Return these findings before any code or task writes:
 
----
+| Check | Pass condition / action |
+|---|---|
+| Viability | Bounded, clear entry points, session-sized verification. Otherwise propose a verifiable slice. Missing done-condition = unclear. |
+| Current Posture | Preparation code/DB state matches the documented baseline. A mismatch stops for Planner/FnB; never redefine it silently. |
+| Scope | Every In Scope promise is planned; every Out of Scope item stays out. New/substantively revised specs contain both `## Current Posture` and `## Scope`; ambiguity stops. |
+| Anticipated User Activity | Plan stated roles, audience/reach, access, validation, recovery, authority, safety, process curation, and tenancy invariants. Older absence is allowed; ambiguity is not. |
+| Unclear item | Two plausible readings, missing target/interface, or unstated required knowledge -> ask FnB; do not flag a question they can answer. |
+| Blocker | Missing prerequisite/environment/external dependency -> open one High feature flag and stop at its boundary. |
 
-## Step 2: Analyze
-
-Surface all three before any planning or code:
-
-### Viability
-- Session-completable? Bounded + clear entry points = yes. Multiple layers /
-  migrations / unknown dependencies = no -> say so + propose a session-sized
-  slice.
-- No stated done-condition in the spec -> that is the first unclear item.
-
-### Current posture and scope
-Treat `## Current Posture` as the intended baseline and `## Scope` as the
-delivery boundary. Plan every **In Scope** promise and no **Out of Scope** item.
-If Preparation shows that documented posture and code disagree, stop and return
-the discrepancy to the Planner/FnB; do not silently redefine the baseline.
-
-New specs and substantively revised unfrozen specs must carry both sections
-(see `docs`). Frozen historical specs may predate them; absence there is not a
-blocker, but ambiguity still is.
-
-### Anticipated User Activity
-The spec''s `## Anticipated User Activity` section is governing intent: its
-roles, per-surface audience posture, reach, process curation, safety hardening,
-and tenancy invariants shape the plan — access, validation, recovery, authority,
-and tenancy checks are planned tasks, not afterthoughts. Older specs predate the
-section; absence there is not a blocker.
-
-### Unclear items
-Anything you cannot act on without guessing:
-- Ambiguous between two interpretations
-- Missing a critical detail (which table? which endpoint? which component?)
-- Implies knowledge not stated in the spec
-
-List them and ask the FnB before writing the plan.
-
-### Blockers
-Hard stops — prior work not shipped, missing environment state, unresolved
-external dependency. Open one flag per blocker:
-
-```
-sc mem flag open "[Spec] <what is blocked> | Blocker for: <feature title>" --name SC-### --priority High --feature <feature_id>
+```text
+sc mem flag open "[Spec] <blocked fact> | Blocker for: <feature>" \
+  --name SC-### --priority High --feature <feature_id>
 ```
 
-NEVER open a flag for an unclear item resolvable by asking — ask first.
+## 3. Engage and plan
 
----
+Building this session moves `brainstorm|long_term|near_term` to `in_progress`;
+planning ahead moves it to `next`. Matching/later stages are no-ops. Reading
+for reference moves nothing, and unspec''d small fixes have no stage ceremony.
 
-## Step 3: Plan
-
-### Reconcile the stage first
-
-Planning a spec = engaging it to build, so the feature''s `roadmap_status`
-(loaded in Step 1) must catch up to reality. Stages:
-`brainstorm · long_term · near_term · next · in_progress · shipped`.
-
-- At `brainstorm`/`long_term`/`near_term` + building this session ->
-  `sc mem roadmap status <feature_id> in_progress`
-- Planning ahead only (no build this session) -> move it to `next`.
-- Already at `in_progress` (or further) -> no-op; don''t churn it.
-
-The transition fires because you *act on* the spec — reading one for
-reference moves nothing. No spec governing the work (quick UI fix, minor
-migration) -> skip all stage handling (see Stance).
-
-### Confirm the work-stream too
-
-Check the feature''s work-stream (`roadmap.project_id` — the Flow-view
-grouping). Ungrouped -> assign now so the feature shows in a flow:
-
-```
-sc mem roadmap project <feature_id> <shortname>   # ''none'' to clear
+```text
+sc mem roadmap status <feature_id> in_progress
 ```
 
-Stream obvious -> assign; ambiguous -> surface to the FnB; already assigned
--> no-op. Full create/assess procedure (new streams, new features) = the
-`docs` skill; this is only the engage-time confirmation.
+Confirm `roadmap.project_id`. Assign the obvious stream; ask FnB if ambiguous;
+leave an existing assignment unchanged:
 
-### Write the task plan
-
-Analysis clear + blockers resolved or accepted -> generate the task list.
-Always this shape:
-
-| seq | title | role |
-|---|---|---|
-| 0 | Preparation | Always first — read code paths, verify DB state, confirm entry points |
-| 1..N | `<impl step title>` | As many as the scope needs; each independently verifiable |
-| N+1 | Verification | Always last — run tests, smoke-test against done-condition, check the build against the spec''s Anticipated User Activity section, snapshot + render |
-
-Add one task per seq with `sc mem task add` — each write is live in the
-shared DB immediately:
-
-```
-sc mem task add "Preparation"  --feature <id> --doc <doc_id> --seq 0 --desc "Read code paths, verify DB state, confirm entry points"
-sc mem task add "<Step 1>"     --feature <id> --doc <doc_id> --seq 1 --desc "<what it does>"
-sc mem task add "<Step N>"     --feature <id> --doc <doc_id> --seq <N> --desc "<what it does>"
-sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <N+1> --desc "Run tests, smoke-test every In Scope promise and done-condition, check the build against Anticipated User Activity assurance, snapshot + render"
+```text
+sc mem roadmap project <feature_id> <shortname>
 ```
 
-Then set `current_state` — nothing done yet, next = Preparation:
+Create exactly: Preparation, independently verifiable implementation steps,
+then Verification. Each write is immediately durable:
 
+```text
+sc mem task add "Preparation" --feature <id> --doc <doc_id> --seq 0 \
+  --desc "Read code paths, verify DB state, confirm entry points"
+sc mem task add "<step>" --feature <id> --doc <doc_id> --seq <n> \
+  --desc "<independently verifiable outcome>"
+sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <last> \
+  --desc "Test every scope promise, done-condition, audience assurance, snapshot, and render"
+sc mem state "[<feature>] — last: —. next: Preparation."
 ```
-sc mem state "[<feature_title>] — last: —. next: Preparation."
-```
 
----
+No task plan = no implementation.
 
-## Step 4: Track session by session
+## 4. Execute one task at a time
 
-**Agents overlay:** this shell granted `agents` + FnB invoked `--agents` ->
-that skill''s overlay replaces this step''s one-task-at-a-time loop with
-adjudicated waves. Load it and apply it on top of this step.
+When FnB explicitly invoked `--agents`, load `agents`; its adjudicated waves
+overlay this loop. Otherwise:
 
-At each work session''s start, load the plan:
-
-```
+```text
 sc mem get tasks --doc <doc_id>
-```
-
-Find the first `pending` task -> mark it in progress:
-
-```
 sc mem task start <task_id>
-```
-
-Work ONLY that task. When done:
-
-```
+# work and verify only this task
 sc mem task done <task_id>
 ```
 
-A planned task overtaken by a feature split or re-scope (its work moved to
-another feature/spec, never built here) is cancelled, not done:
+After completion, re-read the ledger. Set `current_state` to the highest done
+task + lowest pending task. Start the next only after the current task is
+verified and durably done. Work moved to another feature/spec is cancelled,
+never marked done or left pending under a shipped feature:
 
-```
+```text
 sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"
+sc mem state "[<feature>] — last: <last_done>. next: <next_up>."
 ```
 
-NEVER mark unbuilt work `done` and NEVER leave it `pending` under a shipped
-feature — the task ledger is how a planner answers "is this feature actually
-finished."
+The final Verification task runs focused/full gates, every In Scope
+done-condition, and the Anticipated User Activity contract. Unexpected reach,
+weakened hardening, or crossed tenancy is a failure. A large spec may stop
+after a verified task slice; leave later tasks pending and state the next one.
 
-Re-read the plan (`sc mem get tasks --doc <doc_id>`) and resolve from it:
-`last_done` = highest-`seq` `done` task; `next_up` = lowest-`seq` `pending`.
-Advance `current_state`:
+## 5. Ship and hand docs to Planner
 
+All tasks done + Verification green -> deliver:
+
+1. `sc mem roadmap status <feature_id> shipped`
+2. Open one Medium docs-pending feature flag.
+3. Message the planner: read shipped code, freeze the spec, write a `kind=doc`
+   document under the feature, then close the flag. Confirm the durable message.
+4. Tell FnB that code shipped and Planner owns freeze + docs. No planner shell ->
+   message nobody; tell FnB and leave the flag open.
+
+```text
+sc mem flag open "[Docs] <feature> shipped, doc pending | Blocker for: <feature> doc" \
+  --name SC-### --priority Medium --feature <feature_id>
 ```
-sc mem state "[<feature_title>] — last: <last_done>. next: <next_up>."
-```
 
-`next_up` NULL = all tasks done -> set current_state to reflect that.
+Do not freeze or author the shipped doc as Developer.
 
----
+## Scope change and stop rules
 
-## Step 5: Hand off on completion
+Small growth within the same intent -> revise the unfrozen spec with `docs`, add
+tasks, continue. A separate mental model -> stop and recommend a new feature +
+spec; never absorb it silently.
 
-Verification task passes (`next_up` NULL — the existing done-line) = feature
-delivered. As the dev: flip the horizon + hand the paperwork to the planner.
-Do NOT freeze the spec or write the doc — that''s the planner (`docs` skill).
-
-1. **Flip the horizon to shipped:**
-   ```
-   sc mem roadmap status <feature_id> shipped
-   ```
-2. **Open a docs-pending flag + message the planner with full instructions.**
-   `shipped` + an open flag = the honest interim state; the message carries
-   everything the planner needs without digging:
-   ```
-   sc mem flag open "[Docs] <feature> shipped, doc pending | Blocker for: <feature> doc" --name SC-### --priority Medium --feature <feature_id>
-   sc mem message send <planner-shortname> "**[Docs pending] <feature_title> (feature <feature_id>)**
-
-   Spec <doc_id> shipped. Flag SC-### is open — your action required:
-
-   1. **Read the shipped code first.** Write the doc from what actually shipped, not from the spec. Drift happens and decisions get made in production — the spec captures the intent, the code is the truth.
-   2. Freeze the spec: \`sc mem doc freeze <doc_id>\`
-   3. Write the doc (\`kind=''doc''\`) under feature <feature_id> (see the \`docs\` skill).
-   4. Close flag SC-### when the doc is live."
-   ```
-3. **Surface to the FnB:** "shipped; the planner needs to freeze the spec +
-   write the doc." The planner closes the flag when the doc lands.
-
-No planner-flavor shell in this fork -> message nobody; surface to the FnB
-directly and leave the docs-pending flag open for whoever picks up docs.
-
----
-
-## Watch for creep while you build
-
-Mid-build, the work crosses the spec''s In Scope / Out of Scope boundary:
-
-- **Small growth** (same mental model, a few more tasks) -> the unfrozen spec
-  is living; edit it (`sc mem doc edit`) and carry on. No ceremony.
-- **A separate coherent intent** (a new mental-model boundary — the
-  granularity test in the `docs` skill) -> do NOT quietly absorb it.
-  Recommend a **new spec** to the FnB, authored by the planner against its
-  own feature. Significant creep = planning event, not dev improvisation.
-
----
-
-## Stance
-
-- **Analyze before acting.** Analysis finds the gap between what the spec
-  says and what the code does.
-- **One task at a time.** Start task N+1 only after task N is verified +
-  marked done.
-- **Verification is not optional.** It is the last task; skipping it makes
-  "done" meaningless.
-- **Scope and Anticipated User Activity are intent.** Verification checks every
-  In Scope promise and the audience/assurance contract — an Out of Scope
-  capability, reach beyond the stated roles, weakened hardening obligation, or
-  data crossing a tenancy line is a finding, not a nuance.
-- **Spec too large for one session** -> scope a slice at Preparation: cover
-  steps 1–K verifiable now, leave K+1–N pending. NEVER start work that can''t
-  be verified before the session ends.
-- **current_state always reflects the plan.** Update after every task
-  completion — last done + next up. The next session resumes from it without
-  reading the full task list first.
-- **The stage tracks reality — spec''d work only.** Engaging a spec ->
-  `in_progress`; finishing -> `shipped`; already matching -> no-op, don''t
-  churn. Work with no spec (quick UI tweaks, minor migrations) is exempt
-  entirely: no promotion, no handoff, no creep check. Stage discipline never
-  blocks small things.',
+Stop for unresolved ambiguity/blocker, at the end of a verified session slice,
+or after the shipped/docs handoff. `current_state` must always point to the
+durable plan rather than reproduce its rationale.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET
@@ -3874,27 +3741,21 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
   0,
   '# sprint_dev — own one editing lane
 
-Use for an actionable work-unit assignment in an armed Sprint. Marking that
-Sprint message read is acceptance and starts work immediately. If you cannot
-accept, decline with a concrete reason; never leave it unread and waking.
-
-Use the simplest path supported by current durable state. Treat ownership,
-lifecycle preconditions, durable writes, and typed handoffs as hard boundaries;
-use judgment for implementation and verification within them. Repeat a read
-only when later activity could have changed it or the next command requires
-live revalidation.
+Use for an actionable work-unit assignment in an armed Sprint. Use the simplest
+path supported by current durable state. Treat ownership, lifecycle
+preconditions, durable writes, and typed handoffs as hard boundaries; use
+judgment inside them. Repeat a read only when later activity could have changed
+it or the next command requires live revalidation.
 
 ## Route the entry
 
-Load `sprint_dev` on every entry, then classify the trigger:
+Load `sprint_dev` on every entry, then classify it:
 
-- For a Sprint assignment, verdict, question, blocker, or other relay message,
-  inspect the Sprint inbox once and handle the relevant message.
-- For a self-describing engine-wide PR fact, inspect that fact and the
-  registered PR directly. Do not manufacture a Sprint inbox item; perform the
-  once-only inbox check immediately before the next typed handoff.
-- For a live FnB instruction, preserve its authority distinctly and inspect
-  only the durable state needed to act safely.
+| Trigger | First read / action |
+|---|---|
+| Assignment, verdict, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; accept or handle the relevant message. |
+| Self-describing engine-wide PR fact | Inspect the fact + registered PR directly. Do not manufacture a Sprint inbox item; check the inbox once immediately before the next typed handoff. |
+| Live FnB instruction | Preserve its authority; read only durable state needed for safe action. |
 
 ```text
 sc sprint inbox --sprint <id>
@@ -3902,35 +3763,26 @@ sc sprint accept --sprint <id> --message <message-id>
 sc sprint decline --sprint <id> --message <message-id> --reason <reason>
 ```
 
-Use `accept` or `decline` for actionable work. After acting on an informational
-question, answer, blocker, or context message, run `accept` for that message.
-For informational messages it only marks the message read; it does not change
-Sprint or work-unit state.
+Accepting marks assignment ownership and starts work. Decline with a concrete
+reason when unable to accept. After handling an informational message, run
+`accept`; it marks the message read and does not change Sprint or work-unit
+state.
 
-## Orient and bound the lane
+Assignments and review requests use Force-new delivery; verdicts and PR-event
+wakes use Re-enter. Delivery waits for a natural boundary; the runtime owns
+bundling, rotation, and recovery. Stop after a successful typed handoff.
+
+## Bound the lane
 
 Read the assignment, expected output, bound spec revision, dependencies,
-assigned Reviewer, repository/worktree, merge grant, and prior judgments. One
-Developer shell may own one active work unit in the Sprint. Do not start a
-second editing lane or edit another shell''s worktree.
+Reviewer, repository/worktree, merge grant, and prior judgments. Own at most one
+active work unit; never start a second editing lane or edit another shell''s
+worktree. Resolve ambiguity with the shippable in-scope reading + recorded
+rationale. Ask the Planner before changing the unit boundary, shared interface,
+deliverable cut, priority, or scope.
 
-If the requirement is ambiguous, choose the shippable reading within your
-unit''s scope, record the choice and rationale, and continue. Escalate changes to
-the unit boundary, interfaces another unit consumes, deliverable cuts, or scope
-growth to the Planner.
-
-Assignments use Force-new delivery; Reviewer verdicts and engine-wide PR facts
-use Re-enter. Neither displaces a live turn; delivery waits for its natural
-boundary, and the runtime owns bundling, rotation, and recovery. Stop after a
-successful typed handoff so the next delivery can proceed cleanly.
-
-## Questions, answers, blockers, and failures
-
-Put one concrete question, answer, blocker, or useful context item in a short
-body file. Declare the message intent and whether the required reply belongs to
-this work unit or the whole Sprint.
-
-A question or blocker about this lane requires a reply and names the work unit:
+Put one question, blocker, decision, answer, or useful context item in a short
+body file. Unit questions/blockers require a reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
@@ -3938,149 +3790,116 @@ sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --key <stable-key>
 ```
 
-Use `--intent blocker` instead for a blocked lane. A cross-unit, closeout, or
-external-authority ruling is a Sprint-level decision:
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level decisions:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent decision --requires-reply --sprint-level --key <stable-key>
 ```
 
-Answer the stored sender through the original message. The server inherits its
-unit or Sprint scope; never add `--work-unit` or `--sprint-level` to a reply:
+Reply through the original message; the server inherits its scope, so never add
+`--work-unit` or `--sprint-level` to a reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent information --reply-to <message-id> --key <stable-key>
 ```
 
-Ask the Planner about scope, priority, or cross-unit decisions and the Reviewer
-about review evidence. Confirm the reply write, then mark the handled incoming
-message read with `accept`. For a blocker or integrity concern, send the Planner
-evidence, impact, the exact action needed, and your recommendation. Continue
-safe independent work, but stop at a decision boundary when an answer is
-required. Unread recovery owns re-waking; do not send duplicate reminders.
+Ask the Reviewer about review evidence and the Planner about scope or
+cross-unit authority. Confirm the durable reply, then `accept` the incoming
+message. At a decision boundary, stop until the required answer arrives;
+unread recovery re-wakes, so send no duplicate reminder.
 
-Choose one stable key for the intended recipient, exact body, intent, reply
-linkage, and scope. Reuse it only when retrying that same write; use a new key
-when any of those fields changes.
+A stable key identifies recipient + exact body + intent + reply linkage +
+scope. Reuse it only for the same failed/ambiguous write; when any of those
+fields changes, use a new key. Keep bodies near 6,000 characters and below the
+8,000-character hard limit; run `wc -m < <path>`. A handoff completes only when
+the command exits successfully and confirms its durable message/state + wake.
+If a command is rejected or transport fails, correct and retry safely. If the
+relay itself fails, give FnB the attempted command, evidence, impact, and
+recommendation; invent no alternate protocol.
 
-Keep the body near 6,000 characters and below the 8,000 hard maximum; run
-`wc -m < <path>`. A handoff is complete only when the Sprint command exits
-successfully and confirms the durable write and wake.
+A Developer does not pause the Sprint. Report blocker or integrity evidence to
+the Planner, continue safe independent work, and stop at the unsafe boundary.
+The Reviewer decides continue/replan/pause; the Planner executes the decision.
 
-If a command is rejected or transport fails, the handoff is incomplete. Correct
-and retry when safe. If the relay itself fails, surface the attempted command,
-evidence, impact, and recommendation to FnB; do not invent an alternate
-protocol. A Developer does not pause the Sprint. The Reviewer decides whether
-the evidence warrants continuing, re-planning, or pausing; the Planner executes
-that decision.
-
-## Sprint artifact paths
-
-Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
-report drafts, and Dev scratch proof) go to the gitignored
-`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR''d in the work repo; a review-notes commit is a finding.
-
-DB rows stay the durable record: judgments via `record-review`, report bodies in
-`sprint_reports`, and decisions in the durable relay. Files in the Sprint
-artifact directory are working material only.
+Store scratch proof, diffs, evidence packets, review notes, and report drafts in
+gitignored `shared/sprints/sprint-<n>/`. Never commit or PR them. Durable
+judgments belong in `record-review`, reports in `sprint_reports`, and decisions
+in the relay.
 
 ## Build and verify
 
-Sync the assigned repository, work on a feature branch, match the surrounding
-code, and implement the smallest complete change. Keep external calls outside
-database transactions. Preserve durable identities and append-only evidence.
+Sync the assigned repository, branch, implement the smallest complete change,
+and exercise the unit''s independent gate + realistic failures. Keep external
+calls outside DB transactions; preserve durable identities and append-only
+evidence. Record CI failures, infrastructure anomalies, retries, review
+friction, and known departures for closeout.
 
-Verification must exercise the unit''s independent stage gate and realistic
-failure paths. A local exploratory number is not merge evidence. Record real CI
-failures, anomalous infrastructure failures, retries, review friction, and
-known departures for the final report.
-
-Immediately before a typed Developer handoff (`complete-unit`, `register-pr`,
-or `request-review`), re-run `sc sprint inbox --sprint <id>` once and act on
-anything new; a ruling may have arrived during the build. This is a once-only
-pre-handoff check. After the handoff confirms its durable write, stop without a
-further inbox pass. The reopened-PR recovery sequence below is the one
-exception: its single inbox check covers the exact registration replay and the
-immediately following review request, which remains the turn''s final action.
+Immediately before `complete-unit`, `register-pr`, or `request-review`, re-run
+`sc sprint inbox --sprint <id>` once and act on new messages. After the typed
+handoff confirms its durable write, stop without another inbox pass. The
+reopened-PR route below is the sole exception.
 
 ## Report-only or no-code completion
 
-An explicitly planned report-only or no-code lane completes with its durable
-result instead of a PR. Code lanes cannot use this path; they complete only
-after merge authorization and observation.
-
-Keep the result at about 6,000 characters or fewer; 8,000 is the hard maximum.
-Run `wc -m < <path>` before submitting, then require a successful command and
-durable completion receipt.
+Only an explicitly planned report/no-code lane may finish without a PR. Keep
+the result near 6,000 characters and below 8,000; run `wc -m < <path>`, perform
+the pre-handoff inbox check, then require a durable completion receipt:
 
 ```text
 sc sprint complete-unit --sprint <id> --work-unit <id> \
   --result-file <path>
 ```
 
-Register the PR through the authoritative Sprint surface and retain ownership
-until it is green. After `register-pr` succeeds, the native registered-PR
-watcher creates an engine-wide subscription owned by your shell. It supplies
-self-describing red, green, and externally closed facts as Re-enter wakes even
-after chat rotation or outside an armed Sprint. On red, diagnose and fix the PR.
-On green, judge readiness rather than forwarding mechanically. Planner and
-Reviewer receive no PR-event wakes.
+Stop after success. A code lane continues through merge observation.
+
+## Register and observe the PR
 
 ```text
 sc sprint register-pr --sprint <id> --repository <owner/name> \
   --pr <number> --work-unit <id>
 ```
 
-If GitHub closed this registered PR externally and you reopened, rebased, and
-pushed the same PR, replay the exact `register-pr` command above. The replay
-keeps the registered PR and ownership unchanged while taking one fresh watcher
-snapshot; `created: false` is the expected registration receipt. Confirm that
-write, perform no second inbox pass, then immediately attempt the typed
-`request-review`; do not wait for a second PR-fact wake. An unchanged state at
-the same head is intentionally deduplicated, so that wake would not exist. The
-review gate consumes the fresh durable snapshot: green proceeds, while any
-other state returns the existing watcher diagnostic without a partial handoff.
-Reuse the original stable key only when retrying a request that never returned
-a durable receipt; a new review round uses a new key. Do not register a
-replacement PR or ask the Planner to bypass the observed-green gate.
+After `register-pr` succeeds, retain ownership through green. The native
+registered-PR watcher creates your engine-wide subscription and sends
+self-describing red/green/externally-closed PR-event wakes as Re-enter, even
+outside an armed Sprint. Fix red; judge green. Planner and Reviewer receive no
+PR-event wakes.
 
-Outside that reopened-PR recovery sequence, when no local implementation action
-remains, stop and await the native PR-fact wake. Use Sprint-native wakes for
-coordination. Do not start a recurring shell loop, scheduled job, manual
-watcher daemon, or external PR watcher to track the registered PR.
+If the same registered PR was externally closed, then reopened, rebased, and
+pushed, replay the exact `register-pr` command. Require `created: false`, which
+keeps identity/ownership and takes a fresh snapshot. Its one pre-handoff inbox
+check covers registration replay + the immediately following review request.
+Do not wait for a second PR-fact wake: immediately request review. Green
+proceeds; any other snapshot returns the watcher diagnostic without partial
+handoff. Never register a replacement PR or ask the Planner to bypass observed
+green.
 
-If a watcher-dependent gate has stalled, one bounded inspection is sanctioned:
+Otherwise, when no local action remains, stop for the native PR fact. Start no
+recurring loop, scheduled job, daemon, or external watcher. A stalled gate
+permits one bounded read, then stop or report its evidence:
 
 ```text
 sc sprint watcher-state --sprint <id>
 ```
 
-Run it once to distinguish a stale or never-started watcher from red, pending,
-or absent PR observation, then stop or return the evidence to the Planner. Do
-not repeat the read as a polling loop.
+Do not repeat this read as a polling loop.
 
-## Review handoff
+## Review handoff and correction
 
-Complete a review handoff in this exact order. Every review round uses
-Force-new delivery, so stop cleanly after the request confirms and let the
-Reviewer begin in a fresh chat with the full bundled request:
+Complete each round in order:
 
-1. Finish the readiness judgment and every local verification step.
-2. Perform the once-only typed-handoff inbox check above, act on newly arrived
-   messages, and mark every handled informational message read with `accept`.
-3. Choose `submit` for the first review round or `resubmit` after a
-   changes-requested verdict. The engine injects the PR URL, registered Sprint
-   PR id, exact durable green head SHA, and work-unit id into the Reviewer''s
-   canonical bare one-line locator. Create no readiness file and include no
-   scope narrative,
-   verification evidence, judgment rationale, or review-focus steering. Put
-   only the work-unit id and spec reference in the PR body, and write no PR
-   comments or annotations.
-4. As the literal final action of the turn, send the typed handoff with one
-   stable retry key:
+1. Finish readiness judgment + local verification.
+2. Perform the once-only inbox check; handle and `accept` new messages.
+3. Use `submit` first or `resubmit` after changes requested. The engine injects
+   the PR URL, registered id, exact green head, and work-unit id into the
+   Reviewer''s canonical bare one-line locator. Create no readiness file. Send
+   no scope narrative, verification evidence, rationale, or review-focus
+   steering. Put only the work-unit id and spec reference in the PR body; write
+   no PR comments or annotations.
+4. As the literal final action, run:
 
 ```text
 sc sprint request-review \
@@ -4088,69 +3907,54 @@ sc sprint request-review \
   --intent <submit|resubmit> --key <stable-key>
 ```
 
-5. When the command confirms the durable write and Reviewer wake, immediately
-   stop and await the native verdict wake. Run no trailing command.
+5. Require confirmation of the durable write + Reviewer wake; run no trailing
+   command and stop and await the native verdict wake.
 
-A changes-requested verdict returns as Re-enter to your registry chat. Apply
-every blocking finding, re-establish green, and hand back with a new stable
-review key and `--intent resubmit`. Do not narrate how prior findings were
-cleared; the Reviewer verifies that from the full diff at the engine-injected
-exact head. Record
-disagreements as judgment; the Reviewer owns scope/severity decisions and the
-Planner executes any resulting action.
+Changes requested returns by Re-enter. Apply every blocking finding,
+re-establish green, and resubmit with a new review-round key. Do not narrate
+cleared findings; the Reviewer verifies the full diff at the engine-injected
+head. Record disagreements as judgment. Reviewer owns scope/severity; Planner
+executes resulting action.
 
 ## Merge boundary
 
-Approval alone is stale evidence. Immediately before merge, ask the engine to
-re-read live GitHub state and revalidate the armed grant, ownership, work-unit
-state, approved head, and checks:
+Approval is stale evidence. Immediately before merge, re-read live GitHub,
+grant, ownership, unit state, approved head, and checks through:
 
 ```text
 sc sprint authorize-merge \
   --sprint <id> --registered-pr <registered-id>
 ```
 
-Merge only the exact repository, PR number, and head SHA returned. If the
-command refuses, do not work around it; wait for the watcher or return to the
-appropriate loop.
+Merge only the returned repository, PR, and head SHA. A refusal means wait for
+the watcher or re-enter the appropriate loop; never bypass it.
 
 ## Post-merge handoff
 
-After the exact authorized merge succeeds, complete close-out in this order:
+After the authorized merge:
 
-1. Clean the worktree and collect the merged PR identity, merge SHA, unit
-   result, verification evidence, and judgments in the handoff body file.
-2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
-   mark every handled informational message read with `accept`.
-3. Run `wc -m < <path>`; keep the report near 6,000 characters and below the
-   8,000-character hard maximum.
-4. As the literal final action of the turn, send the merged-work handoff to the
-   Planner:
+1. Clean the worktree; put merged PR + SHA, unit result, verification,
+   judgments, and departures in the handoff file.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle and `accept` new items.
+3. Run `wc -m < <path>`; keep the body near 6,000 characters and below 8,000.
+4. As the literal final action, send:
 
 ```text
 sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
   --intent handoff --key <stable-merged-handoff-key>
 ```
 
-5. When the command confirms the durable write and Planner wake, stop
-   immediately. Run no trailing Git, Sprint, inbox, cleanup, or status command.
-   Automatic merge observation records the durable PR transition; the Planner
-   uses this handoff wake to release the next wave.
+5. Require the durable message + Planner wake, then stop immediately. Run no trailing Git,
+   Sprint, inbox, cleanup, or status command. Automatic merge
+   observation records the PR transition; this handoff releases the next wave.
 
 ## Report and stop
 
 Report broken bases, destructive ambiguity, unavailable GitHub, untrustworthy
-runners, provider exhaustion, or an unrecoverable environment to the Planner
-with evidence, impact, and a recommendation. Stop at the unsafe boundary while
-the Reviewer decides whether to continue, re-plan, or pause and the Planner
-executes that decision.
-
-Stop when the unit is merged and reported, declined, awaiting Planner/FnB
-recovery, returned to review, or paused awaiting a native PR-fact or verdict
-wake. For normal review and merge handoffs, the
-ordered procedures above place inbox handling before the typed handoff and make
-that handoff the turn''s last action. Ask the Planner for later work only after
-the current editing lane is terminal.',
+runners, provider exhaustion, or unrecoverable environment with evidence,
+impact, and recommendation. Stop when merged + reported, declined, returned to
+review, paused for a native wake, or awaiting Planner/FnB recovery. Ask for
+later work only after this editing lane is terminal.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET
@@ -4166,114 +3970,75 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
   0,
   '# sprint_pln — govern the armed Sprint
 
-Use as the originating Planner after `sprint_prep` arms the Sprint. The system
-captures deterministic facts; the Reviewer decides and documents, and the
-Planner acts. Execute Reviewer decisions without taking over their judgment or
-report authorship. The FnB retains the board-level override established by
-decision #46.
+Use as originating Planner after `sprint_prep` arms a Sprint. System records
+facts; Reviewer owns review/conformance judgment + reports; Planner owns plan
+structure and executes control transitions. FnB retains board-level override
+under decision #46.
 
 Use the simplest path supported by current durable state. Treat authority,
-lifecycle preconditions, durable writes, and typed handoffs as hard boundaries;
-use judgment for investigation and execution within them. Repeat a read only
-when later activity could have changed it or the next command requires live
-revalidation.
+lifecycle preconditions, durable writes, and typed handoffs as hard boundaries.
+Repeat a read only when later activity could have changed it or the next command
+requires live revalidation.
 
 ## Route the entry
 
-Classify the entry before reading an inbox:
+Load `sprint_pln` on every entry, then classify:
 
-- For a Sprint-scoped control decision, merged-work handoff, question, blocker,
-  or other relay message, inspect the Sprint inbox once and handle that message.
-- For the self-contained engine-wide clean-completion receipt, inspect the
-  receipt and terminal Sprint state directly. It is informational: do not run
-  the Sprint inbox, accept it, or issue a close command.
-- For a live FnB instruction, act under the board-level override and name that
-  authority in the durable evidence.
+| Trigger | Route |
+|---|---|
+| Sprint decision, merged-work handoff, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; handle that message. |
+| Self-contained clean-completion receipt | Inspect receipt + terminal state directly; it is informational—do not run the Sprint inbox, accept it, or close again. |
+| Live FnB instruction | Act under board override; name FnB authority in durable evidence. |
 
-Load `sprint_pln` on every entry. Do not turn entry routing into a polling loop.
+Do not poll. Armed runtime owns scheduled dispatch + unread wake recovery;
+registered-PR watcher owns subscription observation. Developer-owned subscriptions send
+red/green/closed facts to Developers, never Planner.
 
-## Start from durable state
+Assignments/review requests use Force-new delivery; Planner-bound results use
+Re-enter. Delivery waits for a natural boundary; runtime owns bundling,
+rotation, recovery, and coordinate mode. Stop after a successful typed handoff.
 
-The armed runtime owns scheduled dispatch and unread wake recovery. The
-registered-PR watcher owns subscription observation. React to their durable
-facts; use the Planner turn for dispatch, plan structure, and exact execution of
-durable Reviewer decisions. The Reviewer owns review and conformance judgment
-plus the conformance and final Sprint reports. The Planner owns the plan and its
-control transitions: it may modify, repeat, recall, reassign, or reroute work on
-its own operational judgment, and it executes Reviewer decisions that cross
-those same boundaries. Clean conformance approval performs its own atomic
-terminal transition.
+## Durable running loop
 
-Assignments and review requests use Force-new delivery. Planner-bound results
-use Re-enter. Neither displaces a live turn; delivery waits for its natural
-boundary, and the runtime owns bundling, rotation, recovery, and coordinate
-mode. Stop after a successful typed handoff so delivery can proceed cleanly.
-
-Start with the durable trigger, then read only the lifecycle, work-unit,
-dependency, route, PR, expectation, or anomaly facts needed for the current
-decision. Viewing a participant conversation is observation, not activity;
-never manufacture progress from browser presence.
+Read only lifecycle, unit, dependency, route, PR, expectation, and anomaly
+facts required by the trigger. Browser presence is not progress.
 
 ```text
 sc sprint inbox --sprint <id>
 sc sprint accept --sprint <id> --message <message-id>
 sc sprint decline --sprint <id> --message <message-id> --reason <reason>
-```
-
-Release every dependency-ready lane through the production surface:
-
-```text
 sc sprint dispatch --sprint <id>
 ```
 
-The returned ids are wake identities. Work-unit disposition and messages are
-the authoritative release facts. Dispatch is safe to repeat: occupied Developer
-lanes and stable assignment generations prevent double booking.
+Dispatch every dependency-ready lane; returned ids are wake identities.
+Disposition + messages are release facts. Stable assignment generations and
+occupied lanes make dispatch repeat-safe.
 
-Accept or decline only when the inbox item is actionable. After acting on an
-informational question, answer, blocker, or evidence message, run `accept` for
-that message. For informational messages it only marks the message read; it does
-not change Sprint or work-unit state.
+Accept/decline only actionable items. After acting on an informational message,
+run `accept`; it marks the message read and does not change Sprint or work-unit
+state.
 
-## Running loop
-
-- Keep dependencies as the only hard sequence. When reality requires a re-plan,
-  restructure the current projection under Planner authority and record why.
-  Ask the Reviewer when the change depends on review or conformance judgment;
-  do not outsource ordinary assignment, capacity, or route judgment. Never
-  rewrite completed history.
-- Let Developers own their PRs through green, review, correction, and merge.
-  Let Reviewers own verdicts and Sprint decisions. Do not proxy routine
-  handoffs or substitute Planner judgment for a Reviewer decision.
-- Consume passive system facts without waking yourself into every transition.
-  Route a decision boundary to the Reviewer; act when its Re-enter decision
-  message arrives.
-- Record the Reviewer decision identity, the exact action taken, and the action
-  receipt. Do not rewrite its rationale as Planner-authored judgment evidence.
-- A mid-Sprint spec edit is allowed only by the owning Planner or FnB. Record
-  the prior and new exact revision hashes. When acting as Planner, require a
-  durable Reviewer decision before the edit. The running Sprint remains bound
-  to its approved revision unless that decision explicitly says otherwise.
-
-Use Sprint-native wakes for coordination. Do not start a recurring shell loop,
-scheduled job, manual participant boot, or external PR watcher to track Sprint
-state. When a watcher-dependent gate has stalled, use the bounded read once:
+- Keep dependencies as hard sequence; restructure current projection under
+  Planner authority, record why, and never rewrite completed history.
+- Developers own PR green/review/correction/merge. Reviewers own verdicts and
+  conformance. Do not proxy routine handoffs or judgments.
+- Record Reviewer decision id + exact action + receipt; never rewrite rationale
+  as Planner judgment.
+- Mid-Sprint spec edits require owning Planner/FnB + durable Reviewer decision.
+  Record old/new revision hashes; binding changes only when the decision says so.
+- Use native wakes. Start no recurring loop, scheduled job, manual participant
+  boot, or external watcher. One stalled-gate inspection is allowed:
 
 ```text
 sc sprint watcher-state --sprint <id>
 ```
 
-It distinguishes a stale or never-started watcher from red, pending, or absent
-PR observation and includes the newest bounded poll failures. Do not repeat it
-as a polling loop; act on the evidence, then return control to native delivery.
+Do not repeat this read as a polling loop. Act on its bounded watcher evidence,
+then return to native delivery.
 
-## Questions, answers, blockers, and failures
+## Relay contract
 
-Put one concrete question, answer, decision, blocker, or useful context item in
-a short body file. Declare the message intent and whether the required reply
-belongs to one work unit or the whole Sprint.
-
-A question or blocker about one lane requires a reply and names that unit:
+Unit question/blocker requiring reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
@@ -4281,66 +4046,49 @@ sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --key <stable-key>
 ```
 
-Use `--intent blocker` instead for a blocked lane. A cross-unit, closeout, or
-external-authority ruling is a Sprint-level decision:
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent decision --requires-reply --sprint-level --key <stable-key>
 ```
 
-Answer the stored sender through the original message. The server inherits its
-unit or Sprint scope; never add `--work-unit` or `--sprint-level` to a reply:
+Answer through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent information --reply-to <message-id> --key <stable-key>
 ```
 
-Confirm the reply write, then mark the handled incoming message read with
-`accept`. For a blocker, include evidence, impact, and the exact action needed.
-Continue safe independent governance, but stop at a decision boundary when an
-answer is required. Unread recovery owns re-waking; do not send duplicate
-reminders.
+Confirm reply, then `accept` incoming. A missing answer stops at the decision
+boundary; unread recovery re-wakes, so send no duplicate. Choose a stable key
+for recipient + body + intent + reply + scope; reuse it only for that identical
+write. When any of those fields changes, use a new key.
 
-Choose one stable key for the intended recipient, exact body, intent, reply
-linkage, and scope. Reuse it only when retrying that same write; use a new key
-when any of those fields changes.
-Keep the body near 6,000 characters and below the 8,000 hard maximum; run
-`wc -m < <path>`. A handoff is complete only when the Sprint command exits
-successfully and confirms the durable write and wake.
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. Handoff completes only when the command exits successfully
+and confirms durable write + wake. If a command is rejected or transport fails,
+correct/retry safely. If relay itself fails, give FnB attempted command +
+durable evidence; invent no alternate protocol. Relay Developer integrity
+evidence, impact, and recommendation to Reviewer. Send required context before
+pausing because paused Sprint relay is unavailable.
 
-If a command is rejected or transport fails, the handoff is incomplete. Correct
-and retry when safe. If the relay itself fails, surface the attempted command
-and durable evidence to FnB; do not invent an alternate protocol. Relay a
-Developer integrity concern to the Reviewer with its evidence, impact, and
-recommendation. Send needed context before pausing because the Sprint relay is
-unavailable while paused.
-
-## Sprint artifact paths
-
-Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
-report drafts, and Dev scratch proof) go to the gitignored
-`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR''d in the work repo; a review-notes commit is a finding.
-
-DB rows stay the durable record: judgments via `record-review`, report bodies in
-`sprint_reports`, and decisions in the durable relay. Files in the Sprint
-artifact directory are working material only.
+Keep scratch review notes, diffs, evidence, reports, and proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit/branch/PR them. Durable judgment,
+reports, and decisions belong in `record-review`, `sprint_reports`, and relay.
 
 ## Reviewer decisions and Planner actions
 
-Review, conformance, re-enter, and abort judgments remain Reviewer decisions.
-Planner independently owns operational plan structure, including pause-safe
-recall, cancellation of unreleased scope, reassignment, repeated task lanes,
-and participant route changes. When an action does arrive as a durable Reviewer
-→ Planner Re-enter decision, resolve every required-reply decision through its
-original message before acting. Complete this order without reordering:
+Review/conformance/re-enter/abort judgment remains Reviewer-owned. Planner
+independently owns operational plan structure: pause-safe recall, cancellation
+of unreleased scope, reassignment, repeated task lanes, and route changes.
 
-1. Re-run `sc sprint inbox --sprint <id>`, verify the decision came from the
-   assigned Reviewer, and retain its message id.
-2. Put a short acknowledgement of the exact requested transition in a body
-   file, then send the linked reply:
+For a required-reply Reviewer→Planner Re-enter decision, keep this order:
+
+1. Re-run `sc sprint inbox --sprint <id>`; verify assigned Reviewer + retain id.
+2. Send linked acknowledgement:
 
 ```text
 sc sprint send --sprint <id> --to <reviewer-shortname> --body-file <path> \
@@ -4348,85 +4096,68 @@ sc sprint send --sprint <id> --to <reviewer-shortname> --body-file <path> \
   --key <stable-control-reply-key>
 ```
 
-3. Require the reply command to confirm its durable message and wake. Retry the
-   same command and key if it fails or does not confirm both.
-4. Mark the original decision accepted and require a successful receipt:
+3. Require the reply command to confirm its durable message and wake; retry the
+   same command/key if ambiguous.
+4. Accept the decision:
 
 ```text
 sc sprint accept --sprint <id> --message <decision-message-id>
 ```
 
-5. Only after acceptance confirms, execute the requested transition without
-   re-adjudicating the decision. The linked reply must precede any pause or
+5. Only after acceptance, execute the requested transition without
+   re-adjudicating it. The linked reply must precede any pause or
    abort that makes the Sprint relay unavailable.
 
-Record the decision message id, reply receipt, acceptance receipt, and action
-receipt together. Clean conformance instead closes atomically and sends an
-informational engine-wide completion receipt; it requires no linked reply or
-Sprint inbox acceptance.
+Record decision id + reply, acceptance, and action receipts. Clean conformance
+closes atomically and sends informational receipt; no reply/accept is needed.
 
-The FnB board-level override from decision #46 is unaffected: a live FnB
-instruction may direct or supersede any action. Name that override in the
-evidence instead of attributing it to the Reviewer.
-
-If a requested action fails a lifecycle, authority, or disposition precondition,
-do not substitute a different action. Send the refusal and current durable state
-back to the Reviewer (or surface it directly to FnB for an FnB override), then
-stop at that decision boundary.
+The FnB board-level override from decision #46 remains distinct. If action
+fails lifecycle/authority/disposition precondition, send refusal + durable state
+to Reviewer (or FnB for override), substitute nothing, and stop.
 
 ### Pause or resume
 
-Pause on a Reviewer decision or when Planner needs a safe restructuring window.
-Transition durably, stop external Sprint services, persist interrupt intent,
-preserve every partial artifact, and retain the governing judgment and evidence
-for recovery:
+Pause for Reviewer decision or safe Planner restructuring; preserve partial
+artifacts, interrupt intent, judgment, and evidence:
 
 ```text
 sc sprint pause --sprint <id> --reason <decision-or-restructure-reason>
 ```
 
-Resume after the requested recovery/restructure is fully recorded, or on a
-later Reviewer decision or FnB override. Reconcile native runs, unread messages,
-pending wakes, work units, registered PRs, capacity, and spec drift, then act
-with the supplied reason:
+Resume only after recording recovery/restructure and reconciling native runs,
+unread messages, wakes, units, PRs, capacity, and spec drift:
 
 ```text
 sc sprint resume --sprint <id> [--reason <validated-reconciliation-reason>]
 ```
 
-An exhausted recovery wake is bounded manual-recovery evidence, not a retry
-loop. Preserve the unread message and failed wake, involve FnB, and do not create
-recursive fallbacks. Drift informs; it never silently blocks resume.
+Exhausted recovery wake = bounded manual evidence: preserve unread message +
+failed wake, involve FnB, create no recursive fallback. Drift informs but never
+silently blocks resume.
 
-PR ownership inherited from an aborted Sprint is an originating-Planner repair
-boundary. Keep the replacement Sprint paused and establish the exact old and
-new ownership. The originating Planner may reconcile that identity; the FnB
-retains the same operation as a board-level override:
+Aborted-Sprint PR ownership repair belongs to the originating Planner. Keep
+replacement Sprint paused; establish old/new identity. The originating Planner
+may reconcile that identity (FnB may override):
 
 ```text
 sc sprint reconcile-pr --sprint <replacement-id> --repository <owner/repo> \
   --pr <number> --work-unit <replacement-unit-id> --reason <recovery-reason>
 ```
 
-The command refuses a live source Sprint or target Sprint, a non-originating
-Planner, a non-code or already owned target unit, and a closed unmerged PR. It
-records the old and new owners plus the live GitHub head and acting authority.
-If the PR is already merged, it also records the merge commit and completes the
-replacement unit as explicit recovery evidence. Treat the receipt as recovery
-evidence; wait for a separate Reviewer decision before resuming.
+It refuses a live source Sprint or target Sprint, a non-originating Planner,
+invalid/owned target, and closed-unmerged PR. Receipt records owners, live head,
+authority, and merged completion when applicable. Require a separate Reviewer
+decision before resuming.
 
 ### Modify, recall, repeat, reassign, or reroute
 
-Planner may cancel one unreleased work unit with its retained terminal reason.
-When cancellation executes a Reviewer decision, preserve that decision id in
-the reason and evidence:
+Cancel unreleased scope with retained terminal reason/Reviewer id:
 
 ```text
-sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <cancellation-reason>
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reason>
 ```
 
-Edit any subset of an unreleased lane directly. Omitted fields retain their
-current values; `--clear-dependencies` is the explicit empty dependency set:
+Edit an unreleased lane; omitted fields stay, `--clear-dependencies` means none:
 
 ```text
 sc sprint replan-unit --sprint <id> --work-unit <id> \
@@ -4436,33 +4167,24 @@ sc sprint replan-unit --sprint <id> --work-unit <id> \
   [--output-kind code|report-only|no-code]
 ```
 
-Do not edit a released lane in place. To change an accepted or pending
-assignment, first pause so dispatch cannot race the edit, recall the unmerged
-lane, replan it, then resume:
+Never edit a released lane in place. Pause → recall unmerged lane → replan →
+resume:
 
 ```text
 sc sprint pause --sprint <id> --reason <restructure-reason>
-sc sprint recall-unit --sprint <id> --work-unit <id> \
-  --reason <why-the-old-assignment-is-obsolete>
+sc sprint recall-unit --sprint <id> --work-unit <id> --reason <obsolete-reason>
 sc sprint replan-unit --sprint <id> --work-unit <id> <changed-fields>
 sc sprint resume --sprint <id> --reason <validated-replan-reason>
 ```
 
-Recall preserves the old accepted/declined message and event history, returns
-only an unmerged lane to `planned`, and refuses completed, cancelled, or
-PR-bound work. For a PR-bound lane, leave it intact and plan a replacement or
-use the supported PR-ownership recovery path; never force the projection back.
-Resume dispatches a fresh assignment generation.
+Recall preserves message/event history, returns only unmerged work to planned,
+and refuses terminal/PR-bound work. PR-bound work stays; plan replacement or use
+reconciliation. Resume creates fresh assignment generation. One spec task may
+govern repeated verification/replacement lanes; each lane lists it once. Do not
+duplicate the spec task.
 
-The same governing spec task may deliberately appear in more than one work
-unit. Use this for conformance reruns, repeat verification, or replacement work
-whose scope is still governed by the original task. Do not create a duplicate
-spec task merely to satisfy lane membership. Each work unit still lists a task
-at most once.
-
-To change which model will receive future assignments or reviews, pause first
-when the Sprint is armed, clear the participant''s released expectation through
-recall or completion, then replace its exact route:
+To change future assignment/review model, pause armed Sprint, clear released
+expectation, then validate + replace route:
 
 ```text
 sc sprint reroute-participant --sprint <id> --participant-shell <id> \
@@ -4470,41 +4192,24 @@ sc sprint reroute-participant --sprint <id> --participant-shell <id> \
   [--route <display-route>]
 ```
 
-Prepared Sprints may reroute before arm. Armed Sprints must pause; Developer
-routes reject any released lane and Reviewer routes reject an in-review lane.
-The engine validates the new route before writing it. Existing chats and runs
-stay immutable history; the next Force-new assignment or review request rotates
-onto the replacement route. Only already-declared participants can be selected
-or rerouted.
-
-If a Developer or Reviewer declines, preserve the reason and choose the
-replacement assignment or route from current capacity before issuing a fresh
-assignment. Ask the Reviewer only when that choice changes review or
-conformance judgment.
+Prepared Sprints may reroute directly. Armed Developer route rejects released
+lane; Reviewer route rejects in-review lane. Existing chats/runs remain history;
+next Force-new delivery uses replacement. Reroute declared participants only.
+On decline, preserve reason and choose replacement from current capacity; ask
+Reviewer only if review/conformance judgment changes.
 
 ### Re-enter after conformance
 
-A Reviewer `re-enter` decision names the in-Sprint findings, the governing
-tasks (existing ids when scope is unchanged; new title and description when
-scope is new), and the suggested
-unit grouping, waves, dependencies, routing, and capacity rationale. The
-Reviewer should identify independent lanes, expected review overlap, and useful
-reserve. Preserve that projection; do not silently absorb extra scope, maximize
-shell occupancy, or turn post-Sprint findings into delivery work.
-
-Reuse an existing task id when the decision repeats or repairs that exact
-governing scope. Cut a new task only for genuinely new scope:
+Reviewer decision names findings; governing tasks (existing for same scope,
+new title/description for new scope); and grouping, waves, dependencies,
+routing, capacity. Preserve it; do not absorb extra/post-Sprint scope or
+maximize occupancy.
 
 ```text
 sc mem task add "<task-title>" --feature <feature-id> \
   --doc <governing-spec-document-id> --seq <next-seq> \
   --desc "<task-description>"
-```
 
-Create the requested bound work units from those task ids, wiring the Reviewer''s
-waves and dependencies directly:
-
-```text
 sc sprint plan-unit --sprint <id> \
   --developer-shell <id> --reviewer-shell <id> --title <title> \
   --expected-output-file <path> --task <task-id> \
@@ -4512,76 +4217,51 @@ sc sprint plan-unit --sprint <id> \
   [--output-kind code|report-only|no-code]
 ```
 
-After every named task is bound, confirm the routes are available and the
-dependency graph and capacity plan match the decision. Planner may reassign or
-reroute for operational capacity; send the concrete conflict back to the
-Reviewer when that adaptation changes the Reviewer''s scope or conformance
-judgment. Then release the new ready lanes with `sc sprint dispatch --sprint <id>`. When
-the added work reaches terminal disposition, the engine sends the Reviewer the
-next delivery-terminal wake; the Planner does not initiate the next conformance
-pass.
+Reuse task for exact repair/repeat; add only genuinely new scope. Bind every
+task, then confirm routes + dependency graph and capacity plan match the
+decision. Planner may reassign or reroute for operational capacity; tell
+Reviewer if conflict changes scope/judgment. Release ready lanes with
+`sc sprint dispatch --sprint <id>`. Engine sends next delivery-terminal wake;
+Planner does not initiate conformance.
 
 ### Conclude or abort
 
-The Reviewer decides when the Sprint is done. A clean `record-conformance`
-command atomically stores conformance, follow-ups, the Reviewer-authored final
-report, completed lifecycle, and an informational engine-wide Planner receipt.
-When that Re-enter arrives, confirm the receipt names the expected Sprint,
-reports, outcome, and completed state. Do not run `complete`; closure is already
-durable and the notification is informational because closure is already
-terminal.
-Successful completion also closes every other active participant chat
-immutably linked to that Sprint. The originating Planner and report-authoring
-Reviewer remain open. Do not manually close peer chats as a second closeout
-action. Pause, abort, re-entry, failed conformance, and rejected fallback
-completion retain their existing no-cleanup behavior.
+The clean `record-conformance` command atomically stores conformance, follow-ups,
+Reviewer-authored final report, completion, and informational engine-wide
+Planner receipt. On Re-enter, verify Sprint/reports/outcome/completed state.
+Do not run `complete`; notification is informational because closure is already
+terminal. Planner does not author a second report. The originating Planner and
+report-authoring Reviewer remain open. Do not manually close peer chats. Pause,
+abort, re-entry, failed conformance, and rejected fallback retain no-cleanup
+behavior.
 
-Do not run `compile-report` by default, synthesize the final report, or
-editorialize the Reviewer body. The Reviewer compiles its own evidence. A
-Planner compile remains a valid FnB-directed fallback:
+Do not compile or editorialize by default; Reviewer owns evidence/report. Only
+FnB-directed fallback may run:
 
 ```text
 sc sprint compile-report --sprint <id> --limit 50 \
   > shared/sprints/sprint-<n>/evidence.json
 ```
 
-Do not wait for or request a conclude action message after the completion receipt.
-Abort is likewise an action taken only on a Reviewer decision or FnB override;
-it is terminal and deletes nothing.
+Abort only on Reviewer decision/FnB override; it is terminal and deletes
+nothing.
 
 ## Handoffs and stop
 
-Planner → Developer assignments and Developer → Reviewer review requests use
-Force-new delivery; Developer/Reviewer → Planner results are Re-enter. Forced
-delivery waits for the prior live turn''s natural boundary; runtime delivery
-owns the rest. These are delivery guarantees, not a parent/child chat topology.
-The Planner receives no PR-event wakes; Developer-owned subscriptions carry
-red, green, and externally closed facts directly to the owning Developer.
+Planner receives no PR-event wakes. Never dispatch the next wave from merge
+observation. The merged-work handoff wake is the only normal next-wave dispatch trigger.
+On it:
 
-Never dispatch the next wave from a merge-observation turn. The Developer''s
-merged-work handoff wake is the only normal next-wave dispatch trigger. On that
-wake, complete the turn in this exact order:
+1. Run `sc sprint inbox --sprint <id>`; inspect merged handoff + unit/dependency state.
+2. Handle earlier informational items and `accept` each, including handoff.
+3. Finish reconciliation and Planner bookkeeping; no work remains.
+4. As literal final action run `sc sprint dispatch --sprint <id>`.
+5. Require durable assignments + New wakes, then stop. Run no trailing command.
+   Empty dispatch remains final; investigate only on a later durable wake.
 
-1. Run `sc sprint inbox --sprint <id>` and inspect the durable merged-work
-   handoff plus current work-unit and dependency state.
-2. Act on every earlier informational item and mark each handled item read with
-   `accept`, including the Developer handoff.
-3. Finish all reconciliation, judgment recording, and other Planner
-   bookkeeping. No work remains after this step.
-4. As the literal final action of the turn, release dependency-ready lanes:
-
-```text
-sc sprint dispatch --sprint <id>
-```
-
-5. When the command confirms the durable assignment writes and New wakes, stop
-   immediately. Run no trailing command. Empty dispatch is still the final
-   action for that handoff turn; investigate only on a later durable wake.
-
-On a clean completion receipt, verify the named Sprint is terminal and record
-the bounded receipt; run no close command. The Planner does not author a second
-report, accept an actionable handoff, or wait for another actor to finish the
-Sprint.',
+On a clean completion receipt, verify terminal Sprint + bounded receipt; run no
+close command. Planner does not author a second report, accept an actionable
+handoff, or wait for another actor to finish the Sprint.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET
@@ -4784,70 +4464,53 @@ INSERT INTO skills (name, description, category, command, common, content, is_de
   0,
   '# sprint_rev — independent review and conformance
 
-Use in one of two modes: a work-unit PR review during the loop, or the final
-whole-Sprint conformance pass. Pre-declaration QAQC is a third entry condition,
-before a Sprint exists. The evidence differs; independence does not. The
-Reviewer decides and documents review and conformance judgments; the Planner
-owns operational plan structure and acts on control transitions. The FnB
-retains the board-level override established by decision #46.
+Use for pre-declaration QAQC, one work-unit review, or whole-Sprint
+conformance. The Reviewer decides review/conformance; the Planner owns
+operational plan structure + control execution. FnB retains the board-level
+override from decision #46.
 
 Use the simplest path supported by current durable state. Treat independence,
 authority, lifecycle preconditions, durable writes, and typed handoffs as hard
-boundaries; use judgment for investigation and review within them. Repeat a
-read only when later activity could have changed it or the next command
-requires live revalidation.
+boundaries. Repeat a read only when later activity could have changed it or the
+next command requires live revalidation.
 
 ## Route the entry
 
 Classify the entry before reading an inbox:
 
-- Pre-declaration QAQC begins from an explicit Planner or FnB request through
-  the ordinary shell-to-shell channel. Read and sign the exact current spec
-  body directly; there is no Sprint id or Sprint inbox to inspect yet.
-- A work-unit review request or delivery-terminal notification is Sprint-scoped.
-  Inspect the Sprint inbox once and accept the actionable request before work.
-- For a live FnB instruction, preserve its board-level authority distinctly and
-  inspect only the durable state needed for an independent decision.
+| Entry | Route |
+|---|---|
+| Explicit pre-declaration request | Read/sign the exact current spec directly; there is no Sprint id or Sprint inbox to inspect yet. |
+| Work-unit review / `sprint.delivery_terminal` | Inspect the Sprint inbox once; accept the actionable request. |
+| Live FnB instruction | Preserve board-level authority; read only durable state needed for independent judgment. |
 
-Record pre-declaration QAQC through the authenticated surface:
+QAQC precedes all Sprint inbox commands:
 
 ```text
 sc sprint record-qaqc --document <spec-document-id> \
   --verdict pass [--findings-document <document-id>]
 ```
 
-Once a Sprint is armed, review and conformance entries arrive through durable
-wakes. Load `sprint_rev` on every entry, then use the Sprint inbox for the
-Sprint-scoped cases above:
+For an armed Sprint, load `sprint_rev` on every entry:
 
 ```text
 sc sprint inbox --sprint <id>
 sc sprint accept --sprint <id> --message <message-id>
-```
-
-Decline an actionable request you cannot take, with a concrete reason:
-
-```text
 sc sprint decline --sprint <id> --message <message-id> --reason <reason>
 ```
 
-Use `accept` or `decline` for actionable work. After acting on an informational
-question, answer, blocker, or context message, run `accept` for that message.
-For informational messages it only marks the message read; it does not change
-Sprint or work-unit state.
+Decline actionable work only with a concrete reason. After handling an
+informational message, run `accept`; it marks the message read and does not
+change Sprint or work-unit state.
 
-Review requests use Force-new delivery. Reviewer verdicts to Developers and
-decisions to Planners use Re-enter. Neither displaces a live turn; delivery
-waits for its natural boundary, and the runtime owns bundling, rotation, and
-recovery. Stop after a successful typed handoff. Reviewers never receive
-PR-event subscription wakes.
+Review requests use Force-new delivery. Verdicts and Planner decisions use
+Re-enter. Delivery waits for a natural boundary; the runtime owns bundling,
+rotation, and recovery. Stop after a successful typed handoff. Reviewers never
+receive PR-event wakes.
 
-## Questions, answers, blockers, and failures
+## Relay contract and authority
 
-Put one concrete question, answer, blocker, or useful context item in a short
-body file. Declare the message intent and whether the required reply belongs to
-one work unit or the whole Sprint. Ask the Developer for missing PR evidence
-with a unit-scoped question:
+Ask the Developer for unit evidence with a unit-scoped question/blocker:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
@@ -4855,179 +4518,120 @@ sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --key <stable-key>
 ```
 
-Use `--intent blocker` instead when the unit cannot advance. Ask the Planner for
-durable state or action-feasibility facts without delegating Reviewer judgment.
-A cross-unit review, closeout, re-enter, abort, or safety ruling is a
-Sprint-level decision:
+Use `--intent blocker` when the unit cannot advance. Cross-unit, closeout,
+re-enter, abort, and safety rulings are Sprint-level decisions:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent decision --requires-reply --sprint-level --key <stable-key>
 ```
 
-Answer the stored sender through the original message. The server inherits its
-unit or Sprint scope; never add `--work-unit` or `--sprint-level` to a reply:
+Reply through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
 
 ```text
 sc sprint send --sprint <id> --to <shortname> --body-file <path> \
   --intent information --reply-to <message-id> --key <stable-key>
 ```
 
-Confirm the reply write, then mark the handled incoming message read with
-`accept`. A blocker or integrity concern is evidence for your decision. If
-action is needed, send the Planner the decision, impact, exact action, and
-recommendation. Continue safe independent review, but stop at the decision
-boundary when missing facts prevent an honest decision. Unread recovery owns
-re-waking; do not send duplicate reminders.
+Confirm a reply, then `accept` its incoming message. Missing facts stop review
+at the decision boundary; unread recovery re-wakes, so send no duplicate.
+A stable key identifies recipient + exact body + intent + reply + scope. Reuse
+it only for the same failed/ambiguous write; when any of those fields changes,
+use a new key.
 
-Choose one stable key for the intended recipient, exact body, intent, reply
-linkage, and scope. Reuse it only when retrying that same write; use a new key
-when any of those fields changes.
-
-Keep the body near 6,000 characters and below the 8,000 hard maximum; run
-`wc -m < <path>`. A handoff is complete only when the Sprint command exits
-successfully and confirms the durable write and wake.
-
-If a command is rejected or transport fails, the verdict or handoff is
-incomplete. Correct and retry when safe. If the relay itself fails, surface the
-attempted command, evidence, impact, and recommendation to FnB; do not invent an
-alternate protocol. A Reviewer decides whether review or conformance evidence
-warrants changes requested, re-entry, abort, or conclusion; the Planner
-independently decides ordinary operational replanning and executes control
-transitions. Record a live FnB override as FnB authority, not Reviewer judgment.
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. A handoff completes only when the command exits successfully
+and confirms the durable write + wake. If a command is rejected or transport fails,
+the verdict/handoff is incomplete. Correct and retry safely. If the relay itself fails,
+give FnB the attempted command, evidence, impact, and recommendation; invent no
+alternate protocol.
 
 ## Sprint artifact paths
 
-Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
-report drafts, and Dev scratch proof) go to the gitignored
-`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR''d in the work repo; a review-notes commit is a finding.
-
-DB rows stay the durable record: judgments via `record-review`, report bodies in
-`sprint_reports`, and decisions in the durable relay. Files in the Sprint
-artifact directory are working material only.
+Keep review notes, diffs, evidence, reports, and scratch proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit, branch, or PR them. Durable records
+belong in `record-review`, `sprint_reports`, and the relay.
 
 ## Conformance decisions and Planner controls
 
-The Reviewer owns review, re-enter, abort, and conclude judgments. The Planner
-independently owns operational plan structure: pausing for safe edits, recalling
-unreleased work, modifying or repeating task lanes, reassigning work, changing
-participant routes, cancelling unreleased scope, and resuming after validation.
-A clean conformance approval atomically performs its own close. Base a Reviewer
-judgment on durable Sprint state,
-the exact bound revisions, current work/PR facts, progress-carrier evidence, and any
-ratified judgment; ambiguous silence is not enough to corrupt a disposition.
+Reviewer owns review, re-enter, abort, and conclude judgments. Planner
+independently owns operational plan structure: safe-edit pauses, recalling
+unreleased work, lane changes/repeats, assignment/routing, unreleased-scope
+cancellation, and validated resume. Reviewer never runs standalone pause,
+replan, recall, reroute, cancel, resume, complete, or abort actions; clean
+`record-conformance` alone performs its narrow atomic close.
 
-Send re-enter, abort, or safety-critical control recommendations through the
-durable `send` surface above. A clean conclude instead runs the atomic
-`record-conformance` close below. Every Reviewer → Planner route is Re-enter.
-The Reviewer-authored body must name:
+Base judgment on durable Sprint state, bound revisions, current work/PR facts,
+progress-carrier evidence, and ratified judgments. Every Reviewer→Planner route
+is Re-enter. A decision body names:
 
 - `decision`: `re-enter`, `abort`, or the exact safety-critical recommendation;
-- the evidence and rationale owned by the Reviewer;
-- exact Sprint/work-unit ids, reason, outcome, and complete action arguments;
-- any immediate safety impact that the FnB must see.
+- Reviewer-owned evidence + rationale;
+- exact Sprint/unit ids, reason, outcome, and complete action arguments;
+- immediate safety impact for FnB.
 
-The Planner marks the message handled, verifies the assigned Reviewer, and acts
-on the judgment without surrendering its separate authority over the concrete
-plan. The clean completion receipt is informational because the Sprint is
-already terminal. The Reviewer never runs the standalone pause, replan, recall,
-reroute, cancel, resume, complete, or abort action; its clean
-`record-conformance` command owns the narrow automatic close. If a requested
-action is rejected, inspect the returned durable state and issue a revised
-judgment only when the evidence supports one; never ask the Planner to improvise
-around a precondition.
-
-The FnB board-level override from decision #46 is unaffected. A live FnB
-instruction can direct or supersede any decision; preserve it as a distinct
-authority record.
+Planner verifies Reviewer identity and executes the transition without
+surrendering plan authority. A rejected action requires a revised judgment
+supported by returned durable state, never an improvised bypass. A live FnB
+instruction supersedes as distinct FnB board-level override authority under
+decision #46.
 
 ## Severity rubric
 
-This skill owns severity. The governing spec intentionally does not.
-
 - **Critical** — active security/authority violation, destructive corruption,
-  or a condition that makes continued operation unsafe.
+  or unsafe continued operation.
 - **Major** — wrong behavior, data loss, broken invariant, material spec
-  violation, or a loop/recovery path that can silently wedge delivery.
-- **Medium** — a concrete correctness or recovery gap likely to bite normal
-  use soon, including missing negative enforcement or an unreliable handoff.
-- **Low** — bounded cleanup, clarity, test depth, or resilience improvement that
-  does not make the delivered behavior wrong now.
+  violation, or silently wedged delivery/recovery.
+- **Medium** — concrete normal-use correctness/recovery gap, missing negative
+  enforcement, or unreliable handoff.
+- **Low** — bounded cleanup, clarity, test-depth, or resilience improvement;
+  delivered behavior remains correct.
 
-During a work-unit review, Critical/Major/Medium block approval; Low is a
-report note. During close-out conformance, severity does not decide timing: the
-Reviewer judges whether each finding requires in-Sprint patching or is an
-acceptable post-Sprint follow-up.
+Critical/Major/Medium block unit approval; Low is a report note. At closeout,
+severity does not decide timing: Reviewer judges whether each finding requires in-Sprint patching
+or acceptable post-Sprint follow-up.
 
 ## Work-unit review
 
-Accept the actionable review request and retain that exact message id as the
-identity of this review round. Its readiness body must be only the bare
-locator: submitting or resubmitting intent, PR URL, registered Sprint PR id,
-exact head SHA, and work-unit id. Treat scope narrative, verification evidence,
-judgment rationale, or review-focus steering in that body as a protocol defect;
-do not use it to frame the review. Neither party writes PR comments or
-annotations, and the PR body contains only the work-unit id and spec reference.
+Accept the request and retain that exact message id. Its body is a bare locator:
+intent, PR URL, registered PR id, exact head, work-unit id. Scope narrative,
+verification, rationale, or focus steering is a protocol defect. PR comments
+and annotations are forbidden; PR body contains only unit id + spec reference.
 
-Bind every inspection and the eventual verdict to the accepted request''s
-message id, registered PR, work unit, and exact head. Another request in the
-same delivery, another unit assigned to this Reviewer, or role activity in a
-different conversation does not belong to this round. Accept and review each
-request explicitly; never infer a review lane from Reviewer identity alone.
-
-Review the exact bound spec revision and the full diff at the request''s exact
-head, then inspect checks, tests, relevant runtime evidence, and ratified
-judgments. Each round is clean: no prior Developer evidence or prose is input,
-and prior findings are cleared only when the code at the new head proves they
-are cleared. Review code quality, edge cases/failure paths, and spec
-conformance. Trace the real path; do not trust names or PR prose.
+Bind inspection/verdict to the accepted request''s message id, registered PR,
+work unit, and exact head. Review each request explicitly. Read the exact spec
+revision + full diff at that head, then checks, tests, relevant runtime facts,
+and ratified judgments. Each round is clean: no prior Developer evidence or
+prose; prior findings clear only when the new head proves it. Trace code paths,
+failure cases, and spec behavior rather than names or PR prose.
 
 ### Red-check doctrine
 
 Accepted-red is not a legal review outcome. A departure that leaves checks
-failing is never acceptable: do not note the failure and approve anyway. The
-review handoff remains green-only, without exception or waiver.
+failing is never acceptable; the handoff remains green-only, without exception
+or waiver: do not note the failure and approve anyway.
 
-`Note it and pass anyway` is the acceptance-shaped anti-pattern. In the
-dos-arch incident, a Reviewer accepted known-failing tests as a scoped
-departure and created a deadlock: the green-only handoff gate could never pass.
-Decision #93 records why this no-waiver rule exists.
+- In-scope failure -> record `changes_requested` so the Developer fixes them and restores green.
+- Out-of-scope failure -> keep the lane unapproved and send the Planner a `replan`
+  decision naming the failures; Planner widens the lane or cuts follow-up work.
 
-When failing checks are within the lane''s ratified scope, record
-`changes_requested` so the Developer fixes them and re-establishes green. When
-the failures are outside that scope, name the blocking failures in the finding
-and send the Planner a `replan` decision through the control protocol. The
-Planner must either widen the lane explicitly or cut a follow-up work unit; the
-current lane remains unapproved until the resulting work is green.
-
-Read resolved closure evidence through the authenticated memory surface; no SQL
-or mutation is needed. Use the exact form for a cited flag and the scoped form
-to audit every resolved flag attached to the feature:
+Read cited and feature-scoped resolved flag evidence through memory, never SQL:
 
 ```text
 sc mem get flags <flag-id>
 sc mem get flags --feature <feature-id> --resolved
 ```
 
-Findings must state:
-
-- severity and concise title;
-- violated behavior or invariant;
-- exact code/evidence location;
-- a reproducible consequence; and
-- the fix boundary, without prescribing unnecessary architecture.
+Each finding pins severity/title, violated invariant, exact location/evidence,
+reproducible consequence, and fix boundary without unnecessary architecture.
 
 Complete a unit verdict in this exact order:
 
-1. Finish the review, findings, and verdict body; no inspection remains after
-   this step.
-2. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
-   mark every handled informational message read with `accept`.
-3. Run `wc -m < <path>`; keep the verdict near 6,000 characters and below the
-   8,000-character hard maximum.
-4. As the literal final action of the turn, record the typed verdict through
-   the authenticated surface:
+1. Finish every inspection, finding, and verdict body.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle + `accept` new items.
+3. Run `wc -m < <path>`; require near 6,000 and below 8,000 characters.
+4. As the literal final action, run:
 
 ```text
 sc sprint record-review \
@@ -5035,107 +4639,65 @@ sc sprint record-review \
   --verdict changes_requested --body-file <path> --key <stable-key>
 ```
 
-5. When the command confirms the durable write and Developer wake, stop
-   immediately. Run no trailing command.
+5. Require durable judgment evidence + Developer Re-enter wake. Run no trailing command;
+   stop.
 
-Use `approved` only when no Critical/Major/Medium finding remains. The engine
-checks that the request was accepted and still binds to the reviewed head,
-records judgment evidence and sends a Re-enter wake to the Developer. Do not
-message around this surface;
-an unrecorded verdict cannot unlock merge.
+Use `approved` only with no Critical/Major/Medium finding. Engine validation
+requires the accepted request and reviewed head. Do not message around the
+surface; an unrecorded verdict cannot unlock merge.
 
 ## Delivery-terminal closeout
 
-The `sprint.delivery_terminal` notification is the entry signal for
-whole-Sprint conformance. Retain that exact notification message id and its
-delivered wake as the closeout entry identity; another Reviewer turn or an old
-terminal notification does not carry this episode. On that wake, inspect the
-inbox, lifecycle, and current work-unit state first. If the lifecycle is already
-`completed` or `aborted`, mark the informational notification handled with
-`accept` and stop. If any non-terminal unit is visible, the wake is stale: mark
-it handled with `accept`, exit, and await the next episode''s delivery-terminal
-wake. Only an armed Sprint whose units are all terminal enters conformance.
+Retain the exact notification message id + delivered wake as this closeout
+episode''s identity. Inspect inbox, lifecycle, and units first:
 
-Compile the bounded evidence packet first and do so yourself, then judge
-integrated `main` against every governing bound revision, exact recorded
-mid-Sprint revision fact, and ratified judgment:
+- Already completed/aborted -> `accept` notification and stop.
+- If any non-terminal unit is visible, the wake is stale -> `accept`, stop, and
+  await a fresh delivery-terminal episode.
+- Only an armed Sprint whose units are all terminal enters conformance.
+
+Compile the bounded evidence packet first, yourself:
 
 ```text
 sc sprint compile-report --sprint <id> --limit 50 \
   > shared/sprints/sprint-<n>/evidence.json
 ```
 
-Increase the bound only when truncation counters show the default omitted
-needed evidence; 200 is the maximum. The packet supplies facts, not judgment.
-If every work unit was cancelled and nothing shipped, the honest decision is
-`abort`, not `conclude`.
+Increase only when truncation omitted needed evidence; maximum 200. Judge
+integrated `main` against every bound/current revision + ratified judgment. All
+units cancelled and nothing shipped -> `abort`, not `conclude`.
 
-After classifying the requirements, choose exactly one branch:
+Choose one branch:
 
-- **In-Sprint patching required.** Do not run `record-conformance`. Send the
-  Planner a durable `re-enter` decision naming every blocking finding; each
-  spec task to cut against the governing spec document, with title and
-  description; and the suggested unit grouping, waves, dependencies,
-  Developer/Reviewer routing, and capacity rationale. Identify independent
-  lanes, expected review overlap, useful reserve, and why additional capacity
-  would or would not shorten the critical path. The durable decision is the
-  failed-pass record.
-  After three re-entry episodes in one Sprint, escalate the non-convergence to
-  FnB instead of starting another patch round.
-- **Clean or post-Sprint-only findings.** Prepare the conformance report,
-  findings, final Sprint report, reason, and outcome. Submit them through the
-  atomic `record-conformance` protocol below: the engine commits the evidence,
-  completed lifecycle, informational Planner receipt, and wake together. Do not
-  send a separate conclude message.
+- **In-Sprint patching required.** Do not run `record-conformance`. Send Planner
+  a durable `re-enter` decision with every blocking finding; each spec task''s
+  title and description; grouping, waves, dependencies, routing, and capacity
+  rationale. State independent lanes, expected review overlap, useful reserve,
+  and critical-path effect. After three re-entry episodes, escalate
+  non-convergence to FnB.
+- **Clean or post-Sprint-only findings.** Prepare conformance report, findings,
+  final report, reason, and outcome; submit the atomic close below. Send no
+  conclude message.
 
 ## Whole-Sprint conformance
 
-Review the integrated system, not unit diffs. Classify each requirement as:
+Review the integrated system, not unit diffs. Classify every requirement
+`as-specced`, `deviated-intentionally` with ratified judgment,
+`deviated-silently`, or `unimplemented`; the last two are findings. Include
+spec document + work-unit ids when known.
 
-- `as-specced`;
-- `deviated-intentionally` with its ratified judgment;
-- `deviated-silently`; or
-- `unimplemented`.
+For the clean branch, write a conformance report and JSON findings array with
+`severity`, `title`, `body`, `spec_document_id`, and `work_unit_id`. Keep the
+report and each body near 6,000 and below 8,000 characters; run
+`wc -m < <report>` and validate each body.
 
-The last two are findings. Include spec document id and work-unit id when known.
-For the clean or post-Sprint-only branch, write the conformance report and a
-JSON findings array:
+Before recording conformance, author the final Sprint report. Name Reviewer as
+author and cover governing scope/revisions, shipped units/PRs, judgments +
+ratified deviations, failures/retries/recovery/anomalies, conclusion,
+follow-ups, and evidence location. Keep it near 6,000 and below 8,000; preserve
+discrepancies.
 
-```json
-[
-  {
-    "severity": "Major",
-    "title": "Integrated seam diverges",
-    "body": "Evidence and consequence.",
-    "spec_document_id": 46,
-    "work_unit_id": 9
-  }
-]
-```
-
-Keep the conformance report and each finding body at about 6,000 characters or
-fewer; 8,000 is the hard maximum for each. Run `wc -m < <report>` and length-check
-each finding body before submission.
-
-Before recording conformance, author the final Sprint report. Name the Reviewer
-as its author and answer:
-
-1. Which exact scope and revisions governed?
-2. What shipped, through which work units and PRs?
-3. Which Reviewer judgments and ratified deviations shaped the result?
-4. What failed, retried, paused, recovered, or remained anomalous?
-5. What did conformance conclude?
-6. Which follow-ups or unresolved items require FnB disposition?
-7. Where is the complete evidence?
-
-Keep the final report at about 6,000 characters or fewer and below the 8,000
-hard maximum; run `wc -m < <report>`. Do not smooth discrepancies into a
-success narrative. Keep the final report below 8,000 characters, then choose
-the exact completion reason, terminal outcome, and stable completion key. The
-engine stores the final report unchanged and generates the Planner receipt from
-the committed report and follow-up identities.
-
-Record the clean branch as one atomic final write:
+Record one atomic final write:
 
 ```text
 sc sprint record-conformance \
@@ -5144,41 +4706,27 @@ sc sprint record-conformance \
   --key <stable-pass-key>
 ```
 
-The receipt must name the conformance report id, final report id, follow-up ids,
-completed state, Planner message id, and Planner wake id. This creates
-append-only evidence, pending follow-ups, terminal lifecycle, and one
-informational engine-wide Planner Re-enter in the same transaction. Never
-record conformance first and then close around it; send no conclude message.
-On that successful commit, the engine also closes every other active chat
-immutably linked to the Sprint. The originating Planner and this
-report-authoring Reviewer remain open. Do not manually close peer chats as an
-extra closeout step. Pause, abort, re-entry, failed conformance, and rejected
-fallback completion keep their existing no-cleanup behavior.
-Never reopen an editing
-lane after recording; the re-enter branch defers the report until added scope
-reaches terminal disposition and a fresh delivery-terminal wake starts the next
-episode. Surface any immediate safety risk to FnB.
+Require receipt: conformance report id, final report id, follow-up ids,
+completed state, Planner message id, and Planner wake id. The transaction adds
+append-only evidence, follow-ups, terminal state, and one informational engine-wide Planner Re-enter;
+send no conclude message. Successful conformance also closes other Sprint-linked
+chats while the originating Planner + report-authoring Reviewer stay open. Do
+not manually close peer chats. Pause, abort, re-entry, failed conformance, and
+rejected fallback retain no-cleanup behavior. Never reopen editing after recording; a re-enter defers
+reports until new scope is terminal and a fresh delivery-terminal wake arrives.
 
 ## Stop
 
-For unit review, follow the ordered verdict procedure above: inbox handling and
-all evidence work precede `record-review`; the durable verdict is the literal
-last action, then the Reviewer stops.
+Unit review ends with the ordered `record-review` write as the literal final
+action.
 
-For the clean or post-Sprint-only branch, require both reports, findings,
-reason, and outcome to replay idempotently. For the re-enter or abort branch,
-confirm that the decision body carries the complete evidence and exact
-requested action. Then complete this final handoff order:
+For closeout, first re-run `sc sprint inbox --sprint <id>`, handle + `accept`
+new messages, then confirm every artifact/body is final and below 8,000.
 
-1. Re-run `sc sprint inbox --sprint <id>`, act on newly arrived messages, and
-   mark every handled informational message read with `accept`.
-2. Confirm every Reviewer-authored artifact and decision body is final and
-   below its 8,000-character hard maximum.
-3. For a clean conclude, run the atomic `record-conformance` command above as
-   the literal final action. When it confirms completed state and all receipt
-   identities, stop immediately; the Planner is already notified.
-4. For re-enter or abort, deliver the decision to the Planner as the literal
-   final action:
+- Clean conclude -> run the atomic `record-conformance` command above as the
+  literal final action. When it confirms completed state and all receipt
+  identities, stop immediately; Planner is notified.
+- Re-enter/abort -> as literal final action send:
 
 ```text
 sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
@@ -5186,8 +4734,8 @@ sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
   --key <stable-decision-handoff-key>
 ```
 
-5. When the command confirms the durable write and Planner wake, stop
-   immediately. Run no trailing command until another native wake arrives.',
+Require durable write + Planner wake, then stop immediately. Run no trailing
+command until another native wake.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/.super-coder/migrations/0202_reseed_context_efficient_skills.sql
+++ b/.super-coder/migrations/0202_reseed_context_efficient_skills.sql
@@ -1,0 +1,965 @@
+-- 0201 — reseed context-efficient shell execution skills.
+-- Existing installs receive compact role/spec procedures without losing durable workflow contracts.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'spec',
+  'Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step.',
+  'craft',
+  NULL,
+  0,
+  '# spec — analyze and execute a spec
+
+Load before implementing any feature/spec/roadmap item. A governing spec is
+missing -> use `docs` to author it first. Analyze before code; unresolved
+ambiguity goes to FnB, while hard blockers get flags. `<self>` = your shell id.
+
+## 1. Select the spec
+
+Never auto-pick the latest document. Read the complete selected body + task
+ledger:
+
+```text
+sc mem get documents --feature <id>
+sc mem get documents --doc <doc_id>
+sc mem get tasks --doc <doc_id>
+```
+
+The feature list includes `kind`, `seq`, `frozen`, and `task_count`. Resume the
+one unfrozen spec with tasks. An unfrozen zero-task spec is backlog; engaging it
+creates the plan below. Multiple plausible open specs -> ask FnB. Existing
+tasks -> skip planning and track the first unfinished one.
+
+## 2. Analyze before planning
+
+Return these findings before any code or task writes:
+
+| Check | Pass condition / action |
+|---|---|
+| Viability | Bounded, clear entry points, session-sized verification. Otherwise propose a verifiable slice. Missing done-condition = unclear. |
+| Current Posture | Preparation code/DB state matches the documented baseline. A mismatch stops for Planner/FnB; never redefine it silently. |
+| Scope | Every In Scope promise is planned; every Out of Scope item stays out. New/substantively revised specs contain both `## Current Posture` and `## Scope`; ambiguity stops. |
+| Anticipated User Activity | Plan stated roles, audience/reach, access, validation, recovery, authority, safety, process curation, and tenancy invariants. Older absence is allowed; ambiguity is not. |
+| Unclear item | Two plausible readings, missing target/interface, or unstated required knowledge -> ask FnB; do not flag a question they can answer. |
+| Blocker | Missing prerequisite/environment/external dependency -> open one High feature flag and stop at its boundary. |
+
+```text
+sc mem flag open "[Spec] <blocked fact> | Blocker for: <feature>" \
+  --name SC-### --priority High --feature <feature_id>
+```
+
+## 3. Engage and plan
+
+Building this session moves `brainstorm|long_term|near_term` to `in_progress`;
+planning ahead moves it to `next`. Matching/later stages are no-ops. Reading
+for reference moves nothing, and unspec''d small fixes have no stage ceremony.
+
+```text
+sc mem roadmap status <feature_id> in_progress
+```
+
+Confirm `roadmap.project_id`. Assign the obvious stream; ask FnB if ambiguous;
+leave an existing assignment unchanged:
+
+```text
+sc mem roadmap project <feature_id> <shortname>
+```
+
+Create exactly: Preparation, independently verifiable implementation steps,
+then Verification. Each write is immediately durable:
+
+```text
+sc mem task add "Preparation" --feature <id> --doc <doc_id> --seq 0 \
+  --desc "Read code paths, verify DB state, confirm entry points"
+sc mem task add "<step>" --feature <id> --doc <doc_id> --seq <n> \
+  --desc "<independently verifiable outcome>"
+sc mem task add "Verification" --feature <id> --doc <doc_id> --seq <last> \
+  --desc "Test every scope promise, done-condition, audience assurance, snapshot, and render"
+sc mem state "[<feature>] — last: —. next: Preparation."
+```
+
+No task plan = no implementation.
+
+## 4. Execute one task at a time
+
+When FnB explicitly invoked `--agents`, load `agents`; its adjudicated waves
+overlay this loop. Otherwise:
+
+```text
+sc mem get tasks --doc <doc_id>
+sc mem task start <task_id>
+# work and verify only this task
+sc mem task done <task_id>
+```
+
+After completion, re-read the ledger. Set `current_state` to the highest done
+task + lowest pending task. Start the next only after the current task is
+verified and durably done. Work moved to another feature/spec is cancelled,
+never marked done or left pending under a shipped feature:
+
+```text
+sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"
+sc mem state "[<feature>] — last: <last_done>. next: <next_up>."
+```
+
+The final Verification task runs focused/full gates, every In Scope
+done-condition, and the Anticipated User Activity contract. Unexpected reach,
+weakened hardening, or crossed tenancy is a failure. A large spec may stop
+after a verified task slice; leave later tasks pending and state the next one.
+
+## 5. Ship and hand docs to Planner
+
+All tasks done + Verification green -> deliver:
+
+1. `sc mem roadmap status <feature_id> shipped`
+2. Open one Medium docs-pending feature flag.
+3. Message the planner: read shipped code, freeze the spec, write a `kind=doc`
+   document under the feature, then close the flag. Confirm the durable message.
+4. Tell FnB that code shipped and Planner owns freeze + docs. No planner shell ->
+   message nobody; tell FnB and leave the flag open.
+
+```text
+sc mem flag open "[Docs] <feature> shipped, doc pending | Blocker for: <feature> doc" \
+  --name SC-### --priority Medium --feature <feature_id>
+```
+
+Do not freeze or author the shipped doc as Developer.
+
+## Scope change and stop rules
+
+Small growth within the same intent -> revise the unfrozen spec with `docs`, add
+tasks, continue. A separate mental model -> stop and recommend a new feature +
+spec; never absorb it silently.
+
+Stop for unresolved ambiguity/blocker, at the end of a verified session slice,
+or after the shipped/docs handoff. `current_state` must always point to the
+durable plan rather than reproduce its rationale.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_dev',
+  'Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge only after live authorization, and record judgment without overlapping edits.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_dev — own one editing lane
+
+Use for an actionable work-unit assignment in an armed Sprint. Use the simplest
+path supported by current durable state. Treat ownership, lifecycle
+preconditions, durable writes, and typed handoffs as hard boundaries; use
+judgment inside them. Repeat a read only when later activity could have changed
+it or the next command requires live revalidation.
+
+## Route the entry
+
+Load `sprint_dev` on every entry, then classify it:
+
+| Trigger | First read / action |
+|---|---|
+| Assignment, verdict, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; accept or handle the relevant message. |
+| Self-describing engine-wide PR fact | Inspect the fact + registered PR directly. Do not manufacture a Sprint inbox item; check the inbox once immediately before the next typed handoff. |
+| Live FnB instruction | Preserve its authority; read only durable state needed for safe action. |
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Accepting marks assignment ownership and starts work. Decline with a concrete
+reason when unable to accept. After handling an informational message, run
+`accept`; it marks the message read and does not change Sprint or work-unit
+state.
+
+Assignments and review requests use Force-new delivery; verdicts and PR-event
+wakes use Re-enter. Delivery waits for a natural boundary; the runtime owns
+bundling, rotation, and recovery. Stop after a successful typed handoff.
+
+## Bound the lane
+
+Read the assignment, expected output, bound spec revision, dependencies,
+Reviewer, repository/worktree, merge grant, and prior judgments. Own at most one
+active work unit; never start a second editing lane or edit another shell''s
+worktree. Resolve ambiguity with the shippable in-scope reading + recorded
+rationale. Ask the Planner before changing the unit boundary, shared interface,
+deliverable cut, priority, or scope.
+
+Put one question, blocker, decision, answer, or useful context item in a short
+body file. Unit questions/blockers require a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level decisions:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Reply through the original message; the server inherits its scope, so never add
+`--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Ask the Reviewer about review evidence and the Planner about scope or
+cross-unit authority. Confirm the durable reply, then `accept` the incoming
+message. At a decision boundary, stop until the required answer arrives;
+unread recovery re-wakes, so send no duplicate reminder.
+
+A stable key identifies recipient + exact body + intent + reply linkage +
+scope. Reuse it only for the same failed/ambiguous write; when any of those
+fields changes, use a new key. Keep bodies near 6,000 characters and below the
+8,000-character hard limit; run `wc -m < <path>`. A handoff completes only when
+the command exits successfully and confirms its durable message/state + wake.
+If a command is rejected or transport fails, correct and retry safely. If the
+relay itself fails, give FnB the attempted command, evidence, impact, and
+recommendation; invent no alternate protocol.
+
+A Developer does not pause the Sprint. Report blocker or integrity evidence to
+the Planner, continue safe independent work, and stop at the unsafe boundary.
+The Reviewer decides continue/replan/pause; the Planner executes the decision.
+
+Store scratch proof, diffs, evidence packets, review notes, and report drafts in
+gitignored `shared/sprints/sprint-<n>/`. Never commit or PR them. Durable
+judgments belong in `record-review`, reports in `sprint_reports`, and decisions
+in the relay.
+
+## Build and verify
+
+Sync the assigned repository, branch, implement the smallest complete change,
+and exercise the unit''s independent gate + realistic failures. Keep external
+calls outside DB transactions; preserve durable identities and append-only
+evidence. Record CI failures, infrastructure anomalies, retries, review
+friction, and known departures for closeout.
+
+Immediately before `complete-unit`, `register-pr`, or `request-review`, re-run
+`sc sprint inbox --sprint <id>` once and act on new messages. After the typed
+handoff confirms its durable write, stop without another inbox pass. The
+reopened-PR route below is the sole exception.
+
+## Report-only or no-code completion
+
+Only an explicitly planned report/no-code lane may finish without a PR. Keep
+the result near 6,000 characters and below 8,000; run `wc -m < <path>`, perform
+the pre-handoff inbox check, then require a durable completion receipt:
+
+```text
+sc sprint complete-unit --sprint <id> --work-unit <id> \
+  --result-file <path>
+```
+
+Stop after success. A code lane continues through merge observation.
+
+## Register and observe the PR
+
+```text
+sc sprint register-pr --sprint <id> --repository <owner/name> \
+  --pr <number> --work-unit <id>
+```
+
+After `register-pr` succeeds, retain ownership through green. The native
+registered-PR watcher creates your engine-wide subscription and sends
+self-describing red/green/externally-closed PR-event wakes as Re-enter, even
+outside an armed Sprint. Fix red; judge green. Planner and Reviewer receive no
+PR-event wakes.
+
+If the same registered PR was externally closed, then reopened, rebased, and
+pushed, replay the exact `register-pr` command. Require `created: false`, which
+keeps identity/ownership and takes a fresh snapshot. Its one pre-handoff inbox
+check covers registration replay + the immediately following review request.
+Do not wait for a second PR-fact wake: immediately request review. Green
+proceeds; any other snapshot returns the watcher diagnostic without partial
+handoff. Never register a replacement PR or ask the Planner to bypass observed
+green.
+
+Otherwise, when no local action remains, stop for the native PR fact. Start no
+recurring loop, scheduled job, daemon, or external watcher. A stalled gate
+permits one bounded read, then stop or report its evidence:
+
+```text
+sc sprint watcher-state --sprint <id>
+```
+
+Do not repeat this read as a polling loop.
+
+## Review handoff and correction
+
+Complete each round in order:
+
+1. Finish readiness judgment + local verification.
+2. Perform the once-only inbox check; handle and `accept` new messages.
+3. Use `submit` first or `resubmit` after changes requested. The engine injects
+   the PR URL, registered id, exact green head, and work-unit id into the
+   Reviewer''s canonical bare one-line locator. Create no readiness file. Send
+   no scope narrative, verification evidence, rationale, or review-focus
+   steering. Put only the work-unit id and spec reference in the PR body; write
+   no PR comments or annotations.
+4. As the literal final action, run:
+
+```text
+sc sprint request-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --intent <submit|resubmit> --key <stable-key>
+```
+
+5. Require confirmation of the durable write + Reviewer wake; run no trailing
+   command and stop and await the native verdict wake.
+
+Changes requested returns by Re-enter. Apply every blocking finding,
+re-establish green, and resubmit with a new review-round key. Do not narrate
+cleared findings; the Reviewer verifies the full diff at the engine-injected
+head. Record disagreements as judgment. Reviewer owns scope/severity; Planner
+executes resulting action.
+
+## Merge boundary
+
+Approval is stale evidence. Immediately before merge, re-read live GitHub,
+grant, ownership, unit state, approved head, and checks through:
+
+```text
+sc sprint authorize-merge \
+  --sprint <id> --registered-pr <registered-id>
+```
+
+Merge only the returned repository, PR, and head SHA. A refusal means wait for
+the watcher or re-enter the appropriate loop; never bypass it.
+
+## Post-merge handoff
+
+After the authorized merge:
+
+1. Clean the worktree; put merged PR + SHA, unit result, verification,
+   judgments, and departures in the handoff file.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle and `accept` new items.
+3. Run `wc -m < <path>`; keep the body near 6,000 characters and below 8,000.
+4. As the literal final action, send:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --intent handoff --key <stable-merged-handoff-key>
+```
+
+5. Require the durable message + Planner wake, then stop immediately. Run no trailing Git,
+   Sprint, inbox, cleanup, or status command. Automatic merge
+   observation records the PR transition; this handoff releases the next wave.
+
+## Report and stop
+
+Report broken bases, destructive ambiguity, unavailable GitHub, untrustworthy
+runners, provider exhaustion, or unrecoverable environment with evidence,
+impact, and recommendation. Stop when merged + reported, declined, returned to
+review, paused for a native wake, or awaiting Planner/FnB recovery. Ask for
+later work only after this editing lane is terminal.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
+
+Use as originating Planner after `sprint_prep` arms a Sprint. System records
+facts; Reviewer owns review/conformance judgment + reports; Planner owns plan
+structure and executes control transitions. FnB retains board-level override
+under decision #46.
+
+Use the simplest path supported by current durable state. Treat authority,
+lifecycle preconditions, durable writes, and typed handoffs as hard boundaries.
+Repeat a read only when later activity could have changed it or the next command
+requires live revalidation.
+
+## Route the entry
+
+Load `sprint_pln` on every entry, then classify:
+
+| Trigger | Route |
+|---|---|
+| Sprint decision, merged-work handoff, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; handle that message. |
+| Self-contained clean-completion receipt | Inspect receipt + terminal state directly; it is informational—do not run the Sprint inbox, accept it, or close again. |
+| Live FnB instruction | Act under board override; name FnB authority in durable evidence. |
+
+Do not poll. Armed runtime owns scheduled dispatch + unread wake recovery;
+registered-PR watcher owns subscription observation. Developer-owned subscriptions send
+red/green/closed facts to Developers, never Planner.
+
+Assignments/review requests use Force-new delivery; Planner-bound results use
+Re-enter. Delivery waits for a natural boundary; runtime owns bundling,
+rotation, recovery, and coordinate mode. Stop after a successful typed handoff.
+
+## Durable running loop
+
+Read only lifecycle, unit, dependency, route, PR, expectation, and anomaly
+facts required by the trigger. Browser presence is not progress.
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+sc sprint dispatch --sprint <id>
+```
+
+Dispatch every dependency-ready lane; returned ids are wake identities.
+Disposition + messages are release facts. Stable assignment generations and
+occupied lanes make dispatch repeat-safe.
+
+Accept/decline only actionable items. After acting on an informational message,
+run `accept`; it marks the message read and does not change Sprint or work-unit
+state.
+
+- Keep dependencies as hard sequence; restructure current projection under
+  Planner authority, record why, and never rewrite completed history.
+- Developers own PR green/review/correction/merge. Reviewers own verdicts and
+  conformance. Do not proxy routine handoffs or judgments.
+- Record Reviewer decision id + exact action + receipt; never rewrite rationale
+  as Planner judgment.
+- Mid-Sprint spec edits require owning Planner/FnB + durable Reviewer decision.
+  Record old/new revision hashes; binding changes only when the decision says so.
+- Use native wakes. Start no recurring loop, scheduled job, manual participant
+  boot, or external watcher. One stalled-gate inspection is allowed:
+
+```text
+sc sprint watcher-state --sprint <id>
+```
+
+Do not repeat this read as a polling loop. Act on its bounded watcher evidence,
+then return to native delivery.
+
+## Relay contract
+
+Unit question/blocker requiring reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Answer through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Confirm reply, then `accept` incoming. A missing answer stops at the decision
+boundary; unread recovery re-wakes, so send no duplicate. Choose a stable key
+for recipient + body + intent + reply + scope; reuse it only for that identical
+write. When any of those fields changes, use a new key.
+
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. Handoff completes only when the command exits successfully
+and confirms durable write + wake. If a command is rejected or transport fails,
+correct/retry safely. If relay itself fails, give FnB attempted command +
+durable evidence; invent no alternate protocol. Relay Developer integrity
+evidence, impact, and recommendation to Reviewer. Send required context before
+pausing because paused Sprint relay is unavailable.
+
+Keep scratch review notes, diffs, evidence, reports, and proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit/branch/PR them. Durable judgment,
+reports, and decisions belong in `record-review`, `sprint_reports`, and relay.
+
+## Reviewer decisions and Planner actions
+
+Review/conformance/re-enter/abort judgment remains Reviewer-owned. Planner
+independently owns operational plan structure: pause-safe recall, cancellation
+of unreleased scope, reassignment, repeated task lanes, and route changes.
+
+For a required-reply Reviewer→Planner Re-enter decision, keep this order:
+
+1. Re-run `sc sprint inbox --sprint <id>`; verify assigned Reviewer + retain id.
+2. Send linked acknowledgement:
+
+```text
+sc sprint send --sprint <id> --to <reviewer-shortname> --body-file <path> \
+  --intent information --reply-to <decision-message-id> \
+  --key <stable-control-reply-key>
+```
+
+3. Require the reply command to confirm its durable message and wake; retry the
+   same command/key if ambiguous.
+4. Accept the decision:
+
+```text
+sc sprint accept --sprint <id> --message <decision-message-id>
+```
+
+5. Only after acceptance, execute the requested transition without
+   re-adjudicating it. The linked reply must precede any pause or
+   abort that makes the Sprint relay unavailable.
+
+Record decision id + reply, acceptance, and action receipts. Clean conformance
+closes atomically and sends informational receipt; no reply/accept is needed.
+
+The FnB board-level override from decision #46 remains distinct. If action
+fails lifecycle/authority/disposition precondition, send refusal + durable state
+to Reviewer (or FnB for override), substitute nothing, and stop.
+
+### Pause or resume
+
+Pause for Reviewer decision or safe Planner restructuring; preserve partial
+artifacts, interrupt intent, judgment, and evidence:
+
+```text
+sc sprint pause --sprint <id> --reason <decision-or-restructure-reason>
+```
+
+Resume only after recording recovery/restructure and reconciling native runs,
+unread messages, wakes, units, PRs, capacity, and spec drift:
+
+```text
+sc sprint resume --sprint <id> [--reason <validated-reconciliation-reason>]
+```
+
+Exhausted recovery wake = bounded manual evidence: preserve unread message +
+failed wake, involve FnB, create no recursive fallback. Drift informs but never
+silently blocks resume.
+
+Aborted-Sprint PR ownership repair belongs to the originating Planner. Keep
+replacement Sprint paused; establish old/new identity. The originating Planner
+may reconcile that identity (FnB may override):
+
+```text
+sc sprint reconcile-pr --sprint <replacement-id> --repository <owner/repo> \
+  --pr <number> --work-unit <replacement-unit-id> --reason <recovery-reason>
+```
+
+It refuses a live source Sprint or target Sprint, a non-originating Planner,
+invalid/owned target, and closed-unmerged PR. Receipt records owners, live head,
+authority, and merged completion when applicable. Require a separate Reviewer
+decision before resuming.
+
+### Modify, recall, repeat, reassign, or reroute
+
+Cancel unreleased scope with retained terminal reason/Reviewer id:
+
+```text
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reason>
+```
+
+Edit an unreleased lane; omitted fields stay, `--clear-dependencies` means none:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  [--developer-shell <id>] [--reviewer-shell <id>] [--title <title>] \
+  [--expected-output-file <path>] [--task <task-id>] [--wave <n>] \
+  [--depends-on <work-unit-id> | --clear-dependencies] \
+  [--output-kind code|report-only|no-code]
+```
+
+Never edit a released lane in place. Pause → recall unmerged lane → replan →
+resume:
+
+```text
+sc sprint pause --sprint <id> --reason <restructure-reason>
+sc sprint recall-unit --sprint <id> --work-unit <id> --reason <obsolete-reason>
+sc sprint replan-unit --sprint <id> --work-unit <id> <changed-fields>
+sc sprint resume --sprint <id> --reason <validated-replan-reason>
+```
+
+Recall preserves message/event history, returns only unmerged work to planned,
+and refuses terminal/PR-bound work. PR-bound work stays; plan replacement or use
+reconciliation. Resume creates fresh assignment generation. One spec task may
+govern repeated verification/replacement lanes; each lane lists it once. Do not
+duplicate the spec task.
+
+To change future assignment/review model, pause armed Sprint, clear released
+expectation, then validate + replace route:
+
+```text
+sc sprint reroute-participant --sprint <id> --participant-shell <id> \
+  --harness <harness> [--model <model>] [--effort <effort>] \
+  [--route <display-route>]
+```
+
+Prepared Sprints may reroute directly. Armed Developer route rejects released
+lane; Reviewer route rejects in-review lane. Existing chats/runs remain history;
+next Force-new delivery uses replacement. Reroute declared participants only.
+On decline, preserve reason and choose replacement from current capacity; ask
+Reviewer only if review/conformance judgment changes.
+
+### Re-enter after conformance
+
+Reviewer decision names findings; governing tasks (existing for same scope,
+new title/description for new scope); and grouping, waves, dependencies,
+routing, capacity. Preserve it; do not absorb extra/post-Sprint scope or
+maximize occupancy.
+
+```text
+sc mem task add "<task-title>" --feature <feature-id> \
+  --doc <governing-spec-document-id> --seq <next-seq> \
+  --desc "<task-description>"
+
+sc sprint plan-unit --sprint <id> \
+  --developer-shell <id> --reviewer-shell <id> --title <title> \
+  --expected-output-file <path> --task <task-id> \
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>] \
+  [--output-kind code|report-only|no-code]
+```
+
+Reuse task for exact repair/repeat; add only genuinely new scope. Bind every
+task, then confirm routes + dependency graph and capacity plan match the
+decision. Planner may reassign or reroute for operational capacity; tell
+Reviewer if conflict changes scope/judgment. Release ready lanes with
+`sc sprint dispatch --sprint <id>`. Engine sends next delivery-terminal wake;
+Planner does not initiate conformance.
+
+### Conclude or abort
+
+The clean `record-conformance` command atomically stores conformance, follow-ups,
+Reviewer-authored final report, completion, and informational engine-wide
+Planner receipt. On Re-enter, verify Sprint/reports/outcome/completed state.
+Do not run `complete`; notification is informational because closure is already
+terminal. Planner does not author a second report. The originating Planner and
+report-authoring Reviewer remain open. Do not manually close peer chats. Pause,
+abort, re-entry, failed conformance, and rejected fallback retain no-cleanup
+behavior.
+
+Do not compile or editorialize by default; Reviewer owns evidence/report. Only
+FnB-directed fallback may run:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Abort only on Reviewer decision/FnB override; it is terminal and deletes
+nothing.
+
+## Handoffs and stop
+
+Planner receives no PR-event wakes. Never dispatch the next wave from merge
+observation. The merged-work handoff wake is the only normal next-wave dispatch trigger.
+On it:
+
+1. Run `sc sprint inbox --sprint <id>`; inspect merged handoff + unit/dependency state.
+2. Handle earlier informational items and `accept` each, including handoff.
+3. Finish reconciliation and Planner bookkeeping; no work remains.
+4. As literal final action run `sc sprint dispatch --sprint <id>`.
+5. Require durable assignments + New wakes, then stop. Run no trailing command.
+   Empty dispatch remains final; investigate only on a later durable wake.
+
+On a clean completion receipt, verify terminal Sprint + bounded receipt; run no
+close command. Planner does not author a second report, accept an actionable
+handoff, or wait for another actor to finish the Sprint.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_rev',
+  'Review Sprints v2 work and whole-Sprint conformance — own review, re-enter, abort, and conclude judgments, author the conformance and Sprint reports, and direct safety actions through durable messages.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_rev — independent review and conformance
+
+Use for pre-declaration QAQC, one work-unit review, or whole-Sprint
+conformance. The Reviewer decides review/conformance; the Planner owns
+operational plan structure + control execution. FnB retains the board-level
+override from decision #46.
+
+Use the simplest path supported by current durable state. Treat independence,
+authority, lifecycle preconditions, durable writes, and typed handoffs as hard
+boundaries. Repeat a read only when later activity could have changed it or the
+next command requires live revalidation.
+
+## Route the entry
+
+Classify the entry before reading an inbox:
+
+| Entry | Route |
+|---|---|
+| Explicit pre-declaration request | Read/sign the exact current spec directly; there is no Sprint id or Sprint inbox to inspect yet. |
+| Work-unit review / `sprint.delivery_terminal` | Inspect the Sprint inbox once; accept the actionable request. |
+| Live FnB instruction | Preserve board-level authority; read only durable state needed for independent judgment. |
+
+QAQC precedes all Sprint inbox commands:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
+
+For an armed Sprint, load `sprint_rev` on every entry:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Decline actionable work only with a concrete reason. After handling an
+informational message, run `accept`; it marks the message read and does not
+change Sprint or work-unit state.
+
+Review requests use Force-new delivery. Verdicts and Planner decisions use
+Re-enter. Delivery waits for a natural boundary; the runtime owns bundling,
+rotation, and recovery. Stop after a successful typed handoff. Reviewers never
+receive PR-event wakes.
+
+## Relay contract and authority
+
+Ask the Developer for unit evidence with a unit-scoped question/blocker:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` when the unit cannot advance. Cross-unit, closeout,
+re-enter, abort, and safety rulings are Sprint-level decisions:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Reply through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Confirm a reply, then `accept` its incoming message. Missing facts stop review
+at the decision boundary; unread recovery re-wakes, so send no duplicate.
+A stable key identifies recipient + exact body + intent + reply + scope. Reuse
+it only for the same failed/ambiguous write; when any of those fields changes,
+use a new key.
+
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. A handoff completes only when the command exits successfully
+and confirms the durable write + wake. If a command is rejected or transport fails,
+the verdict/handoff is incomplete. Correct and retry safely. If the relay itself fails,
+give FnB the attempted command, evidence, impact, and recommendation; invent no
+alternate protocol.
+
+## Sprint artifact paths
+
+Keep review notes, diffs, evidence, reports, and scratch proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit, branch, or PR them. Durable records
+belong in `record-review`, `sprint_reports`, and the relay.
+
+## Conformance decisions and Planner controls
+
+Reviewer owns review, re-enter, abort, and conclude judgments. Planner
+independently owns operational plan structure: safe-edit pauses, recalling
+unreleased work, lane changes/repeats, assignment/routing, unreleased-scope
+cancellation, and validated resume. Reviewer never runs standalone pause,
+replan, recall, reroute, cancel, resume, complete, or abort actions; clean
+`record-conformance` alone performs its narrow atomic close.
+
+Base judgment on durable Sprint state, bound revisions, current work/PR facts,
+progress-carrier evidence, and ratified judgments. Every Reviewer→Planner route
+is Re-enter. A decision body names:
+
+- `decision`: `re-enter`, `abort`, or the exact safety-critical recommendation;
+- Reviewer-owned evidence + rationale;
+- exact Sprint/unit ids, reason, outcome, and complete action arguments;
+- immediate safety impact for FnB.
+
+Planner verifies Reviewer identity and executes the transition without
+surrendering plan authority. A rejected action requires a revised judgment
+supported by returned durable state, never an improvised bypass. A live FnB
+instruction supersedes as distinct FnB board-level override authority under
+decision #46.
+
+## Severity rubric
+
+- **Critical** — active security/authority violation, destructive corruption,
+  or unsafe continued operation.
+- **Major** — wrong behavior, data loss, broken invariant, material spec
+  violation, or silently wedged delivery/recovery.
+- **Medium** — concrete normal-use correctness/recovery gap, missing negative
+  enforcement, or unreliable handoff.
+- **Low** — bounded cleanup, clarity, test-depth, or resilience improvement;
+  delivered behavior remains correct.
+
+Critical/Major/Medium block unit approval; Low is a report note. At closeout,
+severity does not decide timing: Reviewer judges whether each finding requires in-Sprint patching
+or acceptable post-Sprint follow-up.
+
+## Work-unit review
+
+Accept the request and retain that exact message id. Its body is a bare locator:
+intent, PR URL, registered PR id, exact head, work-unit id. Scope narrative,
+verification, rationale, or focus steering is a protocol defect. PR comments
+and annotations are forbidden; PR body contains only unit id + spec reference.
+
+Bind inspection/verdict to the accepted request''s message id, registered PR,
+work unit, and exact head. Review each request explicitly. Read the exact spec
+revision + full diff at that head, then checks, tests, relevant runtime facts,
+and ratified judgments. Each round is clean: no prior Developer evidence or
+prose; prior findings clear only when the new head proves it. Trace code paths,
+failure cases, and spec behavior rather than names or PR prose.
+
+### Red-check doctrine
+
+Accepted-red is not a legal review outcome. A departure that leaves checks
+failing is never acceptable; the handoff remains green-only, without exception
+or waiver: do not note the failure and approve anyway.
+
+- In-scope failure -> record `changes_requested` so the Developer fixes them and restores green.
+- Out-of-scope failure -> keep the lane unapproved and send the Planner a `replan`
+  decision naming the failures; Planner widens the lane or cuts follow-up work.
+
+Read cited and feature-scoped resolved flag evidence through memory, never SQL:
+
+```text
+sc mem get flags <flag-id>
+sc mem get flags --feature <feature-id> --resolved
+```
+
+Each finding pins severity/title, violated invariant, exact location/evidence,
+reproducible consequence, and fix boundary without unnecessary architecture.
+
+Complete a unit verdict in this exact order:
+
+1. Finish every inspection, finding, and verdict body.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle + `accept` new items.
+3. Run `wc -m < <path>`; require near 6,000 and below 8,000 characters.
+4. As the literal final action, run:
+
+```text
+sc sprint record-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --verdict changes_requested --body-file <path> --key <stable-key>
+```
+
+5. Require durable judgment evidence + Developer Re-enter wake. Run no trailing command;
+   stop.
+
+Use `approved` only with no Critical/Major/Medium finding. Engine validation
+requires the accepted request and reviewed head. Do not message around the
+surface; an unrecorded verdict cannot unlock merge.
+
+## Delivery-terminal closeout
+
+Retain the exact notification message id + delivered wake as this closeout
+episode''s identity. Inspect inbox, lifecycle, and units first:
+
+- Already completed/aborted -> `accept` notification and stop.
+- If any non-terminal unit is visible, the wake is stale -> `accept`, stop, and
+  await a fresh delivery-terminal episode.
+- Only an armed Sprint whose units are all terminal enters conformance.
+
+Compile the bounded evidence packet first, yourself:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Increase only when truncation omitted needed evidence; maximum 200. Judge
+integrated `main` against every bound/current revision + ratified judgment. All
+units cancelled and nothing shipped -> `abort`, not `conclude`.
+
+Choose one branch:
+
+- **In-Sprint patching required.** Do not run `record-conformance`. Send Planner
+  a durable `re-enter` decision with every blocking finding; each spec task''s
+  title and description; grouping, waves, dependencies, routing, and capacity
+  rationale. State independent lanes, expected review overlap, useful reserve,
+  and critical-path effect. After three re-entry episodes, escalate
+  non-convergence to FnB.
+- **Clean or post-Sprint-only findings.** Prepare conformance report, findings,
+  final report, reason, and outcome; submit the atomic close below. Send no
+  conclude message.
+
+## Whole-Sprint conformance
+
+Review the integrated system, not unit diffs. Classify every requirement
+`as-specced`, `deviated-intentionally` with ratified judgment,
+`deviated-silently`, or `unimplemented`; the last two are findings. Include
+spec document + work-unit ids when known.
+
+For the clean branch, write a conformance report and JSON findings array with
+`severity`, `title`, `body`, `spec_document_id`, and `work_unit_id`. Keep the
+report and each body near 6,000 and below 8,000 characters; run
+`wc -m < <report>` and validate each body.
+
+Before recording conformance, author the final Sprint report. Name Reviewer as
+author and cover governing scope/revisions, shipped units/PRs, judgments +
+ratified deviations, failures/retries/recovery/anomalies, conclusion,
+follow-ups, and evidence location. Keep it near 6,000 and below 8,000; preserve
+discrepancies.
+
+Record one atomic final write:
+
+```text
+sc sprint record-conformance \
+  --sprint <id> --body-file <report> --findings-file <json> \
+  --final-report-file <final-report> --reason <reason> --outcome <outcome> \
+  --key <stable-pass-key>
+```
+
+Require receipt: conformance report id, final report id, follow-up ids,
+completed state, Planner message id, and Planner wake id. The transaction adds
+append-only evidence, follow-ups, terminal state, and one informational engine-wide Planner Re-enter;
+send no conclude message. Successful conformance also closes other Sprint-linked
+chats while the originating Planner + report-authoring Reviewer stay open. Do
+not manually close peer chats. Pause, abort, re-entry, failed conformance, and
+rejected fallback retain no-cleanup behavior. Never reopen editing after recording; a re-enter defers
+reports until new scope is terminal and a fresh delivery-terminal wake arrives.
+
+## Stop
+
+Unit review ends with the ordered `record-review` write as the literal final
+action.
+
+For closeout, first re-run `sc sprint inbox --sprint <id>`, handle + `accept`
+new messages, then confirm every artifact/body is final and below 8,000.
+
+- Clean conclude -> run the atomic `record-conformance` command above as the
+  literal final action. When it confirms completed state and all receipt
+  identities, stop immediately; Planner is notified.
+- Re-enter/abort -> as literal final action send:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level \
+  --key <stable-decision-handoff-key>
+```
+
+Require durable write + Planner wake, then stop immediately. Run no trailing
+command until another native wake.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/migrations/0202_reseed_context_efficient_skills.sql
+++ b/.super-coder/migrations/0202_reseed_context_efficient_skills.sql
@@ -1,11 +1,11 @@
--- 0201 — reseed context-efficient shell execution skills.
+-- 0202 — reseed context-efficient shell execution skills.
 -- Existing installs receive compact role/spec procedures without losing durable workflow contracts.
 
 BEGIN;
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'spec',
-  'Execute a spec across sessions — analyze viability, surface blockers and unclear items, break into tasks (Preparation → impl steps → Verification), and track progress in spec_tasks. Updates current_state at every step.',
+  'Load before implementing any feature, spec, or roadmap item. Analyze viability, surface blockers, plan Preparation → implementation → Verification, and track spec_tasks/current_state across sessions.',
   'craft',
   NULL,
   0,

--- a/.super-coder/scripts/artifact_policy.py
+++ b/.super-coder/scripts/artifact_policy.py
@@ -92,6 +92,12 @@ def review_patch_root() -> Path:
     return LOCAL_DIR / "review-patches"
 
 
+def devkit_log_root(repo_root: Path | None = None) -> Path:
+    """Ignored logs for fork-owned dev-kit verification hooks."""
+    local_dir = LOCAL_DIR if repo_root is None else repo_root / ".sc-state" / "local"
+    return local_dir / "devkit-logs"
+
+
 @contextmanager
 def content_write_lock():
     """Serialize snapshot + flat-render pairs across API and CLI processes."""

--- a/.super-coder/scripts/devkit.py
+++ b/.super-coder/scripts/devkit.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 import sys
 import time
+import unicodedata
 import uuid
 from collections import deque
 from collections.abc import Mapping, Sequence
@@ -43,6 +44,7 @@ DIAGNOSTIC = re.compile(
 )
 DISPLAY_LINE_BYTE_LIMIT = 1024
 DISPLAY_SCAN_BYTE_LIMIT = 4096
+INTERRUPT_TERMINATE_TIMEOUT = 1.0
 
 
 class DevkitConfigError(RuntimeError):
@@ -406,7 +408,32 @@ def _shell_status(returncode: int) -> int:
     return 128 - returncode if returncode < 0 else returncode
 
 
+def _sanitize_display(text: str) -> str:
+    clean = ANSI_ESCAPE.sub(
+        b"", text.encode("utf-8", errors="backslashreplace")
+    ).decode("utf-8", errors="replace")
+    visible: list[str] = []
+    named = {"\n": r"\n", "\r": r"\r", "\b": r"\b", "\t": r"\t"}
+    for character in clean:
+        category = unicodedata.category(character)
+        if category[0] != "C" and category not in {"Zl", "Zp"}:
+            visible.append(character)
+            continue
+        if character in named:
+            visible.append(named[character])
+            continue
+        codepoint = ord(character)
+        if codepoint <= 0xFF:
+            visible.append(f"\\x{codepoint:02x}")
+        elif codepoint <= 0xFFFF:
+            visible.append(f"\\u{codepoint:04x}")
+        else:
+            visible.append(f"\\U{codepoint:08x}")
+    return "".join(visible)
+
+
 def _truncate_display(text: str) -> str:
+    text = _sanitize_display(text)
     encoded = text.encode("utf-8")
     if len(encoded) <= DISPLAY_LINE_BYTE_LIMIT:
         return text
@@ -513,6 +540,7 @@ def _bounded_envelope(
     line_limit = FAILURE_LINE_LIMIT if failed else SUCCESS_LINE_LIMIT
     byte_limit = FAILURE_BYTE_LIMIT if failed else SUCCESS_BYTE_LIMIT
     prefix = [_truncate_display(line) for line in prefix]
+    excerpt = [_truncate_display(line) for line in excerpt]
     recovery = _truncate_display(recovery)
     fixed = [*prefix, recovery]
     kept: list[str] = []
@@ -556,6 +584,17 @@ def _run_full(command: Sequence[str], hook: Hook, child_environment: Mapping[str
     return _shell_status(completed.returncode)
 
 
+def _terminate_and_reap(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=INTERRUPT_TERMINATE_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
 def _run_compact(
     checkout: Path,
     hook: Hook,
@@ -586,6 +625,7 @@ def _run_compact(
         try:
             returncode = process.wait()
         except BaseException:
+            _terminate_and_reap(process)
             log.flush()
             os.fsync(log.fileno())
             relative = running.relative_to(main_checkout)

--- a/.super-coder/scripts/devkit.py
+++ b/.super-coder/scripts/devkit.py
@@ -14,14 +14,35 @@ import shlex
 import shutil
 import subprocess
 import sys
+import time
+import uuid
+from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PureWindowsPath
 from typing import Any
 
+from artifact_policy import devkit_log_root
+
 DECLARATION_PATH = Path(".subfloor/dev-kit.json")
 HOOK_NAMES = frozenset(("deps", "test", "lint", "typecheck"))
 MOUNT_NAME = re.compile(r"\A[a-z0-9][a-z0-9_-]{0,47}\Z")
+COMPACT_HOOKS = frozenset(("test", "lint", "typecheck"))
+OUTPUT_MODES = frozenset(("compact", "full"))
+LOG_RETENTION = 20
+SUCCESS_LINE_LIMIT = 80
+SUCCESS_BYTE_LIMIT = 16 * 1024
+FAILURE_LINE_LIMIT = 240
+FAILURE_BYTE_LIMIT = 48 * 1024
+ANSI_ESCAPE = re.compile(
+    rb"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|[@-_])"
+)
+DIAGNOSTIC = re.compile(
+    r"\b(?:error|errors|fail|failed|failure|fatal|panic|traceback|warning|warnings)\b",
+    re.IGNORECASE,
+)
+DISPLAY_LINE_BYTE_LIMIT = 1024
+DISPLAY_SCAN_BYTE_LIMIT = 4096
 
 
 class DevkitConfigError(RuntimeError):
@@ -366,6 +387,245 @@ def _resolve_executable(hook: Hook, environment: Mapping[str, str]) -> Path:
     return executable
 
 
+def _main_checkout(checkout: Path) -> Path:
+    result = subprocess.run(
+        ("git", "-C", str(checkout), "rev-parse", "--git-common-dir"),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise _error("$checkout", "cannot resolve Git common directory")
+    common = Path(result.stdout.strip())
+    if not common.is_absolute():
+        common = checkout / common
+    return common.resolve().parent
+
+
+def _shell_status(returncode: int) -> int:
+    return 128 - returncode if returncode < 0 else returncode
+
+
+def _truncate_display(text: str) -> str:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= DISPLAY_LINE_BYTE_LIMIT:
+        return text
+    clipped = encoded[: DISPLAY_LINE_BYTE_LIMIT - 24]
+    while clipped:
+        try:
+            prefix = clipped.decode("utf-8")
+            break
+        except UnicodeDecodeError:
+            clipped = clipped[:-1]
+    else:
+        prefix = ""
+    return prefix + " … [line truncated]"
+
+
+def _display_line(raw: bytes, *, source_truncated: bool = False) -> str:
+    clean = ANSI_ESCAPE.sub(b"", raw.rstrip(b"\r\n"))
+    text = clean.decode("utf-8", errors="replace")
+    if source_truncated:
+        text += " … [line truncated]"
+    return _truncate_display(text)
+
+
+@dataclass(frozen=True)
+class LogScan:
+    byte_count: int
+    line_count: int
+    head: tuple[tuple[int, str], ...]
+    diagnostics: tuple[tuple[int, str], ...]
+    tail: tuple[tuple[int, str], ...]
+
+
+def _scan_log(path: Path, *, failed: bool) -> LogScan:
+    head_limit = 40 if failed else 0
+    diagnostic_limit = 80 if failed else 24
+    tail_limit = 80 if failed else 40
+    head: list[tuple[int, str]] = []
+    diagnostics: list[tuple[int, str]] = []
+    tail: deque[tuple[int, str]] = deque(maxlen=tail_limit)
+    line_count = 0
+
+    def record(raw: bytes, source_truncated: bool) -> None:
+        nonlocal line_count
+        line_count += 1
+        displayed = _display_line(raw, source_truncated=source_truncated)
+        item = (line_count, displayed)
+        if len(head) < head_limit:
+            head.append(item)
+        if len(diagnostics) < diagnostic_limit and DIAGNOSTIC.search(displayed):
+            diagnostics.append(item)
+        tail.append(item)
+
+    pending = bytearray()
+    source_truncated = False
+    with path.open("rb") as handle:
+        while chunk := handle.read(64 * 1024):
+            pieces = chunk.split(b"\n")
+            for index, piece in enumerate(pieces):
+                room = max(0, DISPLAY_SCAN_BYTE_LIMIT - len(pending))
+                pending.extend(piece[:room])
+                source_truncated = source_truncated or len(piece) > room
+                if index < len(pieces) - 1:
+                    record(bytes(pending), source_truncated)
+                    pending.clear()
+                    source_truncated = False
+    if pending or source_truncated:
+        record(bytes(pending), source_truncated)
+    return LogScan(
+        byte_count=path.stat().st_size,
+        line_count=line_count,
+        head=tuple(head),
+        diagnostics=tuple(diagnostics),
+        tail=tuple(tail),
+    )
+
+
+def _excerpt_lines(scan: LogScan, *, failed: bool) -> list[str]:
+    sections = (
+        (("head", scan.head), ("diagnostic digest", scan.diagnostics), ("tail", scan.tail))
+        if failed
+        else (("diagnostic digest", scan.diagnostics), ("tail", scan.tail))
+    )
+    lines: list[str] = []
+    emitted: set[int] = set()
+    for label, items in sections:
+        unique = [(number, text) for number, text in items if number not in emitted]
+        if not unique:
+            continue
+        lines.append(f"dev-kit {label}:")
+        for number, value in unique:
+            lines.append(f"  {number}: {value}")
+            emitted.add(number)
+    omitted = scan.line_count - len(emitted)
+    if omitted > 0:
+        lines.append(f"dev-kit excerpt omitted: {omitted} lines")
+    elif scan.line_count == 0:
+        lines.append("dev-kit excerpt: (empty output)")
+    return lines
+
+
+def _bounded_envelope(
+    prefix: Sequence[str], excerpt: Sequence[str], recovery: str, *, failed: bool
+) -> str:
+    line_limit = FAILURE_LINE_LIMIT if failed else SUCCESS_LINE_LIMIT
+    byte_limit = FAILURE_BYTE_LIMIT if failed else SUCCESS_BYTE_LIMIT
+    prefix = [_truncate_display(line) for line in prefix]
+    recovery = _truncate_display(recovery)
+    fixed = [*prefix, recovery]
+    kept: list[str] = []
+    for line in excerpt:
+        candidate = [*prefix, *kept, line, recovery]
+        rendered = "\n".join(candidate) + "\n"
+        if len(candidate) > line_limit or len(rendered.encode("utf-8")) > byte_limit:
+            break
+        kept.append(line)
+    if len(kept) < len(excerpt):
+        marker = "dev-kit excerpt omitted: display bound reached"
+        candidate = [*prefix, *kept, marker, recovery]
+        rendered = "\n".join(candidate) + "\n"
+        if len(candidate) <= line_limit and len(rendered.encode("utf-8")) <= byte_limit:
+            kept.append(marker)
+    result = "\n".join([*prefix, *kept, recovery]) + "\n"
+    if len(fixed) > line_limit or len(result.encode("utf-8")) > byte_limit:
+        raise RuntimeError("dev-kit envelope metadata exceeds its display bound")
+    return result
+
+
+def _prune_logs(directory: Path) -> None:
+    dated = []
+    for path in directory.glob("*.log"):
+        try:
+            dated.append((path.stat().st_mtime_ns, path.name, path))
+        except FileNotFoundError:
+            continue
+    finalized = [item[2] for item in sorted(dated, reverse=True)]
+    for old in finalized[LOG_RETENTION:]:
+        old.unlink(missing_ok=True)
+
+
+def _run_full(command: Sequence[str], hook: Hook, child_environment: Mapping[str, str]) -> int:
+    completed = subprocess.run(
+        command,
+        cwd=hook.cwd,
+        env=child_environment,
+        check=False,
+    )
+    return _shell_status(completed.returncode)
+
+
+def _run_compact(
+    checkout: Path,
+    hook: Hook,
+    command: Sequence[str],
+    arguments: Sequence[str],
+    child_environment: Mapping[str, str],
+    seat: str,
+) -> int:
+    main_checkout = _main_checkout(checkout)
+    directory = devkit_log_root(main_checkout) / hook.name
+    directory.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    name = f"{stamp}-{os.getpid()}-{uuid.uuid4().hex}.running"
+    running = directory / name
+    started = time.monotonic()
+    with running.open("xb") as log:
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=hook.cwd,
+                env=child_environment,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+            )
+        except OSError:
+            running.unlink(missing_ok=True)
+            raise
+        try:
+            returncode = process.wait()
+        except BaseException:
+            log.flush()
+            os.fsync(log.fileno())
+            relative = running.relative_to(main_checkout)
+            print(f"dev-kit log interrupted: {relative}", file=sys.stderr)
+            raise
+        log.flush()
+        os.fsync(log.fileno())
+
+    finalized = running.with_suffix(".log")
+    running.replace(finalized)
+    duration = time.monotonic() - started
+    status = _shell_status(returncode)
+    failed = status != 0
+    scan = _scan_log(finalized, failed=failed)
+    relative = finalized.relative_to(main_checkout)
+    recovery_args = shlex.join(("./sc", hook.name, *arguments))
+    prefix = [
+        f"dev-kit checkout: {checkout}",
+        f"dev-kit seat: {seat}",
+        f"dev-kit hook: {hook.name}",
+        f"dev-kit command: {shlex.join(command)}",
+        f"dev-kit cwd: {hook.cwd}",
+        f"dev-kit exit status: {status}",
+        f"dev-kit duration: {duration:.3f}s",
+        f"dev-kit output: {scan.byte_count} bytes, {scan.line_count} lines",
+        f"dev-kit log: {relative}",
+        (
+            f"dev-kit hook state: failed — {hook.name!r} exited {status}"
+            if failed
+            else f"dev-kit hook state: ready — {hook.name!r}"
+        ),
+    ]
+    recovery = f"dev-kit full output: SC_DEVKIT_OUTPUT=full {recovery_args}"
+    sys.stderr.write(
+        _bounded_envelope(prefix, _excerpt_lines(scan, failed=failed), recovery, failed=failed)
+    )
+    _prune_logs(directory)
+    return status
+
+
 def run_hook(
     invocation_root: Path,
     hook_name: str,
@@ -400,43 +660,57 @@ def run_hook(
             "SC_DEVKIT_HOOK": hook_name,
         }
     )
+    output_mode = child_environment.get("SC_DEVKIT_OUTPUT", "compact")
+    if hook_name in COMPACT_HOOKS and output_mode not in OUTPUT_MODES:
+        print(
+            "dev-kit hook state: invalid — SC_DEVKIT_OUTPUT must be "
+            "'compact' or 'full'",
+            file=sys.stderr,
+        )
+        return 64
     requested = (*hook.argv, *arguments)
-    print(f"dev-kit checkout: {checkout}", file=sys.stderr)
-    print(f"dev-kit seat: {seat}", file=sys.stderr)
-    print(f"dev-kit cwd: {hook.cwd}", file=sys.stderr)
-    print(f"dev-kit argv: {shlex.join(requested)}", file=sys.stderr)
+    if hook_name not in COMPACT_HOOKS or output_mode == "full":
+        print(f"dev-kit checkout: {checkout}", file=sys.stderr)
+        print(f"dev-kit seat: {seat}", file=sys.stderr)
+        print(f"dev-kit cwd: {hook.cwd}", file=sys.stderr)
+        print(f"dev-kit argv: {shlex.join(requested)}", file=sys.stderr)
     try:
         executable = _resolve_executable(hook, child_environment)
     except OSError as exc:
+        if hook_name in COMPACT_HOOKS and output_mode == "compact":
+            print(f"dev-kit checkout: {checkout}", file=sys.stderr)
+            print(f"dev-kit seat: {seat}", file=sys.stderr)
+            print(f"dev-kit cwd: {hook.cwd}", file=sys.stderr)
+            print(f"dev-kit argv: {shlex.join(requested)}", file=sys.stderr)
         print(f"dev-kit hook state: failed — start failed: {exc}", file=sys.stderr)
         return 126
 
     command = (str(executable), *hook.argv[1:], *arguments)
-    print(f"dev-kit executable: {executable}", file=sys.stderr)
+    compact = hook_name in COMPACT_HOOKS and output_mode == "compact"
     try:
-        completed = subprocess.run(
-            command,
-            cwd=hook.cwd,
-            env=child_environment,
-            check=False,
-        )
+        if compact:
+            status = _run_compact(
+                checkout, hook, command, arguments, child_environment, seat
+            )
+        else:
+            print(f"dev-kit executable: {executable}", file=sys.stderr)
+            status = _run_full(command, hook, child_environment)
     except OSError as exc:
         print(
             f"dev-kit hook state: failed — start failed for {executable}: {exc}",
             file=sys.stderr,
         )
         return 126
-    if completed.returncode < 0:
-        return 128 - completed.returncode
-    if completed.returncode == 0:
-        print(f"dev-kit hook state: ready — {hook_name!r}", file=sys.stderr)
-    else:
-        print(
-            f"dev-kit hook state: failed — {hook_name!r} exited "
-            f"{completed.returncode}",
-            file=sys.stderr,
-        )
-    return completed.returncode
+    if not compact:
+        if status == 0:
+            print(f"dev-kit hook state: ready — {hook_name!r}", file=sys.stderr)
+        else:
+            print(
+                f"dev-kit hook state: failed — {hook_name!r} exited "
+                f"{status}",
+                file=sys.stderr,
+            )
+    return status
 
 
 def main(argv: Sequence[str]) -> int:

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -97,7 +97,8 @@
     ".super-coder/migrations/0198_reseed_engine_authored_review_handoff.sql",
     ".super-coder/migrations/0199_sprint_live_replanning.sql",
     ".super-coder/migrations/0200_reseed_sprint_live_replanning.sql",
-    ".super-coder/migrations/0201_sprint_cleanup_targets.sql"
+    ".super-coder/migrations/0201_sprint_cleanup_targets.sql",
+    ".super-coder/migrations/0202_reseed_context_efficient_skills.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_artifact_policy.py
+++ b/tests/test_artifact_policy.py
@@ -61,6 +61,15 @@ class ArtifactPolicyTest(unittest.TestCase):
         self.assertEqual(
             artifact_policy.render_root(), self.state / "local" / "renders"
         )
+        self.assertEqual(
+            artifact_policy.devkit_log_root(),
+            self.state / "local" / "devkit-logs",
+        )
+        other = self.tmp / "other-checkout"
+        self.assertEqual(
+            artifact_policy.devkit_log_root(other),
+            other / ".sc-state" / "local" / "devkit-logs",
+        )
 
     def test_instance_can_opt_into_local(self):
         self.write_json(artifact_policy.INSTANCE_CONFIG, {"artifact_mode": "local"})

--- a/tests/test_devkit_declaration.py
+++ b/tests/test_devkit_declaration.py
@@ -293,6 +293,18 @@ class RunnerTest(unittest.TestCase):
             check=False,
         )
 
+    def full_environment(self, **updates: str) -> dict[str, str]:
+        environment = dict(os.environ)
+        environment["SC_DEVKIT_OUTPUT"] = "full"
+        environment.update(updates)
+        return environment
+
+    def compact_log(self, done: subprocess.CompletedProcess) -> Path:
+        line = next(
+            item for item in done.stderr.splitlines() if item.startswith("dev-kit log: ")
+        )
+        return self.root / line.removeprefix("dev-kit log: ")
+
     def test_absent_invalid_and_missing_hook_are_distinct(self):
         absent = self.run_hook("test")
         self.assertEqual(absent.returncode, 78)
@@ -327,7 +339,7 @@ class RunnerTest(unittest.TestCase):
             }
         )
         arguments = ("$(touch escaped)", "*.py", "two words", "--leading")
-        done = self.run_hook("test", *arguments)
+        done = self.run_hook("test", *arguments, env=self.full_environment())
         self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
         payload = json.loads(done.stdout)
         self.assertEqual(payload["argv"], ["declared arg", *arguments])
@@ -347,8 +359,9 @@ class RunnerTest(unittest.TestCase):
         )
         tool.chmod(0o755)
         self.write({"version": 1, "hooks": {"lint": {"argv": ["fork-tool", "check"]}}})
-        environment = dict(os.environ)
-        environment.update({"PATH": f"{binary}:{environment['PATH']}", "SC_SANDBOX": "1"})
+        environment = self.full_environment(
+            PATH=f"{binary}:{os.environ['PATH']}", SC_SANDBOX="1"
+        )
         done = self.run_hook("lint", "literal arg", env=environment)
         self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
         self.assertEqual(done.stdout, "seat=docker args=check literal arg\n")
@@ -412,6 +425,235 @@ class RunnerTest(unittest.TestCase):
         failed = self.run_hook("test")
         self.assertEqual(failed.returncode, 137)
 
+    def test_compact_success_is_bounded_and_raw_log_is_byte_complete(self):
+        child = self.root / "huge-success"
+        child.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            "for number in range(10000):\n"
+            "    prefix = b'\\x1b[31mwarning\\x1b[0m' if number == 4321 else b'line'\n"
+            "    sys.stdout.buffer.write(prefix + b'-' + str(number).encode() + b'\\n')\n"
+        )
+        child.chmod(0o755)
+        self.write({"version": 1, "hooks": {"test": {"argv": ["./huge-success"]}}})
+
+        done = self.run_hook("test")
+
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+        displayed = done.stdout + done.stderr
+        self.assertLessEqual(len(displayed.splitlines()), 80)
+        self.assertLessEqual(len(displayed.encode()), 16 * 1024)
+        self.assertNotIn("\x1b", displayed)
+        self.assertIn("dev-kit exit status: 0", displayed)
+        self.assertIn("dev-kit output:", displayed)
+        self.assertIn("10000 lines", displayed)
+        self.assertIn("SC_DEVKIT_OUTPUT=full ./sc test", displayed)
+        log = self.compact_log(done)
+        expected = b"".join(
+            (
+                (b"\x1b[31mwarning\x1b[0m" if number == 4321 else b"line")
+                + b"-"
+                + str(number).encode()
+                + b"\n"
+            )
+            for number in range(10000)
+        )
+        self.assertEqual(log.read_bytes(), expected)
+        self.assertEqual(list(log.parent.glob("*.running")), [])
+
+    def test_compact_failure_preserves_status_bounds_and_omission_evidence(self):
+        child = self.root / "huge-failure"
+        child.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            "for number in range(2000):\n"
+            "    label = 'fatal error' if number == 999 else 'detail'\n"
+            "    print(f'{label}-{number}')\n"
+            "raise SystemExit(23)\n"
+        )
+        child.chmod(0o755)
+        self.write({"version": 1, "hooks": {"lint": {"argv": ["./huge-failure"]}}})
+
+        done = self.run_hook("lint")
+
+        self.assertEqual(done.returncode, 23)
+        displayed = done.stdout + done.stderr
+        self.assertLessEqual(len(displayed.splitlines()), 240)
+        self.assertLessEqual(len(displayed.encode()), 48 * 1024)
+        self.assertIn("fatal error-999", displayed)
+        self.assertIn("excerpt omitted:", displayed)
+        self.assertIn("hook state: failed", displayed)
+        raw = self.compact_log(done).read_text()
+        self.assertTrue(raw.startswith("detail-0\n"))
+        self.assertIn("fatal error-999\n", raw)
+        self.assertTrue(raw.endswith("detail-1999\n"))
+
+    def test_compact_single_huge_line_keeps_memory_and_display_bounded(self):
+        child = self.root / "huge-line"
+        child.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            "sys.stdout.buffer.write(b'x' * (2 * 1024 * 1024))\n"
+        )
+        child.chmod(0o755)
+        self.write({"version": 1, "hooks": {"test": {"argv": ["./huge-line"]}}})
+
+        done = self.run_hook("test")
+
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+        displayed = done.stdout + done.stderr
+        self.assertLessEqual(len(displayed.splitlines()), 80)
+        self.assertLessEqual(len(displayed.encode()), 16 * 1024)
+        self.assertIn("[line truncated]", displayed)
+        self.assertEqual(self.compact_log(done).stat().st_size, 2 * 1024 * 1024)
+
+    def test_full_mode_inherits_streams_and_status_without_creating_a_log(self):
+        child = self.root / "full-failure"
+        child.write_text(
+            "#!/bin/sh\nprintf 'full-out\\n'\nprintf 'full-err\\n' >&2\nexit 17\n"
+        )
+        child.chmod(0o755)
+        self.write({"version": 1, "hooks": {"typecheck": {"argv": ["./full-failure"]}}})
+
+        done = self.run_hook("typecheck", env=self.full_environment())
+
+        self.assertEqual(done.returncode, 17)
+        self.assertEqual(done.stdout, "full-out\n")
+        self.assertIn("full-err\n", done.stderr)
+        self.assertNotIn("dev-kit log:", done.stderr)
+        self.assertFalse((self.root / ".sc-state").exists())
+
+    def test_compact_log_merges_stdout_and_stderr_without_losing_bytes(self):
+        child = self.root / "merged"
+        child.write_text(
+            "#!/usr/bin/env python3\n"
+            "import os\n"
+            "os.write(1, b'first-out\\n')\n"
+            "os.write(2, b'second-err\\n')\n"
+            "os.write(1, b'third-out\\n')\n"
+        )
+        child.chmod(0o755)
+        self.write({"version": 1, "hooks": {"lint": {"argv": ["./merged"]}}})
+
+        done = self.run_hook("lint")
+
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+        self.assertEqual(
+            self.compact_log(done).read_bytes(),
+            b"first-out\nsecond-err\nthird-out\n",
+        )
+
+    def test_invalid_mode_rejects_before_child_and_deps_ignores_the_mode(self):
+        marker = self.root / "ran"
+        child = self.root / "child"
+        child.write_text(f"#!/bin/sh\ntouch '{marker}'\nprintf 'direct-output\\n'\n")
+        child.chmod(0o755)
+        self.write(
+            {
+                "version": 1,
+                "hooks": {
+                    "test": {"argv": ["./child"]},
+                    "deps": {"argv": ["./child"]},
+                },
+            }
+        )
+        environment = dict(os.environ)
+        environment["SC_DEVKIT_OUTPUT"] = "verbose"
+
+        invalid = self.run_hook("test", env=environment)
+        self.assertEqual(invalid.returncode, 64)
+        self.assertIn("must be 'compact' or 'full'", invalid.stderr)
+        self.assertFalse(marker.exists())
+
+        deps = self.run_hook("deps", env=environment)
+        self.assertEqual(deps.returncode, 0, deps.stdout + deps.stderr)
+        self.assertEqual(deps.stdout, "direct-output\n")
+        self.assertTrue(marker.exists())
+        self.assertNotIn("dev-kit log:", deps.stderr)
+
+    def test_compact_retention_keeps_newest_twenty_and_never_running_files(self):
+        child = self.root / "success"
+        child.write_text("#!/bin/sh\nprintf 'new-log\\n'\n")
+        child.chmod(0o755)
+        self.write({"version": 1, "hooks": {"test": {"argv": ["./success"]}}})
+        directory = self.root / ".sc-state" / "local" / "devkit-logs" / "test"
+        directory.mkdir(parents=True)
+        for number in range(25):
+            path = directory / f"old-{number:02d}.log"
+            path.write_text(str(number))
+            os.utime(path, ns=(number + 1, number + 1))
+        live = directory / "other-process.running"
+        live.write_text("still-live")
+
+        done = self.run_hook("test")
+
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+        finalized = list(directory.glob("*.log"))
+        self.assertEqual(len(finalized), 20)
+        self.assertIn(self.compact_log(done), finalized)
+        self.assertEqual(live.read_text(), "still-live")
+
+    def test_concurrent_compact_runs_use_distinct_atomic_logs(self):
+        child = self.root / "capture"
+        child.write_text("#!/bin/sh\nprintf '%s\\n' \"$1\"\n")
+        child.chmod(0o755)
+        self.write({"version": 1, "hooks": {"lint": {"argv": ["./capture"]}}})
+        commands = [
+            (sys.executable, str(RUNNER), "run", str(self.root), "lint", value)
+            for value in ("first", "second")
+        ]
+        processes = [
+            subprocess.Popen(
+                command,
+                cwd=self.root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            for command in commands
+        ]
+        for process in processes:
+            process.communicate(timeout=10)
+
+        self.assertEqual([process.returncode for process in processes], [0, 0])
+        logs = list(
+            (self.root / ".sc-state" / "local" / "devkit-logs" / "lint").glob("*.log")
+        )
+        self.assertEqual(len(logs), 2)
+        self.assertEqual({path.read_text() for path in logs}, {"first\n", "second\n"})
+        self.assertEqual(
+            list(logs[0].parent.glob("*.running")),
+            [],
+        )
+
+    def test_interruption_retains_running_log_and_reports_its_path(self):
+        child = self.root / "interrupt"
+        child.write_text("#!/bin/sh\nexit 0\n")
+        child.chmod(0o755)
+        self.write({"version": 1, "hooks": {"test": {"argv": ["./interrupt"]}}})
+
+        class InterruptedProcess:
+            def wait(self):
+                raise KeyboardInterrupt
+
+        output = io.StringIO()
+        with contextlib.redirect_stderr(output), mock.patch.object(
+            devkit.subprocess, "Popen", return_value=InterruptedProcess()
+        ), mock.patch.object(
+            devkit, "invoking_checkout", return_value=self.root.resolve()
+        ), mock.patch.object(
+            devkit, "_main_checkout", return_value=self.root.resolve()
+        ), self.assertRaises(KeyboardInterrupt):
+            devkit.run_hook(self.root, "test", ())
+
+        running = list(
+            (self.root / ".sc-state" / "local" / "devkit-logs" / "test").glob(
+                "*.running"
+            )
+        )
+        self.assertEqual(len(running), 1)
+        self.assertIn(str(running[0].relative_to(self.root)), output.getvalue())
+
     def test_dangling_provision_reference_fails_before_child_execution(self):
         marker = self.root / "child-ran"
         child = self.root / "child"
@@ -462,9 +704,12 @@ class RunnerTest(unittest.TestCase):
         (linked / ".subfloor" / "dev-kit.json").write_text(
             json.dumps({"version": 1, "hooks": {"test": {"argv": ["./.subfloor/root"]}}})
         )
+        environment = dict(os.environ)
+        environment["SC_DEVKIT_OUTPUT"] = "full"
         done = subprocess.run(
             (sys.executable, str(RUNNER), "run", str(linked), "test"),
             cwd=main,
+            env=environment,
             text=True,
             capture_output=True,
             check=False,
@@ -472,6 +717,26 @@ class RunnerTest(unittest.TestCase):
         self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
         self.assertEqual(done.stdout, f"{linked.resolve()}\n")
         self.assertIn(f"dev-kit checkout: {linked.resolve()}", done.stderr)
+
+        compact_environment = dict(os.environ)
+        compact_environment.pop("SC_DEVKIT_OUTPUT", None)
+        compact = subprocess.run(
+            (sys.executable, str(RUNNER), "run", str(linked), "test"),
+            cwd=main,
+            env=compact_environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(compact.returncode, 0, compact.stdout + compact.stderr)
+        log_line = next(
+            line
+            for line in compact.stderr.splitlines()
+            if line.startswith("dev-kit log: ")
+        )
+        log = main / log_line.removeprefix("dev-kit log: ")
+        self.assertEqual(log.read_text(), f"{linked.resolve()}\n")
+        self.assertFalse((linked / ".sc-state").exists())
 
     def test_dispatcher_routes_every_lifecycle_verb_through_one_adapter(self):
         dispatch = (ROOT / ".super-coder" / "scripts" / "dispatch.sh").read_text()
@@ -660,6 +925,7 @@ class DispatcherHelpTest(unittest.TestCase):
         scripts.mkdir(parents=True)
         shutil.copy2(RUNNER, scripts / "devkit.py")
         shutil.copy2(RUNNER.with_name("cli_entry.py"), scripts / "cli_entry.py")
+        shutil.copy2(RUNNER.with_name("artifact_policy.py"), scripts / "artifact_policy.py")
         (self.root / ".subfloor").mkdir()
         capture = self.root / ".subfloor" / "capture"
         capture.write_text("#!/bin/sh\nprintf '<%s>\\n' \"$@\"\n")
@@ -674,7 +940,13 @@ class DispatcherHelpTest(unittest.TestCase):
 
     def run_dispatch(self, *arguments: str, python: str = sys.executable):
         environment = dict(os.environ)
-        environment.update({"SC_CALLER_ROOT": str(self.root), "SC_PYTHON": python})
+        environment.update(
+            {
+                "SC_CALLER_ROOT": str(self.root),
+                "SC_PYTHON": python,
+                "SC_DEVKIT_OUTPUT": "full",
+            }
+        )
         return subprocess.run(
             ("sh", str(self.dispatch), "test", *arguments),
             cwd=self.root,

--- a/tests/test_devkit_declaration.py
+++ b/tests/test_devkit_declaration.py
@@ -507,6 +507,33 @@ class RunnerTest(unittest.TestCase):
         self.assertIn("[line truncated]", displayed)
         self.assertEqual(self.compact_log(done).stat().st_size, 2 * 1024 * 1024)
 
+    def test_compact_display_normalizes_controls_before_enforcing_bounds(self):
+        child = self.root / "controls"
+        raw = b"raw\rreturn\bbackspace\x00nul\x1b[31mred\x1b[0m\n"
+        child.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            f"sys.stdout.buffer.write({raw!r})\n"
+        )
+        child.chmod(0o755)
+        self.write({"version": 1, "hooks": {"test": {"argv": ["./controls"]}}})
+        adversarial = "return\rback\bspace\x1b[31m" + ("metadata-line\n" * 100)
+
+        done = self.run_hook("test", adversarial)
+
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+        displayed = done.stdout + done.stderr
+        self.assertLessEqual(len(displayed.splitlines()), 80)
+        self.assertLessEqual(len(displayed.encode()), 16 * 1024)
+        for control in ("\n", "\r", "\b", "\x00", "\x1b"):
+            if control == "\n":
+                continue
+            self.assertNotIn(control, displayed)
+        self.assertIn(r"metadata-line\n", displayed)
+        self.assertIn(r"return\rback\bspace", displayed)
+        self.assertIn(r"raw\rreturn\bbackspace\x00nulred", displayed)
+        self.assertEqual(self.compact_log(done).read_bytes(), raw)
+
     def test_full_mode_inherits_streams_and_status_without_creating_a_log(self):
         child = self.root / "full-failure"
         child.write_text(
@@ -626,19 +653,47 @@ class RunnerTest(unittest.TestCase):
             [],
         )
 
-    def test_interruption_retains_running_log_and_reports_its_path(self):
+    def test_interruption_reaps_real_child_retains_log_and_reports_path(self):
         child = self.root / "interrupt"
-        child.write_text("#!/bin/sh\nexit 0\n")
+        child.write_text("#!/usr/bin/env python3\nimport time\ntime.sleep(60)\n")
         child.chmod(0o755)
         self.write({"version": 1, "hooks": {"test": {"argv": ["./interrupt"]}}})
 
+        real_popen = devkit.subprocess.Popen
+        spawned = []
+
         class InterruptedProcess:
-            def wait(self):
-                raise KeyboardInterrupt
+            def __init__(self, *args, **kwargs):
+                self.child = real_popen(*args, **kwargs)
+                self.interrupted = False
+                spawned.append(self.child)
+
+            def poll(self):
+                return self.child.poll()
+
+            def terminate(self):
+                return self.child.terminate()
+
+            def kill(self):
+                return self.child.kill()
+
+            def wait(self, *args, **kwargs):
+                if not self.interrupted:
+                    self.interrupted = True
+                    raise KeyboardInterrupt
+                return self.child.wait(*args, **kwargs)
+
+        def cleanup_children():
+            for process in spawned:
+                if process.poll() is None:
+                    process.kill()
+                process.wait()
+
+        self.addCleanup(cleanup_children)
 
         output = io.StringIO()
         with contextlib.redirect_stderr(output), mock.patch.object(
-            devkit.subprocess, "Popen", return_value=InterruptedProcess()
+            devkit.subprocess, "Popen", side_effect=InterruptedProcess
         ), mock.patch.object(
             devkit, "invoking_checkout", return_value=self.root.resolve()
         ), mock.patch.object(
@@ -653,6 +708,10 @@ class RunnerTest(unittest.TestCase):
         )
         self.assertEqual(len(running), 1)
         self.assertIn(str(running[0].relative_to(self.root)), output.getvalue())
+        self.assertEqual(len(spawned), 1)
+        self.assertIsNotNone(spawned[0].returncode)
+        with self.assertRaises(ProcessLookupError):
+            os.kill(spawned[0].pid, 0)
 
     def test_dangling_provision_reference_fails_before_child_execution(self):
         marker = self.root / "child-ran"

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -1567,6 +1567,13 @@ class SprintSkillTest(unittest.TestCase):
         self.assertNotIn("sc sprint pause --sprint <id>", developer)
 
         spec = SPEC_SKILL.read_text()
+        parsed_spec = seed_skills.parse_skill(SPEC_SKILL)
+        self.assertEqual(
+            parsed_spec["description"],
+            "Load before implementing any feature, spec, or roadmap item. "
+            "Analyze viability, surface blockers, plan Preparation → implementation "
+            "→ Verification, and track spec_tasks/current_state across sessions.",
+        )
         spec_sections = [
             "## 1. Select the spec",
             "## 2. Analyze before planning",

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -33,16 +33,12 @@ CHAT_CLEANUP_SKILLS = {"sprint_close", "sprint_pln", "sprint_rev"}
 PROGRESS_CARRIER_ROLE_SKILLS = {"sprint_dev", "sprint_pln", "sprint_rev"}
 LIVE_REPLAN_ROLE_SKILLS = {"sprint_pln", "sprint_rev"}
 
-ARTIFACT_PATH_RULE = """## Sprint artifact paths
-
-Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
-report drafts, and Dev scratch proof) go to the gitignored
-`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
-PR'd in the work repo; a review-notes commit is a finding.
-
-DB rows stay the durable record: judgments via `record-review`, report bodies in
-`sprint_reports`, and decisions in the durable relay. Files in the Sprint
-artifact directory are working material only."""
+SPEC_SKILL = ENGINE / "assets" / "skills" / "spec" / "SKILL.md"
+CONTEXT_EFFICIENT_SKILLS = ("sprint_dev", "sprint_rev", "sprint_pln", "spec")
+CONTEXT_EFFICIENT_SKILL_BYTE_CEILING = 44_361
+CONTEXT_EFFICIENT_RESEED = (
+    ENGINE / "migrations" / "0202_reseed_context_efficient_skills.sql"
+)
 
 
 class SprintSkillTest(unittest.TestCase):
@@ -88,6 +84,55 @@ class SprintSkillTest(unittest.TestCase):
                     )
                 ]
                 self.assertEqual([flavor], grants)
+
+    def test_context_efficient_terminal_reseed_is_exact_and_idempotent(self):
+        with sqlite3.connect(":memory:") as con:
+            con.executescript(
+                "CREATE TABLE skills ("
+                "skill_id INTEGER PRIMARY KEY, name TEXT UNIQUE, description TEXT, "
+                "category TEXT, command TEXT, common INTEGER, content TEXT, "
+                "is_deleted INTEGER DEFAULT 0);"
+            )
+            for index, name in enumerate(CONTEXT_EFFICIENT_SKILLS, 1):
+                con.execute(
+                    "INSERT INTO skills VALUES (?,?,?,?,?,?,?,1)",
+                    (index, name, "stale", "stale", "stale", 1, "stale"),
+                )
+            con.execute(
+                "INSERT INTO skills VALUES (99,'fork_only','local','fork',NULL,0,"
+                "'bespoke body',0)"
+            )
+
+            migration = CONTEXT_EFFICIENT_RESEED.read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+
+            for name in CONTEXT_EFFICIENT_SKILLS:
+                parsed = seed_skills.parse_skill(ASSETS / name / "SKILL.md")
+                actual = con.execute(
+                    "SELECT description,category,command,common,content,is_deleted "
+                    "FROM skills WHERE name=?",
+                    (name,),
+                ).fetchone()
+                self.assertEqual(
+                    tuple(actual),
+                    (
+                        parsed["description"],
+                        parsed["category"],
+                        parsed["command"],
+                        parsed["common"],
+                        parsed["content"],
+                        0,
+                    ),
+                )
+            local = con.execute(
+                "SELECT description,category,command,common,content,is_deleted "
+                "FROM skills WHERE name='fork_only'"
+            ).fetchone()
+            self.assertEqual(
+                tuple(local),
+                ("local", "fork", None, 0, "bespoke body", 0),
+            )
 
     def test_handoff_migration_converges_a_drifted_existing_skill_body(self):
         con = sqlite3.connect(":memory:")
@@ -757,6 +802,11 @@ class SprintSkillTest(unittest.TestCase):
             ).read_text()
             con.executescript(migration)
             con.executescript(migration)
+            for later_migration in sorted(
+                (ENGINE / "migrations").glob("*.sql")
+            ):
+                if later_migration.name > "0198_reseed_engine_authored_review_handoff.sql":
+                    con.executescript(later_migration.read_text())
 
             parsed = seed_skills.parse_skill(ASSETS / "sprint_dev" / "SKILL.md")
             row = con.execute(
@@ -803,6 +853,11 @@ class SprintSkillTest(unittest.TestCase):
             ).read_text()
             con.executescript(migration)
             con.executescript(migration)
+            for later_migration in sorted(
+                (ENGINE / "migrations").glob("*.sql")
+            ):
+                if later_migration.name > "0200_reseed_sprint_live_replanning.sql":
+                    con.executescript(later_migration.read_text())
 
             for name in sorted(LIVE_REPLAN_ROLE_SKILLS):
                 with self.subTest(name=name):
@@ -970,15 +1025,21 @@ class SprintSkillTest(unittest.TestCase):
             planner,
         )
 
-    def test_closeout_role_skills_share_the_exact_artifact_path_rule(self):
+    def test_closeout_role_skills_keep_artifacts_local_and_db_records_durable(self):
         for name in sorted(CLOSEOUT_ROLE_SKILLS):
             with self.subTest(name=name):
                 body = (ASSETS / name / "SKILL.md").read_text()
-                self.assertEqual(body.count(ARTIFACT_PATH_RULE), 1)
+                normalized = " ".join(body.split())
+                self.assertGreaterEqual(body.count("shared/sprints/sprint-<n>/"), 1)
+                self.assertIn("gitignored", normalized)
+                self.assertRegex(normalized, r"[Nn]ever commit|never committed")
+                self.assertIn("durable", normalized)
+                self.assertIn("record-review", normalized)
+                self.assertIn("sprint_reports", normalized)
+                self.assertIn("relay", normalized)
 
     def test_close_skill_routes_to_owning_roles_and_keeps_fallback_bounded(self):
         close = (ASSETS / "sprint_close" / "SKILL.md").read_text()
-        normalized = " ".join(close.split())
         self.assertIn("## Route the entry", close)
         self.assertIn("Load `sprint_rev`", close)
         self.assertIn("Load `sprint_pln`", close)
@@ -1328,9 +1389,12 @@ class SprintSkillTest(unittest.TestCase):
             self.assertIn(guidance, reviewer)
 
     def test_reviewer_forbids_accepted_red_and_routes_failures(self):
-        reviewer = " ".join(
-            (ASSETS / "sprint_rev" / "SKILL.md").read_text().split()
-        )
+        body = (ASSETS / "sprint_rev" / "SKILL.md").read_text()
+        reviewer = " ".join(body.split())
+        red = reviewer[
+            reviewer.index("### Red-check doctrine"):
+            reviewer.index("Complete a unit verdict in this exact order")
+        ]
         for guidance in (
             "Accepted-red is not a legal review outcome",
             "A departure that leaves checks failing is never acceptable",
@@ -1338,13 +1402,11 @@ class SprintSkillTest(unittest.TestCase):
             "send the Planner a `replan` decision",
             "remains green-only, without exception or waiver",
             "do not note the failure and approve anyway",
-            "`Note it and pass anyway` is the acceptance-shaped anti-pattern",
-            "In the dos-arch incident",
-            "created a deadlock: the green-only handoff gate could never pass",
-            "Decision #93 records why this no-waiver rule exists",
         ):
             with self.subTest(guidance=guidance):
-                self.assertIn(guidance, reviewer)
+                self.assertIn(guidance, red)
+        self.assertLess(red.index("In-scope failure"), red.index("Out-of-scope failure"))
+        self.assertNotIn("approve anyway", red.split("do not note", 1)[0].lower())
 
     def test_every_affected_file_argument_names_the_hard_ceiling(self):
         parser = sprint_cli.build_parser()
@@ -1475,6 +1537,128 @@ class SprintSkillTest(unittest.TestCase):
             (ASSETS / "sprint_pln" / "SKILL.md").read_text().split()
         )
         self.assertIn("do not run the Sprint inbox, accept it", planner)
+
+    def test_compact_developer_and_spec_keep_every_stateful_route(self):
+        developer = (ASSETS / "sprint_dev" / "SKILL.md").read_text()
+        developer_sections = [
+            "## Route the entry",
+            "## Bound the lane",
+            "## Build and verify",
+            "## Report-only or no-code completion",
+            "## Register and observe the PR",
+            "## Review handoff and correction",
+            "## Merge boundary",
+            "## Post-merge handoff",
+            "## Report and stop",
+        ]
+        positions = [developer.index(section) for section in developer_sections]
+        self.assertEqual(positions, sorted(positions))
+        for command in (
+            "sc sprint complete-unit",
+            "sc sprint register-pr",
+            "sc sprint watcher-state",
+            "sc sprint request-review",
+            "sc sprint authorize-merge",
+            "--intent handoff --key <stable-merged-handoff-key>",
+        ):
+            self.assertEqual(developer.count(command), 1)
+        self.assertIn("created: false", developer)
+        self.assertIn("--intent <submit|resubmit>", developer)
+        self.assertNotIn("sc sprint pause --sprint <id>", developer)
+
+        spec = SPEC_SKILL.read_text()
+        spec_sections = [
+            "## 1. Select the spec",
+            "## 2. Analyze before planning",
+            "## 3. Engage and plan",
+            "## 4. Execute one task at a time",
+            "## 5. Ship and hand docs to Planner",
+            "## Scope change and stop rules",
+        ]
+        positions = [spec.index(section) for section in spec_sections]
+        self.assertEqual(positions, sorted(positions))
+        for command in (
+            "sc mem get documents --feature <id>",
+            "sc mem get documents --doc <doc_id>",
+            "sc mem get tasks --doc <doc_id>",
+            "sc mem task add \"Preparation\"",
+            "sc mem task add \"Verification\"",
+            "sc mem task start <task_id>",
+            "sc mem task done <task_id>",
+            "sc mem task cancel <task_id>",
+            "sc mem roadmap status <feature_id> shipped",
+        ):
+            self.assertIn(command, spec)
+        normalized = " ".join(spec.split())
+        for invariant in (
+            "Current Posture",
+            "In Scope",
+            "Out of Scope",
+            "Anticipated User Activity",
+            "tenancy",
+            "No task plan = no implementation",
+            "Do not freeze or author the shipped doc as Developer",
+        ):
+            self.assertIn(invariant, normalized)
+        self.assertLess(spec.index("sc mem task start"), spec.index("sc mem task done"))
+        self.assertNotIn("sc mem doc freeze", spec)
+
+    def test_compact_planner_keeps_control_and_replan_routes(self):
+        planner = (ASSETS / "sprint_pln" / "SKILL.md").read_text()
+        sections = [
+            "## Route the entry",
+            "## Durable running loop",
+            "## Relay contract",
+            "## Reviewer decisions and Planner actions",
+            "### Pause or resume",
+            "### Modify, recall, repeat, reassign, or reroute",
+            "### Re-enter after conformance",
+            "### Conclude or abort",
+            "## Handoffs and stop",
+        ]
+        positions = [planner.index(section) for section in sections]
+        self.assertEqual(positions, sorted(positions))
+        for command in (
+            "sc sprint watcher-state --sprint <id>",
+            "sc sprint reconcile-pr",
+            "sc sprint cancel-unit",
+            "sc sprint replan-unit",
+            "sc sprint recall-unit",
+            "sc sprint reroute-participant",
+            "sc mem task add",
+            "sc sprint plan-unit",
+        ):
+            self.assertIn(command, planner)
+        recall_route = planner[
+            planner.index("Never edit a released lane in place"):
+            planner.index("Recall preserves message/event history")
+        ]
+        ordered = [
+            recall_route.index(command)
+            for command in (
+                "sc sprint pause",
+                "sc sprint recall-unit",
+                "sc sprint replan-unit",
+                "sc sprint resume",
+            )
+        ]
+        self.assertEqual(ordered, sorted(ordered))
+        self.assertNotIn("sc sprint monitor", planner)
+
+    def test_context_efficient_skills_meet_budget_without_auxiliary_resources(self):
+        paths = [ASSETS / name / "SKILL.md" for name in CONTEXT_EFFICIENT_SKILLS]
+        sizes = {path.parent.name: len(path.read_bytes()) for path in paths}
+
+        self.assertLessEqual(
+            sum(sizes.values()),
+            CONTEXT_EFFICIENT_SKILL_BYTE_CEILING,
+        )
+        for path in paths:
+            with self.subTest(skill=path.parent.name):
+                self.assertEqual(
+                    sorted(item.name for item in path.parent.iterdir()),
+                    ["SKILL.md"],
+                )
 
     def test_role_handoffs_are_explicitly_ordered_and_message_last(self):
         developer = (ASSETS / "sprint_dev" / "SKILL.md").read_text()


### PR DESCRIPTION
## Summary

- make test, lint, and typecheck dev-kit hooks compact by default while preserving exact merged child output in retained per-hook logs
- preserve child exit/signal semantics, bounded success/failure excerpts, ANSI-safe display, concurrent runs, linked-worktree placement, interruption recovery, and explicit full-output mode
- terminate and reap interrupted children while retaining the `.running` log; normalize embedded controls before physical line/byte accounting
- compact the spec, Developer, Reviewer, and Planner skills to 40,172 aggregate bytes while preserving their durable Sprint routes and invariants
- restore and pin the spec frontmatter trigger for feature/spec/roadmap implementation
- reseed fresh installs and upgrades through migration 0202, with exact/idempotent projection tests

## Verification

- `./sc render-check`
- `./sc verify`
- `./sc test` — 2,270 passed on current `main`
- focused review regression — 102 passed, 148 subtests passed
- archived regression/replay corpus remains green
- changed-file Ruff — clean (EXE001 ignored for the repository's pre-existing executable-bit mismatch)
- `git diff --check`
- all PR checks green: tests, verify, render-check, Python 3.9 host contract, CodeQL, and both analysis jobs

Whole-tree lint/typecheck remain noisy on existing baseline debt: repository-wide Ruff findings and a duplicate `maintainer` module under an archived shared scratch fixture. Focused mypy reports only the unchanged pre-existing untyped `mounts` local in `devkit.py`.

Implements Feature #41 / Spec #134, tasks #420-#426. Review blockers SC-1095–SC-1097 are resolved at `cd4f091` and exact-head re-review is requested.
