### PR TITLE
fix(sprint): confirm informational message reads

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2730,14 +2730,22 @@ class Handler(BaseHTTPRequestHandler):
                 )
                 return self._send(200, {"changed": changed})
             if path == "/_sc/sprint/inbox-read":
+                message_id = self._sprint_integer(body, "message_id")
                 disposition = sprint_message_delivery.SprintMessageStore(
                     con
                 ).mark_read(
-                    self._sprint_integer(body, "message_id"),
+                    message_id,
                     shell_id,
                     sprint_id=sprint_id,
                 )
-                return self._send(200, {"disposition": disposition})
+                return self._send(
+                    200,
+                    {
+                        "message_id": message_id,
+                        "read": True,
+                        "disposition": disposition,
+                    },
+                )
             if path == "/_sc/sprint/inbox-decline":
                 message_id = sprint_message_delivery.SprintMessageStore(con).decline(
                     self._sprint_integer(body, "message_id"),

--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -34,6 +34,15 @@ reason when unable to accept. After handling an informational message, run
 `accept`; it marks the message read and does not change Sprint or work-unit
 state.
 
+An unusable success receipt from idempotent bookkeeping does not stall the
+Sprint. Retry the exact command once, then use its normal read surface once to
+prove the exact postcondition. For informational `accept`, prior inbox presence
++ absence of that exact message id proves the read landed. Continue under that
+proof + name the receipt defect in the next normal handoff. NEVER use this
+recovery to infer assignment ownership, review outcome, merge authorization,
+lifecycle/work-unit transition, governing revision, PR head/green state, or
+cleanup authority. An unproved postcondition stops.
+
 Assignments and review requests use Force-new delivery; verdicts and PR-event
 wakes use Re-enter. Delivery waits for a natural boundary; the runtime owns
 bundling, rotation, and recovery. Stop after a successful typed handoff.

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -55,6 +55,15 @@ Accept/decline only actionable items. After acting on an informational message,
 run `accept`; it marks the message read and does not change Sprint or work-unit
 state.
 
+An unusable success receipt from idempotent bookkeeping does not stall the
+Sprint. Retry the exact command once, then use its normal read surface once to
+prove the exact postcondition. For informational `accept`, prior inbox presence
++ absence of that exact message id proves the read landed. Continue under that
+proof + name the receipt defect in the next normal handoff. NEVER use this
+recovery to infer assignment ownership, review outcome, merge authorization,
+lifecycle/work-unit transition, governing revision, PR head/green state, or
+cleanup authority. An unproved postcondition stops.
+
 - Keep dependencies as hard sequence; restructure current projection under
   Planner authority, record why, and never rewrite completed history.
 - Developers own PR green/review/correction/merge. Reviewers own verdicts and

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -46,6 +46,15 @@ Decline actionable work only with a concrete reason. After handling an
 informational message, run `accept`; it marks the message read and does not
 change Sprint or work-unit state.
 
+An unusable success receipt from idempotent bookkeeping does not stall the
+Sprint. Retry the exact command once, then use its normal read surface once to
+prove the exact postcondition. For informational `accept`, prior inbox presence
++ absence of that exact message id proves the read landed. Continue under that
+proof + name the receipt defect in the next normal handoff. NEVER use this
+recovery to infer assignment ownership, review outcome, merge authorization,
+lifecycle/work-unit transition, governing revision, PR head/green state, or
+cleanup authority. An unproved postcondition stops.
+
 Review requests use Force-new delivery. Verdicts and Planner decisions use
 Re-enter. Delivery waits for a natural boundary; the runtime owns bundling,
 rotation, and recovery. Stop after a successful typed handoff. Reviewers never

--- a/.super-coder/migrations/0207_reseed_sprint_receipt_recovery.sql
+++ b/.super-coder/migrations/0207_reseed_sprint_receipt_recovery.sql
@@ -1,0 +1,892 @@
+-- 0207 — reseed bounded Sprint receipt recovery guidance.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_dev',
+  'Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge only after live authorization, and record judgment without overlapping edits.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_dev — own one editing lane
+
+Use for an actionable work-unit assignment in an armed Sprint. Use the simplest
+path supported by current durable state. Treat ownership, lifecycle
+preconditions, durable writes, and typed handoffs as hard boundaries; use
+judgment inside them. Repeat a read only when later activity could have changed
+it or the next command requires live revalidation.
+
+## Route the entry
+
+Load `sprint_dev` on every entry, then classify it:
+
+| Trigger | First read / action |
+|---|---|
+| Assignment, verdict, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; accept or handle the relevant message. |
+| Self-describing engine-wide PR fact | Inspect the fact + registered PR directly. Do not manufacture a Sprint inbox item; check the inbox once immediately before the next typed handoff. |
+| Live FnB instruction | Preserve its authority; read only durable state needed for safe action. |
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Accepting marks assignment ownership and starts work. Decline with a concrete
+reason when unable to accept. After handling an informational message, run
+`accept`; it marks the message read and does not change Sprint or work-unit
+state.
+
+An unusable success receipt from idempotent bookkeeping does not stall the
+Sprint. Retry the exact command once, then use its normal read surface once to
+prove the exact postcondition. For informational `accept`, prior inbox presence
++ absence of that exact message id proves the read landed. Continue under that
+proof + name the receipt defect in the next normal handoff. NEVER use this
+recovery to infer assignment ownership, review outcome, merge authorization,
+lifecycle/work-unit transition, governing revision, PR head/green state, or
+cleanup authority. An unproved postcondition stops.
+
+Assignments and review requests use Force-new delivery; verdicts and PR-event
+wakes use Re-enter. Delivery waits for a natural boundary; the runtime owns
+bundling, rotation, and recovery. Stop after a successful typed handoff.
+
+## Bound the lane
+
+Read the assignment, expected output, bound spec revision, dependencies,
+Reviewer, repository/worktree, merge grant, and prior judgments. Own at most one
+active work unit; never start a second editing lane or edit another shell''s
+worktree. Resolve ambiguity with the shippable in-scope reading + recorded
+rationale. Ask the Planner before changing the unit boundary, shared interface,
+deliverable cut, priority, or scope.
+
+Put one question, blocker, decision, answer, or useful context item in a short
+body file. Unit questions/blockers require a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level decisions:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Reply through the original message; the server inherits its scope, so never add
+`--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Ask the Reviewer about review evidence and the Planner about scope or
+cross-unit authority. Confirm the durable reply, then `accept` the incoming
+message. At a decision boundary, stop until the required answer arrives;
+unread recovery re-wakes, so send no duplicate reminder.
+
+A stable key identifies recipient + exact body + intent + reply linkage +
+scope. Reuse it only for the same failed/ambiguous write; when any of those
+fields changes, use a new key. Keep bodies near 6,000 characters and below the
+8,000-character hard limit; run `wc -m < <path>`. A handoff completes only when
+the command exits successfully and confirms its durable message/state + wake.
+If a command is rejected or transport fails, correct and retry safely. If the
+relay itself fails, give FnB the attempted command, evidence, impact, and
+recommendation; invent no alternate protocol.
+
+A Developer does not pause the Sprint. Report blocker or integrity evidence to
+the Planner, continue safe independent work, and stop at the unsafe boundary.
+The Reviewer decides continue/replan/pause; the Planner executes the decision.
+
+Store scratch proof, diffs, evidence packets, review notes, and report drafts in
+gitignored `shared/sprints/sprint-<n>/`. Never commit or PR them. Durable
+judgments belong in `record-review`, reports in `sprint_reports`, and decisions
+in the relay.
+
+## Build and verify
+
+Sync the assigned repository, branch, implement the smallest complete change,
+and exercise the unit''s independent gate + realistic failures. Keep external
+calls outside DB transactions; preserve durable identities and append-only
+evidence. Record CI failures, infrastructure anomalies, retries, review
+friction, and known departures for closeout.
+
+Immediately before `complete-unit`, `register-pr`, or `request-review`, re-run
+`sc sprint inbox --sprint <id>` once and act on new messages. After the typed
+handoff confirms its durable write, stop without another inbox pass. The
+reopened-PR route below is the sole exception.
+
+## Report-only or no-code completion
+
+Only an explicitly planned report/no-code lane may finish without a PR. Keep
+the result near 6,000 characters and below 8,000; run `wc -m < <path>`, perform
+the pre-handoff inbox check, then require a durable completion receipt:
+
+```text
+sc sprint complete-unit --sprint <id> --work-unit <id> \
+  --result-file <path>
+```
+
+Stop after success. A code lane continues through merge observation.
+
+## Register and observe the PR
+
+```text
+sc sprint register-pr --sprint <id> --repository <owner/name> \
+  --pr <number> --work-unit <id>
+```
+
+After `register-pr` succeeds, retain ownership through green. The native
+registered-PR watcher creates your engine-wide subscription and sends
+self-describing red/green/externally-closed PR-event wakes as Re-enter, even
+outside an armed Sprint. Fix red; judge green. Planner and Reviewer receive no
+PR-event wakes.
+
+If the same registered PR was externally closed, then reopened, rebased, and
+pushed, replay the exact `register-pr` command. Require `created: false`, which
+keeps identity/ownership and takes a fresh snapshot. Its one pre-handoff inbox
+check covers registration replay + the immediately following review request.
+Do not wait for a second PR-fact wake: immediately request review. Green
+proceeds; any other snapshot returns the watcher diagnostic without partial
+handoff. Never register a replacement PR or ask the Planner to bypass observed
+green.
+
+Otherwise, when no local action remains, stop for the native PR fact. Start no
+recurring loop, scheduled job, daemon, or external watcher. A stalled gate
+permits one bounded read, then stop or report its evidence:
+
+```text
+sc sprint watcher-state --sprint <id>
+```
+
+Do not repeat this read as a polling loop.
+
+## Review handoff and correction
+
+Complete each round in order:
+
+1. Finish readiness judgment + local verification.
+2. Perform the once-only inbox check; handle and `accept` new messages.
+3. Use `submit` first or `resubmit` after changes requested. The engine injects
+   the PR URL, registered id, exact green head, and work-unit id into the
+   Reviewer''s canonical bare one-line locator. Create no readiness file. Send
+   no scope narrative, verification evidence, rationale, or review-focus
+   steering. Put only the work-unit id and spec reference in the PR body; write
+   no PR comments or annotations.
+4. As the literal final action, run:
+
+```text
+sc sprint request-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --intent <submit|resubmit> --key <stable-key>
+```
+
+5. Require confirmation of the durable write + Reviewer wake; run no trailing
+   command and stop and await the native verdict wake.
+
+Changes requested returns by Re-enter. Apply every blocking finding,
+re-establish green, and resubmit with a new review-round key. Do not narrate
+cleared findings; the Reviewer verifies the full diff at the engine-injected
+head. Record disagreements as judgment. Reviewer owns scope/severity; Planner
+executes resulting action.
+
+## Merge boundary
+
+Approval is stale evidence. Immediately before merge, re-read live GitHub,
+grant, ownership, unit state, approved head, and checks through:
+
+```text
+sc sprint authorize-merge \
+  --sprint <id> --registered-pr <registered-id>
+```
+
+Merge only the returned repository, PR, and head SHA. A refusal means wait for
+the watcher or re-enter the appropriate loop; never bypass it.
+
+## Post-merge handoff
+
+After the authorized merge:
+
+1. Clean the worktree; put merged PR + SHA, unit result, verification,
+   judgments, and departures in the handoff file.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle and `accept` new items.
+3. Run `wc -m < <path>`; keep the body near 6,000 characters and below 8,000.
+4. As the literal final action, send:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --intent handoff --key <stable-merged-handoff-key>
+```
+
+5. Require the durable message + Planner wake, then stop immediately. Run no trailing Git,
+   Sprint, inbox, cleanup, or status command. Automatic merge
+   observation records the PR transition; this handoff releases the next wave.
+
+## Report and stop
+
+Report broken bases, destructive ambiguity, unavailable GitHub, untrustworthy
+runners, provider exhaustion, or unrecoverable environment with evidence,
+impact, and recommendation. Stop when merged + reported, declined, returned to
+review, paused for a native wake, or awaiting Planner/FnB recovery. Ask for
+later work only after this editing lane is terminal.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_rev',
+  'Review Sprints v2 work and whole-Sprint conformance — own review, re-enter, abort, and conclude judgments, author the conformance and Sprint reports, and direct safety actions through durable messages.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_rev — independent review and conformance
+
+Use for pre-declaration QAQC, one work-unit review, or whole-Sprint
+conformance. The Reviewer decides review/conformance; the Planner owns
+operational plan structure + control execution. FnB retains the board-level
+override from decision #46.
+
+Use the simplest path supported by current durable state. Treat independence,
+authority, lifecycle preconditions, durable writes, and typed handoffs as hard
+boundaries. Repeat a read only when later activity could have changed it or the
+next command requires live revalidation.
+
+## Route the entry
+
+Classify the entry before reading an inbox:
+
+| Entry | Route |
+|---|---|
+| Explicit pre-declaration request | Read/sign the exact current spec directly; there is no Sprint id or Sprint inbox to inspect yet. |
+| Work-unit review / `sprint.delivery_terminal` | Inspect the Sprint inbox once; accept the actionable request. |
+| Live FnB instruction | Preserve board-level authority; read only durable state needed for independent judgment. |
+
+QAQC precedes all Sprint inbox commands:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
+
+For an armed Sprint, load `sprint_rev` on every entry:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Decline actionable work only with a concrete reason. After handling an
+informational message, run `accept`; it marks the message read and does not
+change Sprint or work-unit state.
+
+An unusable success receipt from idempotent bookkeeping does not stall the
+Sprint. Retry the exact command once, then use its normal read surface once to
+prove the exact postcondition. For informational `accept`, prior inbox presence
++ absence of that exact message id proves the read landed. Continue under that
+proof + name the receipt defect in the next normal handoff. NEVER use this
+recovery to infer assignment ownership, review outcome, merge authorization,
+lifecycle/work-unit transition, governing revision, PR head/green state, or
+cleanup authority. An unproved postcondition stops.
+
+Review requests use Force-new delivery. Verdicts and Planner decisions use
+Re-enter. Delivery waits for a natural boundary; the runtime owns bundling,
+rotation, and recovery. Stop after a successful typed handoff. Reviewers never
+receive PR-event wakes.
+
+## Relay contract and authority
+
+Ask the Developer for unit evidence with a unit-scoped question/blocker:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` when the unit cannot advance. Cross-unit, closeout,
+re-enter, abort, and safety rulings are Sprint-level decisions:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Reply through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Confirm a reply, then `accept` its incoming message. Missing facts stop review
+at the decision boundary; unread recovery re-wakes, so send no duplicate.
+A stable key identifies recipient + exact body + intent + reply + scope. Reuse
+it only for the same failed/ambiguous write; when any of those fields changes,
+use a new key.
+
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. A handoff completes only when the command exits successfully
+and confirms the durable write + wake. If a command is rejected or transport fails,
+the verdict/handoff is incomplete. Correct and retry safely. If the relay itself fails,
+give FnB the attempted command, evidence, impact, and recommendation; invent no
+alternate protocol.
+
+## Sprint artifact paths
+
+Keep review notes, diffs, evidence, reports, and scratch proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit, branch, or PR them. Durable records
+belong in `record-review`, `sprint_reports`, and the relay.
+
+## Conformance decisions and Planner controls
+
+Reviewer owns review, re-enter, abort, and conclude judgments. Planner
+independently owns operational plan structure: safe-edit pauses, recalling
+unreleased work, lane changes/repeats, assignment/routing, unreleased-scope
+cancellation, and validated resume. Reviewer never runs standalone pause,
+replan, recall, reroute, cancel, resume, complete, or abort actions; clean
+`record-conformance` alone performs its narrow atomic close.
+
+Base judgment on durable Sprint state, bound revisions, current work/PR facts,
+progress-carrier evidence, and ratified judgments. Every Reviewer→Planner route
+is Re-enter. A decision body names:
+
+- `decision`: `re-enter`, `abort`, or the exact safety-critical recommendation;
+- Reviewer-owned evidence + rationale;
+- exact Sprint/unit ids, reason, outcome, and complete action arguments;
+- immediate safety impact for FnB.
+
+Planner verifies Reviewer identity and executes the transition without
+surrendering plan authority. A rejected action requires a revised judgment
+supported by returned durable state, never an improvised bypass. A live FnB
+instruction supersedes as distinct FnB board-level override authority under
+decision #46.
+
+## Severity rubric
+
+- **Critical** — active security/authority violation, destructive corruption,
+  or unsafe continued operation.
+- **Major** — wrong behavior, data loss, broken invariant, material spec
+  violation, or silently wedged delivery/recovery.
+- **Medium** — concrete normal-use correctness/recovery gap, missing negative
+  enforcement, or unreliable handoff.
+- **Low** — bounded cleanup, clarity, test-depth, or resilience improvement;
+  delivered behavior remains correct.
+
+Critical/Major/Medium block unit approval; Low is a report note. At closeout,
+severity does not decide timing: Reviewer judges whether each finding requires in-Sprint patching
+or acceptable post-Sprint follow-up.
+
+## Work-unit review
+
+Accept the request and retain that exact message id. Its body is a bare locator:
+intent, PR URL, registered PR id, exact head, work-unit id. Scope narrative,
+verification, rationale, or focus steering is a protocol defect. PR comments
+and annotations are forbidden; PR body contains only unit id + spec reference.
+
+Bind inspection/verdict to the accepted request''s message id, registered PR,
+work unit, and exact head. Review each request explicitly. Read the exact spec
+revision + full diff at that head, then checks, tests, relevant runtime facts,
+and ratified judgments. Each round is clean: no prior Developer evidence or
+prose; prior findings clear only when the new head proves it. Trace code paths,
+failure cases, and spec behavior rather than names or PR prose.
+
+### Red-check doctrine
+
+Accepted-red is not a legal review outcome. A departure that leaves checks
+failing is never acceptable; the handoff remains green-only, without exception
+or waiver: do not note the failure and approve anyway.
+
+- In-scope failure -> record `changes_requested` so the Developer fixes them and restores green.
+- Out-of-scope failure -> keep the lane unapproved and send the Planner a `replan`
+  decision naming the failures; Planner widens the lane or cuts follow-up work.
+
+Read cited and feature-scoped resolved flag evidence through memory, never SQL:
+
+```text
+sc mem get flags <flag-id>
+sc mem get flags --feature <feature-id> --resolved
+```
+
+Each finding pins severity/title, violated invariant, exact location/evidence,
+reproducible consequence, and fix boundary without unnecessary architecture.
+
+Complete a unit verdict in this exact order:
+
+1. Finish every inspection, finding, and verdict body.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle + `accept` new items.
+3. Run `wc -m < <path>`; require near 6,000 and below 8,000 characters.
+4. As the literal final action, run:
+
+```text
+sc sprint record-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --verdict changes_requested --body-file <path> --key <stable-key>
+```
+
+5. Require durable judgment evidence + Developer Re-enter wake. Run no trailing command;
+   stop.
+
+Use `approved` only with no Critical/Major/Medium finding. Engine validation
+requires the accepted request and reviewed head. Do not message around the
+surface; an unrecorded verdict cannot unlock merge.
+
+## Delivery-terminal closeout
+
+Retain the exact notification message id + delivered wake as this closeout
+episode''s identity. Proceed only when the notification names this shell as the
+selected conformance owner for its current ownership generation. A different
+Reviewer accepts the informational notification if received and records no
+conformance. Inspect inbox, lifecycle, and units first:
+
+- Already completed/aborted -> `accept` notification and stop.
+- If any non-terminal unit is visible, the wake is stale -> `accept`, stop, and
+  await a fresh delivery-terminal episode.
+- Only an armed Sprint whose units are all terminal enters conformance.
+
+Compile the bounded evidence packet first, yourself:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Increase only when truncation omitted needed evidence; maximum 200. Judge
+integrated `main` against every bound/current revision + ratified judgment. All
+units cancelled and nothing shipped -> `abort`, not `conclude`.
+
+Choose one branch:
+
+- **In-Sprint patching required.** Do not run `record-conformance`. Send Planner
+  a durable `re-enter` decision with every blocking finding; each spec task''s
+  title and description; grouping, waves, dependencies, routing, and capacity
+  rationale. State independent lanes, expected review overlap, useful reserve,
+  and critical-path effect. After three re-entry episodes, escalate
+  non-convergence to FnB.
+- **Clean or post-Sprint-only findings.** Prepare conformance report, findings,
+  final report, reason, and outcome; submit the atomic close below. Send no
+  conclude message.
+
+## Whole-Sprint conformance
+
+Review the integrated system, not unit diffs. Classify every requirement
+`as-specced`, `deviated-intentionally` with ratified judgment,
+`deviated-silently`, or `unimplemented`; the last two are findings. Include
+spec document + work-unit ids when known.
+
+For the clean branch, write a conformance report and JSON findings array with
+`severity`, `title`, `body`, `spec_document_id`, and `work_unit_id`. Keep the
+report and each body near 6,000 and below 8,000 characters; run
+`wc -m < <report>` and validate each body.
+
+Before recording conformance, author the final Sprint report. Name Reviewer as
+author and cover governing scope/revisions, shipped units/PRs, judgments +
+ratified deviations, failures/retries/recovery/anomalies, conclusion,
+follow-ups, and evidence location. Keep it near 6,000 and below 8,000; preserve
+discrepancies.
+
+Record one atomic final write:
+
+```text
+sc sprint record-conformance \
+  --sprint <id> --body-file <report> --findings-file <json> \
+  --final-report-file <final-report> --reason <reason> --outcome <outcome> \
+  --key <stable-pass-key>
+```
+
+Require receipt: conformance report id, final report id, follow-up ids,
+completed state, Planner message id, and Planner wake id. The transaction adds
+append-only evidence, follow-ups, terminal state, and one informational engine-wide Planner Re-enter;
+send no conclude message. Require cleanup projection `pending`; cleanup runs
+after participant turns exit. Do not reset a worktree, poll cleanup, or wait
+before stopping. The Planner receives the later engine-authored receipt.
+Successful conformance also closes other Sprint-linked
+chats while the originating Planner + report-authoring Reviewer stay open. Do
+not manually close peer chats. Pause, abort, re-entry, failed conformance, and
+rejected fallback retain no-cleanup behavior. Never reopen editing after recording; a re-enter defers
+reports until new scope is terminal and a fresh delivery-terminal wake arrives.
+
+## Stop
+
+Unit review ends with the ordered `record-review` write as the literal final
+action.
+
+For closeout, first re-run `sc sprint inbox --sprint <id>`, handle + `accept`
+new messages, then confirm every artifact/body is final and below 8,000.
+
+- Clean conclude -> run the atomic `record-conformance` command above as the
+  literal final action. When it confirms completed state, pending cleanup, and
+  all receipt identities, stop immediately; Planner is notified.
+- Re-enter/abort -> as literal final action send:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level \
+  --key <stable-decision-handoff-key>
+```
+
+Require durable write + Planner wake, then stop immediately. Run no trailing
+command until another native wake.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
+
+Use as originating Planner after `sprint_prep` arms a Sprint. System records
+facts; Reviewer owns review/conformance judgment + reports; Planner owns plan
+structure and executes control transitions. FnB retains board-level override
+under decision #46.
+
+Use the simplest path supported by current durable state. Treat authority,
+lifecycle preconditions, durable writes, and typed handoffs as hard boundaries.
+Repeat a read only when later activity could have changed it or the next command
+requires live revalidation.
+
+## Route the entry
+
+Load `sprint_pln` on every entry, then classify:
+
+| Trigger | Route |
+|---|---|
+| Sprint decision, merged-work handoff, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; handle that message. |
+| Engine-wide completion or cleanup receipt | Inspect receipt + terminal state directly; it is informational—do not run the Sprint inbox, accept it, or close again. |
+| Live FnB instruction | Act under board override; name FnB authority in durable evidence. |
+
+Do not poll. Armed runtime owns scheduled dispatch + unread wake recovery;
+registered-PR watcher owns subscription observation. Developer-owned subscriptions send
+red/green/closed facts to Developers, never Planner.
+
+Assignments/review requests use Force-new delivery; Planner-bound results use
+Re-enter. Delivery waits for a natural boundary; runtime owns bundling,
+rotation, recovery, and coordinate mode. Stop after a successful typed handoff.
+
+## Durable running loop
+
+Read only lifecycle, unit, dependency, route, PR, expectation, and anomaly
+facts required by the trigger. Browser presence is not progress.
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+sc sprint dispatch --sprint <id>
+```
+
+Dispatch every dependency-ready lane; returned ids are wake identities.
+Disposition + messages are release facts. Stable assignment generations and
+occupied lanes make dispatch repeat-safe.
+
+Accept/decline only actionable items. After acting on an informational message,
+run `accept`; it marks the message read and does not change Sprint or work-unit
+state.
+
+An unusable success receipt from idempotent bookkeeping does not stall the
+Sprint. Retry the exact command once, then use its normal read surface once to
+prove the exact postcondition. For informational `accept`, prior inbox presence
++ absence of that exact message id proves the read landed. Continue under that
+proof + name the receipt defect in the next normal handoff. NEVER use this
+recovery to infer assignment ownership, review outcome, merge authorization,
+lifecycle/work-unit transition, governing revision, PR head/green state, or
+cleanup authority. An unproved postcondition stops.
+
+- Keep dependencies as hard sequence; restructure current projection under
+  Planner authority, record why, and never rewrite completed history.
+- Developers own PR green/review/correction/merge. Reviewers own verdicts and
+  conformance. Do not proxy routine handoffs or judgments.
+- Record Reviewer decision id + exact action + receipt; never rewrite rationale
+  as Planner judgment.
+- Mid-Sprint spec edits require owning Planner/FnB + durable Reviewer decision.
+  Record old/new revision hashes; binding changes only when the decision says so.
+- Use native wakes. Start no recurring loop, scheduled job, manual participant
+  boot, or external watcher. One stalled-gate inspection is allowed:
+
+```text
+sc sprint watcher-state --sprint <id>
+```
+
+Do not repeat this read as a polling loop. Act on its bounded watcher evidence,
+then return to native delivery.
+
+## Relay contract
+
+Unit question/blocker requiring reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Answer through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Confirm reply, then `accept` incoming. A missing answer stops at the decision
+boundary; unread recovery re-wakes, so send no duplicate. Choose a stable key
+for recipient + body + intent + reply + scope; reuse it only for that identical
+write. When any of those fields changes, use a new key.
+
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. Handoff completes only when the command exits successfully
+and confirms durable write + wake. If a command is rejected or transport fails,
+correct/retry safely. If relay itself fails, give FnB attempted command +
+durable evidence; invent no alternate protocol. Relay Developer integrity
+evidence, impact, and recommendation to Reviewer. Send required context before
+pausing because paused Sprint relay is unavailable.
+
+Keep scratch review notes, diffs, evidence, reports, and proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit/branch/PR them. Durable judgment,
+reports, and decisions belong in `record-review`, `sprint_reports`, and relay.
+
+## Reviewer decisions and Planner actions
+
+Review/conformance/re-enter/abort judgment remains Reviewer-owned. Planner
+independently owns operational plan structure: pause-safe recall, cancellation
+of unreleased scope, reassignment, repeated task lanes, and route changes.
+
+For a required-reply Reviewer→Planner Re-enter decision, keep this order:
+
+1. Re-run `sc sprint inbox --sprint <id>`; verify assigned Reviewer + retain id.
+2. Send linked acknowledgement:
+
+```text
+sc sprint send --sprint <id> --to <reviewer-shortname> --body-file <path> \
+  --intent information --reply-to <decision-message-id> \
+  --key <stable-control-reply-key>
+```
+
+3. Require the reply command to confirm its durable message and wake; retry the
+   same command/key if ambiguous.
+4. Accept the decision:
+
+```text
+sc sprint accept --sprint <id> --message <decision-message-id>
+```
+
+5. Only after acceptance, execute the requested transition without
+   re-adjudicating it. The linked reply must precede any pause or
+   abort that makes the Sprint relay unavailable.
+
+Record decision id + reply, acceptance, and action receipts. Clean conformance
+closes atomically and sends informational receipt; no reply/accept is needed.
+
+The FnB board-level override from decision #46 remains distinct. If action
+fails lifecycle/authority/disposition precondition, send refusal + durable state
+to Reviewer (or FnB for override), substitute nothing, and stop.
+
+### Pause or resume
+
+Pause for Reviewer decision or safe Planner restructuring; preserve partial
+artifacts, interrupt intent, judgment, and evidence:
+
+```text
+sc sprint pause --sprint <id> --reason <decision-or-restructure-reason>
+```
+
+Resume only after recording recovery/restructure and reconciling native runs,
+unread messages, wakes, units, PRs, capacity, and spec drift:
+
+```text
+sc sprint resume --sprint <id> [--reason <validated-reconciliation-reason>]
+```
+
+Preserve the current conformance owner on ordinary resume. Replace that owner
+only while paused, only with an eligible participating Reviewer, and always
+record a reason:
+
+```text
+sc sprint resume --sprint <id> \
+  --conformance-reviewer-shell <replacement-shell-id> \
+  --reason <ownership-replacement-reason>
+```
+
+Require the receipt and board projection to show the replacement owner and a
+new ownership generation before treating the Sprint as resumed.
+
+Exhausted recovery wake = bounded manual evidence: preserve unread message +
+failed wake, involve FnB, create no recursive fallback. Drift informs but never
+silently blocks resume.
+
+Aborted-Sprint PR ownership repair belongs to the originating Planner. Keep
+replacement Sprint paused; establish old/new identity. The originating Planner
+may reconcile that identity (FnB may override):
+
+```text
+sc sprint reconcile-pr --sprint <replacement-id> --repository <owner/repo> \
+  --pr <number> --work-unit <replacement-unit-id> --reason <recovery-reason>
+```
+
+It refuses a live source Sprint or target Sprint, a non-originating Planner,
+invalid/owned target, and closed-unmerged PR. Receipt records owners, live head,
+authority, and merged completion when applicable. Require a separate Reviewer
+decision before resuming.
+
+### Modify, recall, repeat, reassign, or reroute
+
+Cancel unreleased scope with retained terminal reason/Reviewer id:
+
+```text
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reason>
+```
+
+Edit an unreleased lane; omitted fields stay, `--clear-dependencies` means none:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  [--developer-shell <id>] [--reviewer-shell <id>] [--title <title>] \
+  [--expected-output-file <path>] [--task <task-id>] [--wave <n>] \
+  [--depends-on <work-unit-id> | --clear-dependencies] \
+  [--output-kind code|report-only|no-code]
+```
+
+Never edit a released lane in place. Pause → recall unmerged lane → replan →
+resume:
+
+```text
+sc sprint pause --sprint <id> --reason <restructure-reason>
+sc sprint recall-unit --sprint <id> --work-unit <id> --reason <obsolete-reason>
+sc sprint replan-unit --sprint <id> --work-unit <id> <changed-fields>
+sc sprint resume --sprint <id> --reason <validated-replan-reason>
+```
+
+Recall preserves message/event history, returns only unmerged work to planned,
+and refuses terminal/PR-bound work. PR-bound work stays; plan replacement or use
+reconciliation. Resume creates fresh assignment generation. One spec task may
+govern repeated verification/replacement lanes; each lane lists it once. Do not
+duplicate the spec task.
+
+To change future assignment/review model, pause armed Sprint, clear released
+expectation, then validate + replace route:
+
+```text
+sc sprint reroute-participant --sprint <id> --participant-shell <id> \
+  --harness <harness> [--model <model>] [--effort <effort>] \
+  [--route <display-route>]
+```
+
+Prepared Sprints may reroute directly. Armed Developer route rejects released
+lane; Reviewer route rejects in-review lane. Existing chats/runs remain history;
+next Force-new delivery uses replacement. Reroute declared participants only.
+On decline, preserve reason and choose replacement from current capacity; ask
+Reviewer only if review/conformance judgment changes.
+
+### Re-enter after conformance
+
+Reviewer decision names findings; governing tasks (existing for same scope,
+new title/description for new scope); and grouping, waves, dependencies,
+routing, capacity. Preserve it; do not absorb extra/post-Sprint scope or
+maximize occupancy.
+
+```text
+sc mem task add "<task-title>" --feature <feature-id> \
+  --doc <governing-spec-document-id> --seq <next-seq> \
+  --desc "<task-description>"
+
+sc sprint plan-unit --sprint <id> \
+  --developer-shell <id> --reviewer-shell <id> --title <title> \
+  --expected-output-file <path> --task <task-id> \
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>] \
+  [--output-kind code|report-only|no-code]
+```
+
+Reuse task for exact repair/repeat; add only genuinely new scope. Bind every
+task, then confirm routes + dependency graph and capacity plan match the
+decision. Planner may reassign or reroute for operational capacity; tell
+Reviewer if conflict changes scope/judgment. Release ready lanes with
+`sc sprint dispatch --sprint <id>`. Engine sends next delivery-terminal wake;
+Planner does not initiate conformance.
+
+### Conclude or abort
+
+The clean `record-conformance` command atomically stores conformance, follow-ups,
+Reviewer-authored final report, completion, and informational engine-wide
+Planner receipt. On Re-enter, verify Sprint/reports/outcome/completed state.
+Do not run `complete`; notification is informational because closure is already
+terminal. Planner does not author a second report. The originating Planner and
+report-authoring Reviewer remain open. Do not manually close peer chats. Pause,
+abort, re-entry, failed conformance, and rejected fallback retain no-cleanup
+behavior.
+
+The initial completion receipt reports `cleanup_state=pending`. Delivery is
+finished, but managed worktrees are not reusable. Stop for the engine-wide
+cleanup receipt; do not poll or manually reset participant trees. On
+`cleanup_state=succeeded`, treat the slots as reusable. On failure, inspect once
+and retry only after correcting the named condition:
+
+```text
+sc sprint cleanup-status --sprint <id>
+sc sprint cleanup --sprint <id> --key <stable-retry-key>
+```
+
+Require `created`, cleanup request id, action, exact target ids, and aggregate
+projection. Reuse the key only for the same request. FnB alone may add
+`--adopt-legacy` for a completed Sprint with no scheduled targets; neither caller
+supplies a path.
+
+Do not compile or editorialize by default; Reviewer owns evidence/report. Only
+FnB-directed fallback may run:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Abort only on Reviewer decision/FnB override; it is terminal and deletes
+nothing.
+
+## Handoffs and stop
+
+Planner receives no PR-event wakes. Never dispatch the next wave from merge
+observation. The merged-work handoff wake is the only normal next-wave dispatch trigger.
+On it:
+
+1. Run `sc sprint inbox --sprint <id>`; inspect merged handoff + unit/dependency state.
+2. Handle earlier informational items and `accept` each, including handoff.
+3. Finish reconciliation and Planner bookkeeping; no work remains.
+4. As literal final action run `sc sprint dispatch --sprint <id>`.
+5. Require durable assignments + New wakes, then stop. Run no trailing command.
+   Empty dispatch remains final; investigate only on a later durable wake.
+
+On an initial clean completion receipt, verify the named Sprint is terminal and
+record `cleanup_state=pending`; run no close command. Stop until the
+engine-authored cleanup success or failure receipt arrives. The Planner does
+not author a second report, accept an actionable handoff, poll cleanup, or ask
+another role to reset a worktree.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -103,7 +103,8 @@
     ".super-coder/migrations/0203_sprint_cleanup_recovery.sql",
     ".super-coder/migrations/0204_sprint_governing_revision_evidence.sql",
     ".super-coder/migrations/0205_sprint_conformance_ownership.sql",
-    ".super-coder/migrations/0206_reseed_sprint_conformance_ownership.sql"
+    ".super-coder/migrations/0206_reseed_sprint_conformance_ownership.sql",
+    ".super-coder/migrations/0207_reseed_sprint_receipt_recovery.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -392,6 +392,68 @@ class SprintCliApiTest(unittest.TestCase):
                 str(self.document_id),
             )
 
