### PR TITLE
fix(models): isolate OpenCode catalogue failures

### DIFF
--- a/.super-coder/api/model_catalog.py
+++ b/.super-coder/api/model_catalog.py
@@ -415,9 +415,7 @@ def _finish_cache_publication(
     winner = _load_cache()
     if winner and _cache_matches_authority(winner, con):
         return _served(_with_live_opencode(
-            {**winner, "stale": bool(
-                winner.get("stale") or winner.get("partial")
-            )},
+            {**winner, "stale": bool(winner.get("stale"))},
             opencode_provider,
         ), con)
     return {**response, "stale": True,
@@ -699,7 +697,10 @@ def persist_routes(con, payload: dict, *, publication_locked: bool = False) -> N
     completed_at = payload.get("refresh_completed_at") or payload.get("fetched_at") \
         or datetime.now(timezone.utc).isoformat()
     generation_id = uuid.uuid4().hex
-    failed = bool(payload.get("stale") or payload.get("partial"))
+    # A best-effort source failure is partial, not stale. Publish the routes
+    # that were freshly observed and leave only the missing harness's prior
+    # routes stale. A genuinely stale/fallback payload still fails closed.
+    failed = bool(payload.get("stale"))
     state = "failed" if failed else "successful"
     verification = payload.get("verification") or {}
     harness_statuses = verification.get("harnesses") or {}
@@ -725,7 +726,7 @@ def persist_routes(con, payload: dict, *, publication_locked: bool = False) -> N
     error_summary = {
         "error": payload.get("error"),
         "errors": payload.get("errors") or [],
-    } if failed else None
+    } if failed or payload.get("partial") else None
     payload_digest = route_bindings.digest_json({
         "v": payload.get("v", PAYLOAD_VERSION),
         "fetched_at": payload.get("fetched_at"),
@@ -770,6 +771,11 @@ def persist_routes(con, payload: dict, *, publication_locked: bool = False) -> N
                 "UPDATE model_routes SET stale=1,last_error='not observed in latest generation'"
             )
             for harness, block in (payload.get("harnesses") or {}).items():
+                if block.get("error"):
+                    con.execute(
+                        "UPDATE model_routes SET last_error=? WHERE harness=?",
+                        (block["error"], harness),
+                    )
                 headless = int(_headless_supported(harness))
                 for entry in block.get("models") or []:
                     route_key = (harness, entry["id"])
@@ -1124,9 +1130,7 @@ def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
         )
     if serve_cached:
         return _served(_with_live_opencode(
-            {**cached, "stale": bool(
-                cached.get("stale") or cached.get("partial")
-            )},
+            {**cached, "stale": bool(cached.get("stale"))},
             opencode_provider), con)
     refresh_started_at = datetime.now(timezone.utc).isoformat()
     try:
@@ -1203,7 +1207,7 @@ def catalog(refresh: bool = False, fetch=_http_json, env=os.environ,
             fallback, response, con, opencode_provider
         )
     response = _with_live_opencode(
-        {**fresh, "stale": bool(fresh.get("partial"))}, opencode_provider
+        {**fresh, "stale": False}, opencode_provider
     )
     response["refresh_started_at"] = refresh_started_at
     response["refresh_completed_at"] = datetime.now(timezone.utc).isoformat()

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -11,6 +11,7 @@ import secrets
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import threading
 import time
@@ -50,6 +51,7 @@ SHELL_RUNTIME_DIR = ENGINE / "run" / "opencode-shells"
 TURN_TIMEOUT_SECONDS = 5400.0
 _SERVER_LOCK = threading.RLock()
 _SERVER_PROCESS: subprocess.Popen | None = None
+_SERVER_ENDPOINT = SERVER_ENDPOINT
 _SERVER_PASSWORD: str | None = None
 _SERVER_LOG_HANDLE = None
 
@@ -82,11 +84,34 @@ def _read_server_state() -> dict[str, Any] | None:
     return data
 
 
-def _write_server_state(pid: int, password: str) -> None:
+def _server_endpoint(port: int) -> str:
+    return f"http://127.0.0.1:{port}"
+
+
+def _server_port(state: Mapping[str, Any]) -> int:
+    """Return a validated recorded port, accepting legacy fixed-port state."""
+    port = state.get("port", 4096)
+    if (
+        isinstance(port, bool)
+        or not isinstance(port, int)
+        or not 1 <= port <= 65535
+    ):
+        return 4096
+    return port
+
+
+def _available_loopback_port() -> int:
+    """Ask the kernel for a currently available private sidecar port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return listener.getsockname()[1]
+
+
+def _write_server_state(pid: int, password: str, port: int) -> None:
     SERVER_STATE.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(SERVER_STATE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w", encoding="utf-8") as handle:
-        json.dump({"pid": pid, "password": password}, handle)
+        json.dump({"pid": pid, "password": password, "port": port}, handle)
 
 
 def _clear_server_state() -> None:
@@ -137,10 +162,10 @@ def _reap_orphan_server(pid: int) -> None:
         pass
 
 
-def _server_healthy(password: str | None) -> bool:
+def _server_healthy(endpoint: str, password: str | None) -> bool:
     try:
         health = UrlHttpTransport(
-            SERVER_ENDPOINT,
+            endpoint,
             password=password,
             timeout=1.0,
         ).request("GET", "/global/health")
@@ -153,37 +178,44 @@ def _server_healthy(password: str | None) -> bool:
     )
 
 
-def ensure_server(*, timeout: float = 10.0) -> str | None:
-    """Return the credential for a healthy loopback ``opencode serve``.
+def ensure_server(*, timeout: float = 10.0) -> tuple[str, str | None]:
+    """Return the endpoint and credential for a healthy ``opencode serve``.
 
     Browser conversations are server-backed, so the engine owns the local
     sidecar lifecycle instead of requiring an operator to start it by hand.
     An already-running compatible server is reused. A server started here is
     loopback-only and protected with an in-memory Basic Auth password.
     """
-    global _SERVER_PROCESS, _SERVER_PASSWORD, _SERVER_LOG_HANDLE
+    global _SERVER_PROCESS, _SERVER_ENDPOINT, _SERVER_PASSWORD
+    global _SERVER_LOG_HANDLE
     with _SERVER_LOCK:
         configured_password = os.environ.get("OPENCODE_SERVER_PASSWORD")
         state = _read_server_state()
         state_pid = state["pid"] if state else None
-        candidate_passwords = []
-        for password in (
-            _SERVER_PASSWORD,
-            state["password"] if state else None,
-            configured_password,
-            None,
+        state_endpoint = (
+            _server_endpoint(_server_port(state)) if state else None
+        )
+        candidates = []
+        for endpoint, password in (
+            (_SERVER_ENDPOINT, _SERVER_PASSWORD),
+            (state_endpoint, state["password"] if state else None),
+            (SERVER_ENDPOINT, configured_password),
+            (SERVER_ENDPOINT, None),
         ):
-            if password not in candidate_passwords:
-                candidate_passwords.append(password)
-        for password in candidate_passwords:
-            if _server_healthy(password):
+            candidate = (endpoint, password)
+            if endpoint is not None and candidate not in candidates:
+                candidates.append(candidate)
+        for endpoint, password in candidates:
+            if _server_healthy(endpoint, password):
+                _SERVER_ENDPOINT = endpoint
                 _SERVER_PASSWORD = password
-                return password
+                return endpoint, password
 
         if state_pid is not None:
             # A server this engine started outlived the process that spawned
-            # it (restart, crash) and answers none of our passwords. Reap the
-            # verified orphan so the managed spawn below can take the port.
+            # it (restart, crash) and answers none of our passwords. Reap only
+            # the verified orphan before starting an independently addressed
+            # replacement.
             _clear_server_state()
             if _pid_is_opencode_serve(state_pid):
                 _reap_orphan_server(state_pid)
@@ -204,6 +236,8 @@ def ensure_server(*, timeout: float = 10.0) -> str | None:
             )
 
         password = configured_password or secrets.token_urlsafe(32)
+        port = _available_loopback_port()
+        endpoint = _server_endpoint(port)
         env = dict(os.environ)
         env["OPENCODE_SERVER_PASSWORD"] = password
         env.setdefault("OPENCODE_SERVER_USERNAME", "opencode")
@@ -218,7 +252,7 @@ def ensure_server(*, timeout: float = 10.0) -> str | None:
                     "--hostname",
                     "127.0.0.1",
                     "--port",
-                    "4096",
+                    str(port),
                     "--log-level",
                     "WARN",
                 ],
