### PR TITLE
fix(opencode): per-model variant family + orphan server re-adoption

### DIFF
--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -10,6 +10,7 @@ import re
 import secrets
 import shlex
 import shutil
+import signal
 import subprocess
 import threading
 import time
@@ -44,6 +45,7 @@ from .base import (
 ENGINE = Path(__file__).resolve().parents[2]
 SERVER_ENDPOINT = "http://127.0.0.1:4096"
 SERVER_LOG = ENGINE / "logs" / "opencode-server.log"
+SERVER_STATE = ENGINE / "run" / "opencode-server.json"
 SHELL_RUNTIME_DIR = ENGINE / "run" / "opencode-shells"
 TURN_TIMEOUT_SECONDS = 5400.0
 _SERVER_LOCK = threading.RLock()
@@ -62,6 +64,77 @@ OPENAI_PROVIDER_PACKAGES = frozenset({
     "@ai-sdk/openai", "@ai-sdk/openai-compatible", "@ai-sdk/azure",
 })
 ANTHROPIC_PROVIDER_PACKAGES = frozenset({"@ai-sdk/anthropic"})
+
+
+def _read_server_state() -> dict[str, Any] | None:
+    """Return the recorded managed-server identity, if any is readable."""
+    try:
+        data = json.loads(SERVER_STATE.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if (
+        not isinstance(data, dict)
+        or not isinstance(data.get("pid"), int)
+        or isinstance(data["pid"], bool)
+        or not isinstance(data.get("password"), str)
+    ):
+        return None
+    return data
+
+
+def _write_server_state(pid: int, password: str) -> None:
+    SERVER_STATE.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(SERVER_STATE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump({"pid": pid, "password": password}, handle)
+
+
+def _clear_server_state() -> None:
+    try:
+        SERVER_STATE.unlink()
+    except OSError:
+        pass
+
+
+def _pid_is_opencode_serve(pid: int) -> bool:
+    """Best-effort identity check so only an opencode serve is ever reaped."""
+    try:
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+        cmdline = raw.replace(b"\x00", " ").decode("utf-8", errors="replace")
+    except OSError:
+        try:
+            result = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "args="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        if result.returncode != 0:
+            return False
+        cmdline = result.stdout
+    parts = cmdline.split()
+    return "serve" in parts and any(
+        os.path.basename(part) == "opencode" for part in parts
+    )
+
+
+def _reap_orphan_server(pid: int) -> None:
+    """Terminate a recorded orphan that fails every health check."""
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        return
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if not _pid_is_opencode_serve(pid):
+            return
+        time.sleep(0.05)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
 
 
 def _server_healthy(password: str | None) -> bool:
@@ -91,14 +164,29 @@ def ensure_server(*, timeout: float = 10.0) -> str | None:
     global _SERVER_PROCESS, _SERVER_PASSWORD, _SERVER_LOG_HANDLE
     with _SERVER_LOCK:
         configured_password = os.environ.get("OPENCODE_SERVER_PASSWORD")
+        state = _read_server_state()
+        state_pid = state["pid"] if state else None
         candidate_passwords = []
-        for password in (_SERVER_PASSWORD, configured_password, None):
+        for password in (
+            _SERVER_PASSWORD,
+            state["password"] if state else None,
+            configured_password,
+            None,
+        ):
             if password not in candidate_passwords:
                 candidate_passwords.append(password)
         for password in candidate_passwords:
             if _server_healthy(password):
                 _SERVER_PASSWORD = password
                 return password
+
+        if state_pid is not None:
+            # A server this engine started outlived the process that spawned
+            # it (restart, crash) and answers none of our passwords. Reap the
+            # verified orphan so the managed spawn below can take the port.
+            _clear_server_state()
+            if _pid_is_opencode_serve(state_pid):
+                _reap_orphan_server(state_pid)
 
         if _SERVER_PROCESS is not None and _SERVER_PROCESS.poll() is None:
             raise AdapterError(
@@ -155,6 +243,7 @@ def ensure_server(*, timeout: float = 10.0) -> str | None:
                 break
             if _server_healthy(password):
                 _SERVER_PASSWORD = password
+                _write_server_state(_SERVER_PROCESS.pid, password)
                 return password
             time.sleep(0.05)
 
@@ -186,6 +275,10 @@ def stop_server() -> None:
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=3)
+        if process is not None:
+            # Our own managed server is gone; drop its re-adoption record.
+            # An adopted orphan (never in _SERVER_PROCESS) keeps its record.
+            _clear_server_state()
         if _SERVER_LOG_HANDLE is not None:
             _SERVER_LOG_HANDLE.close()
             _SERVER_LOG_HANDLE = None
@@ -214,13 +307,23 @@ def _collision_identity(value: str) -> str:
     return unicodedata.normalize("NFKC", value.strip()).casefold()
 
 
-def _provider_family(provider: Mapping[str, Any]) -> str | None:
-    package = provider.get("npm")
+def _provider_family(package: Any) -> str | None:
+    if not isinstance(package, str):
+        return None
     if package in OPENAI_PROVIDER_PACKAGES:
         return "openai-ai-sdk"
     if package in ANTHROPIC_PROVIDER_PACKAGES:
         return "anthropic-ai-sdk"
     return None
+
+
+def _model_family(provider: Mapping[str, Any], model: Mapping[str, Any]) -> str | None:
+    # opencode's /provider projection carries the SDK package at
+    # model.api.npm; a top-level provider npm is legacy fallback.
+    api = model.get("api")
+    if isinstance(api, Mapping) and api.get("npm"):
+        return _provider_family(api.get("npm"))
+    return _provider_family(provider.get("npm"))
 
 
 def _contains_forbidden_key(value: Any) -> bool:
@@ -331,13 +434,13 @@ def connected_models(state: Mapping[str, Any] | None = None) -> list[dict[str, A
         if not isinstance(provider, dict) or provider.get("id") not in connected:
             continue
         provider_id = provider["id"]
-        provider_family = _provider_family(provider)
         for model_id, model in (provider.get("models") or {}).items():
             if not isinstance(model_id, str) or not isinstance(model, dict):
                 continue
             status = model.get("status")
             if status not in (None, "active"):
                 continue
+            provider_family = _model_family(provider, model)
             variants = admitted_variants(
                 model.get("variants"), provider_family=provider_family, model=model
             )

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -2,6 +2,7 @@
 """Managed OpenCode server lifecycle and connected-provider projection."""
 from __future__ import annotations
 
+import json
 import os
 import sys
 import tempfile
@@ -17,7 +18,8 @@ from conversation_adapters import opencode  # noqa: E402
 
 
 class FakeProcess:
-    def __init__(self) -> None:
+    def __init__(self, pid: int = 4321) -> None:
+        self.pid = pid
         self.returncode = None
         self.terminated = False
         self.killed = False
@@ -48,6 +50,12 @@ class OpenCodeServerTest(unittest.TestCase):
         )
         self.log_patch.start()
         self.addCleanup(self.log_patch.stop)
+        self.state_path = Path(self.tmp.name) / "opencode-server.json"
+        self.state_patch = mock.patch.object(
+            opencode, "SERVER_STATE", self.state_path
+        )
+        self.state_patch.start()
+        self.addCleanup(self.state_patch.stop)
         opencode._SERVER_PROCESS = None
         opencode._SERVER_PASSWORD = None
         opencode._SERVER_LOG_HANDLE = None
@@ -101,6 +109,66 @@ class OpenCodeServerTest(unittest.TestCase):
         opencode.stop_server()
         self.assertTrue(process.terminated)
         self.assertFalse(process.killed)
+
+    def test_orphaned_managed_server_is_readopted_via_recorded_password(self):
+        self.state_path.write_text(
+            json.dumps({"pid": os.getpid(), "password": "orphan-secret"})
+        )
+        with mock.patch.object(
+            opencode,
+            "_server_healthy",
+            side_effect=lambda password: password == "orphan-secret",
+        ), mock.patch.object(opencode.subprocess, "Popen") as spawn, \
+                mock.patch.object(opencode, "_reap_orphan_server") as reap:
+            password = opencode.ensure_server()
+
+        self.assertEqual(password, "orphan-secret")
+        spawn.assert_not_called()
+        reap.assert_not_called()
+        self.assertTrue(self.state_path.exists())
+
+    def test_unreachable_orphan_is_reaped_then_respawned(self):
+        self.state_path.write_text(
+            json.dumps({"pid": 4322, "password": "stale-secret"})
+        )
+        process = FakeProcess(pid=9999)
+        checks = iter([False, False, False, True])
+        with mock.patch.dict(os.environ, {}, clear=False), \
+                mock.patch.object(
+                    opencode, "_server_healthy",
+                    side_effect=lambda _password: next(checks),
+                ), mock.patch.object(
+                    opencode, "_pid_is_opencode_serve", return_value=True
+                ) as identify, mock.patch.object(
+                    opencode, "_reap_orphan_server"
+                ) as reap, mock.patch.object(
+                    opencode.shutil, "which", return_value="/bin/opencode"
+                ), mock.patch.object(
+                    opencode.secrets, "token_urlsafe", return_value="fresh-secret"
+                ), mock.patch.object(
+                    opencode.subprocess, "Popen", return_value=process
+                ):
+            os.environ.pop("OPENCODE_SERVER_PASSWORD", None)
+            password = opencode.ensure_server(timeout=1)
+
+        self.assertEqual(password, "fresh-secret")
+        identify.assert_called_once_with(4322)
+        reap.assert_called_once_with(4322)
+        self.assertEqual(
+            json.loads(self.state_path.read_text()),
+            {"pid": 9999, "password": "fresh-secret"},
+        )
+
+    def test_stop_server_preserves_state_of_adopted_orphan(self):
+        self.state_path.write_text(
+            json.dumps({"pid": 4322, "password": "orphan-secret"})
+        )
+        opencode.stop_server()
+        self.assertTrue(self.state_path.exists())
+
+        opencode._SERVER_PROCESS = FakeProcess()
+        opencode.stop_server()
+        self.assertFalse(self.state_path.exists())
 
     def test_connected_models_excludes_disconnected_and_inactive_routes(self):
         got = opencode.connected_models(
@@ -180,6 +248,63 @@ class OpenCodeServerTest(unittest.TestCase):
             },
         )
         self.assertEqual(model["cli_version"], "1.18.9")
+
+    def test_connected_models_resolves_family_from_model_api_npm(self):
+        # opencode 1.18.x /provider projection carries the SDK package at
+        # model.api.npm; no provider carries a top-level npm (subfloor#1240).
+        got = opencode.connected_models({
+            "_sc_cli_version": "1.18.18",
+            "connected": ["halo"],
+            "all": [{
+                "id": "halo",
+                "models": {
+                    "qwen3.8-27b-q8-mtp2": {
+                        "name": "Qwen3.8 27B Q8 (MTP depth 2)",
+                        "api": {"npm": "@ai-sdk/openai-compatible"},
+                        "variants": {
+                            "none": {"reasoningEffort": "none"},
+                            "medium": {"reasoningEffort": "medium"},
+                        },
+                    }
+                },
+            }],
+        })
+
+        self.assertEqual(len(got), 1)
+        model = got[0]
+        self.assertEqual(model["supported_efforts"], ["none", "medium"])
+        self.assertEqual(
+            model["adapter_metadata"]["provider_family"], "openai-ai-sdk"
+        )
+        self.assertEqual(
+            model["adapter_metadata"]["variant_options_by_effort"],
+            {
+                "none": {"reasoningEffort": "none"},
+                "medium": {"reasoningEffort": "medium"},
+            },
+        )
+
+    def test_connected_models_model_api_npm_wins_over_provider_npm(self):
+        got = opencode.connected_models({
+            "connected": ["mixed"],
+            "all": [{
+                "id": "mixed",
+                "npm": "@ai-sdk/anthropic",
+                "models": {
+                    "openai-backed": {
+                        "api": {"npm": "@ai-sdk/openai-compatible"},
+                        "variants": {"low": {"reasoningEffort": "low"}},
+                    }
+                },
+            }],
+        })
+
+        self.assertEqual(len(got), 1)
+        model = got[0]
+        self.assertEqual(model["supported_efforts"], ["low"])
+        self.assertEqual(
+            model["adapter_metadata"]["provider_family"], "openai-ai-sdk"
+        )
 
     def test_variant_id_collision_rejects_every_member_before_value_admission(self):
         admitted = opencode.admitted_variants(


### PR DESCRIPTION
Fixes #1240.

## Root causes

**1. Thinking variants never admitted (filed as #1240 by halo-inference).**
opencode 1.18.x's `/provider` projection never carries a top-level provider `npm` — verified live against 1.18.18: 0/193 providers have one; the SDK package lives at `model.api.npm`. `_provider_family()` read `provider.get("npm")`, so family was always `None`, `canonical_variant_options()` returned `None`, and `admitted_variants()` dropped every variant of every connected opencode model — `supported_efforts: []` everywhere, and the whole variant path was dead code as shipped.

Fix: resolve the family per model from `model.api.npm`, falling back to the legacy provider-level `npm` (`_model_family()` in `connected_models()`).

**2. Model sync spam: `HARNESS_UNAVAILABLE: opencode serve exited with code 1` on every route.**
`ensure_server()` spawns `opencode serve` with `start_new_session=True`, so the server outlives the engine process — but its random Basic-Auth password died with it. The next engine process failed the health check (401), tried to spawn its own server on the fixed port 4096, the bind failed, and every probe errored until someone killed the orphan by hand. Each failed bind is one `ServeError` line in `logs/opencode-server.log`.

Fix: on spawn, record `{pid, password}` in `run/opencode-server.json` (0600). `ensure_server()` tries the recorded password first — a healthy orphan is re-adopted with no respawn; a wedged orphan that answers no password is reaped (SIGTERM→SIGKILL, only after cmdline identity verification) and respawned. `stop_server()` clears the record only for a server the process itself started, so an adopted orphan stays re-adoptable across restarts. A foreign server the engine never started is still never touched.

## Tests

- New regression tests: family from `model.api.npm` (halo-shaped fixture), model-level npm overriding provider-level, orphan re-adoption, orphan reap-and-respawn with state rewrite, `stop_server` preserving an adopted orphan's record.
- `tests/` full suite: **2625 passed, 2 skipped**.
- Live on this host: killed the wedged 07:11 orphan, exercised the patched module — fresh process re-adopted a simulated orphan via the recorded password with no respawn, and `halo/qwen3.8-27b-q8-mtp2` now resolves `provider_family: openai-ai-sdk` (was `None`).

Note: the live halo model still needs its `variants` block in `~/.config/opencode/opencode.jsonc` (currently absent) for efforts to appear after this lands.

Co-authored-by: Code-02 (super-coder) <noreply@super-coder.local>