+    def test_informational_accept_returns_durable_idempotent_read_receipt(self):
+        con = sqlite3.connect(self.db)
+        con.row_factory = sqlite3.Row
+        try:
+            receipt = sprint_message_delivery.SprintMessageStore(con).relay(
+                self.sprint_id,
+                from_shell_id=2,
+                to_shortname="DEV1",
+                body="Review approved; continue through the live merge gate.",
+                idempotency_key="informational-read-receipt",
+                work_unit_id=self.unit_id,
+            )
+            message_id = receipt.message_id
+        finally:
+            con.close()
+
+        inbox = self.run_cli(
+            TOKENS["developer"], "inbox", "--sprint", str(self.sprint_id)
+        )
+        self.assertIn(message_id, [item["message_id"] for item in inbox["messages"]])
+
+        expected = {
+            "message_id": message_id,
+            "read": True,
+            "disposition": None,
+        }
+        first = self.run_cli(
+            TOKENS["developer"],
+            "accept",
+            "--sprint",
+            str(self.sprint_id),
+            "--message",
+            str(message_id),
+        )
+        replay = self.run_cli(
+            TOKENS["developer"],
+            "accept",
+            "--sprint",
+            str(self.sprint_id),
+            "--message",
+            str(message_id),
+        )
+        self.assertEqual(expected, first)
+        self.assertEqual(expected, replay)
+
+        after = self.run_cli(
+            TOKENS["developer"], "inbox", "--sprint", str(self.sprint_id)
+        )
+        self.assertNotIn(
+            message_id, [item["message_id"] for item in after["messages"]]
+        )
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertIsNotNone(
+                con.execute(
+                    "SELECT read_at FROM wake_message WHERE message_id=?",
+                    (message_id,),
+                ).fetchone()[0]
+            )
+        finally:
+            con.close()
+
     def test_engine_wide_subscription_uses_authenticated_developer_identity(self):
         with mock.patch.object(
             server.sprint_pr_watcher,
@@ -1982,6 +2044,8 @@ class SprintCliApiTest(unittest.TestCase):
             "--message",
             str(report_message),
         )