@@ -241,10 +275,11 @@ def ensure_server(*, timeout: float = 10.0) -> str | None:
         while time.monotonic() < deadline:
             if _SERVER_PROCESS.poll() is not None:
                 break
-            if _server_healthy(password):
+            if _server_healthy(endpoint, password):
+                _SERVER_ENDPOINT = endpoint
                 _SERVER_PASSWORD = password
-                _write_server_state(_SERVER_PROCESS.pid, password)
-                return password
+                _write_server_state(_SERVER_PROCESS.pid, password, port)
+                return endpoint, password
             time.sleep(0.05)
 
         exit_code = _SERVER_PROCESS.poll()
@@ -263,10 +298,12 @@ def ensure_server(*, timeout: float = 10.0) -> str | None:
 
 def stop_server() -> None:
     """Stop only the OpenCode server process this module started."""
-    global _SERVER_PROCESS, _SERVER_PASSWORD, _SERVER_LOG_HANDLE
+    global _SERVER_PROCESS, _SERVER_ENDPOINT, _SERVER_PASSWORD
+    global _SERVER_LOG_HANDLE
     with _SERVER_LOCK:
         process = _SERVER_PROCESS
         _SERVER_PROCESS = None
+        _SERVER_ENDPOINT = SERVER_ENDPOINT
         _SERVER_PASSWORD = None
         if process is not None and process.poll() is None:
             process.terminate()
