### PR TITLE
feat(sprint): Planner unit disposition verbs (resolve-unit + reroute relaxation)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -3072,6 +3072,18 @@ class Handler(BaseHTTPRequestHandler):
                     reason=body.get("reason") or "",
                 )
                 return self._send(200, {"changed": changed})
+            if path == "/_sc/sprint/resolve-unit":
+                planner_shell_id = self._sprint_planner_proxy(
+                    con, sprint_id, shell_id
+                )
+                changed = sprint_domain.SprintWorkUnitStore(con).resolve(
+                    sprint_id,
+                    self._sprint_integer(body, "work_unit_id"),
+                    planner_shell_id,
+                    target=self._sprint_optional_text(body, "target") or "",
+                    reason=self._sprint_optional_text(body, "reason") or "",
+                )
+                return self._send(200, {"changed": changed})
             if path == "/_sc/sprint/inbox-read":
                 message_id = self._sprint_integer(body, "message_id")
                 disposition = sprint_message_delivery.SprintMessageStore(

--- a/.super-coder/migrations/0221_planner_unit_disposition.sql
+++ b/.super-coder/migrations/0221_planner_unit_disposition.sql
@@ -1,0 +1,16 @@
+-- 0221 — Planner unit disposition verbs (spec #161, issue #1220).
+--
+-- resolve-unit supersedes a unit's sprint_pr_work_units links instead of
+-- deleting them: the row stays as link history and every driver of the lane
+-- (PR watcher routing, merge completion, resume PR reconciliation) reads only
+-- active (unsuperseded) links.  A Planner-attributed completion records its
+-- provenance on the unit row; merge/dev completions leave it NULL.
+
+BEGIN;
+
+ALTER TABLE sprint_pr_work_units ADD COLUMN superseded_at TEXT;
+
+ALTER TABLE sprint_work_units ADD COLUMN completion_source TEXT
+    CHECK (completion_source IS NULL OR completion_source='planner_override');
+
+COMMIT;

--- a/.super-coder/migrations/0222_reseed_sprint_pln_disposition_verbs.sql
+++ b/.super-coder/migrations/0222_reseed_sprint_pln_disposition_verbs.sql
@@ -1,11 +1,17 @@
----
-name: sprint_pln
-description: Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.
-category: workflow
-common: false
----
+-- 0222 — reseed sprint_pln with the Planner unit disposition verbs (spec #161).
+-- Documents resolve-unit beside recall/replan and the reroute relaxation for
+-- own-route PR-bound expectations.  Full-body UPSERT converges existing
+-- installations to the asset content.
 
-# sprint_pln — govern the armed Sprint
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
 
 Use as originating Planner after `sprint_prep` arms a Sprint. System records
 facts; Reviewer owns review/conformance judgment + reports; Planner owns plan
@@ -251,7 +257,7 @@ sc sprint resolve-unit --sprint <id> --work-unit <id> \
   --to completed|cancelled --reason <reason>
 ```
 
-Paused-only; retires the lane's open expectations, supersedes its PR links
+Paused-only; retires the lane''s open expectations, supersedes its PR links
 (registration kept for reconcile-pr), and wakes both seats. Recall+replan
 ships revised work; resolve only closes the lane.
 
@@ -265,8 +271,8 @@ sc sprint reroute-participant --sprint <id> --participant-shell <id> \
 ```
 
 Prepared Sprints may reroute directly. Paused reroute retires the
-participant's own released expectations and queues fresh ones on the
-replacement route at resume; another seat's open turn still blocks. Existing
+participant''s own released expectations and queues fresh ones on the
+replacement route at resume; another seat''s open turn still blocks. Existing
 chats/runs remain history; next Force-new delivery uses replacement. Reroute
 declared participants only. On decline, preserve reason and choose
 replacement from current capacity; ask Reviewer only if review/conformance
@@ -353,4 +359,12 @@ On an initial clean completion receipt, verify the named Sprint is terminal and
 record `cleanup_state=pending`; run no close command. Stop until the
 engine-authored cleanup success or failure receipt arrives. The Planner does
 not author a second report, accept an actionable handoff, poll cleanup, or ask
-another role to reset a worktree.
+another role to reset a worktree.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -159,6 +159,16 @@ _EVENT_FIELDS = {
         {"work_unit_id", "result", "output_kind", "source", "transition_key"}
     ),
     "work_unit.cancelled": frozenset({"work_unit_id", "reason"}),
+    "planner_override": frozenset(
+        {
+            "work_unit_id",
+            "before",
+            "after",
+            "reason",
+            "pr_numbers",
+            "retired_message_ids",
+        }
+    ),
     "participant.route_changed": frozenset(
         {"participant_id", "shell_id", "role", "before", "after"}
     ),

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -246,6 +246,21 @@ def cmd_cancel_unit(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_resolve_unit(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/resolve-unit",
+        {
+            "sprint_id": args.sprint,
+            "work_unit_id": args.work_unit,
+            "target": args.to,
+            "reason": args.reason,
+        },
+        idempotent=True,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
 def cmd_arm(args: argparse.Namespace) -> int:
     result = _post(
         "/_sc/sprint/arm",
@@ -655,6 +670,19 @@ def build_parser() -> argparse.ArgumentParser:
     cancel_unit.add_argument("--work-unit", type=int, required=True)
     cancel_unit.add_argument("--reason", required=True)
     cancel_unit.set_defaults(fn=cmd_cancel_unit)
+
+    resolve_unit = sub.add_parser(
+        "resolve-unit",
+        help="Planner force-moves one non-terminal lane to a terminal "
+        "disposition while the Sprint is paused",
+    )
+    resolve_unit.add_argument("--sprint", type=int, required=True)
+    resolve_unit.add_argument("--work-unit", type=int, required=True)
+    resolve_unit.add_argument(
+        "--to", choices=("completed", "cancelled"), required=True
+    )
+    resolve_unit.add_argument("--reason", required=True)
+    resolve_unit.set_defaults(fn=cmd_resolve_unit)
 
     register = sub.add_parser(
         "register-pr", help="Developer registers one PR to its owning work unit"

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -263,6 +263,26 @@ _ROUTE_EVIDENCE_FIELDS = (
 )
 
 
+def _next_assignment_key(
+    con: sqlite3.Connection, sprint_id: int, work_unit_id: int
+) -> str:
+    """Next durable generation key for one lane's work-assignment message."""
+    key_prefix = f"sprint:{sprint_id}:work-unit:{work_unit_id}:assignment:"
+    generation = 0
+    for row in con.execute(
+        "SELECT idempotency_key FROM wake_message "
+        "WHERE work_unit_id=? AND message_kind='work_assignment'",
+        (work_unit_id,),
+    ):
+        key = str(row["idempotency_key"])
+        if not key.startswith(key_prefix):
+            continue
+        suffix = key.removeprefix(key_prefix)
+        if suffix.isdigit():
+            generation = max(generation, int(suffix))
+    return f"{key_prefix}{generation + 1}"
+
+
 def _route_evidence_snapshot(row: dict | sqlite3.Row) -> dict:
     return {field: row[field] for field in _ROUTE_EVIDENCE_FIELDS}
 
@@ -3522,7 +3542,9 @@ class SprintParticipantStore:
                 raise SprintInvariantError(
                     "participant route changed during preflight; retry reroute"
                 )
-            self._require_idle_projection(current, lifecycle)
+            expectation_facts = self._require_idle_projection(
+                current, lifecycle, planner_shell_id=planner_shell_id
+            )
             if lifecycle == "paused":
                 expected = candidate.evidence_snapshot
                 if expected is not None:
@@ -3578,6 +3600,7 @@ class SprintParticipantStore:
                             "shell_id": participant_shell_id,
                             "role": str(current["role"]),
                             "before": before,
+                            "retired_expectations": expectation_facts,
                             "after": {
                                 **after,
                                 "binding_status": (
@@ -3674,32 +3697,49 @@ class SprintParticipantStore:
         self,
         participant: sqlite3.Row,
         lifecycle: str,
-    ) -> None:
+        *,
+        planner_shell_id: int,
+    ) -> list[dict]:
+        """Guard the route change and relax it for own-route expectations.
+
+        A paused Sprint no longer refuses reroute solely because the
+        participant owns released PR-bound units (spec #161): when every
+        blocking open expectation belongs to the participant's own route, the
+        reroute transaction retires it and queues a fresh one on the
+        replacement route (delivered at resume).  Expectations owned by
+        another seat — a released ``ready``/``in_review`` lane for a
+        Developer — still block, as do live wakes, runs, and chats.
+        """
         if lifecycle == "prepared":
-            return
+            return []
         sprint_id = int(participant["sprint_id"])
         shell_id = int(participant["shell_id"])
         if participant["role"] == "developer":
-            active = self.con.execute(
-                "SELECT work_unit_id,disposition FROM sprint_work_units "
+            rows = self.con.execute(
+                "SELECT work_unit_id,disposition,title,expected_output "
+                "FROM sprint_work_units "
                 "WHERE sprint_id=? AND assigned_shell_id=? AND disposition IN "
                 "('ready','active','in_review','fixing','merge_ready') "
-                "ORDER BY work_unit_id LIMIT 1",
+                "ORDER BY work_unit_id",
                 (sprint_id, shell_id),
-            ).fetchone()
+            ).fetchall()
+            relaxable = {"active", "fixing", "merge_ready"}
         else:
-            active = self.con.execute(
-                "SELECT work_unit_id,disposition FROM sprint_work_units "
+            rows = self.con.execute(
+                "SELECT work_unit_id,disposition,title,expected_output "
+                "FROM sprint_work_units "
                 "WHERE sprint_id=? AND reviewer_shell_id=? "
-                "AND disposition='in_review' ORDER BY work_unit_id LIMIT 1",
+                "AND disposition='in_review' ORDER BY work_unit_id",
                 (sprint_id, shell_id),
-            ).fetchone()
-        if active is not None:
-            raise SprintInvariantError(
-                f"participant route still owns released work unit "
-                f"{int(active['work_unit_id'])} ({active['disposition']}); "
-                "recall or finish that expectation first"
-            )
+            ).fetchall()
+            relaxable = {"in_review"}
+        for row in rows:
+            if str(row["disposition"]) not in relaxable:
+                raise SprintInvariantError(
+                    f"participant route still owns released work unit "
+                    f"{int(row['work_unit_id'])} ({row['disposition']}); "
+                    "recall or finish that expectation first"
+                )
         wake = self.con.execute(
             "SELECT wake_id,state FROM sprint_wake_outbox "
             "WHERE participant_id=? AND state IN ('pending','delivering') "
@@ -3731,6 +3771,170 @@ class SprintParticipantStore:
                 f"participant route still owns active chat {chat.chat_id}; "
                 "close and unregister it before reroute"
             )
+        if not rows:
+            return []
+        return self._retire_own_route_expectations(
+            participant,
+            rows,
+            planner_shell_id=planner_shell_id,
+        )
+
+    def _retire_own_route_expectations(
+        self,
+        participant: sqlite3.Row,
+        rows: list[sqlite3.Row],
+        *,
+        planner_shell_id: int,
+    ) -> list[dict]:
+        """Retire each own-route expectation and queue its replacement.
+
+        Units, dispositions, PR links, and review history are not rewritten;
+        the retired generation is declined/resolved, never erased.  Fresh
+        expectations are durable immediately but deliver only once the Sprint
+        is armed again (wake delivery gates on the armed lifecycle).
+        """
+        sprint_id = int(participant["sprint_id"])
+        participant_id = int(participant["participant_id"])
+        planner = self.con.execute(
+            "SELECT participant_id FROM sprint_participants "
+            "WHERE sprint_id=? AND role='planner'",
+            (sprint_id,),
+        ).fetchone()
+        if planner is None:
+            raise SprintInvariantError("Sprint has no Planner participant")
+        planner_participant_id = int(planner["participant_id"])
+
+        from sprint_liveness import SprintLivenessMonitor
+        from sprint_message_delivery import SprintMessageStore
+
+        messages = SprintMessageStore(self.con)
+        monitor = SprintLivenessMonitor(self.con)
+        facts: list[dict] = []
+        for row in rows:
+            unit_id = int(row["work_unit_id"])
+            disposition = str(row["disposition"])
+            if participant["role"] == "developer":
+                if disposition == "merge_ready":
+                    # The lane awaits the Developer's own merge authorization;
+                    # no message expectation is bound to the old route.
+                    facts.append(
+                        {"work_unit_id": unit_id, "disposition": disposition}
+                    )
+                    continue
+                retired = messages.retire_route_expectations_in_transaction(
+                    sprint_id,
+                    unit_id,
+                    retirement_reason=(
+                        "Rerouted by Planner: assignment moved to the "
+                        "replacement route"
+                    ),
+                    resolution="assignment retired by Planner reroute",
+                    kinds=("work_assignment",),
+                )
+                receipt = messages.send_in_transaction(
+                    sprint_id,
+                    from_participant_id=planner_participant_id,
+                    to_participant_id=participant_id,
+                    work_unit_id=unit_id,
+                    message_kind="work_assignment",
+                    body=f"{row['title']}\n\n{row['expected_output']}",
+                    actionable=True,
+                    declared_type="force-new",
+                    idempotency_key=_next_assignment_key(
+                        self.con, sprint_id, unit_id
+                    ),
+                )
+                facts.append(
+                    {
+                        "work_unit_id": unit_id,
+                        "disposition": disposition,
+                        "retired_message_ids": list(retired),
+                        "fresh_message_id": receipt.message_id,
+                    }
+                )
+                continue
+            request = self.con.execute(
+                "SELECT message_id,body,from_participant_id FROM wake_message "
+                "WHERE sprint_id=? AND work_unit_id=? AND to_participant_id=? "
+                "AND message_kind='review_request' "
+                "AND disposition IN ('pending','accepted') "
+                "ORDER BY message_id DESC LIMIT 1",
+                (sprint_id, unit_id, participant_id),
+            ).fetchone()
+            if request is None:
+                raise SprintInvariantError(
+                    f"participant route still owns released work unit "
+                    f"{unit_id} ({disposition}); recall or finish that "
+                    "expectation first"
+                )
+            request_id = int(request["message_id"])
+            evidence = self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='review.requested' "
+                "AND json_extract(payload,'$.message_id')=? "
+                "ORDER BY event_id DESC LIMIT 1",
+                (sprint_id, request_id),
+            ).fetchone()
+            if evidence is None:
+                raise SprintInvariantError(
+                    "open review request has no head evidence"
+                )
+            requested = json.loads(evidence["payload"])
+            messages.supersede_actionable_in_transaction(
+                request_id,
+                "retired by Planner reroute; a fresh review request follows "
+                "on the replacement route",
+            )
+            monitor.resolve_in_transaction(
+                request_id,
+                "review request retired by Planner reroute",
+            )
+            receipt = messages.send_in_transaction(
+                sprint_id,
+                from_participant_id=int(request["from_participant_id"]),
+                to_participant_id=participant_id,
+                work_unit_id=unit_id,
+                message_kind="review_request",
+                body=str(request["body"]),
+                actionable=True,
+                declared_type="force-new",
+                idempotency_key=(
+                    f"sprint:{sprint_id}:work-unit:{unit_id}:"
+                    f"review-request:reroute:{request_id}"
+                ),
+            )
+            self.con.execute(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+                "VALUES (?,'review.requested','planner',?,?)",
+                (
+                    sprint_id,
+                    planner_shell_id,
+                    json.dumps(
+                        {
+                            "head_sha": requested.get("head_sha"),
+                            "message_id": receipt.message_id,
+                            "registered_pr_id": requested.get(
+                                "registered_pr_id"
+                            ),
+                            "source": "planner.reroute",
+                            "retired_message_id": request_id,
+                            "transition_id": requested.get("transition_id"),
+                            "work_unit_id": unit_id,
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+            facts.append(
+                {
+                    "work_unit_id": unit_id,
+                    "disposition": disposition,
+                    "retired_message_ids": [request_id],
+                    "fresh_message_id": receipt.message_id,
+                }
+            )
+        return facts
 
     @staticmethod
     def _projection(participant: sqlite3.Row) -> dict:
@@ -4707,21 +4911,7 @@ class SprintWorkUnitStore:
         unit: sqlite3.Row,
     ) -> int:
         unit_id = int(unit["work_unit_id"])
-        key_prefix = f"sprint:{sprint_id}:work-unit:{unit_id}:assignment:"
-        generation = 0
-        for row in self.con.execute(
-            "SELECT idempotency_key FROM wake_message "
-            "WHERE work_unit_id=? AND message_kind='work_assignment'",
-            (unit_id,),
-        ):
-            key = str(row["idempotency_key"])
-            if not key.startswith(key_prefix):
-                continue
-            suffix = key.removeprefix(key_prefix)
-            if suffix.isdigit():
-                generation = max(generation, int(suffix))
-        generation += 1
-        key = f"{key_prefix}{generation}"
+        key = _next_assignment_key(self.con, sprint_id, unit_id)
         # Local import avoids a module cycle: the message store uses the domain
         # lifecycle for durable failure evidence.
         from sprint_message_delivery import SprintMessageStore

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -1844,7 +1844,8 @@ class SprintLifecycleStore:
                 int(item[0])
                 for item in self.con.execute(
                     "SELECT work_unit_id FROM sprint_pr_work_units "
-                    "WHERE registered_pr_id=? ORDER BY work_unit_id",
+                    "WHERE registered_pr_id=? AND superseded_at IS NULL "
+                    "ORDER BY work_unit_id",
                     (registered_pr_id,),
                 )
             )
@@ -3985,6 +3986,7 @@ class SprintWorkUnitStore:
             registered = self.con.execute(
                 "SELECT registered_pr_id FROM sprint_pr_work_units "
                 "WHERE sprint_id=? AND work_unit_id=? "
+                "AND superseded_at IS NULL "
                 "ORDER BY registered_pr_id LIMIT 1",
                 (sprint_id, work_unit_id),
             ).fetchone()
@@ -4204,6 +4206,146 @@ class SprintWorkUnitStore:
             pause_receipt = self._queue_delivery_terminal(sprint_id)
         if pause_receipt is not None:
             self.lifecycle.signal_pause_receipt(pause_receipt)
+        return True
+
+    def resolve(
+        self,
+        sprint_id: int,
+        work_unit_id: int,
+        planner_shell_id: int,
+        *,
+        target: str,
+        reason: str,
+    ) -> bool:
+        """Force-move one non-terminal lane to a terminal Planner disposition.
+
+        Paused-only, Planner-only, reasoned, and audited: retires the lane's
+        open route expectations, supersedes its PR links (rows retained), and
+        wakes the assigned Developer and Reviewer.  PR-bound units are the
+        point of the verb; ``--to completed`` fabricates no merge observation.
+        """
+        if target not in {"completed", "cancelled"}:
+            raise ValueError("resolve-unit target must be completed or cancelled")
+        reason = reason.strip()
+        if not reason:
+            raise ValueError("work-unit resolution reason is required")
+        if len(reason) > 8000:
+            raise ValueError(
+                f"work-unit resolution reason is {len(reason)} characters; "
+                "maximum is 8000"
+            )
+        with db_driver.write_transaction(self.con, "sprint.work_unit.resolve"):
+            lifecycle, planner_participant_id = self._require_planner(
+                sprint_id, planner_shell_id
+            )
+            if lifecycle != "paused":
+                raise SprintInvariantError(
+                    "work units may be resolved only while the Sprint is paused"
+                )
+            unit = self._unit(sprint_id, work_unit_id)
+            before = str(unit["disposition"])
+            if before in {"completed", "cancelled"}:
+                override = self.con.execute(
+                    "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                    "AND event_type='planner_override' "
+                    "AND json_extract(payload,'$.work_unit_id')=? "
+                    "ORDER BY event_id DESC LIMIT 1",
+                    (sprint_id, work_unit_id),
+                ).fetchone()
+                if override is not None:
+                    prior = json.loads(override["payload"])
+                    if (
+                        before == target
+                        and prior.get("after") == target
+                        and prior.get("reason") == reason
+                    ):
+                        return False
+                raise SprintConflictError(
+                    f"work unit {work_unit_id} is already {before}; "
+                    "resolve-unit does not move a terminal work unit",
+                    {
+                        "code": "work_unit_already_terminal",
+                        "work_unit_id": work_unit_id,
+                        "disposition": before,
+                    },
+                )
+            pr_numbers = [
+                int(row["pr_number"])
+                for row in self.con.execute(
+                    "SELECT pr.pr_number FROM sprint_pr_work_units link "
+                    "JOIN sprint_registered_prs pr "
+                    "ON pr.registered_pr_id=link.registered_pr_id "
+                    "WHERE link.sprint_id=? AND link.work_unit_id=? "
+                    "AND link.superseded_at IS NULL ORDER BY pr.pr_number",
+                    (sprint_id, work_unit_id),
+                )
+            ]
+            from sprint_message_delivery import SprintMessageStore
+
+            messages = SprintMessageStore(self.con)
+            retired_message_ids = messages.retire_route_expectations_in_transaction(
+                sprint_id,
+                work_unit_id,
+                retirement_reason=f"Resolved by Planner as {target}: {reason}",
+                resolution=f"work unit resolved by Planner as {target}: {reason}",
+            )
+            self.con.execute(
+                "UPDATE sprint_pr_work_units SET superseded_at=datetime('now') "
+                "WHERE sprint_id=? AND work_unit_id=? AND superseded_at IS NULL",
+                (sprint_id, work_unit_id),
+            )
+            self.con.execute(
+                "UPDATE sprint_work_units SET disposition=?,completion_result=?,"
+                "completed_at=datetime('now'),updated_at=datetime('now'),"
+                "completion_source=CASE WHEN ?='completed' "
+                "THEN 'planner_override' ELSE completion_source END "
+                "WHERE work_unit_id=?",
+                (target, reason, target, work_unit_id),
+            )
+            # The durable event lands before any wake: it, not the narration,
+            # is the delivery proof of the override.
+            self._event(
+                sprint_id,
+                "planner_override",
+                planner_shell_id,
+                {
+                    "work_unit_id": work_unit_id,
+                    "before": before,
+                    "after": target,
+                    "reason": reason,
+                    "pr_numbers": pr_numbers,
+                    "retired_message_ids": list(retired_message_ids),
+                },
+            )
+            recipients = self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id IN (?,?) "
+                "AND role IN ('developer','reviewer') ORDER BY participant_id",
+                (
+                    sprint_id,
+                    int(unit["assigned_shell_id"]),
+                    int(unit["reviewer_shell_id"]),
+                ),
+            ).fetchall()
+            reason_key = hashlib.sha256(reason.encode()).hexdigest()[:16]
+            for recipient in recipients:
+                messages.send_in_transaction(
+                    sprint_id,
+                    from_participant_id=planner_participant_id,
+                    to_participant_id=int(recipient["participant_id"]),
+                    work_unit_id=work_unit_id,
+                    message_kind="notification",
+                    body=(
+                        f"Planner resolved work unit {work_unit_id} from "
+                        f"{before} to {target}: {reason}"
+                    ),
+                    actionable=False,
+                    declared_type="re-enter",
+                    idempotency_key=(
+                        f"planner-override:{sprint_id}:{work_unit_id}:{target}:"
+                        f"{reason_key}:participant:{int(recipient['participant_id'])}"
+                    ),
+                )
         return True
 
     def complete_from_merge_in_transaction(
@@ -4501,7 +4643,10 @@ class SprintWorkUnitStore:
             body=(
                 f"Merged PR bypassed the Sprint merge grant for work unit "
                 f"{work_unit_id} from {before}; the unit remains incomplete "
-                "and requires Planner disposition."
+                "and requires Planner disposition: pause the Sprint and run "
+                f"`sc sprint resolve-unit --sprint {sprint_id} "
+                f"--work-unit {work_unit_id} --to completed|cancelled "
+                "--reason <text>`."
             ),
             actionable=False,
             declared_type="re-enter",

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -523,37 +523,53 @@ class SprintMessageStore:
                 and message["message_kind"] == "work_assignment"
                 and message["work_unit_id"] is not None
             ):
-                changed = self.con.execute(
-                    "UPDATE sprint_work_units SET disposition='active',"
-                    "updated_at=datetime('now') WHERE sprint_id=? "
-                    "AND work_unit_id=? AND assigned_shell_id=? "
-                    "AND disposition='ready'",
+                # A rerouted lane keeps its released disposition (active or
+                # fixing); only a ready lane transitions on acceptance.
+                lane = self.con.execute(
+                    "SELECT disposition FROM sprint_work_units "
+                    "WHERE sprint_id=? AND work_unit_id=? AND assigned_shell_id=?",
                     (
                         message["sprint_id"],
                         message["work_unit_id"],
                         shell_id,
                     ),
-                ).rowcount
-                if changed != 1:
+                ).fetchone()
+                if lane is None or str(lane["disposition"]) not in {
+                    "ready",
+                    "active",
+                    "fixing",
+                }:
                     raise SprintInvariantError(
                         "work assignment no longer owns a ready editing lane"
                     )
-                self.con.execute(
-                    "INSERT INTO sprint_events "
-                    "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
-                    "VALUES (?,'work_unit.accepted','participant',?,?)",
-                    (
-                        message["sprint_id"],
-                        shell_id,
-                        json.dumps(
-                            {
-                                "message_id": message_id,
-                                "work_unit_id": int(message["work_unit_id"]),
-                            },
-                            sort_keys=True,
+                if str(lane["disposition"]) == "ready":
+                    self.con.execute(
+                        "UPDATE sprint_work_units SET disposition='active',"
+                        "updated_at=datetime('now') WHERE sprint_id=? "
+                        "AND work_unit_id=? AND assigned_shell_id=? "
+                        "AND disposition='ready'",
+                        (
+                            message["sprint_id"],
+                            message["work_unit_id"],
+                            shell_id,
                         ),
-                    ),
-                )
+                    )
+                    self.con.execute(
+                        "INSERT INTO sprint_events "
+                        "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+                        "VALUES (?,'work_unit.accepted','participant',?,?)",
+                        (
+                            message["sprint_id"],
+                            shell_id,
+                            json.dumps(
+                                {
+                                    "message_id": message_id,
+                                    "work_unit_id": int(message["work_unit_id"]),
+                                },
+                                sort_keys=True,
+                            ),
+                        ),
+                    )
             self._cancel_resolved_wakes(message_id)
             return disposition
 

--- a/.super-coder/scripts/sprint_message_delivery.py
+++ b/.super-coder/scripts/sprint_message_delivery.py
@@ -904,6 +904,51 @@ class SprintMessageStore:
             )
         return message_ids
 
+    def retire_route_expectations_in_transaction(
+        self,
+        sprint_id: int,
+        work_unit_id: int,
+        *,
+        retirement_reason: str,
+        resolution: str,
+        kinds: tuple[str, ...] = ("work_assignment", "review_request"),
+    ) -> tuple[int, ...]:
+        """Retire one lane's open route expectations, preserving history.
+
+        Pending expectations are declined with the Planner's reason; accepted
+        ones keep their disposition (they are history) and only their liveness
+        expectation is resolved.  Wake delivery intent is cancelled either way.
+        """
+        if not self.con.in_transaction:
+            raise RuntimeError("expectation retirement requires an active transaction")
+        marks = ",".join("?" for _ in kinds)
+        rows = self.con.execute(
+            "SELECT message_id,disposition FROM wake_message "
+            "WHERE sprint_id=? AND work_unit_id=? "
+            f"AND message_kind IN ({marks}) "
+            "AND disposition IN ('pending','accepted') ORDER BY message_id",
+            (sprint_id, work_unit_id, *kinds),
+        ).fetchall()
+        message_ids = tuple(int(row["message_id"]) for row in rows)
+        if not rows:
+            return ()
+
+        from sprint_liveness import SprintLivenessMonitor
+
+        monitor = SprintLivenessMonitor(self.con)
+        for row in rows:
+            message_id = int(row["message_id"])
+            if row["disposition"] == "pending":
+                self.con.execute(
+                    "UPDATE wake_message SET disposition='declined',"
+                    "read_at=COALESCE(read_at,datetime('now')),decline_reason=? "
+                    "WHERE message_id=? AND disposition='pending'",
+                    (retirement_reason, message_id),
+                )
+                self._cancel_resolved_wakes(message_id)
+            monitor.resolve_in_transaction(message_id, resolution)
+        return message_ids
+
 
 class SprintWakeDeliveryService:
     """Lease wake intents and resolve their chat placement at delivery time."""

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1305,7 +1305,8 @@ class SprintPRWatcher:
             "SELECT l.work_unit_id,u.disposition "
             "FROM sprint_pr_work_units l JOIN sprint_work_units u "
             "ON u.sprint_id=l.sprint_id AND u.work_unit_id=l.work_unit_id "
-            "WHERE l.registered_pr_id=? ORDER BY l.work_unit_id",
+            "WHERE l.registered_pr_id=? AND l.superseded_at IS NULL "
+            "ORDER BY l.work_unit_id",
             (registered_pr_id,),
         ).fetchall() if registered_pr_id is not None else []
         work_unit_id = (

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -366,10 +366,15 @@ class SprintReviewLoopStore:
             int(unit[0])
             for unit in self.con.execute(
                 "SELECT work_unit_id FROM sprint_pr_work_units "
-                "WHERE registered_pr_id=? ORDER BY work_unit_id",
+                "WHERE registered_pr_id=? AND superseded_at IS NULL "
+                "ORDER BY work_unit_id",
                 (registered_pr_id,),
             )
         ]
+        if not unit_ids:
+            # Every link was superseded by a Planner override: the watcher no
+            # longer drives the lane, so the merge projects nothing.
+            return []
         return self.units.complete_from_merge_in_transaction(
             int(row["sprint_id"]),
             unit_ids,

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -115,6 +115,8 @@
     ".super-coder/migrations/0215_reseed_sprint_binding_guidance.sql",
     ".super-coder/migrations/0216_sprint_binding_provenance.sql",
     ".super-coder/migrations/0218_sprint_binding_support_provenance.sql",
+    ".super-coder/migrations/0221_planner_unit_disposition.sql",
+    ".super-coder/migrations/0222_reseed_sprint_pln_disposition_verbs.sql",
     ".super-coder/migrations/0223_model_default_effort_binding.sql"
   ],
   "baseline_migration_ledger": {

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -1485,6 +1485,11 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             (int(notice[0]), int(notice[1]), notice[3]),
         )
         self.assertIn("remains incomplete", notice["body"])
+        self.assertIn(
+            "sc sprint resolve-unit",
+            notice["body"],
+            "the bypass notice names the Planner remedy",
+        )
 
         lifecycle = sprint_domain.SprintLifecycleStore(self.con)
         lifecycle.pause(
@@ -1509,7 +1514,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             ),
         )
 
-    def test_grant_bypassed_resume_after_disposition_change_does_not_conflict(self):
+    def test_grant_bypassed_resume_after_planner_resolution_does_not_conflict(self):
         handoff = self.request_review()
         self.accept_review(handoff.message_id)
         self.reader.current = pull_request(
@@ -1528,6 +1533,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             "WHERE idempotency_key LIKE 'merge-grant-bypassed:%'"
         ).fetchone()
         self.assertIn("from in_review", notice["body"])
+        self.assertIn("resolve-unit", notice["body"])
 
         lifecycle = sprint_domain.SprintLifecycleStore(self.con)
         lifecycle.pause(
@@ -1535,14 +1541,27 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             sprint_domain.LifecycleActor("participant", 1),
             reason="reconcile the bypass",
         )
-        # The Planner dispositions the bypassed unit for fixing before
-        # resuming; resume re-observes the same merged transition.
-        self.con.execute(
-            "UPDATE sprint_work_units SET disposition='fixing' "
-            "WHERE work_unit_id=?",
-            (self.unit_id,),
+        # The Planner resolves the bypassed unit as completed before resuming
+        # (the PR merged out-of-band); resume re-observes the same merged
+        # transition but the superseded link no longer drives the unit.
+        resolved = sprint_domain.SprintWorkUnitStore(self.con).resolve(
+            self.sprint_id,
+            self.unit_id,
+            3,
+            target="completed",
+            reason="PR merged while the Sprint was paused",
         )
-        self.con.commit()
+        self.assertTrue(resolved)
+        self.assertEqual(
+            ("completed", "planner_override"),
+            tuple(
+                self.con.execute(
+                    "SELECT disposition,completion_source FROM sprint_work_units "
+                    "WHERE work_unit_id=?",
+                    (self.unit_id,),
+                ).fetchone()
+            ),
+        )
 
         receipt = lifecycle.resume(
             self.sprint_id,
@@ -1569,6 +1588,237 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
                 "WHERE idempotency_key LIKE 'merge-grant-bypassed:%'"
             ).fetchone()[0],
         )
+
+    def test_merged_fixing_lane_stops_driving_after_planner_resolution(self):
+        # U80 replay: a fixing lane whose PR merged while the Sprint was
+        # paused resolves via resolve-unit; the watcher then leaves the
+        # terminal lane alone and the Sprint resumes cleanly.
+        handoff = self.request_review()
+        self.accept_review(handoff.message_id)
+        changed = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="changes_requested",
+            body="Medium: keep the reviewed head intact.",
+            idempotency_key="u80-changes",
+        )
+        self.assertEqual("fixing", changed.disposition)
+
+        lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="reconcile a PR that merged out-of-band",
+        )
+        self.reader.current = pull_request(
+            state="MERGED", checks="SUCCESS", checks_failed=False
+        )
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual(
+            "fixing",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+            "the merge observer leaves the lane for Planner disposition",
+        )
+        notice = self.con.execute(
+            "SELECT body FROM wake_message "
+            "WHERE idempotency_key LIKE 'merge-grant-bypassed:%'"
+        ).fetchone()
+        self.assertIn("resolve-unit", notice["body"])
+
+        resolved = sprint_domain.SprintWorkUnitStore(self.con).resolve(
+            self.sprint_id,
+            self.unit_id,
+            3,
+            target="completed",
+            reason="PR merged while the Sprint was paused",
+        )
+        self.assertTrue(resolved)
+        self.assertEqual(
+            ("completed", "planner_override"),
+            tuple(
+                self.con.execute(
+                    "SELECT disposition,completion_source FROM sprint_work_units "
+                    "WHERE work_unit_id=?",
+                    (self.unit_id,),
+                ).fetchone()
+            ),
+        )
+
+        # A fresh observation of the same merged PR no longer projects onto
+        # the resolved lane: no completion event, no second bypass notice.
+        self.reader.current = pull_request(
+            state="MERGED",
+            checks="SUCCESS",
+            checks_failed=False,
+            head_sha="d" * 40,
+        )
+        self.watcher.poll_once()
+        self.assertEqual(
+            (1, 1, 0),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_events "
+                    "WHERE event_type='merge.grant_bypassed'),"
+                    "(SELECT COUNT(*) FROM wake_message "
+                    "WHERE idempotency_key LIKE 'merge-grant-bypassed:%'),"
+                    "(SELECT COUNT(*) FROM sprint_events "
+                    "WHERE event_type='work_unit.completed')"
+                ).fetchone()
+            ),
+        )
+
+        receipt = lifecycle.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+        self.assertTrue(receipt.changed)
+        self.assertEqual(
+            "completed",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+
+    def test_reroute_reviewer_retires_pr_bound_review_expectation(self):
+        # Issue #1220 replay: rerouting a Reviewer off a PR-bound in_review
+        # lane retires the old review generation; resume queues a fresh
+        # review request on the replacement route at the same PR head.
+        handoff = self.request_review()
+        self.accept_review(handoff.message_id)
+        self.assertEqual(
+            "in_review",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+        )
+
+        lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="replace the review route",
+        )
+        prepared = sprint_domain.sprint_participant_chats.PreparedParticipantRoute(
+            participant_id=self.reviewer_id,
+            shell_id=2,
+            role="reviewer",
+            shortname="REV1",
+            harness="codex",
+            provider="openai",
+            model="replacement-model",
+            effort="medium",
+            worktree="/tmp/rev1",
+        )
+        with mock.patch.object(
+            sprint_domain.sprint_participant_chats,
+            "prepare_participant_route",
+            return_value=prepared,
+        ):
+            changed_route = sprint_domain.SprintParticipantStore(
+                self.con, probe_harness=lambda _harness: None
+            ).reroute(
+                self.sprint_id,
+                3,
+                participant_shell_id=2,
+                harness="codex",
+                model="replacement-model",
+                effort="medium",
+                route="codex/replacement-model",
+            )
+        self.assertTrue(changed_route)
+
+        retired = self.con.execute(
+            "SELECT disposition,decline_reason FROM wake_message "
+            "WHERE message_id=?",
+            (handoff.message_id,),
+        ).fetchone()
+        self.assertEqual("declined", retired["disposition"])
+        self.assertIn("reroute", retired["decline_reason"])
+        fresh = self.con.execute(
+            "SELECT message_id,disposition,to_participant_id FROM wake_message "
+            "WHERE work_unit_id=? AND message_kind='review_request' "
+            "AND idempotency_key LIKE '%:review-request:reroute:%'",
+            (self.unit_id,),
+        ).fetchone()
+        self.assertIsNotNone(fresh, "reroute queues a fresh review generation")
+        self.assertEqual(self.reviewer_id, int(fresh["to_participant_id"]))
+        self.assertEqual(
+            "in_review",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
+            ).fetchone()[0],
+            "the lane itself is not rewritten",
+        )
+        self.assertIsNone(
+            self.con.execute(
+                "SELECT superseded_at FROM sprint_pr_work_units "
+                "WHERE sprint_id=? AND work_unit_id=?",
+                (self.sprint_id, self.unit_id),
+            ).fetchone()[0],
+            "the PR link stays active",
+        )
+
+        receipt = lifecycle.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="route replaced",
+        )
+        self.assertTrue(receipt.changed)
+        fresh_wake = int(
+            self.con.execute(
+                "SELECT wake_id FROM sprint_wake_messages WHERE message_id=?",
+                (int(fresh["message_id"]),),
+            ).fetchone()[0]
+        )
+        # The reroute-queued request is durable delivery intent once armed:
+        # the wake delivery service can place it on the replacement route.
+        service = sprint_message_delivery.SprintWakeDeliveryService(self.con)
+        delivered: set[int] = set()
+        for attempt in range(4):
+            receipt_delivery = service.deliver_once(
+                f"rerouted-review-{attempt}",
+                lambda conversation, _prompt, _key: conversation,
+            )
+            if receipt_delivery is None:
+                break
+            delivered.add(int(receipt_delivery.wake_id))
+        self.assertIn(fresh_wake, delivered)
+
+    def test_reroute_developer_still_refuses_in_review_lane(self):
+        # The relaxation covers only the participant's own route
+        # expectations; an in_review lane still blocks the Developer's
+        # reroute because the open turn belongs to the Reviewer's seat.
+        handoff = self.request_review()
+        self.accept_review(handoff.message_id)
+        lifecycle = sprint_domain.SprintLifecycleStore(self.con)
+        lifecycle.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="replace the dev route",
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "recall or finish that expectation first",
+        ):
+            sprint_domain.SprintParticipantStore(
+                self.con, probe_harness=lambda _harness: None
+            ).reroute(
+                self.sprint_id,
+                3,
+                participant_shell_id=1,
+                harness="codex",
+                model="replacement-model",
+                effort="medium",
+                route="codex/replacement-model",
+            )
 
     def test_grant_bypassed_merge_resolves_accepted_review_expectation(self):
         handoff = self.request_review()

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -67,6 +67,9 @@ GITHUB_CAPABILITY_RESEED = (
 BINDING_GUIDANCE_RESEED = (
     ENGINE / "migrations" / "0215_reseed_sprint_binding_guidance.sql"
 )
+DISPOSITION_VERBS_RESEED = (
+    ENGINE / "migrations" / "0222_reseed_sprint_pln_disposition_verbs.sql"
+)
 
 
 class SprintSkillTest(unittest.TestCase):
@@ -187,6 +190,7 @@ class SprintSkillTest(unittest.TestCase):
             con.executescript(migration)
             con.executescript(INFORMATIONAL_RECEIPT_RESEED.read_text())
             con.executescript(BINDING_GUIDANCE_RESEED.read_text())
+            con.executescript(DISPOSITION_VERBS_RESEED.read_text())
 
             for name in sorted(CONFORMANCE_OWNER_SKILLS):
                 with self.subTest(name=name):
@@ -239,6 +243,7 @@ class SprintSkillTest(unittest.TestCase):
             migration = INFORMATIONAL_RECEIPT_RESEED.read_text()
             con.executescript(migration)
             con.executescript(migration)
+            con.executescript(DISPOSITION_VERBS_RESEED.read_text())
 
             for name in sorted(HANDOFF_ROLE_SKILLS):
                 with self.subTest(name=name):
@@ -872,6 +877,7 @@ class SprintSkillTest(unittest.TestCase):
             con.executescript(DISPOSABLE_SHELL_BASE_RESEED.read_text())
             con.executescript(GITHUB_CAPABILITY_RESEED.read_text())
             con.executescript(BINDING_GUIDANCE_RESEED.read_text())
+            con.executescript(DISPOSITION_VERBS_RESEED.read_text())
 
             self.assertIsNotNone(
                 con.execute(
@@ -1000,6 +1006,61 @@ class SprintSkillTest(unittest.TestCase):
             row = con.execute(
                 "SELECT description,category,command,common,content,is_deleted "
                 "FROM skills WHERE name='sprint_dev'"
+            ).fetchone()
+            self.assertEqual(
+                (
+                    parsed["description"],
+                    parsed["category"],
+                    parsed["command"],
+                    parsed["common"],
+                    parsed["content"],
+                    0,
+                ),
+                tuple(row),
+            )
+        finally:
+            con.close()
+
+    def test_disposition_verbs_reseed_matches_asset_and_replays_idempotently(self):
+        con = sqlite3.connect(":memory:")
+        try:
+            con.executescript((ENGINE / "schema.sql").read_text())
+            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name >= "0222_reseed_sprint_pln_disposition_verbs.sql":
+                    break
+                con.executescript(migration.read_text())
+            con.execute(
+                "UPDATE skills SET description='stale',category='stale',"
+                "command='stale',common=1,content='no disposition verbs',"
+                "is_deleted=1 WHERE name='sprint_pln'"
+            )
+
+            migration = (
+                ENGINE
+                / "migrations"
+                / "0222_reseed_sprint_pln_disposition_verbs.sql"
+            ).read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+            self.assertIn(
+                "sc sprint resolve-unit",
+                con.execute(
+                    "SELECT content FROM skills WHERE name='sprint_pln'"
+                ).fetchone()[0],
+            )
+            for later_migration in sorted(
+                (ENGINE / "migrations").glob("*.sql")
+            ):
+                if (
+                    later_migration.name
+                    > "0222_reseed_sprint_pln_disposition_verbs.sql"
+                ):
+                    con.executescript(later_migration.read_text())
+
+            parsed = seed_skills.parse_skill(ASSETS / "sprint_pln" / "SKILL.md")
+            row = con.execute(
+                "SELECT description,category,command,common,content,is_deleted "
+                "FROM skills WHERE name='sprint_pln'"
             ).fetchone()
             self.assertEqual(
                 (
@@ -1370,6 +1431,7 @@ class SprintSkillTest(unittest.TestCase):
             "decline",
             "complete-unit",
             "cancel-unit",
+            "resolve-unit",
             "register-pr",
             "reconcile-pr",
             "pause",

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -1294,6 +1294,268 @@ class LiveReplanningTest(SprintDomainCase):
             units.recall(sprint_id, work_unit_id, 3, reason="unsafe rewind")
 
 
+class ResolveUnitTest(SprintDomainCase):
+    def _release_unit(self, sprint_id: int) -> int:
+        assignment_wake = self.store.arm(sprint_id, 3)[0]
+        assignment_message = int(
+            self.con.execute(
+                "SELECT message_id FROM sprint_wake_messages WHERE wake_id=?",
+                (assignment_wake,),
+            ).fetchone()[0]
+        )
+        self.con.execute(
+            "UPDATE wake_message SET delivered_at=datetime('now') "
+            "WHERE message_id=?",
+            (assignment_message,),
+        )
+        self.con.execute(
+            "UPDATE sprint_wake_outbox SET state='delivered',"
+            "delivered_at=datetime('now') WHERE wake_id=?",
+            (assignment_wake,),
+        )
+        self.con.commit()
+        sprint_message_delivery.SprintMessageStore(self.con).mark_read(
+            assignment_message, 1, sprint_id=sprint_id
+        )
+        return assignment_message
+
+    def _pause(self, sprint_id: int) -> None:
+        self.store.pause(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="Planner is restructuring the live plan",
+        )
+
+    def _bind_pr(self, sprint_id: int, work_unit_id: int) -> int:
+        owner = int(
+            self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=1",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+        registered_pr_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_registered_prs "
+                "(sprint_id,owner_participant_id,repository,pr_number) "
+                "VALUES (?,?,'acme/repo',99)",
+                (sprint_id, owner),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_pr_work_units "
+            "(sprint_id,registered_pr_id,work_unit_id) VALUES (?,?,?)",
+            (sprint_id, registered_pr_id, work_unit_id),
+        )
+        self.con.commit()
+        return registered_pr_id
+
+    def test_resolve_refuses_armed_non_planner_blank_and_bad_target(self) -> None:
+        sprint_id, work_unit_id = self.create_sprint()
+        units = sprint_domain.SprintWorkUnitStore(self.con)
+        with self.assertRaisesRegex(ValueError, "must be completed or cancelled"):
+            units.resolve(sprint_id, work_unit_id, 3, target="blocked", reason="x")
+        with self.assertRaisesRegex(ValueError, "resolution reason is required"):
+            units.resolve(sprint_id, work_unit_id, 3, target="completed", reason=" ")
+        self.store.arm(sprint_id, 3)
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "resolved only while the Sprint is paused",
+        ):
+            units.resolve(
+                sprint_id, work_unit_id, 3, target="completed", reason="too early"
+            )
+        self._pause(sprint_id)
+        with self.assertRaisesRegex(
+            sprint_domain.SprintAuthorityError, "only the originating Planner"
+        ):
+            units.resolve(
+                sprint_id, work_unit_id, 4, target="completed", reason="intruder"
+            )
+        self.assertEqual(
+            "ready",
+            self.con.execute(
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (work_unit_id,),
+            ).fetchone()[0],
+        )
+
+    def test_resolve_completed_supersedes_pr_link_and_notifies(self) -> None:
+        sprint_id, work_unit_id = self.create_sprint()
+        assignment_message = self._release_unit(sprint_id)
+        registered_pr_id = self._bind_pr(sprint_id, work_unit_id)
+        self._pause(sprint_id)
+
+        units = sprint_domain.SprintWorkUnitStore(self.con)
+        changed = units.resolve(
+            sprint_id,
+            work_unit_id,
+            3,
+            target="completed",
+            reason="PR #99 merged while the Sprint was paused",
+        )
+
+        self.assertTrue(changed)
+        unit = self.con.execute(
+            "SELECT disposition,completion_result,completion_source,completed_at "
+            "FROM sprint_work_units WHERE work_unit_id=?",
+            (work_unit_id,),
+        ).fetchone()
+        self.assertEqual(
+            (
+                "completed",
+                "PR #99 merged while the Sprint was paused",
+                "planner_override",
+                unit["completed_at"],
+            ),
+            tuple(unit),
+        )
+        self.assertIsNotNone(unit["completed_at"])
+        link = self.con.execute(
+            "SELECT superseded_at FROM sprint_pr_work_units "
+            "WHERE registered_pr_id=? AND work_unit_id=?",
+            (registered_pr_id, work_unit_id),
+        ).fetchone()
+        self.assertIsNotNone(link["superseded_at"])
+        self.assertIsNotNone(
+            self.con.execute(
+                "SELECT 1 FROM sprint_registered_prs WHERE registered_pr_id=?",
+                (registered_pr_id,),
+            ).fetchone(),
+            "resolution retains the PR registration",
+        )
+        self.assertEqual(
+            "accepted",
+            self.con.execute(
+                "SELECT disposition FROM wake_message WHERE message_id=?",
+                (assignment_message,),
+            ).fetchone()[0],
+            "the accepted assignment is history, not rewritten",
+        )
+        event = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='planner_override'",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual(
+            {
+                "after": "completed",
+                "before": "active",
+                "pr_numbers": [99],
+                "reason": "PR #99 merged while the Sprint was paused",
+                "retired_message_ids": [assignment_message],
+                "work_unit_id": work_unit_id,
+            },
+            event,
+        )
+        notices = self.con.execute(
+            "SELECT to_participant_id,body FROM wake_message "
+            "WHERE idempotency_key LIKE 'planner-override:%' "
+            "ORDER BY to_participant_id",
+            (),
+        ).fetchall()
+        recipients = {
+            int(row["participant_id"])
+            for row in self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND role IN ('developer','reviewer')",
+                (sprint_id,),
+            )
+        }
+        self.assertEqual(recipients, {int(row[0]) for row in notices})
+        for notice in notices:
+            self.assertIn("from active to completed", notice["body"])
+            self.assertIn("PR #99 merged", notice["body"])
+
+    def test_resolve_cancelled_keeps_pr_and_leaves_completion_source(self) -> None:
+        sprint_id, work_unit_id = self.create_sprint()
+        self._release_unit(sprint_id)
+        registered_pr_id = self._bind_pr(sprint_id, work_unit_id)
+        self._pause(sprint_id)
+
+        changed = sprint_domain.SprintWorkUnitStore(self.con).resolve(
+            sprint_id,
+            work_unit_id,
+            3,
+            target="cancelled",
+            reason="lane abandoned; the registered PR keeps its history",
+        )
+
+        self.assertTrue(changed)
+        unit = self.con.execute(
+            "SELECT disposition,completion_source FROM sprint_work_units "
+            "WHERE work_unit_id=?",
+            (work_unit_id,),
+        ).fetchone()
+        self.assertEqual(("cancelled", None), tuple(unit))
+        self.assertIsNotNone(
+            self.con.execute(
+                "SELECT superseded_at FROM sprint_pr_work_units "
+                "WHERE registered_pr_id=?",
+                (registered_pr_id,),
+            ).fetchone()[0]
+        )
+
+    def test_resolve_replay_and_terminal_conflicts(self) -> None:
+        sprint_id, work_unit_id = self.create_sprint()
+        self._release_unit(sprint_id)
+        self._pause(sprint_id)
+        units = sprint_domain.SprintWorkUnitStore(self.con)
+        self.assertTrue(
+            units.resolve(
+                sprint_id, work_unit_id, 3, target="completed", reason="done"
+            )
+        )
+
+        self.assertFalse(
+            units.resolve(
+                sprint_id, work_unit_id, 3, target="completed", reason="done"
+            )
+        )
+        self.assertEqual(
+            (1, 2),
+            tuple(
+                self.con.execute(
+                    "SELECT "
+                    "(SELECT COUNT(*) FROM sprint_events "
+                    "WHERE event_type='planner_override'),"
+                    "(SELECT COUNT(*) FROM wake_message "
+                    "WHERE idempotency_key LIKE 'planner-override:%')"
+                ).fetchone()
+            ),
+            "replay returns the prior result without new evidence",
+        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintConflictError, "already completed"
+        ):
+            units.resolve(
+                sprint_id, work_unit_id, 3, target="completed", reason="different"
+            )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintConflictError, "already completed"
+        ):
+            units.resolve(sprint_id, work_unit_id, 3, target="cancelled", reason="done")
+
+    def test_resolve_conflicts_with_externally_completed_unit(self) -> None:
+        sprint_id, work_unit_id = self.create_sprint()
+        self.store.arm(sprint_id, 3)
+        self._pause(sprint_id)
+        units = sprint_domain.SprintWorkUnitStore(self.con)
+        units.recall(sprint_id, work_unit_id, 3, reason="return to plan")
+        self.assertTrue(
+            units.cancel(sprint_id, work_unit_id, 3, reason="scope dropped")
+        )
+
+        with self.assertRaisesRegex(
+            sprint_domain.SprintConflictError, "already cancelled"
+        ):
+            units.resolve(
+                sprint_id, work_unit_id, 3, target="cancelled", reason="scope dropped"
+            )
+
+
 class LifecycleTest(SprintDomainCase):
     def test_sprint_insert_must_start_prepared(self) -> None:
         sprint_id, _ = self.create_sprint()


### PR DESCRIPTION
Spec #161 / feature #57. Links #1220.

The originating Planner can now always move a non-terminal work unit to a terminal disposition, and can reroute a participant whose route owns released PR-bound units — explicit, reasoned, paused-only, and durably audited. Closes the two observed dead ends: the dos-arch U80 incident (a `fixing` unit whose PR merged while paused had no Planner-reachable terminal path) and #1220 (rerouting a Reviewer off a PR-bound `in_review` unit was a closed loop: reroute demanded recall, recall refused PR-bound).

**`sc sprint resolve-unit --sprint <id> --work-unit <id> --to completed|cancelled --reason <text>`** (CLI + token-scoped API). Planner-only (FnB proxy permitted), paused-only, non-blank reason. Any non-terminal source disposition accepted, including PR-bound. One transaction: disposition to target; retirement of the unit's open route expectations; superseding of its `sprint_pr_work_units` links (rows retained with `superseded_at`, and every lane driver — PR watcher routing, merge completion, resume reconciliation — reads only active links); a `planner_override` Sprint event with actor, before/after, reason, and PR numbers; wakes to the assigned Developer and Reviewer. `--to completed` records `completion_source='planner_override'` and fabricates no merge observation. Idempotent: same unit+target+reason replays the prior result; a terminal unit with a different target/reason returns 409.

**Reroute relaxation**: `reroute-participant` no longer refuses solely because the participant owns released PR-bound units. When every blocking open expectation belongs to that participant's own route, the reroute retires those expectations and queues fresh ones on the new route — a fresh review request at the same PR head for `in_review`, a fresh assignment for `active`/`fixing`. Units, dispositions, PR links, and review history are not rewritten. Other seats' expectations still block.

Also: the merge-bypass notice now names the remedy (`sc sprint resolve-unit --to completed|cancelled`) instead of the verb-less "requires Planner disposition"; the `sprint_pln` skill documents both verbs beside recall/replan (two-artifact commit with reseed migration 0222); migration 0221 adds `sprint_pr_work_units.superseded_at` + `sprint_work_units.completion_source`.

Tests: U80 replay (paused `fixing` lane, PR merged → resolve to completed; watcher stops driving it; sprint completes), #1220 replay (paused PR-bound `in_review` → reroute succeeds, old review generation retired, fresh review request delivers on the new route), cross-seat refusal, distinct refusal errors (armed / terminal / blank reason / non-Planner), and the raw-SQL workaround in `test_sprint_review_loop.py` replaced with the real verb. Full suite: 2634 passed, 2 skipped.

Note on migration numbering: 0220 is claimed by #1242 (in review); this branch uses 0221/0222. The ledger keys by filename and both migrations are independent of #1242's, so merge order is safe either way.