### PR TITLE
feat(chat): page long browser transcripts

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -75,11 +75,12 @@ _SENSITIVE_EVENT_KEYS = frozenset(
 )
 SSE_HEARTBEAT_SECONDS = 15.0
 SSE_BATCH = 200
-TRANSCRIPT_MAX_TURNS = 200
+TRANSCRIPT_PAGE_TURNS = 20
+TRANSCRIPT_MAX_TURNS = TRANSCRIPT_PAGE_TURNS
 TRANSCRIPT_MAX_SOURCE_EVENTS = 20_000
 TRANSCRIPT_MAX_SOURCE_BYTES = 8 * 1024 * 1024
 TRANSCRIPT_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
-TRANSCRIPT_PROJECTION_VERSION = 2
+TRANSCRIPT_PROJECTION_VERSION = 3
 TRANSCRIPT_MAX_WARNINGS = 20
 TRANSCRIPT_MAX_ACTIVITY_LABEL_BYTES = 1024
 
@@ -303,6 +304,15 @@ def _cursor_decode(raw: str, kind: str) -> dict:
     if not isinstance(value, dict) or value.get("v") != 1:
         raise ApiError(422, "CURSOR_INVALID", f"invalid {kind} cursor")
     return value
+
+
+def _single_cursor(query, kind: str) -> str | None:
+    values = query.get("cursor")
+    if values is None:
+        return None
+    if len(values) != 1 or not values[0]:
+        raise ApiError(422, "CURSOR_INVALID", f"invalid {kind} cursor")
+    return values[0]
 
 
 def _limit(query, *, default: int = 50, maximum: int = 200) -> int:
@@ -1680,6 +1690,7 @@ def _transcript_projection(
     conversation_id: str,
     *,
     owner_user_id: int,
+    cursor: str | None = None,
     limits: TranscriptLimits = DEFAULT_TRANSCRIPT_LIMITS,
 ) -> dict:
     if con.in_transaction:
@@ -1692,6 +1703,25 @@ def _transcript_projection(
             conversation_id,
             owner_user_id,
         )