@@ -286,9 +323,9 @@ def stop_server() -> None:
 
 def provider_state() -> dict[str, Any]:
     """Return OpenCode's authoritative provider/model connection projection."""
-    password = ensure_server()
+    endpoint, password = ensure_server()
     transport = UrlHttpTransport(
-        SERVER_ENDPOINT,
+        endpoint,
         password=password,
         timeout=10.0,
     )
@@ -500,7 +537,7 @@ class OpenCodeAdapter(ConversationAdapter):
     def __init__(
         self,
         *,
-        endpoint: str = SERVER_ENDPOINT,
+        endpoint: str | None = None,
         password: str | None = None,
         transport: HttpTransport | None = None,
         manifest: Mapping[str, Any] | None = None,
@@ -511,9 +548,13 @@ class OpenCodeAdapter(ConversationAdapter):
         if transport is not None:
             self.transport = transport
         else:
+            if endpoint is None:
+                endpoint, managed_password = ensure_server()
+                if password is None:
+                    password = managed_password
             self.transport = UrlHttpTransport(
                 endpoint,
-                password=password if password is not None else ensure_server(),
+                password=password,
                 timeout=TURN_TIMEOUT_SECONDS,
             )
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -612,6 +612,67 @@ class RoutePersistenceTest(unittest.TestCase):
             "SELECT stale, last_error FROM model_routes WHERE selector='fable'").fetchone()
         self.assertEqual(tuple(row), (1, "network down"))
 
