### PR TITLE
feat(models): bind-time effort fallback chain high → Model default

### DIFF
--- a/.super-coder/api/route_bindings.py
+++ b/.super-coder/api/route_bindings.py
@@ -913,17 +913,22 @@ def _resolve_v2(
         validate_v2_binding(binding)
         return binding, digest_json(binding)
 
-    requested = "high" if effort is None else effort.strip()
-    if harness == "opencode":
-        requested = _ascii_lower(requested)
-    else:
-        requested = requested.lower()
-    if not requested:
-        raise RouteResolutionError(
-            "unsupported_thinking_level",
-            "Thinking level must be non-blank",
-            {"harness": harness, "model": model},
-        )
+    # Decision #223: an omitted effort is resolved against the route's
+    # advertised levels below (high where advertised, else Model default);
+    # only an explicitly supplied effort is normalized and validated here.
+    requested: str | None = None
+    if effort is not None:
+        requested = effort.strip()
+        if harness == "opencode":
+            requested = _ascii_lower(requested)
+        else:
+            requested = requested.lower()
+        if not requested:
+            raise RouteResolutionError(
+                "unsupported_thinking_level",
+                "Thinking level must be non-blank",
+                {"harness": harness, "model": model},
+            )
     if row is None:
         raise RouteResolutionError(
             "thinking_evidence_missing",
@@ -971,6 +976,12 @@ def _resolve_v2(
     _require_controlled_source(row, harness, model, runtime, proof)
 
     supported, effort_metadata = _supported_efforts(row)
+    if requested is None:
+        # Decision #223 bind-time fallback chain: omitted/unselected effort
+        # on a controlled exact route resolves high where advertised, else
+        # the reserved Model default (no effort transport) — every exact
+        # model stays bindable even with no thinking support.
+        requested = "high" if "high" in supported else DEFAULT_EFFORT
     if requested == DEFAULT_EFFORT:
         # Model default: the exact-model evidence, freshness, runtime, and
         # source gates above still apply; only the effort-value membership and

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -700,18 +700,10 @@ def set_flavor_default(con, body) -> tuple[bool, dict | None]:
                 and effort not in supported
                 and effort != route_bindings.DEFAULT_EFFORT
             ):
-                effort = "high" if "high" in supported else None
-                if effort is None:
-                    return False, _flavor_default_error(
-                        "unsupported_thinking_level",
-                        "Select an explicit supported Thinking level before "
-                        "saving this model",
-                        {"harness": harness, "model": model,
-                         "requested_effort": None,
-                         "supported_efforts": supported,
-                         "default_effort": route_bindings.DEFAULT_EFFORT,
-                         "remediation": "select a supported Thinking level or "
-                         "'default' (Model default)"})
+                # Decision #223: omitted/unselected effort is resolved by the
+                # bind-time chain in _resolve_v2 (high where advertised, else
+                # Model default) — no hard 422 for unadvertised omitted-high.
+                effort = None
             try:
                 route_proof = route_bindings._probe_controlled_route(
                     harness, model)

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -435,8 +435,15 @@ function thinkingLevelState(harness, catalog, model, preferred = null) {
   ];
   const fresh = Boolean(
     route && route.availability === "available" && !catalog.stale);
+  // Decision #223: preselect the bind-time fallback chain — a stored effort
+  // (manual override) wins, then high where advertised, then the reserved
+  // Model default; no selection only when nothing is advertised.  Options
+  // stay listed whenever the route advertises any levels.
   const selected = supported.includes(preferred)
-    ? preferred : supported.includes("high") ? "high" : "";
+    ? preferred
+    : supported.includes("high")
+      ? "high"
+      : supported.includes("default") ? "default" : "";
   const support = route?.harness_support_state
     ? ` Support: ${route.harness_support_state}`
       + (route.harness_version ? ` (${route.harness_version}).` : ".")

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -804,6 +804,37 @@ class FlavorDefaultsTest(unittest.TestCase):
         self.assertEqual(err["details"]["default_effort"], "default")
         self.assertEqual(self._row("planner", "codex")["effort"], "default")
 
+    def test_omitted_effort_resolves_by_fallback_chain(self) -> None:
+        # Decision #223: saving a model without an effort resolves high where
+        # advertised, else the reserved Model default — no more hard 422 on
+        # unadvertised omitted-high, so no-thinking models save and bind.
+        self._route("claude", "opus")
+        ok, err = server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "claude",
+                       "model": "opus"})
+        self.assertTrue(ok, err)
+        self.assertEqual(self._row("planner", "claude")["effort"], "high")
+
+        self._route("codex", "gpt-plain", efforts=())
+        ok, err = server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "codex",
+                       "model": "gpt-plain"})
+        self.assertTrue(ok, err)
+        row = self._row("planner", "codex")
+        self.assertEqual((row["model"], row["effort"]), ("gpt-plain", "default"))
+        projection = server.get_flavor_defaults(self.con)["flavors"]["planner"]
+        by_harness = {r["harness"]: r for r in projection}
+        self.assertEqual(by_harness["codex"]["effort_state"], "controlled")
+        self.assertEqual(by_harness["codex"]["effective_effort"], "default")
+
+        # A no-high route with named levels also resolves to Model default.
+        self._route("codex", "gpt-lowonly", efforts=("low",))
+        ok, err = server.set_flavor_default(
+            self.con, {"flavor": "planner", "harness": "codex",
+                       "model": "gpt-lowonly"})
+        self.assertTrue(ok, err)
+        self.assertEqual(self._row("planner", "codex")["effort"], "default")
+
     def test_unsupported_effort_writes_nothing(self) -> None:
         before = tuple(self._row("planner", "claude"))
         self._route("claude", "opus-next")

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -642,10 +642,11 @@ class RoutePersistenceTest(unittest.TestCase):
              "gpt-5.6-sol", "--effort", "high"])
 
     def test_empty_effort_list_alias_admits_only_model_default(self):
