### PR TITLE
Fix Docker parent reference build argument

### DIFF
--- a/.super-coder/scripts/sandbox_devkit.py
+++ b/.super-coder/scripts/sandbox_devkit.py
@@ -1294,7 +1294,7 @@ def build_images(
         "--build-arg",
         f"SC_HARNESS_EPOCH={plan.harness_epoch}",
         "--build-arg",
-        f"SC_PARENT_IMAGE={parent_id}",
+        f"SC_PARENT_IMAGE={plan.parent_ref}",
         "--build-arg",
         f"SC_GITHUB_HOST_TRUST_B64={trust_b64}",
         "--build-arg",

--- a/tests/test_sandbox_devkit_images.py
+++ b/tests/test_sandbox_devkit_images.py
@@ -421,6 +421,9 @@ class SandboxImagePlanTest(unittest.TestCase):
             "SC_GITHUB_HOST_TRUST_SHA256=" + hashlib.sha256(trust).hexdigest(),
             base,
         )
+        self.assertIn("SC_PARENT_IMAGE=python:3.12-slim", base)
+        self.assertNotIn("SC_PARENT_IMAGE=sha256:" + "a" * 64, base)
+        self.assertIn("sc.parent_id=sha256:" + "a" * 64, base)
         self.assertIn("SC_BASE_IMAGE=sha256:" + "b" * 64, extension)
         for key, value in plan.runtime_labels.items():
             self.assertIn(f"{key}={value}", extension)


### PR DESCRIPTION
Closes #1210

## Summary

- pass the configured parent reference to the engine-base Docker FROM argument
- retain the inspected immutable parent ID for labels, identity, cache, and provenance checks
- assert the reference/ID split in regression coverage

## Verification

- focused image suite: 41 passed, 8 subtests passed
- Python 3.9 Linux contract: 121 passed, 1 expected skip
- rootless BuildKit canary through build_images(): built from python:3.12-slim and retained its digest in sc.parent_id
- isolated rebuild/render/render-check: green
- full declared gate: 2477 passed, 1 skipped, 1241 subtests passed
- targeted Ruff: green after excluding the repository's unchanged EXE001/RUF100 baseline findings
- git diff --check: green

The live worktree mirror still reports the pre-existing skills_sc/dev_kit.md drift tracked in #715; the clean isolated render gate passes.
