### PR TITLE
Fix stale Sprint review handoffs after PR head changes

### DIFF
--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -178,6 +178,15 @@ _EVENT_FIELDS = {
     "review.changes_requested": frozenset(
         {"work_unit_id", "registered_pr_id", "message_id", "conversation_id", "head_sha"}
     ),
+    "review.request_invalidated": frozenset(
+        {
+            "work_unit_id",
+            "registered_pr_id",
+            "invalidated_message_id",
+            "head_sha",
+            "previous_head_sha",
+        }
+    ),
     "review.approval_invalidated": frozenset(
         {
             "work_unit_id",

--- a/.super-coder/scripts/sprint_health.py
+++ b/.super-coder/scripts/sprint_health.py
@@ -46,7 +46,9 @@ _EVENT_STAGE = {
     "active": frozenset({"work_unit.accepted"}),
     "blocked": frozenset(),
     "in_review": frozenset({"review.requested"}),
-    "fixing": frozenset({"review.changes_requested"}),
+    "fixing": frozenset(
+        {"review.changes_requested", "review.request_invalidated"}
+    ),
     "merge_ready": frozenset({"review.approved"}),
     "completed": frozenset({"work_unit.completed"}),
     "cancelled": frozenset({"work_unit.cancelled"}),

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -847,6 +847,24 @@ class SprintMessageStore:
             raise KeyError(f"unknown wake message: {message_id}")
         self._cancel_resolved_wakes(message_id)
 
+    def supersede_actionable_in_transaction(
+        self,
+        message_id: int,
+        reason: str,
+    ) -> None:
+        """Retire an actionable message made obsolete by newer workflow facts."""
+        if not self.con.in_transaction:
+            raise RuntimeError("message supersession requires an active transaction")
+        changed = self.con.execute(
+            "UPDATE wake_message SET disposition='declined',"
+            "read_at=COALESCE(read_at,datetime('now')),decline_reason=? "
+            "WHERE message_id=?",
+            (reason, message_id),
+        ).rowcount
+        if changed != 1:
+            raise KeyError(f"unknown wake message: {message_id}")
+        self._cancel_resolved_wakes(message_id)
+
     def recall_work_assignment_in_transaction(
         self,
         sprint_id: int,

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1336,6 +1336,24 @@ class SprintPRWatcher:
         )
         if (
             head_changed
+            and pull_request.head_sha is not None
+            and state not in {"merged", "closed"}
+            and sprint_id is not None
+            and registered_pr_id is not None
+            and len(unit_rows) == 1
+            and unit_rows[0]["disposition"] == "in_review"
+        ):
+            invalidated_message_id = (
+                self.review_loop.invalidate_review_request_for_head_change_in_transaction(
+                    int(sprint_id),
+                    int(registered_pr_id),
+                    pull_request.head_sha,
+                )
+            )
+            if invalidated_message_id is not None:
+                resolved_review_message_ids = (invalidated_message_id,)
+        if (
+            head_changed
             and state not in {"merged", "closed"}
             and len(unit_rows) == 1
             and unit_rows[0]["disposition"] == "merge_ready"

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -46,6 +46,14 @@ class MergeAuthorization:
     head_sha: str
 
 
+@dataclass(frozen=True)
+class _ReviewRequestEvidence:
+    message_id: int
+    disposition: str
+    head_sha: str
+    transition_id: int | None
+
+
 class SprintReviewLoopStore:
     """Compose review state from the existing authoritative Sprint records."""
 
@@ -94,6 +102,11 @@ class SprintReviewLoopStore:
                 str(transition["observed_head_sha"]),
                 intent,
             )
+            previous_request = (
+                self._latest_review_request(lane)
+                if lane["disposition"] == "in_review"
+                else None
+            )
             receipt = self.messages.send_in_transaction(
                 sprint_id,
                 to_participant_id=int(lane["reviewer_participant_id"]),
@@ -109,7 +122,22 @@ class SprintReviewLoopStore:
                 raise SprintInvariantError("active review request has no wake")
             if not receipt.created:
                 return self._handoff_receipt(lane, receipt)
-            if lane["disposition"] not in {"active", "fixing"}:
+            if lane["disposition"] == "in_review":
+                if previous_request is None:
+                    raise SprintInvariantError(
+                        "in-review lane has no durable review request"
+                    )
+                if previous_request.head_sha == transition["observed_head_sha"]:
+                    raise SprintInvariantError(
+                        "review handoff already targets the current PR head"
+                    )
+                self._invalidate_review_request_in_transaction(
+                    lane,
+                    previous_request,
+                    str(transition["observed_head_sha"]),
+                    actor_shell_id=developer_shell_id,
+                )
+            elif lane["disposition"] not in {"active", "fixing"}:
                 raise SprintInvariantError(
                     f"review handoff cannot start from {lane['disposition']}"
                 )
@@ -132,6 +160,31 @@ class SprintReviewLoopStore:
                 },
             )
             return self._handoff_receipt(lane, receipt)
+
+    def invalidate_review_request_for_head_change_in_transaction(
+        self,
+        sprint_id: int,
+        registered_pr_id: int,
+        head_sha: str,
+    ) -> int | None:
+        """Return an in-review lane to its Developer when its PR head moves."""
+        if not self.con.in_transaction:
+            raise RuntimeError("review invalidation requires an active transaction")
+        lane = self._lane(sprint_id, registered_pr_id)
+        if lane["disposition"] != "in_review":
+            return None
+        request = self._latest_review_request(lane)
+        if request is None:
+            raise SprintInvariantError("in-review lane has no durable review request")
+        if request.head_sha == head_sha:
+            return None
+        self._invalidate_review_request_in_transaction(
+            lane,
+            request,
+            head_sha,
+            actor_shell_id=None,
+        )
+        return request.message_id
 
     def record_review(
         self,
@@ -483,6 +536,14 @@ class SprintReviewLoopStore:
     def _accepted_review_request(
         self, lane: sqlite3.Row
     ) -> tuple[int, str, int | None]:
+        latest = self._latest_review_request(lane)
+        if latest is None or latest.disposition != "accepted":
+            raise SprintInvariantError("review verdict requires an accepted request")
+        return latest.message_id, latest.head_sha, latest.transition_id
+
+    def _latest_review_request(
+        self, lane: sqlite3.Row
+    ) -> _ReviewRequestEvidence | None:
         latest = self.con.execute(
             "SELECT message_id,disposition FROM wake_message WHERE sprint_id=? "
             "AND work_unit_id=? AND to_participant_id=? "
@@ -494,8 +555,8 @@ class SprintReviewLoopStore:
                 lane["reviewer_participant_id"],
             ),
         ).fetchone()
-        if latest is None or latest["disposition"] != "accepted":
-            raise SprintInvariantError("review verdict requires an accepted request")
+        if latest is None:
+            return None
         event = self.con.execute(
             "SELECT payload FROM sprint_events WHERE sprint_id=? "
             "AND event_type='review.requested' "
@@ -509,10 +570,59 @@ class SprintReviewLoopStore:
         if not isinstance(head_sha, str) or not head_sha:
             raise SprintInvariantError("accepted review request has no exact head")
         transition_id = json.loads(event["payload"]).get("transition_id")
-        return (
-            int(latest["message_id"]),
-            head_sha,
-            transition_id if isinstance(transition_id, int) else None,
+        return _ReviewRequestEvidence(
+            message_id=int(latest["message_id"]),
+            disposition=str(latest["disposition"]),
+            head_sha=head_sha,
+            transition_id=(
+                transition_id if isinstance(transition_id, int) else None
+            ),
+        )
+
+    def _invalidate_review_request_in_transaction(
+        self,
+        lane: sqlite3.Row,
+        request: _ReviewRequestEvidence,
+        head_sha: str,
+        *,
+        actor_shell_id: int | None,
+    ) -> None:
+        self.messages.supersede_actionable_in_transaction(
+            request.message_id,
+            "superseded by PR head change",
+        )
+        sprint_liveness.SprintLivenessMonitor(self.con).resolve_in_transaction(
+            request.message_id,
+            "review request invalidated by PR head change",
+        )
+        changed = self.con.execute(
+            "UPDATE sprint_work_units SET disposition='fixing',"
+            "updated_at=datetime('now') WHERE work_unit_id=? "
+            "AND disposition='in_review'",
+            (lane["work_unit_id"],),
+        ).rowcount
+        if changed != 1:
+            raise SprintInvariantError("review lane changed during head invalidation")
+        actor_kind = "participant" if actor_shell_id is not None else "system"
+        self.con.execute(
+            "INSERT INTO sprint_events "
+            "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+            "VALUES (?,'review.request_invalidated',?,?,?)",
+            (
+                lane["sprint_id"],
+                actor_kind,
+                actor_shell_id,
+                json.dumps(
+                    {
+                        "head_sha": head_sha,
+                        "invalidated_message_id": request.message_id,
+                        "previous_head_sha": request.head_sha,
+                        "registered_pr_id": int(lane["registered_pr_id"]),
+                        "work_unit_id": int(lane["work_unit_id"]),
+                    },
+                    sort_keys=True,
+                ),
+            ),
         )
 
     def _record_judgment(

--- a/tests/test_sprint_board_api.py
+++ b/tests/test_sprint_board_api.py
@@ -971,6 +971,17 @@ class SprintBoardApiCase(unittest.TestCase):
                 },
             ),
             (
+                "review.request_invalidated",
+                {
+                    "work_unit_id": self.ids["unit"],
+                    "registered_pr_id": 1,
+                    "invalidated_message_id": 8,
+                    "head_sha": "replacement-head",
+                    "previous_head_sha": "stale-head",
+                    "secret": "hidden",
+                },
+            ),
+            (
                 "conformance.recorded",
                 {
                     "report_id": 4,

--- a/tests/test_sprint_health.py
+++ b/tests/test_sprint_health.py
@@ -545,6 +545,30 @@ class SprintHealthCase(unittest.TestCase):
         self.assertEqual("terminal", projected[units["completed"]]["condition"])
         self.assertEqual("terminal", projected[units["cancelled"]]["condition"])
 
+    def test_review_request_invalidation_starts_the_fixing_stage_clock(self) -> None:
+        self.con.execute(
+            "UPDATE sprints SET armed_at='2026-08-10 09:00:00' "
+            "WHERE sprint_id=?",
+            (self.sprint_id,),
+        )
+        unit = self.add_unit(
+            "fixing",
+            developer=3,
+            updated_at="2026-08-10 10:00:00",
+        )
+        self.add_event(
+            "review.request_invalidated",
+            at="2026-08-10 11:55:00",
+            work_unit_id=unit,
+        )
+
+        projected = self.project()["work_units"][unit]
+
+        self.assertEqual(
+            ("waiting_external", "no_progress_grace", "2026-08-10T11:55:00Z"),
+            (projected["condition"], projected["cause"], projected["since"]),
+        )
+
     def test_runtime_and_watcher_fail_only_when_applicable(self) -> None:
         planned = self.add_unit("planned", developer=3)
         active_without_pr = self.add_unit("active", developer=4)

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -769,6 +769,124 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             ],
         )
 
+    def test_in_review_same_head_rejects_a_second_handoff_key(self):
+        first = self.request_review("first-review-key")
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "review handoff already targets the current PR head",
+        ):
+            self.request_review("different-review-key")
+
+        self.assertEqual(
+            [(first.message_id, "first-review-key")],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT message_id,idempotency_key FROM wake_message "
+                    "WHERE work_unit_id=? AND message_kind='review_request'",
+                    (self.unit_id,),
+                )
+            ],
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='review.requested'"
+            ).fetchone()[0],
+        )
+
+    def test_request_review_repairs_a_pre_update_stale_in_review_lane(self):
+        stale = self.request_review("stale-review-key")
+        self.accept_review(stale.message_id)
+        self.seed_historical_expectation(stale.message_id)
+        self.con.execute(
+            "INSERT INTO sprint_pr_transitions "
+            "(registered_pr_id,normalized_state,transition_key,"
+            "observed_head_sha,evidence) VALUES (?,?,?,?,?)",
+            (
+                self.registered_pr_id,
+                "green",
+                "historical-head-change",
+                "b" * 40,
+                json.dumps(
+                    {
+                        "base_sha": "c" * 40,
+                        "checks": "SUCCESS",
+                        "checks_failed": False,
+                    },
+                    sort_keys=True,
+                ),
+            ),
+        )
+        self.con.commit()
+
+        refreshed = self.request_review("replacement-review-key")
+
+        self.assertTrue(refreshed.created)
+        self.assertEqual(
+            (
+                "in_review",
+                (
+                    "Submitting PR for review: "
+                    "https://github.com/acme/repo/pull/42; registered Sprint PR "
+                    f"{self.registered_pr_id}; exact head {'b' * 40}; work unit "
+                    f"{self.unit_id}."
+                ),
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT unit.disposition,message.body "
+                    "FROM sprint_work_units unit JOIN wake_message message "
+                    "ON message.work_unit_id=unit.work_unit_id "
+                    "WHERE unit.work_unit_id=? AND message.message_id=?",
+                    (self.unit_id, refreshed.message_id),
+                ).fetchone()
+            ),
+        )
+        stale_expectation = self.con.execute(
+            "SELECT resolution,next_evaluation_at "
+            "FROM sprint_liveness_expectations WHERE message_id=?",
+            (stale.message_id,),
+        ).fetchone()
+        self.assertEqual(
+            ("review request invalidated by PR head change", None),
+            tuple(stale_expectation),
+        )
+        invalidated = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events "
+                "WHERE event_type='review.request_invalidated'"
+            ).fetchone()[0]
+        )
+        self.assertEqual(
+            (stale.message_id, "a" * 40, "b" * 40),
+            (
+                invalidated["invalidated_message_id"],
+                invalidated["previous_head_sha"],
+                invalidated["head_sha"],
+            ),
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "accepted request"
+        ):
+            self.loop.record_review(
+                self.sprint_id,
+                self.registered_pr_id,
+                2,
+                verdict="approved",
+                body="The obsolete acceptance must not authorize this head.",
+                idempotency_key="premature-refreshed-approval",
+            )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM wake_message "
+                "WHERE idempotency_key='premature-refreshed-approval'"
+            ).fetchone()[0],
+        )
+
     def test_outcome_requires_assigned_reviewer_and_accepted_request(self):
         handoff = self.request_review()
         before = self.con.execute(
@@ -872,7 +990,8 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         self.watcher.poll_once()
 
         with self.assertRaisesRegex(
-            sprint_domain.SprintInvariantError, "request is stale"
+            sprint_domain.SprintInvariantError,
+            "review verdict requires an accepted request",
         ):
             self.loop.record_review(
                 self.sprint_id,
@@ -888,6 +1007,23 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             self.con.execute(
                 "SELECT COUNT(*) FROM wake_message "
                 "WHERE idempotency_key='stale-review-head'"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            ("declined", "superseded by PR head change"),
+            tuple(
+                self.con.execute(
+                    "SELECT disposition,decline_reason FROM wake_message "
+                    "WHERE message_id=?",
+                    (handoff.message_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            "fixing",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
             ).fetchone()[0],
         )
         self.assertEqual(
@@ -1139,6 +1275,97 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             self.loop.authorize_merge(
                 self.sprint_id, self.registered_pr_id, 1
             ).head_sha,
+        )
+
+    def test_head_move_invalidates_an_active_review_request(self):
+        stale = self.request_review("review-before-head-move")
+        self.reader.current = pull_request(
+            checks="SUCCESS", checks_failed=False, head_sha="b" * 40
+        )
+
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(
+            "fixing",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            (1, "declined", "superseded by PR head change", "cancelled"),
+            tuple(
+                self.con.execute(
+                    "SELECT message.read_at IS NOT NULL,message.disposition,"
+                    "message.decline_reason,outbox.state "
+                    "FROM wake_message message "
+                    "JOIN sprint_wake_messages link USING(message_id) "
+                    "JOIN sprint_wake_outbox outbox USING(wake_id) "
+                    "WHERE message.message_id=?",
+                    (stale.message_id,),
+                ).fetchone()
+            ),
+        )
+        invalidated = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events "
+                "WHERE event_type='review.request_invalidated'"
+            ).fetchone()[0]
+        )
+        self.assertEqual(
+            (
+                stale.message_id,
+                self.registered_pr_id,
+                self.unit_id,
+                "a" * 40,
+                "b" * 40,
+            ),
+            (
+                invalidated["invalidated_message_id"],
+                invalidated["registered_pr_id"],
+                invalidated["work_unit_id"],
+                invalidated["previous_head_sha"],
+                invalidated["head_sha"],
+            ),
+        )
+        refreshed = self.request_review("review-after-active-head-move")
+        self.assertEqual(
+            (
+                "in_review",
+                (
+                    "Submitting PR for review: "
+                    "https://github.com/acme/repo/pull/42; registered Sprint PR "
+                    f"{self.registered_pr_id}; exact head {'b' * 40}; work unit "
+                    f"{self.unit_id}."
+                ),
+            ),
+            tuple(
+                self.con.execute(
+                    "SELECT unit.disposition,message.body "
+                    "FROM sprint_work_units unit JOIN wake_message message "
+                    "ON message.work_unit_id=unit.work_unit_id "
+                    "WHERE unit.work_unit_id=? AND message.message_id=?",
+                    (self.unit_id, refreshed.message_id),
+                ).fetchone()
+            ),
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "accepted request"
+        ):
+            self.loop.record_review(
+                self.sprint_id,
+                self.registered_pr_id,
+                2,
+                verdict="approved",
+                body="The stale review acceptance cannot cross the head change.",
+                idempotency_key="stale-acceptance-after-head-move",
+            )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM wake_message "
+                "WHERE idempotency_key='stale-acceptance-after-head-move'"
+            ).fetchone()[0],
         )
 
     def test_merged_head_move_completes_without_requesting_dead_delta_review(self):


### PR DESCRIPTION
Closes #1180

## Summary
- invalidate an active review request when the registered PR head changes, retire its force-new wake, resolve its liveness episode, and return the lane to `fixing`
- let `request-review` atomically repair pre-update `in_review` lanes only when the durable green head differs, while preserving idempotent replay and rejecting same-head duplicate keys
- project the invalidation through Sprint health and the board event allowlist

## Verification
- `./sc test -q tests/` — 2364 passed, 1 skipped, 1227 subtests passed
- `./sc lint --ignore TRY004,EXE001,BLE001,RUF100 <changed files>` — passed (ignored diagnostics are pre-existing in the touched modules)
- declared typecheck still reports the repository baseline only; no diagnostic points at a changed line