### PR TITLE
fix(render): honor retired skills in hermetic check

### DIFF
--- a/.super-coder/scripts/render_check.py
+++ b/.super-coder/scripts/render_check.py
@@ -7,13 +7,14 @@ RENDERED from the DB (documents/roadmap/skills; a skill's source is
 without re-rendering leaves the local browsable copy stale.
 
 HERMETIC by construction: this builds a throwaway DB from authored engine text
-(schema + migrations) plus the local instance snapshot, renders the mirror from THAT
-into a temp tree, and diffs it against the active local `_sc` files. It never opens
-the live `shell_db.db` and never writes into the working tree. So — unlike the
-old version, which rendered from the live DB *into the tree* and then told you to
-`git add` whatever fell out — a stale or dirty local cache DB can no longer make
-this pass or fail wrongly, and can never trick you into committing a regression.
-A local `./sc render-check` is now byte-identical to CI; no `./sc rebuild` first.
+(schema + migrations), the local instance snapshot, and the fork skill-retire
+list, renders the mirror from THAT into a temp tree, and diffs it against the
+active local `_sc` files. It never opens the live `shell_db.db` and never writes
+into the working tree. So — unlike the old version, which rendered from the live
+DB *into the tree* and then told you to `git add` whatever fell out — a stale or
+dirty local cache DB can no longer make this pass or fail wrongly, and can never
+trick you into committing a regression. A local `./sc render-check` is now
+byte-identical to CI; no `./sc rebuild` first.
 
     ./sc render-check
 """
@@ -35,6 +36,7 @@ sys.path.insert(0, str(ENGINE / "scripts"))
 import flat  # noqa: E402
 import artifact_policy  # noqa: E402
 import migrate as migrate_mod  # noqa: E402
+import seed_skills  # noqa: E402
 
 CONTENT = artifact_policy.content_path()
 ACTIVE_ROOT = artifact_policy.render_root()
@@ -42,20 +44,23 @@ ACTIVE_ROOT = artifact_policy.render_root()
 
 def _build_tracked_db(path: Path) -> None:
     """Materialize a DB from authored engine text plus local instance state:
-    content.sql. No map step (the dr_* cache isn't part of the mirror) and no
-    touch of the live DB. This is what a fresh `./sc rebuild` would produce, so
-    its engine skills are always current — the mirror is a pure function of the
-    sources about to be committed."""
+    content.sql plus the fork skill-retire list. No map step (the dr_* cache
+    isn't part of the mirror) and no touch of the live DB. This is what a fresh
+    `./sc rebuild` would produce, so its engine skills are always current — the
+    mirror is a pure function of the sources about to be committed."""
     con = sqlite3.connect(path)
     con.executescript(SCHEMA.read_text())
     con.commit()
     con.close()
     migrate_mod.migrate(str(path))
     content = CONTENT if CONTENT.exists() else CONTENT_LEGACY
-    if content.exists():
-        con = sqlite3.connect(path)
-        con.executescript(content.read_text())
-        con.commit()
+    con = sqlite3.connect(path)
+    try:
+        if content.exists():
+            con.executescript(content.read_text())
+            con.commit()
+        seed_skills.apply_retired(con)
+    finally:
         con.close()
 
 

--- a/tests/test_skill_retire.py
+++ b/tests/test_skill_retire.py
@@ -20,6 +20,7 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+from contextlib import closing
 from pathlib import Path
 from unittest import mock
 
@@ -27,6 +28,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
 import seed_skills
 import skill as skill_cli
+import render_check
 
 ENGINE_SKILLS = ("test_authoring", "review", "git")
 
@@ -260,6 +262,43 @@ class RetireTest(unittest.TestCase):
         skill_cli.cmd_retire(self.con, "test_authoring")
         with self.assertRaises(SystemExit):
             skill_cli.resolve_skill(self.con, "test_authoring")
+
+
+class RenderCheckRetirementTest(unittest.TestCase):
+    def test_hermetic_build_applies_retire_list_after_content(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            schema = root / "schema.sql"
+            content = root / "content.sql"
+            retired = root / "skills_retired.json"
+            db = root / "hermetic.db"
+            schema.write_text(
+                "CREATE TABLE skills (skill_id INTEGER PRIMARY KEY, "
+                "name TEXT NOT NULL UNIQUE, description TEXT, category TEXT, "
+                "content TEXT, command TEXT, common INTEGER NOT NULL DEFAULT 1, "
+                "is_deleted INTEGER NOT NULL DEFAULT 0);"
+            )
+            content.write_text(SEED_SQL)
+            retired.write_text(json.dumps(["test_authoring"]))
+
+            with (
+                mock.patch.object(render_check, "SCHEMA", schema),
+                mock.patch.object(render_check, "CONTENT", content),
+                mock.patch.object(
+                    render_check, "CONTENT_LEGACY", root / "missing.sql"
+                ),
+                mock.patch.object(render_check.migrate_mod, "migrate"),
+                mock.patch.object(seed_skills, "RETIRED_FILE", retired),
+                mock.patch.object(seed_skills, "OUT", content),
+            ):
+                render_check._build_tracked_db(db)
+
+            with closing(sqlite3.connect(db)) as con:
+                rows = con.execute(
+                    "SELECT name, is_deleted FROM skills "
+                    "WHERE name IN ('review', 'test_authoring') ORDER BY name"
+                ).fetchall()
+            self.assertEqual(rows, [("review", 0), ("test_authoring", 1)])
 
 
 class SkillCliConnectionTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #906

## What changed
- apply the fork skill-retire list to the hermetic render-check DB after migrations and snapshot replay
- document the retire list as an input to the hermetic comparison
- add a regression test proving a retired engine skill is hidden while an active sibling remains active

## Verification
- `python3 -W error::ResourceWarning tests/test_skill_retire.py RenderCheckRetirementTest`
- `python3 tests/test_skill_retire.py` (25 tests)
- `python3 tests/test_artifact_policy.py` (11 tests)
- `python3 tests/test_worktree_targets.py` (30 tests)
- `python3 -m py_compile .super-coder/scripts/render_check.py tests/test_skill_retire.py`
- `git diff --check`

Standalone `render_check.py` reaches the comparison successfully but this shell already has unrelated drift in `skills_sc/git.md` and the three Sprint skill renders.