### PR TITLE
feat(boot): conversation boot snapshots — bind, restore, and lifecycle contracts

### DIFF
--- a/.super-coder/migrations/0224_conversation_boot_snapshots.sql
+++ b/.super-coder/migrations/0224_conversation_boot_snapshots.sql
@@ -1,0 +1,47 @@
+-- Feature #24 / spec #163 — one immutable boot snapshot per conversation.
+--
+-- Every durable browser conversation binds exactly one boot-document snapshot
+-- before its first native harness session starts. The row stores the canonical
+-- UTF-8 content plus its SHA-256 digest and byte length so later turns and
+-- closed-chat reopens restore exact bytes without recomposing live shell
+-- state. Conversations created before this migration stay unbound; the broker
+-- binds them once as 'legacy_first_resume' on their first post-upgrade
+-- dispatch.
+--
+-- The snapshot is immutable: no UPDATE and no direct DELETE. The row leaves
+-- only through the owning conversation's retention/delete cascade.
+
+BEGIN;
+
+CREATE TABLE conversation_boot_snapshots (
+    conversation_id     TEXT PRIMARY KEY
+                        REFERENCES conversations(conversation_id)
+                        ON DELETE CASCADE,
+    content             TEXT NOT NULL
+                        CHECK (length(CAST(content AS BLOB))
+                               BETWEEN 1 AND 1048576),
+    content_sha256      TEXT NOT NULL
+                        CHECK (length(content_sha256)=64
+                          AND content_sha256 NOT GLOB '*[^0-9a-f]*'),
+    content_bytes       INTEGER NOT NULL
+                        CHECK (content_bytes > 0
+                          AND content_bytes <= 1048576
+                          AND content_bytes = length(CAST(content AS BLOB))),
+    format_version      INTEGER NOT NULL CHECK (format_version > 0),
+    binding_origin      TEXT NOT NULL
+                        CHECK (binding_origin IN
+                            ('new_conversation','legacy_first_resume')),
+    bound_at            TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- A bound snapshot is immutable: the committed bytes, digest, origin, and
+-- binding time never change. SQLite fires BEFORE DELETE triggers even for
+-- cascade deletes, so deletion is guarded only by conversation ownership and
+-- rides the ON DELETE CASCADE lifecycle.
+CREATE TRIGGER trg_conversation_boot_snapshots_immutable
+BEFORE UPDATE ON conversation_boot_snapshots
+BEGIN
+  SELECT RAISE(ABORT, 'conversation boot snapshot is immutable');
+END;
+
+COMMIT;

--- a/.super-coder/scripts/conversation_boot.py
+++ b/.super-coder/scripts/conversation_boot.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Conversation boot snapshots — one immutable boot document per browser chat.
+
+Spec #163 / decision #224: a durable browser conversation binds exactly one
+boot-document snapshot before its first native harness session starts. Every
+later turn and every closed-chat reopen restores those exact bytes; only a new
+conversation composes fresh boot content. This module is the seam that owns
+binding, validation, and restoration; ``run.prepare_launch`` keeps every other
+per-turn preparation (liveness, worktree, route, environment, archive, skills,
+adapter configuration, permissions) on its current cadence.
+
+Ownership rules:
+- Composition and filesystem work happen outside conversation write
+  transactions; binding is one short compare-and-set transaction. A concurrent
+  winner is authoritative — the loser discards its candidate.
+- A stored row whose digest or byte count disagrees is an invariant failure:
+  fail closed before native dispatch, never repair in place.
+- Conversations that predate the 0224 migration bind once on first
+  post-upgrade dispatch with origin ``legacy_first_resume``; a missing snapshot
+  on a newer conversation is ``BOOT_SNAPSHOT_MISSING``, not a legacy case.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+BOOT_FILES = ("CLAUDE.md", "AGENTS.md")
+FORMAT_VERSION = 1
+MAX_CONTENT_BYTES = 1048576
+MIGRATION_FILENAME = "0224_conversation_boot_snapshots.sql"
+
+PHASE_START = "start"
+PHASE_RESUME = "resume"
+
+
+class BootSnapshotError(RuntimeError):
+    """Stable pre-dispatch refusal owned by boot snapshot integrity."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}")
+
+
+@dataclass(frozen=True)
+class BootDirective:
+    """Explicit launch mode: which conversation this launch belongs to and
+    whether it starts a new native session or resumes an existing one."""
+
+    conversation_id: str
+    phase: str
+
+    def __post_init__(self) -> None:
+        if self.phase not in (PHASE_START, PHASE_RESUME):
+            raise ValueError(f"unknown boot phase {self.phase!r}")
+        if not self.conversation_id:
+            raise ValueError("boot directive requires a conversation id")
+
+
+def content_digest(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _validate_row(row: sqlite3.Row, conversation_id: str) -> dict:
+    snapshot = dict(row)
+    content = snapshot["content"]
+    data = content.encode("utf-8")
+    if (
+        not data
+        or len(data) > MAX_CONTENT_BYTES
+        or snapshot["content_bytes"] != len(data)
+        or snapshot["content_sha256"] != hashlib.sha256(data).hexdigest()
+        or int(snapshot["format_version"]) <= 0
+    ):
+        raise BootSnapshotError(
+            "BOOT_SNAPSHOT_CORRUPT",
+            f"stored boot snapshot for conversation {conversation_id} "
+            "fails digest/byte validation; refusing native dispatch",
+        )
+    return snapshot
+
+
+def load_snapshot(
+    con: sqlite3.Connection, conversation_id: str
+) -> "dict | None":
+    """Read and validate the committed snapshot, or None when unbound."""
+    row = con.execute(
+        "SELECT conversation_id,content,content_sha256,content_bytes,"
+        "format_version,binding_origin,bound_at "
+        "FROM conversation_boot_snapshots WHERE conversation_id=?",
+        (conversation_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return _validate_row(row, conversation_id)
+
+
+def _snapshot_cutover(con: sqlite3.Connection) -> "str | None":
+    """When the 0224 migration was applied, per the migration ledger.
+
+    A missing ledger cannot disprove pre-migration provenance, so it degrades
+    to legacy; a real engine DB always stamps the ledger when applying."""
+    try:
+        row = con.execute(
+            "SELECT applied_at FROM schema_migrations WHERE filename=?",
+            (MIGRATION_FILENAME,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    return str(row[0]) if row else None
+
+
+def _is_legacy(con: sqlite3.Connection, conversation_id: str) -> bool:
+    cutover = _snapshot_cutover(con)
+    if cutover is None:
+        return True
+    created_at = con.execute(
+        "SELECT created_at FROM conversations WHERE conversation_id=?",
+        (conversation_id,),
+    ).fetchone()[0]
+    return str(created_at) < cutover
+
+
+def bind_snapshot(
+    con: sqlite3.Connection,
+    conversation_id: str,
+    content: str,
+    origin: str,
+) -> dict:
+    """Commit one snapshot compare-and-set; return the authoritative row.
+
+    Exactly one contender wins the insert; every other caller reads back the
+    committed winner and validates it instead of overwriting it. The caller's
+    candidate is discarded whenever a row already exists."""
+    data = content.encode("utf-8")
+    if not data or len(data) > MAX_CONTENT_BYTES:
+        raise BootSnapshotError(
+            "BOOT_SNAPSHOT_UNBINDABLE",
+            "composed boot content is empty or exceeds the 1 MiB bound",
+        )
+    own_transaction = not con.in_transaction
+    if own_transaction:
+        con.execute("BEGIN IMMEDIATE")
+    try:
+        con.execute(
+            "INSERT OR IGNORE INTO conversation_boot_snapshots "
+            "(conversation_id,content,content_sha256,content_bytes,"
+            "format_version,binding_origin) VALUES (?,?,?,?,?,?)",
+            (
+                conversation_id,
+                content,
+                hashlib.sha256(data).hexdigest(),
+                len(data),
+                FORMAT_VERSION,
+                origin,
+            ),
+        )
+        row = con.execute(
+            "SELECT conversation_id,content,content_sha256,content_bytes,"
+            "format_version,binding_origin,bound_at "
+            "FROM conversation_boot_snapshots WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()
+        if own_transaction:
+            con.commit()
+    except Exception:
+        if own_transaction:
+            con.rollback()
+        raise
+    if row is None:
+        raise BootSnapshotError(
+            "BOOT_SNAPSHOT_BIND_FAILED",
+            f"no boot snapshot committed for conversation {conversation_id}",
+        )
+    return _validate_row(row, conversation_id)
+
+
+def resolve_boot(
+    con: sqlite3.Connection,
+    directive: "BootDirective | None",
+    compose: Callable[[], str],
+) -> str:
+    """Resolve the exact boot bytes for this launch.
+
+    No directive (interactive CLI, legacy callers): compose fresh, exactly the
+    historical behavior. ``start``: reuse an already-committed snapshot (retry
+    and race losers), else compose once and bind. ``resume``: never compose
+    while a snapshot is stored; an unbound pre-migration conversation binds
+    once as ``legacy_first_resume``, anything newer fails closed."""
+    if directive is None:
+        return compose()
+
+    existing = load_snapshot(con, directive.conversation_id)
+    if existing is not None:
+        return str(existing["content"])
+
+    if directive.phase == PHASE_RESUME and not _is_legacy(
+        con, directive.conversation_id
+    ):
+        raise BootSnapshotError(
+            "BOOT_SNAPSHOT_MISSING",
+            f"conversation {directive.conversation_id} was created after the "
+            "boot snapshot migration but has no stored snapshot",
+        )
+
+    origin = (
+        "legacy_first_resume"
+        if _is_legacy(con, directive.conversation_id)
+        else "new_conversation"
+    )
+    candidate = compose()
+    winner = bind_snapshot(con, directive.conversation_id, candidate, origin)
+    return str(winner["content"])
+
+
+def write_boot_files(work_dir: Path, content: str) -> None:
+    """Materialize the resolved bytes into CLAUDE.md and AGENTS.md.
+
+    When both files already hold exactly these bytes, skip the writes entirely
+    so a resumed conversation's artifacts stay untouched (mtime included).
+    When either differs — a different chat or an external lifecycle replaced
+    them — restore both atomically."""
+    data = content.encode("utf-8")
+    targets = [work_dir / name for name in BOOT_FILES]
+    if all(t.is_file() and t.read_bytes() == data for t in targets):
+        return
+    for target in targets:
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_bytes(data)
+        os.replace(tmp, target)

--- a/.super-coder/scripts/conversation_launch.py
+++ b/.super-coder/scripts/conversation_launch.py
@@ -13,6 +13,7 @@ import route_transport
 import run as run_mod
 import shell_liveness
 from conversation_adapters import ConversationContext
+from conversation_boot import BootDirective, BootSnapshotError
 
 class ConversationLaunchError(RuntimeError):
     """Stable pre-dispatch refusal owned by browser conversation launching."""
@@ -28,8 +29,11 @@ class ConversationLaunchPreparer:
 
     ``run.prepare_launch`` is intentionally reused without executing its argv:
     native conversation adapters own dispatch and streaming, while the normal
-    CLI path remains the source of truth for shell identity, worktree, rendered
-    boot files, harness permissions, session archives, and injected environment.
+    CLI path remains the source of truth for shell identity, worktree,
+    harness permissions, session archives, and injected environment. The boot
+    document is the one exception (spec #163): the directive handed down names
+    the conversation and its start/resume phase, so the conversation's single
+    committed snapshot is bound or restored instead of freshly composed.
     """
 
     def __init__(
@@ -146,6 +150,17 @@ class ConversationLaunchPreparer:
                 "effort": broker_run.effort,
                 "headless_prompt": broker_run.body,
                 "current_leased_run_id": broker_run.run_id,
+                # Explicit conversation launch mode (spec #163): the broker's
+                # leased run knows whether this turn starts a new native
+                # session or resumes the persisted one; boot composition,
+                # binding, and byte restoration key off that, never off file
+                # existence.
+                "boot": BootDirective(
+                    conversation_id=broker_run.conversation_id,
+                    phase=(
+                        "resume" if broker_run.session_before else "start"
+                    ),
+                ),
             }
             if binding is not None:
                 launch_args["route_binding"] = binding
@@ -153,6 +168,10 @@ class ConversationLaunchPreparer:
             plan = self.prepare_launch(
                 **launch_args,
             )
+        except BootSnapshotError as exc:
+            # Snapshot integrity failures keep their stable code so the run
+            # record names the invariant that refused dispatch.
+            raise ConversationLaunchError(exc.code, exc.detail) from exc
         except (run_mod.LaunchError, SystemExit) as exc:
             raise ConversationLaunchError(
                 "CONVERSATION_LAUNCH_REFUSED",

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -55,6 +55,7 @@ from compose import compose_boot  # noqa: E402
 sys.path.insert(0, str(ENGINE / "scripts"))
 import artifact_policy  # noqa: E402
 import callable_floor  # noqa: E402
+import conversation_boot  # noqa: E402
 import db_driver  # noqa: E402
 import git_freshness  # noqa: E402
 import git_prune  # noqa: E402  — boot-time prune of provably-merged local branches
@@ -1185,7 +1186,9 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
                    headless_prompt: "str | None" = None,
                    current_leased_run_id: "int | None" = None,
                    route_binding: "dict | None" = None,
-                   binding_digest: "str | None" = None) -> LaunchPlan:
+                   binding_digest: "str | None" = None,
+                   boot: "conversation_boot.BootDirective | None" = None,
+                   ) -> LaunchPlan:
     """Prepare a launch exactly as main() would, without any TTY.
 
     A browser chat uses the normal harness, model, effort, permission,
@@ -1200,6 +1203,12 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
     the gate — the caller refuses before this runs), the banner/spinner/
     boot summary, tab titles, and git_prune (a hygiene sweep for human
     boots; an engine-driven pane launch must never delete branches).
+
+    ``boot`` carries an explicit conversation launch mode (spec #163): with a
+    BootDirective the boot document is the conversation's one committed
+    snapshot (bound on start, reused or restored on resume) instead of a
+    fresh composition on every call; without it, behavior is unchanged —
+    compose fresh and write on every launch.
 
     Raises LaunchError on a refusal it owns; shared helpers that predate
     this seam (open_db, authenticate, ensure_worktree) still sys.exit, so
@@ -1343,23 +1352,34 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
     floor_note = main_checkout_note(REPO_ROOT)
     work_repo_note = declared_work_repo_note(REPO_ROOT)
 
-    content = compose_boot(con, full, user, session_id, archive_id,
-                           work_dir=work_dir if work_dir != REPO_ROOT else None,
-                           sync_note=sync_note,
-                           floor_note=floor_note,
-                           work_repo_note=work_repo_note,
-                           source_mode=install.is_source_repo(),
-                           devkit_declared=(work_dir / ".subfloor" / "dev-kit.json").is_file(),
-                           devkit_repair=bool(os.environ.get("SC_DEVKIT_REPAIR")),
-                           api_key=full["api_key"],
-                           api_port=api_port,
-                           launch_mode=execution_mode())
+    content = conversation_boot.resolve_boot(
+        con,
+        boot,
+        compose=lambda: compose_boot(
+            con, full, user, session_id, archive_id,
+            work_dir=work_dir if work_dir != REPO_ROOT else None,
+            sync_note=sync_note,
+            floor_note=floor_note,
+            work_repo_note=work_repo_note,
+            source_mode=install.is_source_repo(),
+            devkit_declared=(work_dir / ".subfloor" / "dev-kit.json").is_file(),
+            devkit_repair=bool(os.environ.get("SC_DEVKIT_REPAIR")),
+            api_key=full["api_key"],
+            api_port=api_port,
+            launch_mode=execution_mode()),
+    )
     render_harness_skills(
         con, full["shell_id"], work_dir, adapter
     )
     con.close()
-    for name in ("CLAUDE.md", "AGENTS.md"):
-        atomic_write(work_dir / name, content)
+    if boot is None:
+        # Interactive/legacy launches: fresh boot doc on every launch.
+        for name in ("CLAUDE.md", "AGENTS.md"):
+            atomic_write(work_dir / name, content)
+    else:
+        # Conversation launches: exact committed bytes, untouched when the
+        # files already match, atomically restored when they do not.
+        conversation_boot.write_boot_files(work_dir, content)
 
     # Adapter seam: emitted config, plugin path resolution, always-on and
     # sandbox-only JSON merges — the same permission/config files a normal

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -121,6 +121,9 @@ PER_INSTANCE_TABLES = [
     "conversations",
     "active_shell_chats",
     "conversation_git_targets",
+    # Immutable per-conversation boot snapshot: a child of conversations that
+    # must survive rebuild with it, or every chat would rebind as legacy.
+    "conversation_boot_snapshots",
     "conversation_messages",
     "conversation_runs",
     "conversation_events",

--- a/tests/test_conversation_boot.py
+++ b/tests/test_conversation_boot.py
@@ -1,0 +1,258 @@
+"""Spec #163 conversation_boot seam: bind-once, exact reuse, restore, legacy."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import conversation_boot  # noqa: E402
+from conversation_boot import (  # noqa: E402
+    BootDirective,
+    BootSnapshotError,
+)
+
+
+MIGRATION = "0224_conversation_boot_snapshots.sql"
+
+
+def apply_schema(con: sqlite3.Connection) -> None:
+    con.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+        con.executescript(migration.read_text())
+    con.execute("PRAGMA foreign_keys=ON")
+
+
+@pytest.fixture
+def con():
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    apply_schema(connection)
+    connection.execute(
+        "INSERT INTO users (user_id,username) VALUES (1,'operator')"
+    )
+    connection.execute(
+        "INSERT INTO shells "
+        "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+        "VALUES (1,'Dev','dev1','dev','prompt',1)"
+    )
+    yield connection
+    connection.close()
+
+
+def add_conversation(
+    con: sqlite3.Connection,
+    conversation_id: str,
+    *,
+    created_at: str | None = None,
+) -> str:
+    columns = (
+        "conversation_id,shell_id,owner_user_id,harness,worktree,"
+        "creation_idempotency_key,creation_request_hash"
+    )
+    values: list = [
+        conversation_id, 1, 1, "codex", "/tmp/worktree-1",
+        f"key-{conversation_id}", f"hash-{conversation_id}",
+    ]
+    if created_at is not None:
+        columns += ",created_at"
+        values.append(created_at)
+    con.execute(
+        f"INSERT INTO conversations ({columns}) "
+        f"VALUES ({','.join('?' for _ in values)})",
+        values,
+    )
+    con.commit()
+    return conversation_id
+
+
+def stamp_migration(con: sqlite3.Connection, applied_at: str) -> None:
+    con.execute(
+        "CREATE TABLE IF NOT EXISTS schema_migrations ("
+        "  filename TEXT PRIMARY KEY,"
+        "  applied_at TEXT NOT NULL DEFAULT (datetime('now')))"
+    )
+    con.execute(
+        "INSERT OR REPLACE INTO schema_migrations (filename,applied_at) "
+        "VALUES (?,?)",
+        (MIGRATION, applied_at),
+    )
+    con.commit()
+
+
+def compose_factory(content: str, calls: list) -> object:
+    def compose() -> str:
+        calls.append(content)
+        return content
+    return compose
+
+
+def test_directive_requires_a_known_phase_and_conversation() -> None:
+    with pytest.raises(ValueError):
+        BootDirective(conversation_id="cv_x", phase="reopen")
+    with pytest.raises(ValueError):
+        BootDirective(conversation_id="", phase="start")
+
+
+def test_start_binds_one_new_conversation_snapshot(con) -> None:
+    stamp_migration(con, "2020-01-01 00:00:00")
+    conversation = add_conversation(con, "cv_start")
+    calls: list = []
+
+    content = conversation_boot.resolve_boot(
+        con,
+        BootDirective(conversation_id=conversation, phase="start"),
+        compose_factory("boot A", calls),
+    )
+
+    assert content == "boot A"
+    assert calls == ["boot A"]
+    row = con.execute(
+        "SELECT content_sha256,content_bytes,format_version,binding_origin "
+        "FROM conversation_boot_snapshots WHERE conversation_id=?",
+        (conversation,),
+    ).fetchone()
+    assert tuple(row) == (
+        hashlib.sha256(b"boot A").hexdigest(), 6, 1, "new_conversation",
+    )
+
+
+def test_start_retry_reuses_the_committed_snapshot_without_composing(
+    con,
+) -> None:
+    stamp_migration(con, "2020-01-01 00:00:00")
+    conversation = add_conversation(con, "cv_retry")
+    directive = BootDirective(conversation_id=conversation, phase="start")
+    first_calls: list = []
+    conversation_boot.resolve_boot(con, directive, compose_factory("boot A", first_calls))
+
+    retry_calls: list = []
+    content = conversation_boot.resolve_boot(
+        con, directive, compose_factory("boot B", retry_calls)
+    )
+
+    assert content == "boot A"
+    assert retry_calls == []
+
+
+def test_a_bind_race_keeps_the_first_committed_snapshot(con) -> None:
+    stamp_migration(con, "2020-01-01 00:00:00")
+    conversation = add_conversation(con, "cv_race")
+
+    winner = conversation_boot.bind_snapshot(con, conversation, "boot A", "new_conversation")
+    loser = conversation_boot.bind_snapshot(con, conversation, "boot B", "new_conversation")
+
+    assert winner["content"] == loser["content"] == "boot A"
+    assert winner["binding_origin"] == loser["binding_origin"] == "new_conversation"
+
+
+def test_resume_reuses_stored_bytes_with_zero_compositions(con) -> None:
+    stamp_migration(con, "2020-01-01 00:00:00")
+    conversation = add_conversation(con, "cv_resume")
+    conversation_boot.bind_snapshot(con, conversation, "boot A", "new_conversation")
+    calls: list = []
+
+    content = conversation_boot.resolve_boot(
+        con,
+        BootDirective(conversation_id=conversation, phase="resume"),
+        compose_factory("boot B", calls),
+    )
+
+    assert content == "boot A"
+    assert calls == []
+
+
+def test_resume_adopts_an_unbound_legacy_conversation_once(con) -> None:
+    stamp_migration(con, "2030-01-01 00:00:00")  # cutover after created_at
+    conversation = add_conversation(con, "cv_legacy", created_at="2020-01-01 00:00:00")
+    calls: list = []
+
+    content = conversation_boot.resolve_boot(
+        con,
+        BootDirective(conversation_id=conversation, phase="resume"),
+        compose_factory("legacy boot", calls),
+    )
+
+    assert content == "legacy boot"
+    assert calls == ["legacy boot"]
+    origin = con.execute(
+        "SELECT binding_origin FROM conversation_boot_snapshots "
+        "WHERE conversation_id=?",
+        (conversation,),
+    ).fetchone()[0]
+    assert origin == "legacy_first_resume"
+
+    # Later turns reuse the adopted snapshot without composing again.
+    more_calls: list = []
+    again = conversation_boot.resolve_boot(
+        con,
+        BootDirective(conversation_id=conversation, phase="resume"),
+        compose_factory("other boot", more_calls),
+    )
+    assert again == "legacy boot"
+    assert more_calls == []
+
+
+def test_resume_refuses_an_unbound_post_migration_conversation(con) -> None:
+    stamp_migration(con, "2020-01-01 00:00:00")
+    conversation = add_conversation(con, "cv_missing")
+
+    with pytest.raises(BootSnapshotError) as caught:
+        conversation_boot.resolve_boot(
+            con,
+            BootDirective(conversation_id=conversation, phase="resume"),
+            compose_factory("boot", []),
+        )
+    assert caught.value.code == "BOOT_SNAPSHOT_MISSING"
+
+
+def test_a_stored_row_that_fails_validation_refuses_dispatch(con) -> None:
+    conversation = add_conversation(con, "cv_corrupt")
+    with pytest.raises(BootSnapshotError) as caught:
+        conversation_boot._validate_row(
+            {
+                "conversation_id": conversation,
+                "content": "tampered",
+                "content_sha256": hashlib.sha256(b"original").hexdigest(),
+                "content_bytes": 8,
+                "format_version": 1,
+                "binding_origin": "new_conversation",
+                "bound_at": "2026-08-19 00:00:00",
+            },
+            conversation,
+        )
+    assert caught.value.code == "BOOT_SNAPSHOT_CORRUPT"
+
+
+def test_write_boot_files_skips_matching_and_restores_drift(tmp_path) -> None:
+    content = "immutable boot"
+    conversation_boot.write_boot_files(tmp_path, content)
+    first = {
+        name: (tmp_path / name).stat().st_mtime_ns
+        for name in conversation_boot.BOOT_FILES
+    }
+
+    conversation_boot.write_boot_files(tmp_path, content)
+    assert {
+        name: (tmp_path / name).stat().st_mtime_ns
+        for name in conversation_boot.BOOT_FILES
+    } == first
+
+    # A different chat replaced one file: both restore the exact bytes.
+    (tmp_path / "CLAUDE.md").write_text("other chat")
+    conversation_boot.write_boot_files(tmp_path, content)
+    for name in conversation_boot.BOOT_FILES:
+        assert (tmp_path / name).read_bytes() == content.encode("utf-8")
+
+    # A missing file is restored as well.
+    (tmp_path / "AGENTS.md").unlink()
+    conversation_boot.write_boot_files(tmp_path, content)
+    for name in conversation_boot.BOOT_FILES:
+        assert (tmp_path / name).read_bytes() == content.encode("utf-8")

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -31,6 +31,8 @@ from conversation_adapters import (  # noqa: E402
     OpenCodeAdapter,
     ReconcileResult,
 )
