### PR TITLE
fix(docker): bound substrate storage growth

### DIFF
--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -926,7 +926,7 @@ esac
 # migrate) probes first because it executes host Python. Container entry
 # deliberately remains a Docker handoff rather than a host-runtime gate.
 case "$cmd" in
-  install|ensure-harness|doctor|update|update-harnesses|harness-status|rollback|feature|artifact-mode|eject|remove|init|rebuild|migrate|migration|snapshot|mem|pr|token|persist|job|visual-qa|map-sql|map-sql-rw|render|render-check|map|map-setup|analytics|models|seed-skills|skill|ports|url|preview|serve|vm|vm-broker|vm-bake|vm-broker-up|vm-broker-down|vm-broker-sock|vm-mcp-relay|vm-broker-install|vm-broker-uninstall|ts-broker|ts-broker-up|ts-broker-down|ts-broker-sock|ts-broker-install|ts-broker-uninstall|pm2-broker|pm2-broker-up|pm2-broker-down|pm2-broker-sock|pm2-broker-install|pm2-broker-uninstall|db-broker|db-broker-up|db-broker-down|db-broker-sock|db-broker-install|db-broker-uninstall|db-init|pg-init|pg-up|pg-down|admin|boot|boot-*|run|deps|test|lint|typecheck|launch|down|restart|build|verify|health)
+  install|ensure-harness|doctor|update|update-harnesses|harness-status|docker-cache-gc|rollback|feature|artifact-mode|eject|remove|init|rebuild|migrate|migration|snapshot|mem|pr|token|persist|job|visual-qa|map-sql|map-sql-rw|render|render-check|map|map-setup|analytics|models|seed-skills|skill|ports|url|preview|serve|vm|vm-broker|vm-bake|vm-broker-up|vm-broker-down|vm-broker-sock|vm-mcp-relay|vm-broker-install|vm-broker-uninstall|ts-broker|ts-broker-up|ts-broker-down|ts-broker-sock|ts-broker-install|ts-broker-uninstall|pm2-broker|pm2-broker-up|pm2-broker-down|pm2-broker-sock|pm2-broker-install|pm2-broker-uninstall|db-broker|db-broker-up|db-broker-down|db-broker-sock|db-broker-install|db-broker-uninstall|db-init|pg-init|pg-up|pg-down|admin|boot|boot-*|run|deps|test|lint|typecheck|launch|down|restart|build|verify|health)
     case "$cmd" in
       deps|test|lint|typecheck)
         sc_devkit_help_form "$@" || sc_python_probe ;;
@@ -962,6 +962,7 @@ case "$cmd" in
       "$PY" "$S/install.py" --update-harnesses
     fi ;;
   harness-status)  sc_harness_status ;;
+  docker-cache-gc) exec "$PY" "$S/docker_cache.py" "$@" ;;
   rollback)     exec "$PY" "$S/rollback.py" "$@" ;;
   feature)      exec "$PY" "$S/feature.py" "$@" ;;
   artifact-mode) exec "$PY" "$S/artifact_policy.py" "$@" ;;
@@ -1442,6 +1443,8 @@ super-coder — forkable shell substrate
                              without docker, updates this host's CLIs instead — there the host IS the runtime
   ./sc harness-status      report the harness CLI versions inside the sandbox + whether the image owes a harness rebuild
                              (a model the shells cannot reach is nearly always this — see .super-coder/docs/harness-freshness.md)
+  ./sc docker-cache-gc     remove unused host-global Docker build cache older than seven days
+                             --until <duration> changes the age · --all removes all unused cache
   ./sc rollback            sound undo of a bad update — restore the DB + engine (engine.ref.prev) together
                              --engine-only repairs a new-engine / unchanged-old-DB half floor without restoring a DB backup
   ./sc feature             list the opt-in features (pg · windows · tailnet · pm2 · app-deploy) and the state of both halves (config block + skill grants)