+        self.assertEqual(report_message, accepted["message_id"])
+        self.assertTrue(accepted["read"])
         self.assertEqual("accepted", accepted["disposition"])
         declined_inbox = self.run_cli(
             "dev2-token", "inbox", "--sprint", str(sprint_id)

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -55,6 +55,9 @@ CONTEXT_EFFICIENT_RESEED = (
 CONFORMANCE_OWNER_RESEED = (
     ENGINE / "migrations" / "0206_reseed_sprint_conformance_ownership.sql"
 )
+INFORMATIONAL_RECEIPT_RESEED = (
+    ENGINE / "migrations" / "0207_reseed_sprint_receipt_recovery.sql"
+)
 
 
 class SprintSkillTest(unittest.TestCase):
@@ -124,8 +127,8 @@ class SprintSkillTest(unittest.TestCase):
             con.executescript(migration)
 
             for name in CONTEXT_EFFICIENT_SKILLS:
-                if name in CLEANUP_RECOVERY_SKILLS:
-                    continue  # 0203 deliberately supersedes these role bodies.
+                if name in HANDOFF_ROLE_SKILLS:
+                    continue  # Later reseeds deliberately supersede role bodies.
                 parsed = seed_skills.parse_skill(ASSETS / name / "SKILL.md")
                 actual = con.execute(
                     "SELECT description,category,command,common,content,is_deleted "
@@ -173,6 +176,7 @@ class SprintSkillTest(unittest.TestCase):
             migration = CONFORMANCE_OWNER_RESEED.read_text()
             con.executescript(migration)
             con.executescript(migration)
+            con.executescript(INFORMATIONAL_RECEIPT_RESEED.read_text())
 
             for name in sorted(CONFORMANCE_OWNER_SKILLS):
                 with self.subTest(name=name):
@@ -203,6 +207,82 @@ class SprintSkillTest(unittest.TestCase):
                     ).fetchone()
                 ),
             )
