### PR TITLE
fix(git): make shell bases disposable

### DIFF
--- a/.super-coder/migrations/0208_reseed_disposable_shell_base.sql
+++ b/.super-coder/migrations/0208_reseed_disposable_shell_base.sql
@@ -1,11 +1,14 @@
----
-name: git
-description: Git conventions for a super-coder shell — one repo, one cwd. Sync the base before work, branch before committing, open PRs (never merge without the FnB's OK), attribute commits per-shell. Use before any git work.
-category: substrate
-common: false
----
+-- 0208 — make shell base worktrees explicitly disposable during sync.
 
-# git — version control, the super-coder way
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'git',
+  'Git conventions for a super-coder shell — one repo, one cwd. Sync the base before work, branch before committing, open PRs (never merge without the FnB''s OK), attribute commits per-shell. Use before any git work.',
+  'substrate',
+  NULL,
+  0,
+  '# git — version control, the super-coder way
 
 One repo at its root -> plain `git` (cwd = repo root) is safe.
 
@@ -15,7 +18,7 @@ Project = this repo minus `.super-coder/`. Engine = `.super-coder/` — gitignor
 
 Run the gate every session + before each new unit of work. `shell/<shortname>` = a moving base pinned to `origin/main`, not a content branch — cut feature branches from it. A stale base -> you read code that no longer exists + your PRs conflict on arrival.
 
-The launcher auto-syncs at boot when provably nothing can be lost (on base branch + clean tree + no local-only commits). Read the `sync:` line in ACTIVE SESSION: auto-synced + nothing done since -> current, carry on. Says **NOT auto-synced** / you're mid-session about to start new work -> run:
+The launcher auto-syncs at boot when provably nothing can be lost (on base branch + clean tree + no local-only commits). Read the `sync:` line in ACTIVE SESSION: auto-synced + nothing done since -> current, carry on. Says **NOT auto-synced** / you''re mid-session about to start new work -> run:
 
 1. `git fetch origin main && git rev-list --count HEAD..origin/main` -> record remote freshness; continue through the branch/target gate even when the count is 0.
 2. Compare `git rev-parse --show-toplevel` + `git branch --show-current` with ACTIVE SESSION before any destructive command. A mismatch -> stop + surface it.
@@ -26,7 +29,7 @@ The launcher auto-syncs at boot when provably nothing can be lost (on base branc
 ## Branch -> commit -> push -> PR -> stop
 
 1. NEVER commit to the default branch. Branch first: `git checkout -b <type>/<short-desc>` (feat/fix/chore/docs). *Admin-shell exception:* it boots at the repo root on `main`, exempt from the branch-guard; committing to main is its mandate (engine updates, migrations, approved patches) and it starts each session with `git pull --ff-only`. Every other shell branches, always.
-2. Commit in logical units. End every message with your shell's trailer:
+2. Commit in logical units. End every message with your shell''s trailer:
    ```
    Co-Authored-By: <shell display_name> (super-coder) <noreply@…>
    ```
@@ -34,14 +37,14 @@ The launcher auto-syncs at boot when provably nothing can be lost (on base branc
 
 ## Merging a stack (only when the FnB hands you one)
 
-Merge bottom-up, retargeting before each merge — never rely on GitHub's auto-retarget:
+Merge bottom-up, retargeting before each merge — never rely on GitHub''s auto-retarget:
 
 1. `gh pr view <n> --json mergeable,mergeStateStatus` -> clean.
 2. `gh pr merge <low> --squash --delete-branch`.
 3. BEFORE the next merge: `gh pr edit <next> --base main` — deleting the merged base otherwise orphans the PR above it (GitHub closes it `CONFLICTING`, base ref gone).
 4. Re-check `MERGEABLE` -> merge. Repeat up the stack.
 
-PR already orphaned (base deleted under it) -> the head branch still holds the commits; reopen the SAME PR, don't rebuild:
+PR already orphaned (base deleted under it) -> the head branch still holds the commits; reopen the SAME PR, don''t rebuild:
 
 1. `git push origin <merged-sha>:refs/heads/<deleted-branch>` — `<merged-sha>` = `gh pr view <merged-pr> --json headRefOid`.
 2. `gh pr reopen <closed-pr>` -> `gh pr edit <closed-pr> --base main`.
@@ -51,11 +54,11 @@ PR already orphaned (base deleted under it) -> the head branch still holds the c
 
 Bookend to the sync gate. At end of session: `git status` (uncommitted) + `git rev-list origin/<base>..HEAD` (unpushed) -> resolve every hit:
 
-1. Real work -> commit (attributed, trailer above) + push + open the PR. Don't skip because the session is ending.
+1. Real work -> commit (attributed, trailer above) + push + open the PR. Don''t skip because the session is ending.
 2. Throwaway / experiment -> discard deliberately: `git restore` / `git stash`.
 3. Genuinely unsure -> surface to the FnB + leave it committed-and-pushed on a branch — never sitting uncommitted.
 
-Pass = tree clean, or on a pushed branch with a PR. A dirty/unpushed tree forces the admin's `git_cleanup` to map attribution, check liveness, and commit on your behalf.
+Pass = tree clean, or on a pushed branch with a PR. A dirty/unpushed tree forces the admin''s `git_cleanup` to map attribution, check liveness, and commit on your behalf.
 
 ## After a merge — clean up local
 
@@ -68,16 +71,16 @@ unavailable until `sc sprint cleanup-status --sprint <id>` reports succeeded;
 the originating Planner or FnB uses the Sprint retry surface.
 
 1. Re-pin the base. In a worktree `git checkout main` fails (main is checked out at the repo root; git refuses a branch checked out elsewhere) -> `git checkout shell/<shortname> && git fetch origin && git reset --hard origin/main`. Admin at repo root: `git pull --ff-only` on main.
-2. `git branch -d <branch>`. Squash-merged -> `-d` refuses (commits aren't ancestors of main); confirm the PR shows *merged* on the remote -> `git branch -D <branch>`.
+2. `git branch -d <branch>`. Squash-merged -> `-d` refuses (commits aren''t ancestors of main); confirm the PR shows *merged* on the remote -> `git branch -D <branch>`.
 3. `git fetch --prune`.
 
-NEVER delete a branch carrying unmerged, un-PR'd work — no PR = lost work.
+NEVER delete a branch carrying unmerged, un-PR''d work — no PR = lost work.
 
 ## Never commit the engine or derived files
 
 - `/.super-coder/` is gitignored — never force-add anything under it.
 - Gitignored + regenerated, never commit: `CLAUDE.md`, `AGENTS.md`, `opencode.json`, `.claude/skills/`, `.sc-state/engine.ref.prev` (ephemeral rollback pointer).
-- From a worktree, commit only your project's authored files. Generated
+- From a worktree, commit only your project''s authored files. Generated
   snapshots and `_sc` renders live under ignored `.sc-state/local/` and never
   enter Git. `.sc-state/engine.ref` is the deliberate tracked exception: it is
   the dependency pin and is updated by `sc update`.
@@ -93,4 +96,12 @@ review. There is no generated-content commit or Publish PR. See `snapshot`.
 
 - Before destructive ops, confirm the repo — `git -C <abs-path>` if ever in doubt.
 - Multi-shell: each shell boots into its own worktree at `.sc-worktrees/<shortname>/` on branch `shell/<shortname>`; the launcher keeps the base pinned to `origin/main` (see the sync gate). Worktree isolation is automatic — no shared cwd. Admin shell = the one exception: repo root on `main`.
-- UI preview: worktree edits do NOT show on the fork's main dev server. `sc preview` (start once from the main checkout if not running) serves every shell's worktree UI live (HMR) on the fork's `dev_port`, one subdomain each: `http://<shortname>.localhost:<dev_port>/`. The `post-commit` hook prints your URL after each commit — surface that line to the FnB.
+- UI preview: worktree edits do NOT show on the fork''s main dev server. `sc preview` (start once from the main checkout if not running) serves every shell''s worktree UI live (HMR) on the fork''s `dev_port`, one subdomain each: `http://<shortname>.localhost:<dev_port>/`. The `post-commit` hook prints your URL after each commit — surface that line to the FnB.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -199,9 +199,19 @@ entries are being written faster than they are reconciled.
 ## VERSION CONTROL
 
 Sync before you touch code. Before the first edit of any unit of work, reconcile
-your own tree with `origin/main` — fast-forward your base, or rebase your feature
-branch — so you build on current code. Surface local work to the FnB first; never
-discard it to sync. This is yours to do, not the admin's.
+your own tree with `origin/main` — re-pin your base, or rebase your feature branch
+— so you build on current code.
+
+Treat `shell/<shortname>` as a disposable base, not durable storage. Durable work
+lives in the engine DB or on the remote in a pushed branch with a PR. When that exact
+base has local-only commits, tracked changes, or non-ignored untracked files, do
+not ask whether to preserve them: confirm the ACTIVE SESSION worktree + exact
+base branch, fetch, hard-reset it to `origin/main`, and remove its non-ignored
+untracked files. Pass = `git status --short` is empty + `HEAD` equals
+`origin/main`. This standing authority applies ONLY to `shell/<shortname>`;
+NEVER apply this discard/reset authority to a feature branch or open PR. Surface
+a target/identity mismatch instead of guessing. This is yours to do, not the
+admin's.
 
 Branch before you build. Before the **first edit** of a new unit of work, create
 a branch — `git checkout -b <type>/<short-desc>` (feat/fix/chore/docs). One

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -104,7 +104,8 @@
     ".super-coder/migrations/0204_sprint_governing_revision_evidence.sql",
     ".super-coder/migrations/0205_sprint_conformance_ownership.sql",
     ".super-coder/migrations/0206_reseed_sprint_conformance_ownership.sql",
-    ".super-coder/migrations/0207_reseed_sprint_receipt_recovery.sql"
+    ".super-coder/migrations/0207_reseed_sprint_receipt_recovery.sql",
+    ".super-coder/migrations/0208_reseed_disposable_shell_base.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_git_sync_policy.py
+++ b/tests/test_git_sync_policy.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Regress the disposable shell-base sync policy in boot + Git skill."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+BOOT = ENGINE / "templates" / "boot.md"
+ASSET = ENGINE / "assets" / "skills" / "git" / "SKILL.md"
+RESEED = ENGINE / "migrations" / "0208_reseed_disposable_shell_base.sql"
+
+sys.path.insert(0, str(ENGINE / "scripts"))
+import seed_skills  # noqa: E402
+
+
+class GitSyncPolicyTest(unittest.TestCase):
+    def test_boot_grants_only_exact_shell_base_discard_authority(self):
+        body = " ".join(BOOT.read_text().split())
+        self.assertIn("treat `shell/<shortname>` as a disposable base", body.lower())
+        self.assertIn("do not ask whether to preserve them", body.lower())
+        self.assertIn("`git status --short` is empty", body)
+        self.assertIn("`HEAD` equals `origin/main`", body)
+        self.assertIn(
+            "NEVER apply this discard/reset authority to a feature branch or open PR",
+            body,
+        )
+        self.assertIn("Surface a target/identity mismatch", body)
+
+    def test_git_skill_makes_the_base_reset_executable_and_bounded(self):
+        body = " ".join(ASSET.read_text().split())
+        self.assertIn(
+            "Compare `git rev-parse --show-toplevel` + "
+            "`git branch --show-current` with ACTIVE SESSION",
+            body,
+        )
+        self.assertIn(
+            "`git reset --hard origin/main && git clean -fd`", body
+        )
+        self.assertIn("without asking", body)
+        self.assertIn("a pushed remote branch with a PR", body)
+        self.assertIn("NEVER reset or clean a feature branch / open PR", body)
+        self.assertIn(
+            "`git rev-parse HEAD` equals `git rev-parse origin/main`", body
+        )
+
+    def test_git_reseed_is_exact_idempotent_and_preserves_local_skills(self):
+        with sqlite3.connect(":memory:") as con:
+            con.executescript(
+                "CREATE TABLE skills ("
+                "skill_id INTEGER PRIMARY KEY, name TEXT UNIQUE, description TEXT, "
+                "category TEXT, command TEXT, common INTEGER, content TEXT, "
+                "is_deleted INTEGER DEFAULT 0);"
+                "INSERT INTO skills VALUES "
+                "(1,'git','stale','stale','stale',1,'stale',1);"
+                "INSERT INTO skills VALUES "
+                "(2,'fork_only','local','fork',NULL,0,'bespoke body',0);"
+            )
+            migration = RESEED.read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+
+            parsed = seed_skills.parse_skill(ASSET)
+            actual = con.execute(
+                "SELECT description,category,command,common,content,is_deleted "
+                "FROM skills WHERE name='git'"
+            ).fetchone()
+            self.assertEqual(
+                (
+                    parsed["description"],
+                    parsed["category"],
+                    parsed["command"],
+                    parsed["common"],
+                    parsed["content"],
+                    0,
+                ),
+                actual,
+            )
+            self.assertEqual(
+                ("fork", "bespoke body", 0),
+                con.execute(
+                    "SELECT category,content,is_deleted FROM skills "
+                    "WHERE name='fork_only'"
+                ).fetchone(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -58,6 +58,9 @@ CONFORMANCE_OWNER_RESEED = (
 INFORMATIONAL_RECEIPT_RESEED = (
     ENGINE / "migrations" / "0207_reseed_sprint_receipt_recovery.sql"
 )
+DISPOSABLE_SHELL_BASE_RESEED = (
+    ENGINE / "migrations" / "0208_reseed_disposable_shell_base.sql"
+)
 
 
 class SprintSkillTest(unittest.TestCase):
@@ -858,6 +861,7 @@ class SprintSkillTest(unittest.TestCase):
             con.executescript(migration)
             con.executescript(CONFORMANCE_OWNER_RESEED.read_text())
             con.executescript(INFORMATIONAL_RECEIPT_RESEED.read_text())
+            con.executescript(DISPOSABLE_SHELL_BASE_RESEED.read_text())
 
             self.assertIsNotNone(
                 con.execute(


### PR DESCRIPTION
Follow-up to #1066 and #1172.

## What changed
- declare `shell/<shortname>` bases disposable in the always-loaded boot document
- replace the recurring land/stash/discard question in the Git skill with standing reset authority for that exact base
- require target + branch verification before `git reset --hard origin/main && git clean -fd`
- require a clean status and `HEAD == origin/main` as the postcondition
- keep feature branches and open PRs outside this discard/reset authority
- reseed the Git skill for existing installations

## Why
Durable work is already in the engine DB or on the remote in a pushed branch with a PR. Stale local-only state on a shell base repeatedly causes the same unnecessary clarification round before maintenance can begin.

## Verification
- `47 passed, 34 subtests passed` — Git policy, boot, skill convergence, migrations, and removal manifest
- `render-check` passed against tracked sources
- `git diff --check` passed