+from conversation_boot import BootDirective  # noqa: E402
+import conversation_boot  # noqa: E402
 from conversation_broker import (  # noqa: E402
     BrokerInvariantError,
     BrokerRun,
@@ -1739,6 +1741,577 @@ class ServiceContractTest(ConversationBrokerCase):
         self.assertEqual(adapter.started, 1)
         self.assertEqual(adapter.resumed, 0)
         self.assertTrue(broker.wait_idle())
+
+
+class BootSeamPreparer:
+    """The real conversation_boot seam as the broker's launch_preparer.
+
+    Exercises binding, validation, and byte restoration against the test DB
+    without dragging in the rest of run.prepare_launch; compose is a probe so
+    tests can count compositions and change the volatile shell state between
+    turns. ``last_content`` is the exact byte string this turn resolved and
+    materialized, for dispatch-edge assertions."""
+
+    def __init__(
+        self,
+        db_path: Path,
+        compose,
+        *,
+        archive_id: int,
+        write_failures: int = 0,
+    ) -> None:
+        self.db_path = db_path
+        self.compose = compose
+        self.archive_id = archive_id
+        self.write_failures = write_failures
+        self.compose_calls = 0
+        self.last_content: str | None = None
+
+    def __call__(self, broker_run: BrokerRun):
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        try:
+            directive = BootDirective(
+                conversation_id=broker_run.conversation_id,
+                phase="resume" if broker_run.session_before else "start",
+            )
+
+            def composing() -> str:
+                self.compose_calls += 1
+                return self.compose()
+
+            content = conversation_boot.resolve_boot(con, directive, composing)
+        finally:
+            con.close()
+        if self.write_failures:
+            self.write_failures -= 1
+            raise OSError("injected boot write failure")
+        conversation_boot.write_boot_files(Path(broker_run.worktree), content)
+        self.last_content = content
+        return broker_run.context(), self.archive_id
+
+
+class BootAssertingAdapter(FakeAdapter):
+    """At each native dispatch edge, both worktree boot files must already
+    hold the exact bytes this turn's preparation resolved."""
+
+    def __init__(self, preparer: BootSeamPreparer, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.preparer = preparer
+        self.messages: list[str] = []
+        self.resume_sessions: list[str] = []
+
+    def _assert_boot_owned(self, context: ConversationContext) -> None:
+        expected = self.preparer.last_content
+        if expected is None:
+            raise AssertionError("native dispatch before boot preparation")
+        for name in conversation_boot.BOOT_FILES:
+            actual = (context.worktree / name).read_bytes()
+            if actual != expected.encode("utf-8"):
+                raise AssertionError(f"{name} drifted from the bound snapshot")
+
+    def start(self, context: ConversationContext, message: str) -> NativeTurn:
+        self.messages.append(message)
+        self._assert_boot_owned(context)
+        return super().start(context, message)
+
+    def resume(
+        self,
+        session_ref: str,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        self.messages.append(message)
+        self.resume_sessions.append(session_ref)
+        self._assert_boot_owned(context)
+        return super().resume(session_ref, context, message)
+
+
+class BootSnapshotContractTest(ConversationBrokerCase):
+    """Spec #163 broker boundaries: bind before start, exact reuse on resume."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        con = self.connect()
+        self.archive_id = int(
+            con.execute(
+                "INSERT INTO shell_memory_archives "
+                "(shell_id,session_id,date,full_narrative) "
+                "VALUES (1,'9001','2026-08-19','boot snapshot tests')"
+            ).lastrowid
+        )
+        con.commit()
+        con.close()
+        self.boot_state = {"marker": "one"}
+
+    def compose(self) -> str:
+        return f"boot marker {self.boot_state['marker']}"
+
+    def stamp_ledger(self, applied_at: str = "2000-01-01 00:00:00") -> None:
+        """Mark the 0224 migration applied, so later conversations are new."""
+        con = self.connect()
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS schema_migrations ("
+            "  filename TEXT PRIMARY KEY,"
+            "  applied_at TEXT NOT NULL DEFAULT (datetime('now')))"
+        )
+        con.execute(
+            "INSERT OR REPLACE INTO schema_migrations (filename,applied_at) "
+            "VALUES ('0224_conversation_boot_snapshots.sql',?)",
+            (applied_at,),
+        )
+        con.commit()
+        con.close()
+
+    def snapshot_row(self, conversation_id: str):
+        con = self.connect()
+        row = con.execute(
+            "SELECT content,content_sha256,content_bytes,binding_origin "
+            "FROM conversation_boot_snapshots WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()
+        con.close()
+        return row
+
+    def requeue(self, conversation_id: str) -> int:
+        """Post the next message as the API would: conversation back to queued."""
+        con = self.connect()
+        con.execute(
+            "UPDATE conversations SET state='queued' WHERE conversation_id=?",
+            (conversation_id,),
+        )
+        con.commit()
+        con.close()
+        return self.add_message(conversation_id)
+
+    def add_message_body(self, conversation_id: str, body: str) -> int:
+        self.serial += 1
+        key = f"message-{self.serial}"
+        con = self.connect()
+        message_id = con.execute(
+            "INSERT INTO conversation_messages "
+            "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+            "idempotency_key,request_hash,state) "
+            "VALUES (?,'user','1','prompt',?,?,?,'queued')",
+            (conversation_id, body, key, f"hash-{key}"),
+        ).lastrowid
+        con.execute(
+            "INSERT INTO conversation_outbox (conversation_id,message_id) "
+            "VALUES (?,?)",
+            (conversation_id, message_id),
+        )
+        con.commit()
+        con.close()
+        return int(message_id)
+
+    def file_states(self) -> dict:
+        return {
+            name: (
+                (self.worktree / name).read_bytes(),
+                (self.worktree / name).stat().st_mtime_ns,
+            )
+            for name in conversation_boot.BOOT_FILES
+        }
+
+    def test_first_turn_binds_before_native_start(self) -> None:
+        self.stamp_ledger()
+        preparer = BootSeamPreparer(
+            self.db_path, self.compose, archive_id=self.archive_id
+        )
+        adapter = BootAssertingAdapter(preparer)
+        broker = self.start_broker(
+            lambda _harness: adapter, launch_preparer=preparer
+        )
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            con = self.connect()
+            state = con.execute(
+                "SELECT state FROM conversation_runs WHERE trigger_message_id=?",
+                (message_id,),
+            ).fetchone()
+            con.close()
+            if state and state[0] == "succeeded":
+                break
+            time.sleep(0.01)
+        else:
+            self.fail("first turn did not finish")
+
+        row = self.snapshot_row(conversation_id)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["content"], "boot marker one")
+        self.assertEqual(row["binding_origin"], "new_conversation")
+        self.assertEqual(adapter.messages, ["hello"])
+        self.assertEqual(preparer.compose_calls, 1)
+
+    def test_resume_reuses_bytes_and_never_rewrites_matching_files(self) -> None:
+        self.stamp_ledger()
+        preparer = BootSeamPreparer(
+            self.db_path, self.compose, archive_id=self.archive_id
+        )
+        adapter = BootAssertingAdapter(preparer)
+        broker = self.start_broker(
+            lambda _harness: adapter, launch_preparer=preparer
+        )
+        conversation_id = self.add_conversation()
+        first_message = self.add_message(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, first_message, "succeeded")
+        digest = self.snapshot_row(conversation_id)["content_sha256"]
+        files = self.file_states()
+
+        # Volatile boot inputs change; the conversation's bytes must not.
+        self.boot_state["marker"] = "two"
+        second_message = self.requeue(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, second_message, "succeeded")
+
+        self.assertEqual(adapter.started, 1)
+        self.assertEqual(adapter.resumed, 1)
+        self.assertEqual(adapter.messages, ["hello", "hello"])
+        self.assertEqual(preparer.compose_calls, 1)
+        self.assertEqual(
+            self.snapshot_row(conversation_id)["content_sha256"], digest
+        )
+        self.assertEqual(self.file_states(), files)
+
+    def test_resume_restores_files_replaced_by_another_chat(self) -> None:
+        self.stamp_ledger()
+        preparer = BootSeamPreparer(
+            self.db_path, self.compose, archive_id=self.archive_id
+        )
+        adapter = BootAssertingAdapter(preparer)
+        broker = self.start_broker(
+            lambda _harness: adapter, launch_preparer=preparer
+        )
+        conversation_id = self.add_conversation()
+        first_message = self.add_message(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, first_message, "succeeded")
+        digest = self.snapshot_row(conversation_id)["content_sha256"]
+
+        # A different chat (or any external lifecycle) replaced the shared
+        # worktree files; resume must restore the stored bytes before dispatch.
+        for name in conversation_boot.BOOT_FILES:
+            (self.worktree / name).write_text("another chat's boot")
+        second_message = self.requeue(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, second_message, "succeeded")
+
+        self.assertEqual(adapter.resumed, 1)
+        self.assertEqual(preparer.compose_calls, 1)
+        self.assertEqual(
+            self.snapshot_row(conversation_id)["content_sha256"], digest
+        )
+        for name in conversation_boot.BOOT_FILES:
+            self.assertEqual(
+                (self.worktree / name).read_bytes(),
+                b"boot marker one",
+            )
+
+    def test_boot_write_failure_keeps_snapshot_and_retry_does_not_recompose(
+        self,
+    ) -> None:
+        self.stamp_ledger()
+        preparer = BootSeamPreparer(
+            self.db_path,
+            self.compose,
+            archive_id=self.archive_id,
+            write_failures=1,
+        )
+        adapter = BootAssertingAdapter(preparer)
+        broker = self.start_broker(
+            lambda _harness: adapter, launch_preparer=preparer
+        )
+        conversation_id = self.add_conversation()
+        first_message = self.add_message(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, first_message, "failed")
+
+        # Committed before the failed write; no prompt ever reached a native
+        # session for the first message.
+        row = self.snapshot_row(conversation_id)
+        self.assertIsNotNone(row)
+        self.assertEqual(adapter.started, 0)
+        self.assertEqual(adapter.resumed, 0)
+
+        second_message = self.requeue(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, second_message, "succeeded")
+
+        self.assertEqual(preparer.compose_calls, 1)
+        self.assertEqual(
+            self.snapshot_row(conversation_id)["content_sha256"],
+            row["content_sha256"],
+        )
+        self.assertEqual(adapter.messages, ["hello"])
+
+    def test_unbound_legacy_conversation_adopts_once_on_first_resume(
+        self,
+    ) -> None:
+        # No schema_migrations ledger in this fixture: the conversation cannot
+        # be proven post-migration, so the legacy adoption rule applies.
+        preparer = BootSeamPreparer(
+            self.db_path, self.compose, archive_id=self.archive_id
+        )
+        adapter = BootAssertingAdapter(
+            preparer, native_session_ref="native-old"
+        )
+        broker = self.start_broker(
+            lambda _harness: adapter, launch_preparer=preparer
+        )
+        conversation_id = self.add_conversation(session_ref="native-old")
+        first_message = self.add_message(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, first_message, "succeeded")
+
+        row = self.snapshot_row(conversation_id)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["binding_origin"], "legacy_first_resume")
+        self.assertEqual(adapter.resumed, 1)
+        self.assertEqual(adapter.started, 0)
+
+        second_message = self.requeue(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, second_message, "succeeded")
+        self.assertEqual(preparer.compose_calls, 1)
+        self.assertEqual(
+            self.snapshot_row(conversation_id)["content_sha256"],
+            row["content_sha256"],
+        )
+        self.assertEqual(adapter.resumed, 2)
+
+    def test_unbound_post_migration_conversation_fails_closed(self) -> None:
+        self.stamp_ledger()
+
+        preparer = BootSeamPreparer(
+            self.db_path, self.compose, archive_id=self.archive_id
+        )
+        adapter = BootAssertingAdapter(preparer)
+        broker = self.start_broker(
+            lambda _harness: adapter, launch_preparer=preparer
+        )
+        conversation_id = self.add_conversation(session_ref="native-new")
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, message_id, "failed")
+
+        con = self.connect()
+        error = con.execute(
+            "SELECT error_code FROM conversation_runs "
+            "WHERE trigger_message_id=?",
+            (message_id,),
+        ).fetchone()[0]
+        con.close()
+        self.assertEqual(error, "BOOT_SNAPSHOT_MISSING")
+        self.assertIsNone(self.snapshot_row(conversation_id))
+        self.assertEqual(adapter.started, 0)
+        self.assertEqual(adapter.resumed, 0)
+        self.assertEqual(preparer.compose_calls, 0)
+
+    def wait_message_run(
+        self, conversation_id: str, message_id: int, state: str
+    ) -> None:
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            con = self.connect()
+            row = con.execute(
+                "SELECT state FROM conversation_runs "
+                "WHERE conversation_id=? AND trigger_message_id=?",
+                (conversation_id, message_id),
+            ).fetchone()
+            con.close()
+            if row is not None and row[0] == state:
+                return
+            time.sleep(0.01)
+        self.fail(
+            f"message {message_id} run did not reach {state}"
+        )
+
+    def test_close_reopen_with_rotation_restores_original_snapshot(self) -> None:
+        self.stamp_ledger()
+        preparer = BootSeamPreparer(
+            self.db_path, self.compose, archive_id=self.archive_id
+        )
+        adapter = BootAssertingAdapter(
+            preparer, native_session_ref="native-A"
+        )
+        broker = self.start_broker(
+            lambda _harness: adapter, launch_preparer=preparer
+        )
+        chat_a = self.add_conversation()
+        first = self.add_message(chat_a)
+        broker.notify()
+        self.wait_message_run(chat_a, first, "succeeded")
+        digest_a = self.snapshot_row(chat_a)["content_sha256"]
+        self.assertEqual(
+            self.snapshot_row(chat_a)["content"], "boot marker one"
+        )
+
+        # Close A, then run a different chat B on the same shell: the shared
+        # worktree files move to B's freshly composed snapshot.
+        con = self.connect()
+        con.execute(
+            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
+            "WHERE conversation_id=?",
+            (chat_a,),
+        )
+        con.commit()
+        con.close()
+        self.boot_state["marker"] = "two"
+        chat_b = self.add_conversation()
+        second = self.add_message(chat_b)
+        broker.notify()
+        self.wait_message_run(chat_b, second, "succeeded")
+        digest_b = self.snapshot_row(chat_b)["content_sha256"]
+        self.assertNotEqual(digest_a, digest_b)
+        self.assertEqual(
+            self.snapshot_row(chat_b)["content"], "boot marker two"
+        )
+        for name in conversation_boot.BOOT_FILES:
+            self.assertEqual(
+                (self.worktree / name).read_bytes(), b"boot marker two"
+            )
+
+        # Reopen A (the API's closed->idle walk + active-chat rotation): the
+        # API auto-closes the idle open chat B first, then A's original
+        # snapshot is restored and the original native session resumes.
+        con = self.connect()
+        con.execute(
+            "UPDATE conversations SET state='closed',closed_at=datetime('now') "
+            "WHERE conversation_id=?",
+            (chat_b,),
+        )
+        con.execute(
+            "UPDATE conversations SET state='idle',closed_at=NULL "
+            "WHERE conversation_id=?",
+            (chat_a,),
+        )
+        con.execute(
+            "INSERT OR REPLACE INTO active_shell_chats (shell_id,chat_id) "
+            "VALUES (1,?)",
+            (chat_a,),
+        )
+        con.commit()
+        con.close()
+        third = self.requeue(chat_a)
+        broker.notify()
+        self.wait_message_run(chat_a, third, "succeeded")
+
+        self.assertEqual(adapter.started, 2)  # A's first turn, B's first turn
+        self.assertEqual(adapter.resumed, 1)  # A's reopen resumes native-A
+        self.assertEqual(preparer.compose_calls, 2)  # one per conversation
+        self.assertEqual(
+            self.snapshot_row(chat_a)["content_sha256"], digest_a
+        )
+        for name in conversation_boot.BOOT_FILES:
+            self.assertEqual(
+                (self.worktree / name).read_bytes(), b"boot marker one"
+            )
+
+    def test_broker_restart_between_turns_reuses_the_snapshot(self) -> None:
+        self.stamp_ledger()
+        preparer = BootSeamPreparer(
+            self.db_path, self.compose, archive_id=self.archive_id
+        )
+        first_adapter = BootAssertingAdapter(preparer)
+        broker = self.start_broker(
+            lambda _harness: first_adapter, launch_preparer=preparer
+        )
+        conversation_id = self.add_conversation()
+        first = self.add_message(conversation_id)
+        broker.notify()
+        self.wait_message_run(conversation_id, first, "succeeded")
+        digest = self.snapshot_row(conversation_id)["content_sha256"]
+        broker.stop()
+        broker.join(2)
+        self.assertFalse(broker.is_alive())
+
+        # Engine restart: a fresh broker process resumes the same conversation.
+        second_adapter = BootAssertingAdapter(preparer)
+        restarted = self.start_broker(
+            lambda _harness: second_adapter, launch_preparer=preparer
+        )
+        second = self.requeue(conversation_id)
+        restarted.notify()
+        self.wait_message_run(conversation_id, second, "succeeded")
+
+        self.assertEqual(preparer.compose_calls, 1)
+        self.assertEqual(second_adapter.resumed, 1)
+        self.assertEqual(second_adapter.started, 0)
+        self.assertEqual(
+            self.snapshot_row(conversation_id)["content_sha256"], digest
+        )
+
+    def test_every_supported_harness_resumes_exact_session_and_prompt(self) -> None:
+        """Claude, Codex, Kimi, and OpenCode chats each bind one snapshot and
+        resume the persisted native session with only the next queued prompt."""
+        self.stamp_ledger()
+        preparer = BootSeamPreparer(
+            self.db_path, self.compose, archive_id=self.archive_id
+        )
+        adapters = {
+            harness: BootAssertingAdapter(
+                preparer,
+                harness=harness,
+                native_session_ref=f"native-{harness}",
+            )
+            for harness in ("claude", "codex", "kimi", "opencode")
+        }
+        broker = self.start_broker(
+            lambda harness: adapters[harness], launch_preparer=preparer
+        )
+        for harness, adapter in adapters.items():
+            with self.subTest(harness=harness):
+                conversation_id = self.add_conversation(harness=harness)
+                first = self.add_message_body(
+                    conversation_id, f"first {harness} prompt"
+                )
+                broker.notify()
+                self.wait_message_run(conversation_id, first, "succeeded")
+                digest = self.snapshot_row(conversation_id)["content_sha256"]
+
+                con = self.connect()
+                con.execute(
+                    "UPDATE conversations SET state='queued' "
+                    "WHERE conversation_id=?",
+                    (conversation_id,),
+                )
+                con.commit()
+                con.close()
+                second = self.add_message_body(
+                    conversation_id, f"second {harness} prompt"
+                )
+                broker.notify()
+                self.wait_message_run(conversation_id, second, "succeeded")
+
+                self.assertEqual(adapter.started, 1)
+                self.assertEqual(adapter.resumed, 1)
+                self.assertEqual(
+                    adapter.messages,
+                    [f"first {harness} prompt", f"second {harness} prompt"],
+                )
+                self.assertEqual(
+                    adapter.resume_sessions, [f"native-{harness}"]
+                )
+                self.assertEqual(
+                    self.snapshot_row(conversation_id)["content_sha256"],
+                    digest,
+                )
+                con = self.connect()
+                con.execute(
+                    "UPDATE conversations SET state='closed',"
+                    "closed_at=datetime('now') WHERE conversation_id=?",
+                    (conversation_id,),
+                )
+                con.commit()
+                con.close()
+
+        # Exactly one composition per conversation across all four harnesses.
+        self.assertEqual(preparer.compose_calls, 4)
 
 
 if __name__ == "__main__":

--- a/tests/test_conversation_launch.py
+++ b/tests/test_conversation_launch.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(ENGINE / "api"))
 
 import route_bindings  # noqa: E402
 import run as run_mod  # noqa: E402
+from conversation_boot import BootDirective  # noqa: E402
 from conversation_broker import BrokerRun  # noqa: E402
 from conversation_launch import (  # noqa: E402
     ConversationLaunchError,
@@ -190,7 +191,33 @@ def test_preparer_returns_canonical_environment_and_archive(launch_case):
         "effort": "high",
         "headless_prompt": "Do the work",
         "current_leased_run_id": 7,
+        "boot": BootDirective(
+            conversation_id="cv_" + "a" * 32,
+            phase="start",
+        ),
     }]
+
+
+def test_preparer_marks_a_resume_turn_with_the_resume_phase(launch_case):
+    db_path, worktree = launch_case
+    called = []
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=lambda **kwargs: called.append(kwargs) or SimpleNamespace(
+            cwd=str(worktree),
+            archive_id=42,
+            harness="codex",
+            model="gpt-test",
+            effort="high",
+            env={},
+        ),
+        liveness=lambda: {"supported": True, "processes": []},
+    )
+    preparer(make_run(worktree, session_before="native-session-1"))
+    assert called[0]["boot"] == BootDirective(
+        conversation_id="cv_" + "a" * 32,
+        phase="resume",
+    )
 
 
 def test_preexisting_null_model_chat_refuses_turn_and_preserves_row(launch_case):

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -2,6 +2,7 @@
 """Feature #24 conversation schema, transition, and rebuild contracts."""
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import sys
@@ -1148,6 +1149,7 @@ class SnapshotPolicyTest(ConversationDbCase):
         "conversations",
         "active_shell_chats",
         "conversation_git_targets",
+        "conversation_boot_snapshots",
         "conversation_messages",
         "conversation_runs",
         "conversation_events",
@@ -1237,6 +1239,175 @@ class SnapshotPolicyTest(ConversationDbCase):
             "PRAGMA foreign_key_check"
         ).fetchall(), [])
         target.close()
+
+
+class BootSnapshotSchemaCase(ConversationDbCase):
+    """Spec #163 conversation_boot_snapshots schema contract."""
+
+    MIGRATION = MIGRATIONS / "0224_conversation_boot_snapshots.sql"
+    DIGEST = hashlib.sha256(b"boot content").hexdigest()
+
+    def bind(self, conversation: str, **overrides) -> None:
+        row = {
+            "conversation_id": conversation,
+            "content": "boot content",
+            "content_sha256": self.DIGEST,
+            "content_bytes": len(b"boot content"),
+            "format_version": 1,
+            "binding_origin": "new_conversation",
+        }
+        row.update(overrides)
+        self.con.execute(
+            "INSERT INTO conversation_boot_snapshots "
+            "(conversation_id,content,content_sha256,content_bytes,"
+            "format_version,binding_origin) "
+            "VALUES (?,?,?,?,?,?)",
+            (
+                row["conversation_id"],
+                row["content"],
+                row["content_sha256"],
+                row["content_bytes"],
+                row["format_version"],
+                row["binding_origin"],
+            ),
+        )
+
+    def test_round_trip_and_bound_at_default(self) -> None:
+        conversation = self.add_conversation()
+        self.bind(conversation)
+        row = self.con.execute(
+            "SELECT content,content_sha256,content_bytes,format_version,"
+            "binding_origin,bound_at FROM conversation_boot_snapshots "
+            "WHERE conversation_id=?",
+            (conversation,),
+        ).fetchone()
+        self.assertEqual(
+            tuple(row)[:5],
+            ("boot content", self.DIGEST, 12, 1, "new_conversation"),
+        )
+        self.assertIsNotNone(row[5])
+
+    def test_one_snapshot_per_conversation(self) -> None:
+        conversation = self.add_conversation()
+        self.bind(conversation)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.bind(conversation, binding_origin="legacy_first_resume")
+
+    def test_digest_must_be_lowercase_hex_sha256(self) -> None:
+        conversation = self.add_conversation()
+        for bad in ("x" * 64, "A" + self.DIGEST[1:], self.DIGEST[:63]):
+            with self.subTest(digest=bad):
+                with self.assertRaises(sqlite3.IntegrityError):
+                    self.bind(conversation, content_sha256=bad)
+
+    def test_content_is_bounded_and_non_empty(self) -> None:
+        conversation = self.add_conversation()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.bind(conversation, content="", content_bytes=0)
+        oversized = "a" * (1048576 + 1)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.bind(
+                conversation,
+                content=oversized,
+                content_bytes=len(oversized),
+            )
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.bind(conversation, content="ok", content_bytes=1048577)
+
+    def test_content_bytes_agrees_with_utf8_bytes(self) -> None:
+        conversation = self.add_conversation()
+        text = "boot ünïcode"  # 13 chars, 15 UTF-8 bytes
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.bind(conversation, content=text, content_bytes=len(text))
+        self.bind(
+            conversation,
+            content=text,
+            content_bytes=len(text.encode("utf-8")),
+        )
+
+    def test_format_version_and_origin_are_constrained(self) -> None:
+        conversation = self.add_conversation()
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.bind(conversation, format_version=0)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.bind(conversation, binding_origin="fresh_render")
+
+    def test_snapshot_is_immutable(self) -> None:
+        conversation = self.add_conversation()
+        self.bind(conversation)
+        for column, value in (
+            ("content", "tampered"),
+            ("content_sha256", "f" * 64),
+            ("content_bytes", 99),
+            ("format_version", 2),
+            ("binding_origin", "legacy_first_resume"),
+            ("bound_at", "1999-01-01 00:00:00"),
+        ):
+            with self.subTest(column=column):
+                with self.assertRaises(sqlite3.IntegrityError):
+                    self.con.execute(
+                        "UPDATE conversation_boot_snapshots "
+                        f"SET {column}=? WHERE conversation_id=?",
+                        (value, conversation),
+                    )
+
+    def test_snapshot_follows_conversation_delete_cascade(self) -> None:
+        conversation = self.add_conversation()
+        self.bind(conversation)
+        self.con.execute(
+            "DELETE FROM conversations WHERE conversation_id=?",
+            (conversation,),
+        )
+        self.assertIsNone(
+            self.con.execute(
+                "SELECT 1 FROM conversation_boot_snapshots "
+                "WHERE conversation_id=?",
+                (conversation,),
+            ).fetchone(),
+        )
+
+    def test_migration_leaves_legacy_conversations_unbound(self) -> None:
+        legacy = sqlite3.connect(":memory:")
+        legacy.row_factory = sqlite3.Row
+        apply_schema(legacy, through="0223_model_default_effort_binding.sql")
+        legacy.execute(
+            "INSERT INTO users (user_id, username) VALUES (1,'operator')"
+        )
+        legacy.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (1,'Dev','dev1','dev','prompt',1)"
+        )
+        legacy.execute(
+            "INSERT INTO conversations "
+            "(shell_id,owner_user_id,harness,worktree,state,"
+            "creation_idempotency_key,creation_request_hash) "
+            "VALUES (1,1,'codex','/tmp/worktree-1','idle','legacy','legacy-h')"
+        )
+        legacy.executescript(self.MIGRATION.read_text())
+        legacy.execute("PRAGMA foreign_keys=ON")
+        conversation = legacy.execute(
+            "SELECT conversation_id FROM conversations"
+        ).fetchone()[0]
+        self.assertIsNone(
+            legacy.execute(
+                "SELECT 1 FROM conversation_boot_snapshots "
+                "WHERE conversation_id=?",
+                (conversation,),
+            ).fetchone(),
+        )
+        self.assertEqual(
+            tuple(
+                legacy.execute(
+                    "SELECT state,harness FROM conversations"
+                ).fetchone()
+            ),
+            ("idle", "codex"),
+        )
+        self.assertEqual(
+            legacy.execute("PRAGMA foreign_key_check").fetchall(), []
+        )
+        legacy.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements conversation boot snapshots per spec tasks #564–#568:

