### PR TITLE
Auth canary s14-wu64-d02af53 (https)

### DIFF
--- a/canary/s14-wu64-d02af53-https.txt
+++ b/canary/s14-wu64-d02af53-https.txt
@@ -1,0 +1,1 @@
+sandbox auth conformance s14-wu64-d02af53 https


### PR DESCRIPTION
Disposable sandbox authentication conformance probe; close without merge.