--- a/.super-coder/scripts/docker_cache.py
+++ b/.super-coder/scripts/docker_cache.py
@@ -72,4 +72,6 @@ def main(
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/docker_cache.py
+++ b/.super-coder/scripts/docker_cache.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Explicit host-level garbage collection for unused Docker build cache."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+
+DEFAULT_UNTIL = "168h"
+DURATION = re.compile(r"\A[1-9][0-9]*[smh]\Z")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sc docker-cache-gc",
+        description=(
+            "Remove unused host-global Docker build cache. The default keeps "
+            "cache used within the last seven days."
+        ),
+    )
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument(
+        "--all",
+        action="store_true",
+        help="remove all unused build cache, regardless of age",
+    )
+    scope.add_argument(
+        "--until",
+        metavar="DURATION",
+        default=DEFAULT_UNTIL,
+        help="remove unused cache older than DURATION (default: 168h)",
+    )
+    return parser
+
+
+def _duration(value: str) -> str:
+    if not DURATION.fullmatch(value):
+        raise ValueError("duration must be a positive integer followed by s, m, or h")
+    return value
+
+
+def main(
+    argv: Sequence[str],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> int:
+    args = _parser().parse_args(list(argv))
+    command = ["docker", "builder", "prune", "--all", "--force"]
+    if args.all:
+        print("→ Docker build-cache GC: all unused host-global cache")
+    else:
+        try:
+            until = _duration(args.until)
+        except ValueError as exc:
+            _parser().error(str(exc))
+        command.extend(("--filter", f"until={until}"))
+        print(f"→ Docker build-cache GC: unused host-global cache older than {until}")
+    try:
+        completed = runner(command, check=False, text=True)
+    except OSError as exc:
+        print(f"docker-cache-gc: cannot run docker: {exc}", file=sys.stderr)
+        return 1
+    if completed.returncode:
+        print(
+            f"docker-cache-gc: Docker failed with status {completed.returncode}",
+            file=sys.stderr,
+        )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.super-coder/scripts/sandbox_devkit.py
+++ b/.super-coder/scripts/sandbox_devkit.py
@@ -23,6 +23,7 @@ from typing import Any
 from devkit import Declaration, DevkitConfigError, load_declaration
 
 IMAGE_PREFIX = "super-coder"
+BASE_IMAGE_HISTORY = 2
 HEX_REF = re.compile(r"\A[0-9a-f]{40,64}\Z")
 SAFE_EPOCH = re.compile(r"\A[0-9A-Za-z_.:-]+\Z")
 BASE_LABELS = (
@@ -297,6 +298,7 @@ def _inspect(image: str, *, runner: Runner) -> dict[str, Any]:
         value = json.loads(raw)
         item = value[0]
         image_id = item["Id"]
+        created = item.get("Created")
         labels = item.get("Config", {}).get("Labels") or {}
     except (json.JSONDecodeError, IndexError, KeyError, TypeError) as exc:
         raise SandboxImageError(f"docker returned invalid inspection for {image}") from exc
@@ -304,7 +306,7 @@ def _inspect(image: str, *, runner: Runner) -> dict[str, Any]:
         raise SandboxImageError(f"docker returned invalid image ID for {image}")
     if not isinstance(labels, dict):
         raise SandboxImageError(f"docker returned invalid labels for {image}")
-    return {"id": image_id, "labels": labels}
+    return {"id": image_id, "created": created, "labels": labels}
 
 
 def _require_labels(image: str, expected: dict[str, str], *, runner: Runner) -> str:
@@ -319,6 +321,120 @@ def _require_labels(image: str, expected: dict[str, str], *, runner: Runner) -> 
         )
         raise SandboxImageError(f"sandbox image {image!r} is stale or foreign: {detail}")
     return str(inspected["id"])
+
+
+def _retire_superseded_images(
+    *,
+    image_kind: str,
+    identity_label: str,
+    identity_value: str,
+    current_id: str,
+    keep_prior: int,
+    runner: Runner = subprocess.run,
+) -> list[str]:
+    """Best-effort retirement of superseded images in one ownership scope."""
+    if keep_prior < 0:
+        raise ValueError("keep_prior must be non-negative")
+    try:
+        raw = _run(
+            (
+                "docker", "image", "ls", "--all",
+                "--filter", f"label=sc.image_kind={image_kind}",
+                "--filter", f"label={identity_label}={identity_value}",
+                "--format", "{{.ID}}",
+            ),
+            runner=runner,
+            capture=True,
+        )
+        candidates: dict[str, str] = {}
+        for listed_id in sorted(set(filter(None, raw.splitlines()))):
+            inspected = _inspect(listed_id, runner=runner)
+            labels = inspected["labels"]
+            if (
+                labels.get("sc.image_kind") != image_kind
+                or labels.get(identity_label) != identity_value
+            ):
+                print(
+                    "dev-kit image retention: skipped image whose ownership "
+                    f"labels changed: {listed_id}",
+                    file=sys.stderr,
+                )
+                continue
+            image_id = str(inspected["id"])
+            if image_id == current_id:
+                continue
+            created = inspected.get("created")
+            if not isinstance(created, str) or not created:
+                print(
+                    "dev-kit image retention: skipped image with no creation "
+                    f"timestamp: {image_id}",
+                    file=sys.stderr,
+                )
+                continue
+            candidates[image_id] = created
+
+        newest_first = sorted(
+            candidates.items(), key=lambda item: (item[1], item[0]), reverse=True
+        )
+        removed = []
+        for image_id, _created in newest_first[keep_prior:]:
+            try:
+                _run(
+                    ("docker", "image", "rm", image_id),
+                    runner=runner,
+                    capture=True,
+                )
+            except SandboxImageError as exc:
+                print(
+                    f"dev-kit image retention: kept {image_id}: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            removed.append(image_id)
+        if removed:
+            print(
+                f"dev-kit image retention: removed {len(removed)} "
+                f"superseded {image_kind} image(s)"
+            )
+        return removed
+    except SandboxImageError as exc:
+        print(f"dev-kit image retention: skipped: {exc}", file=sys.stderr)
+        return []
+
+
+def retire_superseded_base_images(
+    plan: ImagePlan,
+    current_id: str,
+    *,
+    keep_prior: int = BASE_IMAGE_HISTORY,
+    runner: Runner = subprocess.run,
+) -> list[str]:
+    """Retain current and recent shared engine-base generations."""
+    return _retire_superseded_images(
+        image_kind="engine-base",
+        identity_label="sc.build_identity",
+        identity_value=plan.base_labels["sc.build_identity"],
+        current_id=current_id,
+        keep_prior=keep_prior,
+        runner=runner,
+    )
+
+
+def retire_superseded_runtime_images(
+    plan: ImagePlan,
+    current_id: str,
+    *,
+    runner: Runner = subprocess.run,
+) -> list[str]:
+    """Retire old extension generations owned by this exact fork."""
+    return _retire_superseded_images(
+        image_kind="fork-extension",
+        identity_label="sc.fork_identity",
+        identity_value=plan.runtime_labels["sc.fork_identity"],
+        current_id=current_id,
+        keep_prior=0,
+        runner=runner,
+    )
 
 
 def build_images(plan: ImagePlan, *, runner: Runner = subprocess.run) -> str:
@@ -343,6 +459,7 @@ def build_images(plan: ImagePlan, *, runner: Runner = subprocess.run) -> str:
     _run(base_command, runner=runner)
     base_id = _require_labels(plan.base_tag, plan.base_labels, runner=runner)
     if not plan.extends_base:
+        retire_superseded_base_images(plan, base_id, runner=runner)
         return plan.base_tag
 
     assert plan.declaration is not None
@@ -361,7 +478,10 @@ def build_images(plan: ImagePlan, *, runner: Runner = subprocess.run) -> str:
         str(sandbox.context),
     ]
     _run(extension_command, runner=runner)
-    _require_labels(plan.runtime_tag, plan.runtime_labels, runner=runner)
+    runtime_id = _require_labels(plan.runtime_tag, plan.runtime_labels, runner=runner)
+    # Retire extension children before their now-unreferenced base parents.
+    retire_superseded_runtime_images(plan, runtime_id, runner=runner)
+    retire_superseded_base_images(plan, base_id, runner=runner)
     return plan.runtime_tag
 
 

--- a/tests/test_docker_cache.py
+++ b/tests/test_docker_cache.py
@@ -1,0 +1,87 @@
+"""Contract tests for explicit Docker build-cache garbage collection."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import docker_cache
+
+
+class Runner:
+    def __init__(self, status: int = 0) -> None:
+        self.status = status
+        self.commands: list[tuple[str, ...]] = []
+
+    def __call__(self, command, *, check, text):
+        self.assertEqualProtocol(check, text)
+        self.commands.append(tuple(command))
+        return subprocess.CompletedProcess(command, self.status)
+
+    @staticmethod
+    def assertEqualProtocol(check, text) -> None:
+        if check is not False or text is not True:
+            raise AssertionError("runner protocol changed")
+
+
+class DockerCacheGcTest(unittest.TestCase):
+    def test_default_keeps_recent_cache(self):
+        runner = Runner()
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output):
+            result = docker_cache.main([], runner=runner)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            runner.commands,
+            [
+                (
+                    "docker",
+                    "builder",
+                    "prune",
+                    "--all",
+                    "--force",
+                    "--filter",
+                    "until=168h",
+                )
+            ],
+        )
+        self.assertIn("older than 168h", output.getvalue())
+
+    def test_all_requires_explicit_flag_and_has_no_age_filter(self):
+        runner = Runner()
+
+        result = docker_cache.main(["--all"], runner=runner)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            runner.commands,
+            [("docker", "builder", "prune", "--all", "--force")],
+        )
+
+    def test_custom_age_is_bounded_to_duration_vocabulary(self):
+        runner = Runner()
+        self.assertEqual(docker_cache.main(["--until", "24h"], runner=runner), 0)
+        self.assertIn("until=24h", runner.commands[0])
+        with self.assertRaises(SystemExit):
+            docker_cache.main(["--until", "yesterday"], runner=Runner())
+
+    def test_docker_failure_is_returned(self):
+        errors = io.StringIO()
+        with contextlib.redirect_stderr(errors):
+            result = docker_cache.main([], runner=Runner(status=23))
+        self.assertEqual(result, 23)
+        self.assertIn("status 23", errors.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docker_cache.py
+++ b/tests/test_docker_cache.py
@@ -72,8 +72,21 @@ class DockerCacheGcTest(unittest.TestCase):
         runner = Runner()
         self.assertEqual(docker_cache.main(["--until", "24h"], runner=runner), 0)
         self.assertIn("until=24h", runner.commands[0])
+        invalid_runner = Runner()
         with self.assertRaises(SystemExit):
-            docker_cache.main(["--until", "yesterday"], runner=Runner())
+            docker_cache.main(["--until", "yesterday"], runner=invalid_runner)
+        self.assertEqual(invalid_runner.commands, [])
+
+    def test_help_does_not_touch_docker(self):
+        runner = Runner()
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as exit_:
+            docker_cache.main(["--help"], runner=runner)
+
+        self.assertEqual(exit_.exception.code, 0)
+        self.assertEqual(runner.commands, [])
+        self.assertIn("usage: sc docker-cache-gc", output.getvalue())
 
     def test_docker_failure_is_returned(self):
         errors = io.StringIO()

--- a/tests/test_sandbox_devkit_images.py
+++ b/tests/test_sandbox_devkit_images.py
@@ -2,7 +2,9 @@
 """Behavioral coverage for fork-extension sandbox image identity."""
 from __future__ import annotations
 
+import contextlib
 import fcntl
+import io
 import json
 import os
 import subprocess
@@ -31,6 +33,7 @@ from sandbox_devkit import (  # noqa: E402
     provisioning_fingerprint,
     provisioning_payload,
     readiness,
+    retire_superseded_base_images,
     volume_plans,
 )
 
@@ -41,6 +44,8 @@ class FakeDocker:
         self.images: dict[str, dict] = {}
         self.volumes: dict[str, dict] = {}
         self.containers: dict[str, str] = {}
+        self.image_remove_failures: set[str] = set()
+        self.build_counter = 0
         self.hook_status = 0
         self.hook_delay = 0.0
 
@@ -56,8 +61,10 @@ class FakeDocker:
                     key, label_value = command[index + 1].split("=", 1)
                     labels[key] = label_value
             image_id = "sha256:" + ("b" if "-base:" in tag else "e") * 64
+            self.build_counter += 1
             self.images[tag] = {
                 "Id": image_id,
+                "Created": f"2026-08-12T12:00:{self.build_counter:02d}Z",
                 "Config": {"Labels": labels},
             }
             return subprocess.CompletedProcess(command, 0, "", "")
@@ -122,6 +129,8 @@ class FakeDocker:
             return subprocess.CompletedProcess(command, 0, "\n".join(ids), "")
         if command[:3] == ("docker", "image", "rm"):
             image_id = command[3]
+            if image_id in self.image_remove_failures:
+                return subprocess.CompletedProcess(command, 1, "", "image is in use")
             self.images = {
                 tag: image for tag, image in self.images.items() if image["Id"] != image_id
             }
@@ -356,6 +365,127 @@ class SandboxImagePlanTest(unittest.TestCase):
         self.assertEqual(result, plan.base_tag)
         self.assertEqual(len(docker.builds()), 1)
         self.assertEqual(plan.runtime_labels["sc.image_kind"], "engine-base")
+
+    def test_build_retires_only_old_owned_base_generations(self):
+        plan = ImageFixture(self.base, "retention", sandbox=False).plan()
+        docker = FakeDocker()
+        prior_ids = []
+        for index in range(4):
+            image_id = "sha256:" + str(index + 1) * 64
+            prior_ids.append(image_id)
+            docker.images[f"super-coder-base:prior-{index}"] = {
+                "Id": image_id,
+                "Created": f"2026-08-0{index + 1}T12:00:00Z",
+                "Config": {"Labels": {
+                    **plan.base_labels,
+                    "sc.engine_ref": str(index + 1) * 40,
+                }},
+            }
+        foreign_id = "sha256:" + "f" * 64
+        docker.images["super-coder-base:foreign"] = {
+            "Id": foreign_id,
+            "Created": "2026-07-01T12:00:00Z",
+            "Config": {"Labels": {
+                **plan.base_labels,
+                "sc.build_identity": "foreign",
+            }},
+        }
+
+        self.assertEqual(build_images(plan, runner=docker), plan.base_tag)
+
+        remaining_ids = {image["Id"] for image in docker.images.values()}
+        self.assertNotIn(prior_ids[0], remaining_ids)
+        self.assertNotIn(prior_ids[1], remaining_ids)
+        self.assertIn(prior_ids[2], remaining_ids)
+        self.assertIn(prior_ids[3], remaining_ids)
+        self.assertIn(foreign_id, remaining_ids)
+        removals = [
+            command for command in docker.commands
+            if command[:3] == ("docker", "image", "rm")
+        ]
+        self.assertEqual({command[3] for command in removals}, set(prior_ids[:2]))
+        listing = next(
+            command for command in docker.commands
+            if command[:3] == ("docker", "image", "ls")
+        )
+        self.assertIn("label=sc.image_kind=engine-base", listing)
+        self.assertIn(
+            f"label=sc.build_identity={plan.base_labels['sc.build_identity']}",
+            listing,
+        )
+
+    def test_retention_keeps_in_use_image_and_does_not_fail_build(self):
+        plan = ImageFixture(self.base, "retention-race", sandbox=False).plan()
+        docker = FakeDocker()
+        old_id = "sha256:" + "1" * 64
+        for index, marker in enumerate(("1", "2", "3"), start=1):
+            image_id = "sha256:" + marker * 64
+            docker.images[f"super-coder-base:race-{marker}"] = {
+                "Id": image_id,
+                "Created": f"2026-07-0{index}T12:00:00Z",
+                "Config": {"Labels": dict(plan.base_labels)},
+            }
+        docker.image_remove_failures.add(old_id)
+        errors = io.StringIO()
+
+        with contextlib.redirect_stderr(errors):
+            result = build_images(plan, runner=docker)
+
+        self.assertEqual(result, plan.base_tag)
+        self.assertIn("image is in use", errors.getvalue())
+        self.assertIn(old_id, {image["Id"] for image in docker.images.values()})
+
+    def test_extension_build_retires_prior_fork_image(self):
+        plan = ImageFixture(self.base, "extension-retention").plan()
+        docker = FakeDocker()
+        old_runtime_id = "sha256:" + "a" * 64
+        docker.images["super-coder-sandbox-old:latest"] = {
+            "Id": old_runtime_id,
+            "Created": "2026-07-01T12:00:00Z",
+            "Config": {"Labels": dict(plan.runtime_labels)},
+        }
+
+        self.assertEqual(build_images(plan, runner=docker), plan.runtime_tag)
+
+        remaining_ids = {image["Id"] for image in docker.images.values()}
+        self.assertNotIn(old_runtime_id, remaining_ids)
+        removals = [
+            command[3] for command in docker.commands
+            if command[:3] == ("docker", "image", "rm")
+        ]
+        self.assertEqual(removals[0], old_runtime_id)
+
+    def test_retention_skips_malformed_owned_image(self):
+        plan = ImageFixture(self.base, "malformed-retention").plan()
+        docker = FakeDocker()
+        malformed_id = "sha256:" + "9" * 64
+        docker.images["super-coder-base:malformed"] = {
+            "Id": malformed_id,
+            "Config": {"Labels": dict(plan.base_labels)},
+        }
+        errors = io.StringIO()
+
+        with contextlib.redirect_stderr(errors):
+            removed = retire_superseded_base_images(
+                plan,
+                "sha256:" + "b" * 64,
+                keep_prior=0,
+                runner=docker,
+            )
+
+        self.assertEqual(removed, [])
+        self.assertIn("no creation timestamp", errors.getvalue())
+        self.assertIn(malformed_id, {image["Id"] for image in docker.images.values()})
+
+    def test_retention_rejects_negative_history(self):
+        plan = ImageFixture(self.base, "negative-retention", sandbox=False).plan()
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            retire_superseded_base_images(
+                plan,
+                "sha256:" + "b" * 64,
+                keep_prior=-1,
+                runner=FakeDocker(),
+            )
 
     def test_declared_volumes_are_install_and_target_scoped(self):
         left_fixture = ImageFixture(self.base, "left", mounts=True)

--- a/tests/test_sandbox_devkit_images.py
+++ b/tests/test_sandbox_devkit_images.py
@@ -394,6 +394,8 @@ class SandboxImagePlanTest(unittest.TestCase):
         self.assertEqual(build_images(plan, runner=docker), plan.base_tag)
 
         remaining_ids = {image["Id"] for image in docker.images.values()}
+        current_id = "sha256:" + "b" * 64
+        self.assertIn(current_id, remaining_ids)
         self.assertNotIn(prior_ids[0], remaining_ids)
         self.assertNotIn(prior_ids[1], remaining_ids)
         self.assertIn(prior_ids[2], remaining_ids)
@@ -404,6 +406,7 @@ class SandboxImagePlanTest(unittest.TestCase):
             if command[:3] == ("docker", "image", "rm")
         ]
         self.assertEqual({command[3] for command in removals}, set(prior_ids[:2]))
+        self.assertNotIn(current_id, {command[3] for command in removals})
         listing = next(
             command for command in docker.commands
             if command[:3] == ("docker", "image", "ls")
@@ -444,16 +447,28 @@ class SandboxImagePlanTest(unittest.TestCase):
             "Created": "2026-07-01T12:00:00Z",
             "Config": {"Labels": dict(plan.runtime_labels)},
         }
+        old_base_ids = []
+        for index, marker in enumerate(("1", "2", "3"), start=1):
+            image_id = "sha256:" + marker * 64
+            old_base_ids.append(image_id)
+            docker.images[f"super-coder-base:extension-prior-{marker}"] = {
+                "Id": image_id,
+                "Created": f"2026-07-0{index}T12:00:00Z",
+                "Config": {"Labels": dict(plan.base_labels)},
+            }
 
         self.assertEqual(build_images(plan, runner=docker), plan.runtime_tag)
 
         remaining_ids = {image["Id"] for image in docker.images.values()}
         self.assertNotIn(old_runtime_id, remaining_ids)
+        self.assertNotIn(old_base_ids[0], remaining_ids)
         removals = [
             command[3] for command in docker.commands
             if command[:3] == ("docker", "image", "rm")
         ]
-        self.assertEqual(removals[0], old_runtime_id)
+        self.assertEqual(removals, [old_runtime_id, old_base_ids[0]])
+        self.assertNotIn("sha256:" + "e" * 64, removals)
+        self.assertNotIn("sha256:" + "b" * 64, removals)
 
     def test_retention_skips_malformed_owned_image(self):
         plan = ImageFixture(self.base, "malformed-retention").plan()

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -143,12 +143,27 @@ class Reader:
         )
 
 
+_SPRINT_CLI_TEMP_PATH: Path | None = None
+
+
+def tearDownModule():
+    """Prove the class cleanup removes its database tree after every suite run."""
+    if _SPRINT_CLI_TEMP_PATH is None:
+        raise AssertionError("SprintCliApiTest did not create its temporary directory")
+    if _SPRINT_CLI_TEMP_PATH.exists():
+        raise AssertionError(
+            f"SprintCliApiTest leaked temporary directory: {_SPRINT_CLI_TEMP_PATH}"
+        )
+
+
 class SprintCliApiTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        global _SPRINT_CLI_TEMP_PATH
         cls._temporary = tempfile.TemporaryDirectory()
         cls.addClassCleanup(cls._temporary.cleanup)
         cls.tmp = Path(cls._temporary.name)
+        _SPRINT_CLI_TEMP_PATH = cls.tmp
         cls.db = cls.tmp / "shell.db"
         con = sqlite3.connect(cls.db)
         con.row_factory = sqlite3.Row

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -146,7 +146,9 @@ class Reader:
 class SprintCliApiTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.tmp = Path(tempfile.mkdtemp())
+        cls._temporary = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(cls._temporary.cleanup)
+        cls.tmp = Path(cls._temporary.name)
         cls.db = cls.tmp / "shell.db"
         con = sqlite3.connect(cls.db)
         con.row_factory = sqlite3.Row

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -44,6 +44,7 @@ class SupervisionFixture:
             "callable_floor.py",
             "db_backup.py",
             "cli_entry.py",
+            "docker_cache.py",
             "engine_manifest.py",
             "global_pointer.py",
             "install.py",
@@ -380,6 +381,24 @@ class RestrictedLaunchTests(unittest.TestCase):
         )
         self.assertIn(" --init ", sandbox_run)
         self.assertFalse(any(line.startswith("docker build ") for line in calls))
+
+    def test_docker_cache_gc_is_explicit_and_age_bounded_by_default(self):
+        result = self.fx.run("docker-cache-gc")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("host-global cache older than 168h", result.stdout)
+        self.assertIn(
+            "docker builder prune --all --force --filter until=168h",
+            self.fx.calls(),
+        )
+
+    def test_docker_cache_gc_all_drops_the_age_filter(self):
+        result = self.fx.run("docker-cache-gc", "--all")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("all unused host-global cache", result.stdout)
+        self.assertIn("docker builder prune --all --force", self.fx.calls())
+        self.assertFalse(any("until=" in line for line in self.fx.calls()))
 
     def test_successful_provision_reports_hook_output_and_ready_state(self):
         self.fx.configure_provision()


### PR DESCRIPTION
## Summary

- retire superseded exact-label fork-extension images before old engine-base parents, retaining two prior shared bases
- keep in-use images safely and never force removal
- add explicit `./sc docker-cache-gc` with a seven-day default and opt-in `--all`
- clean the Sprint CLI suite's class-scoped temporary directory

## Verification

- 76 focused tests passed, plus 25 subtests
- isolated `./sc render-check` passed
- isolated standalone `./sc verify` rebuilt all 155 migrations and completed a headless boot
- `git diff --check` passed