### PR TITLE
feat(sandbox): self-heal Python test tooling

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -72,6 +72,15 @@ LABEL sc.github_host_trust_sha256="${SC_GITHUB_HOST_TRUST_SHA256}"
 # .venv.
 RUN pip install --no-cache-dir "websockets==16.1.1"
 
+# Python project tooling — generic sandbox mechanisms, not fork dependency
+# policy. A fork's declared dev-kit hook and project environment still own its
+# exact test stack. Pin both tools so rebuilding after an engine update restores
+# a deterministic baseline instead of inheriting whatever the host happens to
+# provide.
+RUN pip install --no-cache-dir "uv==0.11.26" "pytest==9.1.1" \
+ && uv --version \
+ && python -m pytest --version
+
 # GitHub CLI (gh) — shells open their own feature PRs from the sandbox.
 # Not in Debian's default repos, so add the official gh apt source. Auth is NOT
 # baked: the token arrives at runtime via GH_TOKEN (`./sc launch` forwards the

--- a/.super-coder/migrations/0228_reseed_python_test_tooling.sql
+++ b/.super-coder/migrations/0228_reseed_python_test_tooling.sql
@@ -1,11 +1,14 @@
----
-name: dev_kit
-description: Run fork-owned dev-kit hooks and diagnose host or Docker provisioning states without inferring project policy.
-category: substrate
-common: false
----
+-- 0228 — reseed self-healing Python test guidance.
+-- Converge existing installs to the image-owned tool and project-venv precedence contract.
 
-# dev_kit — target-aware project tooling
+BEGIN;
+
+UPDATE skills SET
+  description='Run fork-owned dev-kit hooks and diagnose host or Docker provisioning states without inferring project policy.',
+  category='substrate',
+  command=NULL,
+  common=0,
+  content='# dev_kit — target-aware project tooling
 
 `deps`, `test`, `lint`, and `typecheck` are invariant exact-execution hooks on
 both host and Docker seats. The fork owns their argv in the tracked
@@ -24,20 +27,20 @@ and the equivalent baked wrapper in Docker.
 
 ## Read the active seat
 
-Read the boot document's execution-context section before acting. It is the
-authority for this shell's active seat.
+Read the boot document''s execution-context section before acting. It is the
+authority for this shell''s active seat.
 
 - **Host:** commands and project processes run directly on the host. Respect an
   existing supervisor (`pm2`, `systemd`, or `make`) and bind ad-hoc dev servers
   to `127.0.0.1:$SC_DEV_PORT` unless the task requires another interface.
 - **Docker:** the checkout is bind-mounted at its host path. Run a dev server on
   `0.0.0.0:$SC_DEV_PORT`; the published host URL is
-  `http://127.0.0.1:$SC_DEV_PORT`. The FnB's host-supervised app is a separate
+  `http://127.0.0.1:$SC_DEV_PORT`. The FnB''s host-supervised app is a separate
   instance.
 
 Host lifecycle remedies such as `sc launch` and `sc enter --devkit-repair`
 must be run from a host terminal. If this shell is in Docker, exit the container
-before using them. Never restart the FnB's host stack from a sandbox shell.
+before using them. Never restart the FnB''s host stack from a sandbox shell.
 
 ## State and remedy contract
 
@@ -77,7 +80,7 @@ selected.
   prerequisites; it does not elevate or install them.
 
 Read `.subfloor/dev-kit.json` and its executable before invoking a hook. Run
-`sc deps` first only when the declaration makes `deps` the fork's dependency
+`sc deps` first only when the declaration makes `deps` the fork''s dependency
 policy. A fork may choose a virtualenv, npm, another tool, or no dependency step
 at all. In Docker, fork code must treat an out-of-checkout interpreter as
 host-managed and shared: verify it, but never install into it.
@@ -94,7 +97,7 @@ npm, pinned `uv` + `pytest`, and Playwright with Chromium at
 `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright`. These are available mechanisms,
 not inferred lifecycle hooks. On shell boot, an existing assigned-checkout
 `.venv/bin` precedes these baseline tools while the checkout root remains first
-for bare `sc`; pass = project tools use that checkout's interpreter without the
+for bare `sc`; pass = project tools use that checkout''s interpreter without the
 engine creating or repairing its environment. A missing `.venv` remains fork
 policy through declared hooks. Frontend tools such as `svelte-check`, `tsc`,
 and vitest still come from fork-owned dependencies and run only through
@@ -108,7 +111,7 @@ selected image. NEVER install pytest on the host to repair a Docker shell.
 
 When a fork sets `"pg": {}` in `.super-coder/instance.json` (`sc pg-init` adds
 it), `sc launch` starts a `postgres:17` sidecar and forwards `DATABASE_URL` into
