### PR TITLE
fix(models): extend route evidence freshness to seven days

### DIFF
--- a/.super-coder/api/route_bindings.py
+++ b/.super-coder/api/route_bindings.py
@@ -19,7 +19,7 @@ import harness_versions
 from conversation_adapters.base import AdapterError, checked_version_compatibility
 
 CONTRACT_VERSION = 2
-FRESH_HOURS = 24
+FRESH_HOURS = 7 * 24
 HARNESS_SUPPORT_STATES = frozenset({"tested", "best-effort"})
 LEGACY_HARNESS_EVIDENCE_FORMAT = "legacy-semver"
 RAW_HARNESS_EVIDENCE_FORMAT = "raw-observed-v1"
@@ -781,7 +781,7 @@ def _validate_route_freshness(
     if _age_hours(row.get("last_seen_at"), now) > FRESH_HOURS:
         raise RouteResolutionError(
             "thinking_evidence_stale",
-            "Route evidence is older than 24 hours",
+            "Route evidence is older than 7 days",
             {"harness": harness, "model": model, "remediation": "sc models refresh"},
         )
 
@@ -875,7 +875,7 @@ def _require_fresh_route(
         if _age_hours(latest["completed_at"], check_time) > FRESH_HOURS:
             raise RouteResolutionError(
                 "thinking_evidence_stale",
-                "Latest successful catalogue generation is older than 24 hours",
+                "Latest successful catalogue generation is older than 7 days",
                 {"harness": harness, "model": model,
                  "remediation": "sc models refresh"},
             )

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1025,7 +1025,7 @@ class FlavorDefaultsTest(unittest.TestCase):
         self.assertNotEqual(self._row("planner", "codex")["model"], "gpt-drift")
 
     def test_age_expiry_stales_route_and_refuses_selection(self) -> None:
-        old = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat()
+        old = (datetime.now(timezone.utc) - timedelta(days=7, hours=1)).isoformat()
         self._route("claude", "old-opus", seen_at=old)
 
         ok, err = server.set_flavor_default(
@@ -1042,7 +1042,7 @@ class FlavorDefaultsTest(unittest.TestCase):
         self.assertEqual(route["stale"], 1)
         self.assertEqual(
             route["last_error"],
-            "thinking_evidence_stale: Route evidence is older than 24 hours; "
+            "thinking_evidence_stale: Route evidence is older than 7 days; "
             "remediation: sc models refresh",
         )
         self.assertFalse(server.model_route_available(

--- a/tests/test_route_bindings.py
+++ b/tests/test_route_bindings.py
@@ -1763,9 +1763,9 @@ class GenerationPersistenceTest(unittest.TestCase):
             ),
             (
                 "age-expired",
-                (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat(),
+                (datetime.now(timezone.utc) - timedelta(days=7, hours=1)).isoformat(),
                 None,
-                "Route evidence is older than 24 hours",
+                "Route evidence is older than 7 days",
             ),
         )
         for name, fetched_at, supplied_fingerprint, message in cases:
@@ -1803,6 +1803,30 @@ class GenerationPersistenceTest(unittest.TestCase):
                 )
                 self.assertFalse(refused_again["ok"])
                 self.assertEqual(refused_again["code"], "thinking_evidence_stale")
+
+    def test_authoritative_resolution_accepts_evidence_older_than_one_day(self):
+        now = datetime.now(timezone.utc)
+        payload = self.payload("age-within-seven-days")
+        payload["fetched_at"] = (now - timedelta(hours=25)).isoformat()
+        model_catalog.persist_routes(self.con, payload)
+        row = dict(self.con.execute(
+            "SELECT * FROM model_routes WHERE selector='age-within-seven-days'"
+        ).fetchone())
+
+        got = resolve_controlled(
+            self.con,
+            "codex",
+            "age-within-seven-days",
+            fingerprint=row["source_fingerprint"],
+            now=now,
+        )
+
+        self.assertTrue(got["ok"])
+        stored = self.con.execute(
+            "SELECT stale,last_error FROM model_routes "
+            "WHERE selector='age-within-seven-days'"
+        ).fetchone()
+        self.assertEqual(tuple(stored), (0, None))
 
     def test_wrong_seat_source_proof_does_not_stale_shared_route(self):
         model_catalog.persist_routes(self.con, self.payload("seat-bound"))


### PR DESCRIPTION
Extends exact model-route and catalogue-generation freshness from 24 hours to 7 days. Keeps the existing fail-closed stale behavior after the new boundary and updates the user-facing error text.\n\nVerification: ./sc test tests/test_route_bindings.py -q (60 passed, 61 subtests passed).