### PR TITLE
feat(boot): LIMITS section — surface blockers instead of grinding

### DIFF
--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -79,6 +79,18 @@ is a ceiling, not a target: with curation running you sit near 12–14.
 
 ---
 
+## LIMITS
+
+Investigate first — check your skills, the repo map, the docs. But if the
+task requires a skill, tooling, or authority not granted to you, or a rule
+here directs you not to do it, or you are still blocked after a real
+attempt: surface it in chat. Name what's missing or forbidden and what it
+blocks; you may propose a work-around, but never silently substitute one.
+A surfaced blocker is a task half-done — grinding a session against a
+capability you were never granted is worse than stopping early.
+
+---
+
 ## ORIENTATION
 
 Find things by querying the repo map — the `dr_*` tables in `.sc-state/map.db`

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -81,13 +81,16 @@ is a ceiling, not a target: with curation running you sit near 12–14.
 
 ## LIMITS
 
-Investigate first — check your skills, the repo map, the docs. But if the
-task requires a skill, tooling, or authority not granted to you, or a rule
-here directs you not to do it, or you are still blocked after a real
-attempt: surface it in chat. Name what's missing or forbidden and what it
-blocks; you may propose a work-around, but never silently substitute one.
-A surfaced blocker is a task half-done — grinding a session against a
-capability you were never granted is worse than stopping early.
+Be proactive — chase the task, don't wait to be told each step. But
+proactivity has a stopping condition. Investigate first — check your
+skills, the repo map, the docs — and if the task requires a skill,
+tooling, or authority not granted to you, or a rule here directs you not
+to do it, or you are still blocked after a real attempt: the proactive
+move is to surface it in chat, not to keep digging. Name what's missing
+or forbidden and what it blocks; you may propose a work-around, but never
+silently substitute one. A surfaced blocker is a task half-done — grinding
+a session against a capability you were never granted isn't thoroughness,
+it's thrash.
 
 ---
 


### PR DESCRIPTION
Adds a short **LIMITS** section to `.super-coder/templates/boot.md`, placed after LAWS (foundational/behavioral, before the navigational sections).

## Why
Motivated by a live incident: a local-model (Qwen, via OpenCode) admin shell was asked to do a flag sweep, didn't have the flag-sweep skill, and burned ~32k tokens trying to figure it out instead of surfacing the gap. The boot doc already has instance-specific versions of this rule (API unreachable → surface to the FnB; map wrong → report it) but no general directive, so novel cases fall through to the shell's default 'be helpful' bias.

The harness (OpenCode) prompt tells models to be proactive — this section is written to **align with that drive, not contradict it**.

## What it says
- **Be proactive** — chase the task, don't wait to be told each step. Stated first so the section reads as guidance *within* proactivity, not a brake on it.
- **Proactivity has a stopping condition** — investigate first (skills, repo map, docs), but if the task needs a skill, tooling, or authority not granted, a boot rule forbids it, or a real attempt leaves it blocked:
- **Surfacing IS the proactive move** — not a retreat from proactivity. Name what's missing and what it blocks; a work-around may be proposed, never silently substituted.
- Closing line names the failure mode: grinding against an ungranted capability isn't thoroughness, it's thrash.

## Verification
`tests/test_boot_project_vs_engine.py` + `tests/test_fresh_install_shell_contract.py` pass (12/12); no test asserts on boot-doc headings.