-Docker. This is only the fork application's database. The engine memory DB is
+Docker. This is only the fork application''s database. The engine memory DB is
 always SQLite and never reads `DATABASE_URL`.
 
 Inside Docker the app connects by the container hostname in `DATABASE_URL`, not
@@ -116,7 +119,7 @@ Inside Docker the app connects by the container hostname in `DATABASE_URL`, not
 hooks. Data persists in the install-owned Docker volume.
 
 An unset `DATABASE_URL` means no sidecar is configured. A set URL with an empty
-schema means provision the real app DB through the fork's migrations and
+schema means provision the real app DB through the fork''s migrations and
 bootstrap; it is not a blocker and is not permission to create a second
 throwaway database.
 
@@ -125,4 +128,8 @@ throwaway database.
 The declaration and active boot seat are the truth. Diagnose the exact state,
 use the remedy for that seat, and require observable execution evidence rather
 than command narration. Do not convert an absent capability into inferred
-policy or a repair session into a readiness claim.
+policy or a repair session into a readiness claim.',
+  is_deleted=0
+WHERE name='dev_kit';
+
+COMMIT;

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -1194,6 +1194,17 @@ def _cli_version(binary: str) -> "str | None":
     return lines[0].strip() if lines else None
 
 
+def _shell_path(work_dir: Path, inherited: str) -> str:
+    """Put this shell's existing project environment ahead of baseline tools."""
+    entries = [str(REPO_ROOT)]
+    project_bin = work_dir / ".venv" / "bin"
+    if project_bin.is_dir():
+        entries.append(str(project_bin))
+    if inherited:
+        entries.append(inherited)
+    return os.pathsep.join(entries)
+
+
 def prepare_launch(*, shell_id: int, harness: "str | None" = None,
                    model: "str | None" = None, effort: "str | None" = None,
                    headless_prompt: "str | None" = None,
@@ -1489,7 +1500,7 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
     env["SC_HARNESS"] = harness
     env["SC_SHELL_WORKTREE"] = str(work_dir)
     env["SC_ROOT"] = str(REPO_ROOT)
-    env["PATH"] = os.pathsep.join([str(REPO_ROOT), env.get("PATH", "")])
+    env["PATH"] = _shell_path(work_dir, env.get("PATH", ""))
 
     return LaunchPlan(argv=argv, env=env, cwd=str(work_dir),
                       session_id=session_id, archive_id=archive_id,
@@ -2060,7 +2071,7 @@ def main() -> None:
     # vigilance. Works in both the docker sandbox and the no-docker host path since
     # run.py is the single exec chokepoint for every harness.
     env["SC_ROOT"] = str(REPO_ROOT)
-    env["PATH"] = os.pathsep.join([str(REPO_ROOT), env.get("PATH", "")])
+    env["PATH"] = _shell_path(work_dir, env.get("PATH", ""))
     # Operator-declared shared dirs that all shells may write into without
     # branch-guard warnings — host-level handoff/screenshot folders. Set
     # SC_SHARED_DIRS (space-separated absolute paths) in the launch environment;

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -1367,6 +1367,9 @@ def main(argv: list[str]) -> int:
         print("    git pull --ff-only       # brings the repin onto local main")
     print("  A bad update? `./sc rollback` restores the DB + engine together.")
     print("  Restart your session to boot onto the new floor.")
+    if epoch:
+        print("  Image-owned tool changes activate through a normal `./sc restart`;")
+        print("  `restart --no-build` deliberately retains the selected image.")
     return 0
 
 

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -129,7 +129,8 @@
     ".super-coder/migrations/0223_model_default_effort_binding.sql",
     ".super-coder/migrations/0225_focused_dev_verification.sql",
     ".super-coder/migrations/0226_reseed_cartographer_workflow_hardening.sql",
-    ".super-coder/migrations/0227_deepseek_controlled_route_binding.sql"
+    ".super-coder/migrations/0227_deepseek_controlled_route_binding.sql",
+    ".super-coder/migrations/0228_reseed_python_test_tooling.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_devkit_declaration.py
+++ b/tests/test_devkit_declaration.py
@@ -31,7 +31,7 @@ DEVKIT_RESEED = (
     ROOT
     / ".super-coder"
     / "migrations"
-    / "0211_reseed_native_package_dev_kit.sql"
+    / "0228_reseed_python_test_tooling.sql"
 )
 
 

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -85,6 +85,47 @@ class FlavorRouteDefaultsTest(unittest.TestCase):
         )
 
 
+class ShellPathTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name) / "repo"
+        self.worktree = self.root / ".sc-worktrees" / "dev1"
+        self.worktree.mkdir(parents=True)
+        self.root_patch = mock.patch.object(run, "REPO_ROOT", self.root)
+        self.root_patch.start()
+        self.addCleanup(self.root_patch.stop)
+
+    def test_existing_project_environment_precedes_inherited_tools(self) -> None:
+        project_bin = self.worktree / ".venv" / "bin"
+        project_bin.mkdir(parents=True)
+
+        path = run._shell_path(self.worktree, "/usr/local/bin:/usr/bin")
+
+        self.assertEqual(
+            path,
+            f"{self.root}:{project_bin}:/usr/local/bin:/usr/bin",
+        )
+
+    def test_absent_or_non_directory_environment_is_not_injected(self) -> None:
+        self.assertEqual(
+            run._shell_path(self.worktree, "/usr/bin"),
+            f"{self.root}:/usr/bin",
+        )
+        project_bin = self.worktree / ".venv" / "bin"
+        project_bin.parent.mkdir(parents=True)
+        project_bin.write_text("not a directory")
+        self.assertEqual(
+            run._shell_path(self.worktree, "/usr/bin"),
+            f"{self.root}:/usr/bin",
+        )
+
+    def test_interactive_and_prepared_launches_share_the_path_builder(self) -> None:
+        source = (SCRIPTS / "run.py").read_text()
+        assignment = 'env["PATH"] = _shell_path(work_dir, env.get("PATH", ""))'
+        self.assertEqual(source.count(assignment), 2)
+
+
 class _FailAfterArchive:
     """Connection proxy that injects a lock after the archive INSERT."""
 

