### PR TITLE
fix(sprint): dedupe merge-bypass notice on the event, not the body

### DIFF
--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -4265,12 +4265,16 @@ class SprintWorkUnitStore:
                         },
                         actor_kind="system",
                     )
-                self._queue_planner_merge_bypass(
-                    sprint_id,
-                    work_unit_id=int(unit["work_unit_id"]),
-                    transition_key=transition_key,
-                    before=str(unit["disposition"]),
-                )
+                    # The notice mirrors the event and is deduped on the same
+                    # condition: re-observing the merge after the unit's
+                    # disposition moved on (resume reconciliation) must not
+                    # rebuild the body under the same idempotency key.
+                    self._queue_planner_merge_bypass(
+                        sprint_id,
+                        work_unit_id=int(unit["work_unit_id"]),
+                        transition_key=transition_key,
+                        before=str(unit["disposition"]),
+                    )
                 continue
             changed = True
             self.con.execute(

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -1509,6 +1509,67 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             ),
         )
 
+    def test_grant_bypassed_resume_after_disposition_change_does_not_conflict(self):
+        handoff = self.request_review()
+        self.accept_review(handoff.message_id)
+        self.reader.current = pull_request(
+            state="MERGED", checks="SUCCESS", checks_failed=False
+        )
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual(
+            "in_review",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+        notice = self.con.execute(
+            "SELECT body FROM wake_message "
+            "WHERE idempotency_key LIKE 'merge-grant-bypassed:%'"
+        ).fetchone()
+        self.assertIn("from in_review", notice["body"])
+
+        lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="reconcile the bypass",
+        )
+        # The Planner dispositions the bypassed unit for fixing before
+        # resuming; resume re-observes the same merged transition.
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='fixing' "
+            "WHERE work_unit_id=?",
+            (self.unit_id,),
+        )
+        self.con.commit()
+
+        receipt = lifecycle.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual(
+            (1, 1),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_events "
+                    "WHERE event_type='merge.grant_bypassed'),"
+                    "(SELECT COUNT(*) FROM wake_message "
+                    "WHERE idempotency_key LIKE 'merge-grant-bypassed:%')"
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            "from in_review",
+            self.con.execute(
+                "SELECT substr(body,instr(body,'from '),14) FROM wake_message "
+                "WHERE idempotency_key LIKE 'merge-grant-bypassed:%'"
+            ).fetchone()[0],
+        )
+
     def test_grant_bypassed_merge_resolves_accepted_review_expectation(self):
         handoff = self.request_review()
         self.accept_review(handoff.message_id)


### PR DESCRIPTION
## Why

Closes #1235 (second, actual root cause — #1236 fixed a different key).

dos-arch Sprint 21 could not resume from pause: every `sc sprint resume` returned `HTTP 409: Sprint message idempotency key was reused with different input`. Diagnosed against the live fork DB over the tailnet:

- Sprint 21 paused at version 3; work unit 80 in disposition `fixing`.
- Committed notice `merge-grant-bypassed:{transition_key}:unit:80` (message 946) says "…bypassed the Sprint merge grant for work unit 80 **from in_review**…".
- `resume()` → `_reconcile_registered_prs_in_transaction` re-observes the merged PR transition for the still-incomplete unit. The `merge.grant_bypassed` **event** was already deduped by transition key, but `_queue_planner_merge_bypass` ran **unconditionally** and rebuilt the body from the unit's **current** disposition (`from fixing`) under the same idempotency key → `send_in_transaction` 409 → resume rolls back, deterministically, forever.

## Fix

`.super-coder/scripts/sprint_domain.py` — queue the bypass notice only when the bypass event is new (same dedup condition as the event). The original notice's unread delivery is already handled by wake reconciliation on resume, so no notification is lost. No data migration needed: once deployed, dos-arch's next `sc sprint resume --sprint 21` skips the stale notice and proceeds.

## Tests

- New regression test `test_grant_bypassed_resume_after_disposition_change_does_not_conflict` (tests/test_sprint_review_loop.py): bypass recorded `from in_review`, unit moved to `fixing` while paused, then resume. Red on pre-fix code with the exact production error; green after.
- Sprint suites: test_sprint_review_loop + test_sprint_v2_domain + test_sprint_pr_watcher + test_sprint_work_dispatch — 146 passed.

## Trade-off

Considered keeping the re-send but stabilizing the body from the recorded event payload. Rejected: re-notifying an already-delivered, already-acted-on bypass adds noise, and deduping notice+event on one condition is the smaller invariant.