+    def test_partial_opencode_failure_preserves_other_harness_routes(self):
+        claude = self.verification("claude", "2.1.222")
+        opencode = self.verification("opencode", "1.18.18")
+        statuses = {
+            "claude": claude["verification"]["harnesses"]["claude"],
+            "opencode": opencode["verification"]["harnesses"]["opencode"],
+        }
+        initial = {
+            "fetched_at": "2026-08-20T00:00:00+00:00",
+            "stale": False,
+            "harnesses": {
+                "claude": {"models": [mc._entry(
+                    "opus", source="claude-cli", availability="available",
+                    cli_version="claude 2.1.222",
+                )]},
+                "opencode": {"models": [mc._entry(
+                    "halo/qwen", source="opencode-provider-api",
+                    availability="available", cli_version="opencode 1.18.18",
+                )]},
+            },
+            "verification": {"runtime": "host", "harnesses": statuses},
+        }
+        mc.persist_routes(self.con, initial)
+
+        partial = {
+            **initial,
+            "fetched_at": "2026-08-20T00:01:00+00:00",
+            "partial": True,
+            "errors": ["opencode-provider-api: sidecar unavailable"],
+            "harnesses": {
+                "claude": initial["harnesses"]["claude"],
+                "opencode": {
+                    "models": [],
+                    "error": "HARNESS_UNAVAILABLE: sidecar unavailable",
+                },
+            },
+        }
+        mc.persist_routes(self.con, partial)
+
+        rows = self.con.execute(
+            "SELECT harness,selector,stale,last_error FROM model_routes "
+            "ORDER BY harness"
+        ).fetchall()
+        self.assertEqual(
+            [tuple(row) for row in rows],
+            [
+                ("claude", "opus", 0, None),
+                ("opencode", "halo/qwen", 1,
+                 "HARNESS_UNAVAILABLE: sidecar unavailable"),
+            ],
+        )
+        generation = self.con.execute(
+            "SELECT state,error_summary FROM model_catalog_generations "
+            "ORDER BY completed_at DESC,generation_id DESC LIMIT 1"
+        ).fetchone()
+        self.assertEqual(generation["state"], "successful")
+        self.assertEqual(
+            json.loads(generation["error_summary"])["errors"],
+            ["opencode-provider-api: sidecar unavailable"],
+        )
+
     def test_resolver_returns_exact_high_effort_sc_run_call(self):
         fresh = {"fetched_at": datetime.now(timezone.utc).isoformat(), "stale": False,
                  "harnesses": {"codex": {"models": [mc._entry(
@@ -1571,6 +1632,46 @@ class CatalogCacheTest(NoCLI):
         )
         self.assertFalse(second["stale"], "the base cache remains fresh")
         self.assertEqual(provider_models.call_count, 2)
+
+    def test_opencode_overlay_failure_does_not_make_fresh_catalog_stale(self):
+        with mock.patch.object(
+            mc.shutil, "which",
+            side_effect=lambda name: (
+                "/usr/bin/opencode" if name == "opencode" else None
+            ),
+        ):
+            got = mc.catalog(
+                fetch=fetch_ok,
+                env={},
+                run=None,
+                opencode_provider=mock.Mock(
+                    side_effect=RuntimeError("sidecar unavailable")
+                ),
+            )
+            cached = mc.catalog(
+                fetch=fetch_down,
+                env={},
+                run=None,
+                opencode_provider=mock.Mock(
+                    side_effect=RuntimeError("sidecar still unavailable")
+                ),
+            )
+
+        self.assertTrue(got["partial"])
+        self.assertFalse(got["stale"])
+        self.assertIn("claude-opus-4-8", ids(got["harnesses"]["claude"]))
+        self.assertEqual(got["harnesses"]["opencode"]["models"], [])
+        self.assertEqual(
+            got["harnesses"]["opencode"]["error"],
+            "sidecar unavailable",
+        )
+        self.assertTrue(cached["partial"])
+        self.assertFalse(cached["stale"])
+        self.assertIn("claude-opus-4-8", ids(cached["harnesses"]["claude"]))
+        self.assertEqual(
+            cached["harnesses"]["opencode"]["error"],
+            "sidecar still unavailable",
+        )
 
     def test_stale_cache_served_when_refresh_fails(self):
         mc.catalog(fetch=fetch_ok, env={}, run=None)

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -57,6 +57,7 @@ class OpenCodeServerTest(unittest.TestCase):
         self.state_patch.start()
         self.addCleanup(self.state_patch.stop)
         opencode._SERVER_PROCESS = None
+        opencode._SERVER_ENDPOINT = opencode.SERVER_ENDPOINT
         opencode._SERVER_PASSWORD = None
         opencode._SERVER_LOG_HANDLE = None
         self.addCleanup(opencode.stop_server)
@@ -65,27 +66,31 @@ class OpenCodeServerTest(unittest.TestCase):
         with mock.patch.object(
             opencode, "_server_healthy", return_value=True
         ), mock.patch.object(opencode.subprocess, "Popen") as spawn:
-            password = opencode.ensure_server()
+            endpoint, password = opencode.ensure_server()
+        self.assertEqual(endpoint, opencode.SERVER_ENDPOINT)
         self.assertIsNone(password)
         spawn.assert_not_called()
 
-    def test_managed_server_is_loopback_authenticated_and_stoppable(self):
+    def test_managed_server_uses_private_dynamic_loopback_port(self):
         process = FakeProcess()
         checks = iter([False, True])
         with mock.patch.dict(os.environ, {}, clear=False), \
                 mock.patch.object(
                     opencode, "_server_healthy",
-                    side_effect=lambda _password: next(checks),
+                    side_effect=lambda _endpoint, _password: next(checks),
                 ), mock.patch.object(
                     opencode.shutil, "which", return_value="/bin/opencode"
                 ), mock.patch.object(
                     opencode.secrets, "token_urlsafe", return_value="server-secret"
                 ), mock.patch.object(
+                    opencode, "_available_loopback_port", return_value=43210
+                ), mock.patch.object(
                     opencode.subprocess, "Popen", return_value=process
                 ) as spawn:
             os.environ.pop("OPENCODE_SERVER_PASSWORD", None)
-            password = opencode.ensure_server(timeout=1)
+            endpoint, password = opencode.ensure_server(timeout=1)
 
+        self.assertEqual(endpoint, "http://127.0.0.1:43210")
         self.assertEqual(password, "server-secret")
         argv = spawn.call_args.args[0]
         self.assertEqual(
@@ -96,7 +101,7 @@ class OpenCodeServerTest(unittest.TestCase):
                 "--hostname",
                 "127.0.0.1",
                 "--port",
-                "4096",
+                "43210",
                 "--log-level",
                 "WARN",
             ],
@@ -117,11 +122,15 @@ class OpenCodeServerTest(unittest.TestCase):
         with mock.patch.object(
             opencode,
             "_server_healthy",
-            side_effect=lambda password: password == "orphan-secret",
+            side_effect=lambda endpoint, password: (
+                endpoint == opencode.SERVER_ENDPOINT
+                and password == "orphan-secret"
+            ),
         ), mock.patch.object(opencode.subprocess, "Popen") as spawn, \
                 mock.patch.object(opencode, "_reap_orphan_server") as reap:
-            password = opencode.ensure_server()
+            endpoint, password = opencode.ensure_server()
 
+        self.assertEqual(endpoint, opencode.SERVER_ENDPOINT)
         self.assertEqual(password, "orphan-secret")
         spawn.assert_not_called()
         reap.assert_not_called()
@@ -136,7 +145,7 @@ class OpenCodeServerTest(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=False), \
                 mock.patch.object(
                     opencode, "_server_healthy",
-                    side_effect=lambda _password: next(checks),
+                    side_effect=lambda _endpoint, _password: next(checks),
                 ), mock.patch.object(
                     opencode, "_pid_is_opencode_serve", return_value=True
                 ) as identify, mock.patch.object(
@@ -146,17 +155,20 @@ class OpenCodeServerTest(unittest.TestCase):
                 ), mock.patch.object(
                     opencode.secrets, "token_urlsafe", return_value="fresh-secret"
                 ), mock.patch.object(
+                    opencode, "_available_loopback_port", return_value=43211
+                ), mock.patch.object(
                     opencode.subprocess, "Popen", return_value=process
                 ):
             os.environ.pop("OPENCODE_SERVER_PASSWORD", None)
-            password = opencode.ensure_server(timeout=1)
+            endpoint, password = opencode.ensure_server(timeout=1)
 
+        self.assertEqual(endpoint, "http://127.0.0.1:43211")
         self.assertEqual(password, "fresh-secret")
         identify.assert_called_once_with(4322)
         reap.assert_called_once_with(4322)
         self.assertEqual(
             json.loads(self.state_path.read_text()),
-            {"pid": 9999, "password": "fresh-secret"},
+            {"pid": 9999, "password": "fresh-secret", "port": 43211},
         )
 
     def test_stop_server_preserves_state_of_adopted_orphan(self):
@@ -399,14 +411,15 @@ class OpenCodeServerTest(unittest.TestCase):
 
     def test_default_adapter_uses_managed_server_password(self):
         with mock.patch.object(
-            opencode, "ensure_server", return_value="managed-secret"
+            opencode, "ensure_server",
+            return_value=("http://127.0.0.1:43212", "managed-secret"),
         ) as ensure, mock.patch.object(
             opencode, "UrlHttpTransport"
         ) as transport:
             opencode.OpenCodeAdapter()
         ensure.assert_called_once_with()
         transport.assert_called_once_with(
-            opencode.SERVER_ENDPOINT,
+            "http://127.0.0.1:43212",
             password="managed-secret",
             timeout=opencode.TURN_TIMEOUT_SECONDS,
         )


### PR DESCRIPTION
## Summary
- allocate a private loopback port for the managed OpenCode sidecar and persist that endpoint for restart adoption
- keep fresh Claude, Codex, and Kimi routes runnable when the optional OpenCode provider overlay fails
- preserve the exact failing harness error while marking only its unobserved routes stale

## Verification
- python3 tests/test_opencode_server.py (15 passed)
- python3 tests/test_model_catalog.py (43 passed)
- live canary with authenticated port 4096 listener preserved: managed sidecar selected a different port and projected halo/qwen3.8-27b-q8-mtp2
- git diff --check