--- a/tests/test_sandbox_python_toolchain.py
+++ b/tests/test_sandbox_python_toolchain.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Contracts for Subfloor's image-owned Python project mechanisms."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+DOCKERFILE = ROOT / ".super-coder" / "Dockerfile"
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import seed_skills  # noqa: E402
+
+
+class SandboxPythonToolchainTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = DOCKERFILE.read_text()
+        cls.folded = cls.text.replace("\\\n", " ")
+
+    def test_uv_and_pytest_are_exact_pinned_baseline_tools(self) -> None:
+        self.assertIn(
+            'RUN pip install --no-cache-dir "uv==0.11.26" "pytest==9.1.1"',
+            self.folded,
+        )
+        self.assertIn("&& uv --version", self.folded)
+        self.assertIn("&& python -m pytest --version", self.folded)
+
+    def test_harness_refresh_does_not_rebuild_python_tools(self) -> None:
+        tool_at = self.folded.index(
+            'RUN pip install --no-cache-dir "uv==0.11.26" "pytest==9.1.1"'
+        )
+        epoch_at = self.folded.index("ARG SC_HARNESS_EPOCH=0")
+        self.assertLess(tool_at, epoch_at)
+
+
+class PythonToolingSkillReseedTest(unittest.TestCase):
+    def test_terminal_reseed_converges_to_authoritative_dev_kit_skill(self) -> None:
+        expected = seed_skills.parse_skill(
+            ENGINE / "assets" / "seed" / "skills" / "dev_kit" / "SKILL.md"
+        )
+        con = sqlite3.connect(":memory:")
+        self.addCleanup(con.close)
+        con.executescript(
+            "CREATE TABLE skills ("
+            "skill_id INTEGER PRIMARY KEY, name TEXT UNIQUE, description TEXT, "
+            "category TEXT, command TEXT, common INTEGER, content TEXT, "
+            "is_deleted INTEGER DEFAULT 0);"
+            "INSERT INTO skills VALUES "
+            "(1,'dev_kit','stale','stale','stale',1,'stale',1);"
+        )
+        migration = (
+            ENGINE / "migrations" / "0228_reseed_python_test_tooling.sql"
+        ).read_text()
+
+        con.executescript(migration)
+        con.executescript(migration)
+
+        actual = con.execute(
+            "SELECT name,description,category,command,common,content,is_deleted "
+            "FROM skills ORDER BY skill_id"
+        ).fetchall()
+        self.assertEqual(
+            actual,
+            [(
+                expected["name"],
+                expected["description"],
+                expected["category"],
+                expected["command"],
+                expected["common"],
+                expected["content"],
+                0,
+            )],
+        )
+        self.assertIn("pinned `uv` + `pytest`", actual[0][5])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- ship exact-pinned uv 0.11.26 and pytest 9.1.1 in the standard sandbox image
- prefer an existing assigned-worktree .venv/bin in both interactive and prepared/headless shell launches
- converge existing installs through the terminal dev-kit skill migration and explain normal restart activation
- preserve fork-owned hooks: no inferred environment, host package install, or automatic restart

Spec: #168 under Feature #40.

## Verification

- 46 dev-kit declaration and terminal reseed conformance tests passed
- 65 launch, Dockerfile, migration, and update materialization tests passed
- 91 harness epoch, image lifecycle, and restart tests passed
- 8 public skill freshness tests passed
- git diff --check passed

The configured CI suite and render-check own the repository-wide gates.