- **#564** — migration `0224_conversation_boot_snapshots.sql`: one-to-one cascade-owned snapshot table, digest/byte/origin constraints, immutability trigger + 9 schema fixture tests
- **#565** — new `.super-coder/scripts/conversation_boot.py` seam: explicit start/resume `BootDirective`, CAS bind, validated load, skip-or-restore file materialization; `run.prepare_launch` and `conversation_launch.py` wired through it. CLI behavior unchanged without a directive (fresh compose every launch)
- **#566** — broker-boundary contract tests: bind before first native start; write-failure retry keeps committed digest and sends no duplicate prompt; post-migration missing snapshot fails closed as `BOOT_SNAPSHOT_MISSING`
- **#567** — lifecycle tests: close/reopen with rotation restores original digest and native session; broker restart reuses snapshot; fresh digest per new conversation; wake/Sprint/API/reaper suites green
- **#568** — four-harness (claude/codex/kimi/opencode) resume contract: exact persisted session ref, only the next queued prompt, one composition per conversation

## Verification

- Scratch rebuild through `migrate.py` proved the migration applies and stamps the ledger
- Targeted suites green locally: `test_conversation_boot.py`, `test_conversation_schema.py`, `test_conversation_launch.py`, `test_conversation_broker.py` (99 passed, 150 subtests)
- Full `tests/` run delegated to CI (same `./sc test tests/ -q` gate; local run stressed the dev host)

Co-authored-by: Code-01 (super-coder) <noreply@super-coder.local>