-        # Spec #160: an alias that declares no effort list persists
-        # supported_efforts=[]; the reserved 'default' still binds (no effort
-        # transport), while every named level — explicit or the omitted-effort
-        # 'high' rule — keeps failing membership.
+        # Spec #160 + decision #223: an alias that declares no effort list
+        # persists supported_efforts=[]; the reserved 'default' still binds
+        # (no effort transport), omitted effort falls back to it through the
+        # bind-time chain, and every explicit named level keeps failing
+        # membership.
         fresh = {"fetched_at": datetime.now(timezone.utc).isoformat(), "stale": False,
                  "harnesses": {"kimi": {"models": [mc._entry(
                      "kimi-code/legacy", source="kimi-config",
@@ -687,11 +688,14 @@ class RoutePersistenceTest(unittest.TestCase):
              "kimi-code/legacy", "--effort", "default"])
         self.assertEqual(
             route_bindings.digest_json(binding), bound["binding_digest"])
-        for rejected in (named, omitted):
-            self.assertFalse(rejected["ok"])
-            self.assertEqual(rejected["code"], "unsupported_thinking_level")
-            self.assertEqual(
-                rejected["details"]["default_effort"], "default")
+        # Decision #223: the omitted effort resolves to the reserved Model
+        # default with the exact identity of an explicit 'default'.
+        self.assertTrue(omitted["ok"])
+        self.assertEqual(omitted["binding"], binding)
+        self.assertEqual(omitted["binding_digest"], bound["binding_digest"])
+        self.assertFalse(named["ok"])
+        self.assertEqual(named["code"], "unsupported_thinking_level")
+        self.assertEqual(named["details"]["default_effort"], "default")
         self.assertEqual(named["details"]["requested_effort"], "high")
 
     def test_default_binds_alongside_advertised_named_efforts(self):

--- a/tests/test_route_bindings.py
+++ b/tests/test_route_bindings.py
@@ -262,6 +262,58 @@ class BindingIdentityTest(unittest.TestCase):
         self.assertEqual(implicit["evidence_digest"], "4" * 64)
         self.assertEqual(implicit["control_state"], "controlled")
 
+    def test_controlled_omitted_effort_falls_back_to_model_default(self):
+        # Decision #223: omitted effort on a controlled exact route resolves
+        # high where advertised, else the reserved Model default — so a route
+        # without high still binds instead of raising unsupported_thinking_level.
+        runtime = compatible_runtime("0.145.0", harness="codex")
+        no_high = self.controlled_row(
+            supported_efforts='["low","medium"]',
+            effort_metadata=json.dumps({
+                "supported": ["low", "medium"],
+                "default": None,
+                "digests": {"low": "3" * 64, "medium": "6" * 64},
+                "native_variant_ids": {},
+            }),
+        )
+        binding, _ = resolve_controlled_v2(
+            no_high, "codex", "gpt-test", now=self.NOW,
+            runtime_status=runtime,
+        )
+        self.assertEqual(binding["requested_effort"], "default")
+        self.assertEqual(binding["effective_effort"], "default")
+        self.assertIsNone(binding["evidence_digest"])
+        self.assertIsNone(binding["native_variant_id"])
+
+        # A no-thinking route binds through the same chain with the same
+        # identity as an explicit Model default.
+        empty = self.controlled_row(
+            supported_efforts="[]",
+            effort_metadata=json.dumps({
+                "supported": [], "default": None,
+                "digests": {}, "native_variant_ids": {},
+            }),
+        )
+        omitted, omitted_digest = resolve_controlled_v2(
+            empty, "codex", "gpt-test", now=self.NOW,
+            runtime_status=runtime,
+        )
+        explicit, explicit_digest = resolve_controlled_v2(
+            empty, "codex", "gpt-test", "default", now=self.NOW,
+            runtime_status=runtime,
+        )
+        self.assertEqual(omitted["requested_effort"], "default")
+        self.assertEqual(omitted, explicit)
+        self.assertEqual(omitted_digest, explicit_digest)
+
+        # An explicitly stored unadvertised level still fails closed.
+        with self.assertRaises(route_bindings.RouteResolutionError) as raised:
+            resolve_controlled_v2(
+                empty, "codex", "gpt-test", "high", now=self.NOW,
+                runtime_status=runtime,
+            )
+        self.assertEqual(raised.exception.code, "unsupported_thinking_level")
+
     def test_model_default_bypasses_only_the_effort_value_gates(self):
         row = self.controlled_row(
             supported_efforts="[]",

--- a/tests/test_shells_ui_contract.py
+++ b/tests/test_shells_ui_contract.py
@@ -47,12 +47,14 @@ const catalog = {stale: false, harnesses: {codex: {models: [
   {id: "gpt-high", availability: "available", supported_efforts: ["low", "high"],
    harness_support_state: "tested", harness_version: "codex-cli 0.147.0"},
   {id: "gpt-explicit", availability: "available", supported_efforts: ["low", "medium"]},
+  {id: "gpt-plain", availability: "available", supported_efforts: []},
 ]}}};
 console.log(JSON.stringify({
   controlled: thinkingLevelState("codex", catalog, "gpt-high", "low"),
   defaulted: thinkingLevelState("codex", catalog, "gpt-high", null),
   explicit: thinkingLevelState("codex", catalog, "gpt-explicit", null),
   modelDefault: thinkingLevelState("codex", catalog, "gpt-explicit", "default"),
+  noThinking: thinkingLevelState("codex", catalog, "gpt-plain", null),
   harnessDefault: thinkingLevelState("codex", catalog, null, null),
   vibe: thinkingLevelState("vibe", catalog, "devstral", null),
   stale: thinkingLevelState("codex", {...catalog, stale: true}, "gpt-high", "high"),
@@ -63,9 +65,15 @@ console.log(JSON.stringify({
     assert result["controlled"]["supported"] == ["default", "low", "high"]
     assert result["defaulted"]["selected"] == "high"
     assert "Support: tested (codex-cli 0.147.0)" in result["defaulted"]["guidance"]
-    assert result["explicit"]["selected"] == ""
+    # Decision #223: with no stored preference the selector preselects the
+    # bind-time chain — high where advertised, else Model default.
+    assert result["explicit"]["selected"] == "default"
+    assert result["explicit"]["label"] == "Model default"
     assert result["explicit"]["disabled"] is False
     assert result["explicit"]["supported"] == ["default", "low", "medium"]
+    assert result["noThinking"]["selected"] == "default"
+    assert result["noThinking"]["disabled"] is False
+    assert result["noThinking"]["supported"] == ["default"]
     assert result["modelDefault"]["selected"] == "default"
     assert result["modelDefault"]["label"] == "Model default"
     assert "model-default" in result["modelDefault"]["guidance"]


### PR DESCRIPTION
Re-land of #1244, which merged into its stacked base `feat/model-default-effort` instead of `main` (base was not retargeted after #1242 merged). Same change, cherry-picked onto current `main` (`ab06388`).

Implements flag #413 / decision #223.

**Contract (decision #223):** omitted/unselected effort on a controlled exact route resolves at bind time by the chain **high where advertised → reserved `default` (Model default, no effort transport)**. An explicitly stored effort is a manual override that always wins and still requires advertised evidence. Runtime dispatch stays fail-closed (#208); the chain applies at bind/save resolution only. Amends spec #160 clause 1 and spec #149 clause 3's hard 422 on unadvertised omitted-high.

**Changes:**
- `route_bindings._resolve_v2` — omitted effort is resolved after the route's advertised levels are known: `high` where advertised, else `DEFAULT_EFFORT`. Explicit efforts keep the existing normalize + membership/digest gates (fail-closed).
- `server.set_flavor_default` — omitted (or previously stored but now unadvertised) effort defers to the chain instead of returning the `unsupported_thinking_level` 422. No-thinking models save and bind.
- UI `thinkingLevelState` — both selectors (Default Models matrix, chat-new) preselect the same chain: stored preference → `high` → Model default. Options remain listed whenever the route advertises levels; the no-selection "Choose Thinking level" state survives only as a guard.

**Tests:**
- `test_route_bindings.py`: omitted on no-high route binds as `default`; no-thinking route binds with identity identical to explicit `default`; explicit unadvertised level still fails closed.
- `test_api_endpoints.py`: save with omitted effort stores `high` where advertised, `default` on empty and no-high routes.
- `test_model_catalog.py`: empty-effort-list alias — omitted resolve now binds as `default` (was rejected), explicit named level still rejected.
- `test_shells_ui_contract.py`: selector chain matrix updated + no-thinking model case.

Full suite green on the stacked base (2635 passed, 2 skipped); targeted files re-run green on this base (163 passed).