+
+    def test_informational_receipt_reseed_is_exact_and_idempotent(self):
+        with sqlite3.connect(":memory:") as con:
+            con.executescript(
+                "CREATE TABLE skills ("
+                "skill_id INTEGER PRIMARY KEY, name TEXT UNIQUE, description TEXT, "
+                "category TEXT, command TEXT, common INTEGER, content TEXT, "
+                "is_deleted INTEGER DEFAULT 0);"
+            )
+            for index, name in enumerate(sorted(HANDOFF_ROLE_SKILLS), 1):
+                con.execute(
+                    "INSERT INTO skills VALUES (?,?,?,?,?,?,?,1)",
+                    (index, name, "stale", "stale", "stale", 1, "stale"),
+                )
+            con.execute(
+                "INSERT INTO skills VALUES "
+                "(99,'fork_only','local','fork',NULL,0,'bespoke body',0)"
+            )
+
+            migration = INFORMATIONAL_RECEIPT_RESEED.read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+
+            for name in sorted(HANDOFF_ROLE_SKILLS):
+                with self.subTest(name=name):
+                    parsed = seed_skills.parse_skill(ASSETS / name / "SKILL.md")
+                    row = con.execute(
+                        "SELECT description,category,command,common,content,is_deleted "
+                        "FROM skills WHERE name=?",
+                        (name,),
+                    ).fetchone()
+                    self.assertEqual(
+                        (
+                            parsed["description"],
+                            parsed["category"],
+                            parsed["command"],
+                            parsed["common"],
+                            parsed["content"],
+                            0,
+                        ),
+                        tuple(row),
+                    )
+            self.assertEqual(
+                ("fork", "bespoke body", 0),
+                tuple(
+                    con.execute(
+                        "SELECT category,content,is_deleted FROM skills "
+                        "WHERE name='fork_only'"
+                    ).fetchone()
+                ),
+            )
+
+    def test_role_skills_bound_unusable_receipt_recovery(self):
+        for name in sorted(HANDOFF_ROLE_SKILLS):
+            with self.subTest(name=name):
+                body = " ".join(
+                    (ASSETS / name / "SKILL.md").read_text().lower().split()
+                )
+                self.assertIn("retry the exact command once", body)
+                self.assertIn("normal read surface once", body)
+                self.assertIn(
+                    "prior inbox presence + absence of that exact message id proves "
+                    "the read landed",
+                    body,
+                )
+                for forbidden_inference in (
+                    "assignment ownership",
+                    "review outcome",
+                    "merge authorization",
+                    "lifecycle/work-unit transition",
+                    "governing revision",
+                    "pr head/green state",
+                    "cleanup authority",
+                ):
+                    self.assertIn(forbidden_inference, body)
+                self.assertIn("an unproved postcondition stops", body)
 
     def test_handoff_migration_converges_a_drifted_existing_skill_body(self):
         con = sqlite3.connect(":memory:")
@@ -777,6 +857,7 @@ class SprintSkillTest(unittest.TestCase):
             con.executescript(migration)
             con.executescript(migration)
             con.executescript(CONFORMANCE_OWNER_RESEED.read_text())
+            con.executescript(INFORMATIONAL_RECEIPT_RESEED.read_text())
 
             self.assertIsNotNone(
                 con.execute(


### PR DESCRIPTION
Closes #1066

## What changed
- return an explicit `{message_id, read, disposition}` receipt from `sc sprint accept`
- keep informational accepts idempotent while proving the read landed
- grant Developer, Reviewer, and Planner a tightly bounded retry/read-back workaround for unusable bookkeeping receipts
- reseed the updated role skills for existing installations

## Incident evidence
On the Halo `dos-arch` install, Sprint 18 message 572 was delivered at 00:00:01 and durably read at 00:00:22, but the API returned only `{disposition: null}`. The shell treated that unusable receipt as a hard stop; merge authorization did not occur until 05:11:16.

## Verification
- `138 passed, 114 subtests passed` — Sprint CLI, skills, and message delivery
- `25 passed, 34 subtests passed` — migration management and Sprint removal manifest
- `render-check` passed against tracked sources
- `git diff --check` passed