### PR TITLE
fix(sandbox): tolerate pre-existing host UID in image user creation

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -176,12 +176,17 @@ RUN echo "harness epoch: ${SC_HARNESS_EPOCH}" \
       | env KIMI_INSTALL_DIR=/usr/local KIMI_NO_MODIFY_PATH=1 bash
 
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
-# A host GID may already exist in the base image, so creating it unconditionally
-# can fail the build. Reuse an existing GID; only create when absent. The group's
-# *name* is irrelevant; only the numeric GID must match the host for bind-mounted
-# ownership to line up.
+# A host GID or UID may already exist in the base image — sudo builds pass
+# UID/GID 0, which the image's root already owns — so creating either
+# unconditionally can fail the build. Reuse existing IDs; only create when
+# absent. The *names* are irrelevant; only the numeric IDs must match the host
+# for bind-mounted ownership to line up. HOME is /home/${SC_USER} regardless
+# (see ENV below), so ensure that dir even when the user pre-existed (root's
+# real home is /root).
 RUN if ! getent group ${SC_GID} >/dev/null; then groupadd -g ${SC_GID} ${SC_USER}; fi \
- && useradd -m -u ${SC_UID} -g ${SC_GID} -s /bin/bash ${SC_USER}
+ && if ! getent passwd ${SC_UID} >/dev/null; then useradd -m -u ${SC_UID} -g ${SC_GID} -s /bin/bash ${SC_USER}; fi \
+ && mkdir -p /home/${SC_USER} \
+ && chown ${SC_UID}:${SC_GID} /home/${SC_USER}
 
 USER ${SC_USER}
 ENV HOME=/home/${SC_USER}

--- a/tests/test_sc_wrapper.py
+++ b/tests/test_sc_wrapper.py
@@ -255,5 +255,22 @@ class DockerWrapperContractTest(unittest.TestCase):
         self.assertNotIn("via git toplevel or SC_ROOT", wrapper)
 
 
+class DockerSandboxUserContractTest(unittest.TestCase):
+    def test_host_id_collision_cannot_fail_image_build(self) -> None:
+        # sudo builds pass SC_UID/SC_GID 0, which the base image's root already
+        # owns; an unconditional groupadd/useradd exits the build (useradd: 9).
+        dockerfile = (ROOT / ".super-coder" / "Dockerfile").read_text()
+        start = dockerfile.index("RUN if ! getent group ${SC_GID}")
+        block = dockerfile[start : dockerfile.index("\n\n", start)]
+        self.assertIn(
+            "if ! getent group ${SC_GID} >/dev/null; then groupadd", block
+        )
+        self.assertIn(
+            "if ! getent passwd ${SC_UID} >/dev/null; then useradd", block
+        )
+        # HOME is /home/${SC_USER} even for a pre-existing user (root: /root).
+        self.assertIn("mkdir -p /home/${SC_USER}", block)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

`sudo make dos-r` on the halo-inference fork failed during `docker build`:

```
[10/13] RUN if ! getent group 0 ... && useradd -m -u 0 -g 0 -s /bin/bash root
useradd: user 'root' already exists
ERROR: exit code: 9
```

Sudo passes `SC_UID=0 SC_GID=0 SC_USER=root`. The `groupadd` half was already `getent`-guarded for exactly this class of collision, but `useradd` ran unconditionally — any host UID already present in the base image (root being the universal case) killed the build.

## Fix

- Guard `useradd` with `getent passwd ${SC_UID}`, mirroring the GID guard
- `mkdir -p /home/${SC_USER}` + `chown` so `ENV HOME=/home/${SC_USER}` still resolves for a pre-existing user (root's real home is `/root`)

## Verification

- New `DockerSandboxUserContractTest` pins the guarded step (red against `origin/main`: no `getent passwd` in the file)
- `tests/test_sc_wrapper.py` green (11 passed)
- `sh -n` syntax check on the new RUN step; conditional logic exercised for the UID/GID 0 case (both creations correctly skipped)

The end-to-end proof is the failing command itself: after merge + `./sc update`, `sudo make dos-r` on the Dev machine builds past step 10.

Co-authored-by: Code-01 (super-coder) <noreply@super-coder.local>