### PR TITLE
fix(devkit): repair package image cutover

### DIFF
--- a/.super-coder/scripts/sandbox_devkit.py
+++ b/.super-coder/scripts/sandbox_devkit.py
@@ -205,10 +205,11 @@ def _validate_extension_dockerfile(path: Path) -> None:
         )
     if not from_positions:
         raise SandboxImageError("sandbox.dockerfile: must contain a FROM instruction")
-    final_index, final_from = from_positions[-1]
-    if min(arg_positions) > final_index:
+    _, final_from = from_positions[-1]
+    first_from_index = from_positions[0][0]
+    if min(arg_positions) > first_from_index:
         raise SandboxImageError(
-            "sandbox.dockerfile: ARG SC_BASE_IMAGE must precede the final FROM"
+            "sandbox.dockerfile: ARG SC_BASE_IMAGE must be global (before the first FROM)"
         )
     if not re.fullmatch(
         r"FROM\s+(?:--platform=\S+\s+)?\$\{SC_BASE_IMAGE\}(?:\s+AS\s+\S+)?",
@@ -763,16 +764,18 @@ def _run_archive_build(command: Sequence[str], archive: bytes, *, runner: Runner
         )
 
 
-def _apt_dockerfile(packages: Sequence[AptPackage]) -> str:
+def _apt_dockerfile(packages: Sequence[AptPackage], user: str) -> str:
     install = ["apt-get", "install", "-y", "--no-install-recommends"]
     install.extend(package.atom for package in packages)
     return "\n".join(
         (
             "ARG SC_BASE_IMAGE",
             "FROM ${SC_BASE_IMAGE}",
+            "USER root",
             'RUN ["apt-get", "update"]',
             "RUN " + json.dumps(install, separators=(",", ":")),
             'RUN ["sh", "-c", "rm -rf /var/lib/apt/lists/*"]',
+            f"USER {user}",
             "",
         )
     )
@@ -780,7 +783,6 @@ def _apt_dockerfile(packages: Sequence[AptPackage]) -> str:
 
 def _build_package_layer(
     plan: ImagePlan,
-    base_id: str,
     labels: dict[str, str],
     *,
     runner: Runner,
@@ -794,7 +796,7 @@ def _build_package_layer(
             "-f",
             "-",
             "--build-arg",
-            f"SC_BASE_IMAGE={base_id}",
+            f"SC_BASE_IMAGE={plan.base_tag}",
             *_label_arguments(labels),
             empty_context,
         ]
@@ -804,7 +806,7 @@ def _build_package_layer(
                 check=False,
                 text=True,
                 capture_output=True,
-                input=_apt_dockerfile(plan.packages),
+                input=_apt_dockerfile(plan.packages, plan.user),
             )
         except OSError as exc:
             raise SandboxPrerequisiteError(f"cannot run docker: {exc}") from exc
@@ -818,7 +820,6 @@ def _build_package_layer(
 
 def _build_package_runtime(
     plan: ImagePlan,
-    package_id: str,
     labels: dict[str, str],
     *,
     runner: Runner,
@@ -833,7 +834,7 @@ def _build_package_runtime(
             "-f",
             "-",
             "--build-arg",
-            f"SC_BASE_IMAGE={package_id}",
+            f"SC_BASE_IMAGE={plan.package_layer_tag}",
             *_label_arguments(labels),
             empty_context,
         ]
@@ -1350,9 +1351,7 @@ def build_images(
                 package_layer_id="self",
                 context_digest="none",
             )
-            package_id = _build_package_layer(
-                plan, base_id, package_labels, runner=runner
-            )
+            package_id = _build_package_layer(plan, package_labels, runner=runner)
             final_tag, final_id = plan.package_layer_tag, package_id
         if plan.extends_base:
             context_digest, archive, dockerfile_relative = _tracked_context(
@@ -1374,7 +1373,7 @@ def build_images(
                 "-f",
                 dockerfile_relative,
                 "--build-arg",
-                f"SC_BASE_IMAGE={final_id}",
+                f"SC_BASE_IMAGE={final_tag}",
                 *_label_arguments(extension_labels),
                 "-",
             ]
@@ -1391,9 +1390,7 @@ def build_images(
                 context_digest="none",
             )
             final_tag = plan.package_tag
-            final_id = _build_package_runtime(
-                plan, package_id, runtime_labels, runner=runner
-            )
+            final_id = _build_package_runtime(plan, runtime_labels, runner=runner)
         if plan.has_package_contract:
             proof, proof_digest, proof_command = _prove_packages(
                 final_id, plan.packages, runner=runner

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -130,7 +130,8 @@
     ".super-coder/migrations/0225_focused_dev_verification.sql",
     ".super-coder/migrations/0226_reseed_cartographer_workflow_hardening.sql",
     ".super-coder/migrations/0227_deepseek_controlled_route_binding.sql",
-    ".super-coder/migrations/0228_reseed_python_test_tooling.sql"
+    ".super-coder/migrations/0228_reseed_python_test_tooling.sql",
+    ".super-coder/migrations/0229_reseed_messaging_wake_guidance.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,
@@ -552,6 +553,11 @@
       "sc"
     ],
     "allowed_v2_authored_lines": {
+      ".super-coder/assets/skills/messaging/SKILL.md": [
+        "Engine-wide wakes need no Sprint. Sprint-scoped wakes deliver only while that",
+        "Sprint is armed; a producer may create delivery intent earlier and leave it",
+        "queued. Typed Sprint commands and engine producers return their durable"
+      ],
       ".super-coder/ui/app.js": [
         "\"Abort stops active work but retains the complete Sprint history and the Planner's durable abort-report request.\") : \"\",",
         "\"No Sprints yet\",",

--- a/tests/test_sandbox_devkit_images.py
+++ b/tests/test_sandbox_devkit_images.py
@@ -346,6 +346,21 @@ class SandboxImagePlanTest(unittest.TestCase):
                 with self.assertRaisesRegex(SandboxImageError, "SC_BASE_IMAGE"):
                     fixture.plan()
 
+    def test_extension_base_arg_must_be_global_before_first_stage(self):
+        fixture = ImageFixture(self.base, "stage-local-arg")
+        dockerfile = fixture.context / "Fork.Dockerfile"
+        dockerfile.write_text(
+            "FROM busybox AS source\n"
+            "ARG SC_BASE_IMAGE\n"
+            "FROM ${SC_BASE_IMAGE}\n"
+        )
+
+        with self.assertRaisesRegex(
+            SandboxImageError,
+            r"ARG SC_BASE_IMAGE must be global \(before the first FROM\)",
+        ):
+            fixture.plan()
+
     def test_missing_docker_is_a_host_prerequisite_error_not_invalid_state(self):
         fixture = ImageFixture(self.base, "missing-docker")
         completed = subprocess.run(
@@ -397,7 +412,7 @@ class SandboxImagePlanTest(unittest.TestCase):
         self.assertNotIn("state: invalid", completed.stderr)
         self.assertNotIn("--no-build cannot reuse", completed.stderr)
 
-    def test_build_uses_immutable_base_id_exact_context_and_required_labels(self):
+    def test_build_uses_local_base_tag_exact_context_and_required_labels(self):
         fixture = ImageFixture(self.base, "fork")
         plan = fixture.plan()
         docker = FakeDocker()
@@ -424,7 +439,8 @@ class SandboxImagePlanTest(unittest.TestCase):
         self.assertIn("SC_PARENT_IMAGE=python:3.12-slim", base)
         self.assertNotIn("SC_PARENT_IMAGE=sha256:" + "a" * 64, base)
         self.assertIn("sc.parent_id=sha256:" + "a" * 64, base)
-        self.assertIn("SC_BASE_IMAGE=sha256:" + "b" * 64, extension)
+        self.assertIn(f"SC_BASE_IMAGE={plan.base_tag}", extension)
+        self.assertNotIn("SC_BASE_IMAGE=sha256:" + "b" * 64, extension)
         for key, value in plan.runtime_labels.items():
             self.assertIn(f"{key}={value}", extension)
         self.assertEqual(
@@ -473,20 +489,24 @@ class SandboxImagePlanTest(unittest.TestCase):
         package_build = next(
             command for command in docker.builds() if "-package-layer-" in command[command.index("-t") + 1]
         )
-        self.assertIn("SC_BASE_IMAGE=sha256:" + "b" * 64, package_build)
+        self.assertIn(f"SC_BASE_IMAGE={plan.base_tag}", package_build)
+        self.assertNotIn("SC_BASE_IMAGE=sha256:" + "b" * 64, package_build)
         dockerfile = docker.inputs[docker.commands.index(package_build)]
         self.assertEqual(
             dockerfile,
             "ARG SC_BASE_IMAGE\n"
             "FROM ${SC_BASE_IMAGE}\n"
+            "USER root\n"
             'RUN ["apt-get", "update"]\n'
             'RUN ["apt-get","install","-y","--no-install-recommends","curl","jq=1.6-2.1"]\n'
-            'RUN ["sh", "-c", "rm -rf /var/lib/apt/lists/*"]\n',
+            'RUN ["sh", "-c", "rm -rf /var/lib/apt/lists/*"]\n'
+            "USER tester\n",
         )
         runtime_build = next(
             command for command in docker.builds() if "-packages-" in command[command.index("-t") + 1]
         )
-        self.assertIn("SC_BASE_IMAGE=sha256:" + "k" * 64, runtime_build)
+        self.assertIn(f"SC_BASE_IMAGE={plan.package_layer_tag}", runtime_build)
+        self.assertNotIn("SC_BASE_IMAGE=sha256:" + "k" * 64, runtime_build)
         self.assertIn("sc.package_layer_id=sha256:" + "k" * 64, runtime_build)
         proof_command = next(
             command
@@ -507,6 +527,22 @@ class SandboxImagePlanTest(unittest.TestCase):
         self.assertEqual(receipt["format_version"], 2)
         self.assertTrue(receipt["source_tracked_clean"])
         self.assertEqual(preflight_image(plan, runner=docker), plan.package_tag)
+
+    def test_extension_build_uses_local_package_layer_tag(self):
+        fixture = ImageFixture(self.base, "package-extension", packages=["curl"])
+        plan = fixture.plan()
+        docker = FakeDocker()
+
+        self.assertEqual(build_images(plan, runner=docker), plan.runtime_tag)
+
+        extension_build = next(
+            command
+            for command in docker.builds()
+            if command[command.index("-t") + 1] == plan.runtime_tag
+        )
+        self.assertIn(f"SC_BASE_IMAGE={plan.package_layer_tag}", extension_build)
+        self.assertNotIn("SC_BASE_IMAGE=sha256:" + "k" * 64, extension_build)
+        self.assertIn("sc.package_layer_id=sha256:" + "k" * 64, extension_build)
 
     def test_pinned_version_mismatch_falls_back_to_fresh_engine_baseline(self):
         fixture = ImageFixture(


### PR DESCRIPTION
## Summary
- use local image tags for Dockerfile FROM build args while preserving immutable IDs in labels and receipts
- run apt package installation as root, then restore the configured sandbox user
- require SC_BASE_IMAGE to be declared globally before the first Dockerfile stage

## Verification
- ./.subfloor/dev-kit test -q tests/test_sandbox_devkit_images.py
- ./.subfloor/dev-kit lint .super-coder/scripts/sandbox_devkit.py

Closes #1282