+        before_message_id = None
+        if cursor is not None:
+            decoded = _cursor_decode(cursor, "transcript")
+            before_message_id = decoded.get("before_message_id")
+            if (
+                decoded.get("kind") != "transcript"
+                or decoded.get("projection_version")
+                != TRANSCRIPT_PROJECTION_VERSION
+                or decoded.get("conversation_id") != conversation_id
+                or decoded.get("owner_user_id") != owner_user_id
+                or not isinstance(before_message_id, int)
+                or isinstance(before_message_id, bool)
+                or before_message_id <= 0
+            ):
+                raise ApiError(
+                    422,
+                    "CURSOR_INVALID",
+                    "transcript cursor does not match the requested scope",
+                )
         through_sequence = int(
             con.execute(
                 "SELECT COALESCE(MAX(sequence),0) FROM conversation_events "
@@ -1699,6 +1729,12 @@ def _transcript_projection(
                 (conversation_id,),
             ).fetchone()[0]
         )
+        message_boundary = (
+            " AND message_id<?" if before_message_id is not None else ""
+        )
+        message_params = [conversation_id]
+        if before_message_id is not None:
+            message_params.append(before_message_id)
         message_rows = con.execute(
             "WITH ranked AS ("
             " SELECT message_id,body,state,created_at,completed_at,"
@@ -1709,14 +1745,11 @@ def _transcript_projection(
             ") AS message_source_bytes "
             " FROM conversation_messages "
             " WHERE conversation_id=? AND message_kind='prompt'"
-            ") SELECT * FROM ranked WHERE source_rank<=? "
+            + message_boundary
+            + ") SELECT * FROM ranked WHERE source_rank<=? "
             "AND (message_source_bytes<=? OR source_rank=1) "
             "ORDER BY message_id",
-            (
-                conversation_id,
-                limits.max_turns,
-                limits.max_source_bytes,
-            ),
+            (*message_params, limits.max_turns, limits.max_source_bytes),
         ).fetchall()
         total_messages = (
             int(message_rows[0]["total_messages"]) if message_rows else 0
@@ -1737,6 +1770,7 @@ def _transcript_projection(
             else "0"
         )
         active_run_id = conversation["active_run_id"]
+        include_active_run = cursor is None and active_run_id is not None
         run_rows = con.execute(
             "SELECT r.run_id,r.trigger_message_id,r.state,"
             "r.started_at,r.ended_at,r.error_code,r.error_detail,"
@@ -1756,16 +1790,33 @@ def _transcript_projection(
             " AND boundary.sequence<=?) AS latest_boundary_sequence "
             "FROM conversation_runs r WHERE r.conversation_id=? AND ("
             + run_where
-            + (" OR r.run_id=?" if active_run_id is not None else "")
+            + (" OR r.run_id=?" if include_active_run else "")
             + ") ORDER BY r.run_id",
             (
                 through_sequence,
                 through_sequence,
                 conversation_id,
                 *message_ids,
-                *((int(active_run_id),) if active_run_id is not None else ()),
+                *((int(active_run_id),) if include_active_run else ()),
             ),
         ).fetchall()
+        run_ids = [int(row["run_id"]) for row in run_rows]
+        event_scope = []
+        event_scope_params: list[int] = []
+        if message_ids:
+            event_scope.append(f"message_id IN ({marks})")
+            event_scope_params.extend(message_ids)
+        if run_ids:
+            run_marks = ",".join("?" for _ in run_ids)
+            event_scope.append(f"run_id IN ({run_marks})")
+            event_scope_params.extend(run_ids)
+        if cursor is None:
+            event_scope.append(
+                "(message_id IS NULL AND run_id IS NULL AND event_type IN "
+                "('permission.requested','input.requested','run.failed',"
+                "'run.interrupted','run.unknown'))"
+            )
+        event_scope_sql = " OR ".join(event_scope) or "0"
         event_rows = con.execute(
             "WITH ranked AS ("
             " SELECT sequence,event_type,payload_version,payload,message_id,"
@@ -1787,7 +1838,9 @@ def _transcript_projection(
             " ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"
             ") AS segment_anchor_sequence "
             " FROM conversation_events "
-            " WHERE conversation_id=? AND sequence<=?"
+            " WHERE conversation_id=? AND sequence<=? AND ("
+            + event_scope_sql
+            + ")"
             ") SELECT * FROM ranked "
             "WHERE source_rank<=? "
             "AND (source_bytes<=? OR source_rank=1) "
@@ -1795,6 +1848,7 @@ def _transcript_projection(
             (
                 conversation_id,
                 through_sequence,
+                *event_scope_params,
                 limits.max_source_events,
                 remaining_source_bytes,
             ),
@@ -2051,6 +2105,16 @@ def _transcript_projection(
                     default=0,
                 ),
             )
+        older_cursor = None
+        if message_rows and total_messages > len(message_rows):
+            older_cursor = _cursor_encode({
+                "v": 1,
+                "kind": "transcript",
+                "projection_version": TRANSCRIPT_PROJECTION_VERSION,
+                "conversation_id": conversation_id,
+                "owner_user_id": owner_user_id,
+                "before_message_id": min(message_ids),
+            })
         projection = {
             "conversation_id": conversation_id,
             "projection_version": TRANSCRIPT_PROJECTION_VERSION,
@@ -2065,6 +2129,7 @@ def _transcript_projection(
                 "close_requested_at": conversation["close_requested_at"],
             },
             "items": items,
+            "older_cursor": older_cursor,
             "truncation": (
                 _transcript_truncation(
                     reason=reason,
@@ -2079,7 +2144,7 @@ def _transcript_projection(
                 else None
             ),
         }
-        if active_run_id is not None and int(active_run_id) in run_by_id:
+        if include_active_run and int(active_run_id) in run_by_id:
             active_run = run_by_id[int(active_run_id)]
             projection["assistant_cursor"] = {
                 "run_id": int(active_run_id),
@@ -2157,6 +2222,7 @@ def handle(method: str, path: str, headers_raw: str, raw_body: bytes) -> tuple:
                         con,
                         transcript.group(1),
                         owner_user_id=operator["user_id"],
+                        cursor=_single_cursor(query, "transcript"),
                     ),
                 )
             interruptions = _INTERRUPTIONS_PATH.fullmatch(parsed.path)

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2586,6 +2586,8 @@ const CHAT_FLAVOR_ORDER = [
 const CHAT_CONFIGURE_ROUTE = "configure";
 const CHAT_HISTORY_POLL_MS = 2000;
 const CHAT_MODES = ["chat", "diff"];
+const CHAT_TRANSCRIPT_PAGE_TURNS = 20;
+const CHAT_TRANSCRIPT_MAX_PAGES = 5;
 let chatRouteShell = "";
 let chatRouteConversation = "";
 let chatRouteMode = "chat";
@@ -3707,8 +3709,8 @@ async function chatRenderNew(host, shell, defaults, catalog) {
   host.replaceChildren(form);
 }
 
-function chatCreateTranscriptState(snapshot) {
-  if (snapshot.projection_version !== 2)
+function chatTranscriptPageItems(snapshot) {
+  if (snapshot.projection_version !== 3)
     throw new Error("Unsupported transcript projection.");
   const items = new Map();
   for (const item of snapshot.items || []) {
@@ -3722,6 +3724,11 @@ function chatCreateTranscriptState(snapshot) {
     }
     items.set(item.item_id, { ...item });
   }
+  return items;
+}
+
+function chatCreateTranscriptState(snapshot) {
+  const items = chatTranscriptPageItems(snapshot);
   const activeRunId = snapshot.controls?.active_run_id;
   const cursor = snapshot.assistant_cursor || null;
   if ((activeRunId == null) !== (cursor == null)
@@ -3743,26 +3750,104 @@ function chatCreateTranscriptState(snapshot) {
       Number(cursor.segment_anchor_sequence),
     );
   }
+  const order = [...items.keys()].sort((left, right) => {
+    const a = items.get(left);
+    const b = items.get(right);
+    return Number(a.order_sequence) - Number(b.order_sequence)
+      || left.localeCompare(right);
+  });
   return {
+    conversationId: snapshot.conversation_id,
     projectionVersion: snapshot.projection_version,
     throughSequence: Number(snapshot.through_sequence || 0),
     lastSequence: Number(snapshot.through_sequence || 0),
     items,
     assistantAnchors,
-    order: [...items.keys()].sort((left, right) => {
-      const a = items.get(left);
-      const b = items.get(right);
-      return Number(a.order_sequence) - Number(b.order_sequence)
-        || left.localeCompare(right);
-    }),
+    order,
+    pages: [{ itemIds: [...order] }],
     nodes: new Map(),
     dirty: new Set(items.keys()),
+    evicted: new Set(),
     fullBuild: true,
     hiddenDirty: false,
     frame: null,
-    truncation: snapshot.truncation || null,
+    truncation: snapshot.truncation?.reason === "turn_limit"
+      ? null : snapshot.truncation || null,
+    olderCursor: snapshot.older_cursor || null,
+    olderLoading: false,
+    olderError: null,
+    pendingPrepend: false,
+    windowDisplaced: false,
     reconcileError: null,
   };
+}
+
+function chatTranscriptEvictPage(state, index) {
+  const [page] = state.pages.splice(index, 1);
+  if (!page) return;
+  for (const id of page.itemIds) {
+    state.items.delete(id);
+    state.dirty.delete(id);
+    state.evicted.add(id);
+  }
+}
+
+function chatTranscriptRebuildOrder(state) {
+  state.order = state.pages.flatMap((page) => page.itemIds);
+}
+
+function chatMergeOlderTranscriptPage(state, snapshot) {
+  if (snapshot.conversation_id !== state.conversationId)
+    throw new Error("Transcript conversation identity changed.");
+  const incoming = chatTranscriptPageItems(snapshot);
+  const incomingOrder = [...incoming.keys()].sort((left, right) => {
+    const a = incoming.get(left);
+    const b = incoming.get(right);
+    return Number(a.order_sequence) - Number(b.order_sequence)
+      || left.localeCompare(right);
+  });
+  if (!incomingOrder.length)
+    throw new Error("Transcript history page was empty.");
+  if (incomingOrder.some((id) => state.items.has(id)))
+    throw new Error("Transcript history page overlaps loaded turns.");
+  const currentFirst = state.items.get(state.order[0]);
+  const incomingLast = incoming.get(incomingOrder.at(-1));
+  if (currentFirst && Number(incomingLast.order_sequence)
+      >= Number(currentFirst.order_sequence))
+    throw new Error("Transcript history page is out of order.");
+  for (const [id, item] of incoming) {
+    state.items.set(id, item);
+    state.dirty.add(id);
+  }
+  state.pages.unshift({ itemIds: incomingOrder });
+  state.olderCursor = snapshot.older_cursor || null;
+  state.olderError = null;
+  state.pendingPrepend = true;
+  if (snapshot.truncation?.reason !== "turn_limit")
+    state.truncation = snapshot.truncation || state.truncation;
+  while (state.pages.length > CHAT_TRANSCRIPT_MAX_PAGES) {
+    chatTranscriptEvictPage(state, state.pages.length - 2);
+    state.windowDisplaced = true;
+  }
+  chatTranscriptRebuildOrder(state);
+}
+
+function chatTrackLiveTranscriptItem(state, itemId, startsTurn = false) {
+  let page = state.pages.at(-1);
+  const turnCount = page.itemIds.filter(
+    (id) => state.items.get(id)?.kind === "user",
+  ).length;
+  if (startsTurn && turnCount >= CHAT_TRANSCRIPT_PAGE_TURNS) {
+    page = { itemIds: [] };
+    state.pages.push(page);
+  }
+  if (!page.itemIds.includes(itemId)) page.itemIds.push(itemId);
+  while (state.pages.length > CHAT_TRANSCRIPT_MAX_PAGES) {
+    chatTranscriptEvictPage(state, 0);
+    state.pendingPrepend = true;
+    state.windowDisplaced = true;
+  }
+  chatTranscriptRebuildOrder(state);
 }
 
 function chatTranscriptItemNode(item, conversation, retry) {
@@ -3844,17 +3929,69 @@ function chatReconcileBanner(state, reconcile) {
   );
 }
 
+function chatUpdateTranscriptHistoryControl(transcript, state, loadOlder) {
+  let control = transcript.querySelector(".chat-transcript-history");
+  const visible = Boolean(
+    state.olderCursor || state.olderLoading || state.olderError,
+  );
+  if (!visible) {
+    control?.remove();
+    return;
+  }
+  if (!control) {
+    control = el("button", {
+      className: "chat-transcript-history",
+      type: "button",
+    });
+  }
+  control.disabled = state.olderLoading;
+  control.textContent = state.olderLoading
+    ? "Loading earlier messages…"
+    : state.olderError ? "Retry earlier messages" : "Load earlier messages";
+  control.title = state.olderError?.message || "";
+  control.onclick = loadOlder;
+  transcript.insertBefore(control, transcript.firstChild);
+}
+
+function chatUpdateTranscriptWindowGap(transcript, state) {
+  let gap = transcript.querySelector(".chat-transcript-window-gap");
+  if (!state.windowDisplaced || state.pages.length < 2) {
+    gap?.remove();
+    return;
+  }
+  if (!gap) {
+    gap = el(
+      "div",
+      { className: "chat-transcript-window-gap", role: "status" },
+      "Newer history was unloaded to keep this chat responsive. "
+        + "Jump to latest to restore the live window.",
+    );
+  }
+  const livePage = state.pages.at(-1);
+  const liveNode = livePage.itemIds
+    .map((id) => state.nodes.get(id))
+    .find(Boolean);
+  transcript.insertBefore(gap, liveNode || null);
+}
+
 function chatFlushTranscript(
   transcript,
   state,
   conversation,
   retry,
   reconcile,
+  loadOlder,
   shouldFollow,
   onPosition,
 ) {
   const previousTop = transcript.scrollTop;
   const followTail = shouldFollow();
+  const anchor = state.pendingPrepend
+    ? [...transcript.children].find((node) =>
+      node.classList?.contains("chat-bubble")
+        && node.offsetTop + node.offsetHeight >= previousTop)
+    : null;
+  const anchorOffset = anchor ? anchor.offsetTop - previousTop : 0;
   if (state.fullBuild) {
     state.nodes.clear();
     const nodes = [];
@@ -3879,6 +4016,11 @@ function chatFlushTranscript(
     state.fullBuild = false;
     state.dirty.clear();
   } else {
+    for (const id of state.evicted) {
+      state.nodes.get(id)?.remove();
+      state.nodes.delete(id);
+    }
+    state.evicted.clear();
     if (state.order.length && state.nodes.size === 0)
       transcript.querySelector(".chat-empty")?.remove();
     for (const id of state.order) {
@@ -3901,12 +4043,17 @@ function chatFlushTranscript(
     }
     state.dirty.clear();
   }
+  chatUpdateTranscriptHistoryControl(transcript, state, loadOlder);
+  chatUpdateTranscriptWindowGap(transcript, state);
   const working = transcript.querySelector(".chat-working-indicator");
   if (conversation.state === "running" && !working)
     transcript.append(chatWorkingIndicator());
   else if (conversation.state !== "running" && working)
     working.remove();
-  transcript.scrollTop = followTail ? transcript.scrollHeight : previousTop;
+  transcript.scrollTop = followTail
+    ? transcript.scrollHeight
+    : anchor?.isConnected ? anchor.offsetTop - anchorOffset : previousTop;
+  state.pendingPrepend = false;
   onPosition();
 }
 
@@ -3978,7 +4125,14 @@ async function chatRenderOpen(
     jumpToLatest.hidden = followTranscriptTail;
   };
   transcript.onscroll = updateTranscriptFollow;
-  jumpToLatest.onclick = () => {
+  jumpToLatest.onclick = async () => {
+    if (transcriptState.windowDisplaced) {
+      await reconcileTranscript(true);
+      for (let page = 1; page < CHAT_TRANSCRIPT_MAX_PAGES; page += 1) {
+        if (!transcriptState.olderCursor || transcriptState.olderError) break;
+        await loadOlder();
+      }
+    }
     transcript.scrollTop = transcript.scrollHeight;
     updateTranscriptFollow();
   };
@@ -4023,12 +4177,41 @@ async function chatRenderOpen(
     composer.focus();
     await submit();
   };
+  async function loadOlder() {
+    const pageState = transcriptState;
+    const cursor = pageState.olderCursor;
+    if (!cursor || pageState.olderLoading) return;
+    pageState.olderLoading = true;
+    pageState.olderError = null;
+    scheduleTranscript();
+    try {
+      const snapshot = await chatApi(
+        `/conversations/${conversation.conversation_id}/transcript`
+          + `?cursor=${encodeURIComponent(cursor)}`,
+      );
+      if (generation !== chatRenderGeneration
+          || transcriptState !== pageState
+          || pageState.olderCursor !== cursor) return;
+      chatMergeOlderTranscriptPage(pageState, snapshot);
+    } catch (error) {
+      if (generation === chatRenderGeneration
+          && transcriptState === pageState
+          && pageState.olderCursor === cursor)
+        pageState.olderError = error;
+    } finally {
+      if (generation === chatRenderGeneration
+          && transcriptState === pageState)
+        pageState.olderLoading = false;
+      scheduleTranscript();
+    }
+  }
   const flushTranscript = () => chatFlushTranscript(
     transcript,
     transcriptState,
     conversation,
     retry,
     () => reconcileTranscript(true),
+    loadOlder,
     () => followTranscriptTail,
     updateTranscriptFollow,
   );
@@ -4256,7 +4439,7 @@ async function chatRenderOpen(
           completed_at: result.message.completed_at,
           text_truncated: false,
         });
-        transcriptState.order.push(userItemId);
+        chatTrackLiveTranscriptItem(transcriptState, userItemId, true);
         transcriptState.dirty.add(userItemId);
       }
       chatPendingSend = null;
@@ -4405,7 +4588,7 @@ async function chatRenderOpen(
           text_truncated: false,
         };
         transcriptState.items.set(itemId, assistant);
-        transcriptState.order.push(itemId);
+        chatTrackLiveTranscriptItem(transcriptState, itemId);
       }
       assistant.text += event.payload?.text || "";
       assistant.last_sequence = sequence;
@@ -4439,7 +4622,7 @@ async function chatRenderOpen(
         label: activityLabel(event),
         sequence,
       });
-      transcriptState.order.push(itemId);
+      chatTrackLiveTranscriptItem(transcriptState, itemId);
       transcriptState.dirty.add(itemId);
     }
 

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -350,6 +350,17 @@ body.interface-view main {
   border: 1px solid var(--line); border-radius: 7px;
   color: var(--dim); font-size: .75rem;
 }
+.chat-transcript-history {
+  align-self: center; flex: none; padding: .42rem .72rem;
+  border: 1px solid var(--line); border-radius: 7px;
+  background: transparent; color: var(--accent); cursor: pointer;
+  font: inherit; font-size: .75rem;
+}
+.chat-transcript-history:disabled { color: var(--dim); cursor: default; }
+.chat-transcript-window-gap {
+  align-self: stretch; padding: .55rem .7rem; text-align: center;
+  border-block: 1px dashed var(--line); color: var(--dim); font-size: .75rem;
+}
 .chat-transcript-reconcile.error { color: #ef9aa1; }
 .chat-transcript-error { display: grid; gap: .7rem; align-content: start; }
 .chat-state {

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -427,7 +427,7 @@ class ConversationApiCase(unittest.TestCase):
             expected.append((item_id, kind, anchor if kind == "assistant" else None,
                              first, last, value))
         self.assertEqual(actual, expected)
-        self.assertEqual(transcript["projection_version"], 2)
+        self.assertEqual(transcript["projection_version"], 3)
 
     def test_creation_observation_is_post_commit_and_cannot_fail_create(self):
         def observer(db_path, conversation_id):
@@ -2042,7 +2042,7 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
         self.assertEqual(status, 200, transcript)
         self.assertEqual(headers["Cache-Control"], "no-store")
         self.assertEqual(transcript["conversation_id"], conversation_id)
-        self.assertEqual(transcript["projection_version"], 2)
+        self.assertEqual(transcript["projection_version"], 3)
         self.assertEqual(transcript["through_sequence"], through_sequence)
         self.assertEqual(transcript["truncation"], None)
         self.assertEqual(
@@ -2078,6 +2078,101 @@ class ConversationPerformanceFixtureTest(ConversationApiCase):
                 ).fetchone()[0],
                 source_rows,
             )
+
+    def test_transcript_pages_twenty_complete_turns_with_scoped_cursors(
+        self,
+    ) -> None:
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(
+                con,
+                number=704,
+                state="closed",
+            )
+            other_conversation_id = self.seed_conversation(
+                con,
+                number=705,
+                state="closed",
+            )
+            foreign_conversation_id = self.seed_conversation(
+                con,
+                number=706,
+                owner_user_id=2,
+                state="closed",
+            )
+            self.seed_transcript(
+                con,
+                conversation_id=conversation_id,
+                turns=45,
+                deltas_per_turn=1,
+            )
+            con.commit()
+
+        pages = []
+        cursor = None
+        for expected_prompts in (
+            [f"prompt {index}" for index in range(25, 45)],
+            [f"prompt {index}" for index in range(5, 25)],
+            [f"prompt {index}" for index in range(5)],
+        ):
+            suffix = f"?cursor={cursor}" if cursor else ""
+            status, _, transcript = self.request(
+                "GET",
+                f"/api/conversations/{conversation_id}/transcript{suffix}",
+            )
+            self.assertEqual(status, 200, transcript)
+            users = [
+                item for item in transcript["items"] if item["kind"] == "user"
+            ]
+            assistants = [
+                item
+                for item in transcript["items"]
+                if item["kind"] == "assistant"
+            ]
+            self.assertEqual([item["text"] for item in users], expected_prompts)
+            self.assertEqual(len(assistants), len(expected_prompts))
+            self.assertEqual(
+                [item["message_id"] for item in assistants],
+                [item["message_id"] for item in users],
+            )
+            self.assertTrue(all(item["text"] == "x" for item in assistants))
+            pages.append({item["message_id"] for item in users})
+            cursor = transcript["older_cursor"]
+
+        self.assertIsNone(cursor)
+        self.assertEqual(len(set().union(*pages)), 45)
+        self.assertTrue(all(pages[left].isdisjoint(pages[right])
+                            for left in range(3)
+                            for right in range(left + 1, 3)))
+
+        first_status, _, first_page = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/transcript",
+        )
+        self.assertEqual(first_status, 200, first_page)
+        scoped_cursor = first_page["older_cursor"]
+        for path in (
+            (
+                f"/api/conversations/{other_conversation_id}/transcript"
+                f"?cursor={scoped_cursor}"
+            ),
+            (
+                f"/api/conversations/{conversation_id}/transcript"
+                f"?cursor={scoped_cursor}&cursor={scoped_cursor}"
+            ),
+            f"/api/conversations/{conversation_id}/transcript?cursor=not-a-cursor",
+        ):
+            with self.subTest(path=path):
+                status, _, error = self.request("GET", path)
+                self.assertEqual(status, 422, error)
+                self.assertEqual(error["error"]["code"], "CURSOR_INVALID")
+
+        status, _, error = self.request(
+            "GET",
+            f"/api/conversations/{foreign_conversation_id}/transcript"
+            f"?cursor={scoped_cursor}",
+        )
+        self.assertEqual(status, 404, error)
+        self.assertEqual(error["error"]["code"], "CONVERSATION_NOT_FOUND")
 
     def test_transcript_attaches_exact_context_tokens_to_assistant_only(self) -> None:
         with closing(self.connect()) as con:

--- a/tests/test_conversation_release_gate.py
+++ b/tests/test_conversation_release_gate.py
@@ -589,7 +589,7 @@ class CrossHarnessReleaseGateTest(unittest.TestCase):
             f"/api/conversations/{conversation_id}/transcript",
         )
         self.assertEqual(status, 200, transcript)
-        self.assertEqual(transcript["projection_version"], 2)
+        self.assertEqual(transcript["projection_version"], 3)
         self.assertIsNone(transcript["truncation"])
         projected = []
         for item in transcript["items"]:

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -312,8 +312,9 @@ def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():
     keyed = interface[interface.index("function chatCreateTranscriptState"):
                       interface.index("async function renderInterface")]
 
-    assert "snapshot.projection_version !== 2" in keyed
-    assert "items.has(item.item_id)" in keyed
+    assert "snapshot.projection_version !== 3" in interface
+    assert "chatTranscriptPageItems(snapshot)" in keyed
+    assert "items.has(item.item_id)" in interface
     assert "nodes: new Map()" in keyed
     assert "dirty: new Set(items.keys())" in keyed
     assert "transcript.replaceChildren(...nodes)" in keyed
@@ -339,13 +340,107 @@ def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():
     ]
 
 
+def test_transcript_window_keeps_five_twenty_turn_pages_and_live_tail():
+    helpers = APP[
+        APP.index("function chatTranscriptPageItems"):
+        APP.index("function chatTranscriptItemNode")
+    ]
+    script = r"""
+const CHAT_TRANSCRIPT_PAGE_TURNS = 20;
+const CHAT_TRANSCRIPT_MAX_PAGES = 5;
+""" + helpers + r"""
+function snapshot(conversationId, first, last, olderCursor) {
+  return {
+    conversation_id: conversationId,
+    projection_version: 3,
+    through_sequence: 140,
+    controls: {active_run_id: null},
+    older_cursor: olderCursor,
+    truncation: last < 140 ? {reason: "turn_limit"} : null,
+    items: Array.from({length: last - first + 1}, (_, offset) => {
+      const turn = first + offset;
+      return {
+        item_id: `message:${turn}`,
+        kind: "user",
+        order_sequence: turn,
+        message_id: turn,
+        run_id: null,
+        text: `prompt ${turn}`,
+        state: "completed",
+      };
+    }),
+  };
+}
+const state = chatCreateTranscriptState(snapshot("cv_test", 121, 140, "c120"));
+for (const [first, last, cursor] of [
+  [101, 120, "c100"], [81, 100, "c80"], [61, 80, "c60"],
+  [41, 60, "c40"], [21, 40, "c20"], [1, 20, null],
+]) chatMergeOlderTranscriptPage(state, snapshot("cv_test", first, last, cursor));
+
+let overlap = "";
+try {
+  chatMergeOlderTranscriptPage(state, snapshot("cv_test", 1, 20, null));
+} catch (error) { overlap = error.message; }
+
+const beforeLiveUsers = state.order.filter(
+  (id) => state.items.get(id)?.kind === "user",
+).length;
+state.items.set("message:141", {
+  item_id: "message:141", kind: "user", order_sequence: 141,
+  message_id: 141, run_id: null, text: "prompt 141", state: "queued",
+});
+chatTrackLiveTranscriptItem(state, "message:141", true);
+const users = state.order.filter((id) => state.items.get(id)?.kind === "user");
+console.log(JSON.stringify({
+  pages: state.pages.length,
+  beforeLiveUsers,
+  users: users.length,
+  hasOldest: state.items.has("message:1"),
+  hasTailStart: state.items.has("message:121"),
+  hasLive: state.items.has("message:141"),
+  displaced: state.windowDisplaced,
+  overlap,
+}));
+"""
+    assert run_js(script) == {
+        "pages": 5,
+        "beforeLiveUsers": 100,
+        "users": 81,
+        "hasOldest": False,
+        "hasTailStart": True,
+        "hasLive": True,
+        "displaced": True,
+        "overlap": "Transcript history page overlaps loaded turns.",
+    }
+
+
+def test_transcript_history_load_is_retryable_and_preserves_scroll_anchor():
+    keyed = APP[
+        APP.index("function chatCreateTranscriptState"):
+        APP.index("async function renderInterface")
+    ]
+    assert "CHAT_TRANSCRIPT_PAGE_TURNS = 20" in APP
+    assert "CHAT_TRANSCRIPT_MAX_PAGES = 5" in APP
+    assert "if (!cursor || pageState.olderLoading) return" in keyed
+    assert "chatMergeOlderTranscriptPage(pageState, snapshot)" in keyed
+    assert "pageState.olderError = error" in keyed
+    assert "state.pendingPrepend" in keyed
+    assert "anchor.offsetTop - anchorOffset" in keyed
+    assert 'className: "chat-transcript-history"' in keyed
+    assert 'className: "chat-transcript-window-gap"' in keyed
+    assert "await reconcileTranscript(true)" in keyed
+    assert ".chat-transcript-history" in STYLE
+    assert ".chat-transcript-window-gap" in STYLE
+
+
 def test_segmented_transcript_source_contract_is_versioned_and_run_scoped():
     interface = APP[APP.index("const CHAT_HARNESSES"):
                     APP.index("// ── Tabs + boot")]
     keyed = interface[interface.index("function chatCreateTranscriptState"):
                       interface.index("async function renderInterface")]
 
-    assert "snapshot.projection_version !== 2" in keyed
+    assert "snapshot.projection_version !== 3" in interface
+    assert "chatTranscriptPageItems(snapshot)" in keyed
     assert "assistant_cursor" in keyed
     assert "segment_anchor_sequence" in keyed
     assert "tool.started" in keyed
@@ -398,10 +493,9 @@ def test_transcript_follow_pauses_for_reading_and_offers_jump_to_latest():
         "- transcript.clientHeight <= 32"
     ) in interface
     assert "const previousTop = transcript.scrollTop" in interface
-    assert (
-        "transcript.scrollTop = followTail "
-        "? transcript.scrollHeight : previousTop"
-    ) in interface
+    assert "transcript.scrollTop = followTail" in interface
+    assert "? transcript.scrollHeight" in interface
+    assert ": anchor?.isConnected ? anchor.offsetTop - anchorOffset : previousTop" in interface
     assert "const followTail = shouldFollow()" in interface
     assert 'className: "chat-jump-latest"' in interface
     assert 'ariaLabel: "Jump to latest message"' in interface


### PR DESCRIPTION
## Summary
- page transcript projections in fixed 20-turn, owner-scoped cursor windows
- progressively prepend history while retaining at most five pages / 100 turns
- preserve scroll position and live-tail behavior across history eviction

## Verification
- `./sc test` — 2353 passed, 1 skipped
- `./sc test tests/test_conversation_release_gate.py tests/test_conversation_api.py tests/test_conversation_ui.py -q` — 106 passed, 16 subtests passed
- `node --check .super-coder/ui/app.js`
- `python -m py_compile .super-coder/api/conversation_routes.py`
- `git diff --check`

## Trade-off
Deep history keeps the live tail plus the four pages nearest the reader; evicted middle history is marked explicitly. Jump to latest rebuilds the newest five-page window. No transcript cache or storage authority was added.

## Lint note
The declared focused lint hook still reports two pre-existing warnings at `tests/test_conversation_api.py:517` and `tests/test_conversation_ui.py:75`; this change adds no lint finding.