### PR TITLE
fix(render): expose source rows behind document drift

### DIFF
--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -89,6 +89,17 @@ def _document_target(root: Path, rel: str, kind: str) -> Path:
     return root / path
 
 
+def document_rel_path(row) -> str:
+    """Resolve one document row to its managed repo-relative render path."""
+    if row["render_path"]:
+        return row["render_path"]
+    base = "specs_sc" if row["kind"] == "spec" else "docs_sc"
+    slug = row["title"] or f"{row['kind']}-{row['feature_id']}-{row['seq']}"
+    slug = slug.lower().replace(" ", "-").replace("—", "-")
+    slug = "".join(c for c in slug if c.isalnum() or c in "-_")
+    return f"{base}/{slug}.md"
+
+
 # ── Flat visibility render ────────────────────────────────────────────────────
 
 def _render_documents(con, written, skipped, root: Path) -> None:
@@ -106,13 +117,7 @@ def _render_documents(con, written, skipped, root: Path) -> None:
     for r in rows:
         if not r["body"]:
             continue
-        rel = r["render_path"]
-        if not rel:
-            base = "specs_sc" if r["kind"] == "spec" else "docs_sc"
-            slug = (r["title"] or f"{r['kind']}-{r['feature_id']}-{r['seq']}")
-            slug = slug.lower().replace(" ", "-").replace("—", "-")
-            slug = "".join(c for c in slug if c.isalnum() or c in "-_")
-            rel = f"{base}/{slug}.md"
+        rel = document_rel_path(r)
         # Per-document metadata into the rendered frontmatter — where the
         # feature sits in the plan + whether this spec is frozen.
         extra = [

--- a/.super-coder/scripts/render_check.py
+++ b/.super-coder/scripts/render_check.py
@@ -6,23 +6,27 @@ RENDERED from the DB (documents/roadmap/skills; a skill's source is
 `assets/skills/<name>/SKILL.md` → seed migration → DB). Editing that source
 without re-rendering leaves the local browsable copy stale.
 
-HERMETIC by construction: this builds a throwaway DB from authored engine text
+HERMETIC verdict: this builds a throwaway DB from authored engine text
 (schema + migrations), the local instance snapshot, and the fork skill-retire
 list, renders the mirror from THAT into a temp tree, and diffs it against the
-active local `_sc` files. It never opens the live `shell_db.db` and never writes
-into the working tree. So — unlike the old version, which rendered from the live
-DB *into the tree* and then told you to `git add` whatever fell out — a stale or
-dirty local cache DB can no longer make this pass or fail wrongly, and can never
-trick you into committing a regression. A local `./sc render-check` is now
-byte-identical to CI; no `./sc rebuild` first.
+active local `_sc` files. It never writes into the working tree. On drift only,
+it may read the live `shell_db.db` to report which document source fields differ;
+those diagnostics never influence the verdict. So — unlike the old version,
+which rendered from the live DB *into the tree* and then told you to `git add`
+whatever fell out — a stale or dirty local cache DB can no longer make this pass
+or fail wrongly, and can never trick you into committing a regression. A local
+`./sc render-check` verdict is byte-identical to CI; no `./sc rebuild` first.
 
     ./sc render-check
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import sqlite3
 import sys
 import tempfile
+from contextlib import closing
 from pathlib import Path
 
 ENGINE = Path(__file__).resolve().parents[1]
@@ -33,13 +37,14 @@ RENDERED = ["roadmap_sc.md", "specs_sc", "docs_sc", "skills_sc"]
 
 sys.path.insert(0, str(ENGINE / "render"))
 sys.path.insert(0, str(ENGINE / "scripts"))
-import flat  # noqa: E402
 import artifact_policy  # noqa: E402
+import flat  # noqa: E402
 import migrate as migrate_mod  # noqa: E402
 import seed_skills  # noqa: E402
 
 CONTENT = artifact_policy.content_path()
 ACTIVE_ROOT = artifact_policy.render_root()
+LIVE_DB = ENGINE / "shell_db.db"
 
 
 def _build_tracked_db(path: Path) -> None:
@@ -97,6 +102,55 @@ def _rel_files(base: Path) -> set[str]:
     return found
 
 
+def _document_source_rows(con: sqlite3.Connection, rel: str) -> list[dict]:
+    """Summarize every DB row capable of rendering one managed document."""
+    rows = con.execute(
+        "SELECT d.document_id, d.feature_id, d.kind, d.seq, d.title, d.body, "
+        "d.render_path, d.frozen, r.title AS feature_title, r.roadmap_status "
+        "FROM documents d LEFT JOIN roadmap r ON r.feature_id=d.feature_id "
+        "ORDER BY d.document_id"
+    ).fetchall()
+    summaries = []
+    for row in rows:
+        if flat.document_rel_path(row) != rel:
+            continue
+        body = row["body"] or ""
+        summaries.append({
+            "document_id": row["document_id"],
+            "feature_id": row["feature_id"],
+            "kind": row["kind"],
+            "seq": row["seq"],
+            "title": row["title"],
+            "render_path": row["render_path"],
+            "frozen": bool(row["frozen"]),
+            "feature_title": row["feature_title"],
+            "roadmap_status": row["roadmap_status"],
+            "body_bytes": len(body.encode()),
+            "body_sha256": hashlib.sha256(body.encode()).hexdigest(),
+        })
+    return summaries
+
+
+def _document_source_diagnostics(
+    source: sqlite3.Connection,
+    live: sqlite3.Connection,
+    drifted: list[str],
+) -> str:
+    lines = []
+    for rel in drifted:
+        if not rel.startswith(("specs_sc/", "docs_sc/")):
+            continue
+        source_rows = _document_source_rows(source, rel)
+        live_rows = _document_source_rows(live, rel)
+        lines.append(f"  source rows for {rel}:")
+        if source_rows == live_rows:
+            lines.append("    snapshot and live DB rows match; the active mirror is stale")
+            continue
+        lines.append(f"    snapshot: {json.dumps(source_rows, sort_keys=True)}")
+        lines.append(f"    live DB : {json.dumps(live_rows, sort_keys=True)}")
+    return "\n".join(lines)
+
+
 def main() -> int:
     print("render-check: verifying the tracked sources of this checkout")
     for line in _target_lines():
@@ -128,6 +182,20 @@ def main() -> int:
                     and (out / rel).read_bytes() == (ACTIVE_ROOT / rel).read_bytes())
         )
         if drifted:
+            diagnostics = ""
+            if LIVE_DB.is_file():
+                try:
+                    with closing(  # noqa: SIM117 -- Python 3.9 has no parenthesized with
+                        sqlite3.connect(f"file:{LIVE_DB}?mode=ro", uri=True)
+                    ) as live:
+                        with closing(sqlite3.connect(db)) as source:
+                            live.row_factory = sqlite3.Row
+                            source.row_factory = sqlite3.Row
+                            diagnostics = _document_source_diagnostics(
+                                source, live, drifted
+                            )
+                except sqlite3.Error as exc:
+                    diagnostics = f"  source-row diagnostics unavailable: {exc}"
             sys.stderr.write(
                 "✗ render drift: the active flat _sc mirror does not match the\n"
                 "  mirror rendered from the active sources (schema + migrations +\n"
@@ -136,6 +204,7 @@ def main() -> int:
                 + "".join(f"{line}\n" for line in _target_lines())
                 + "\n  drifted:\n"
                 + "".join(f"    {p}\n" for p in drifted)
+                + (f"\n{diagnostics}\n" if diagnostics else "")
                 + "\n  fix:  ./sc rebuild && ./sc render flat\n"
             )
             return 1

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -130,7 +130,8 @@
     ".super-coder/migrations/0225_focused_dev_verification.sql",
     ".super-coder/migrations/0226_reseed_cartographer_workflow_hardening.sql",
     ".super-coder/migrations/0227_deepseek_controlled_route_binding.sql",
-    ".super-coder/migrations/0228_reseed_python_test_tooling.sql"
+    ".super-coder/migrations/0228_reseed_python_test_tooling.sql",
+    ".super-coder/migrations/0229_reseed_messaging_wake_guidance.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,
@@ -552,6 +553,11 @@
       "sc"
     ],
     "allowed_v2_authored_lines": {
+      ".super-coder/assets/skills/messaging/SKILL.md": [
+        "Engine-wide wakes need no Sprint. Sprint-scoped wakes deliver only while that",
+        "Sprint is armed; a producer may create delivery intent earlier and leave it",
+        "queued. Typed Sprint commands and engine producers return their durable"
+      ],
       ".super-coder/ui/app.js": [
         "\"Abort stops active work but retains the complete Sprint history and the Planner's durable abort-report request.\") : \"\",",
         "\"No Sprints yet\",",

--- a/tests/test_render_check.py
+++ b/tests/test_render_check.py
@@ -1,0 +1,101 @@
+"""Diagnostics for render-check source divergence."""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import render_check  # noqa: I001
+
+
+SCHEMA = """
+CREATE TABLE roadmap (
+    feature_id INTEGER PRIMARY KEY,
+    title TEXT,
+    roadmap_status TEXT
+);
+CREATE TABLE documents (
+    document_id INTEGER PRIMARY KEY,
+    feature_id INTEGER,
+    kind TEXT,
+    seq INTEGER,
+    title TEXT,
+    body TEXT,
+    render_path TEXT,
+    frozen INTEGER
+);
+"""
+
+
+def source(body: str, status: str) -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.executescript(SCHEMA)
+    con.execute("INSERT INTO roadmap VALUES (7, 'Gateway', ?)", (status,))
+    con.execute(
+        "INSERT INTO documents VALUES "
+        "(11, 7, 'spec', 1, 'Gateway deployment', ?, "
+        "'specs_sc/gateway-deployment.md', 0)",
+        (body,),
+    )
+    return con
+
+
+class RenderCheckDocumentDiagnosticsTest(unittest.TestCase):
+    def test_drift_names_the_exact_source_fields_from_snapshot_and_live_db(self):
+        snapshot = source("snapshot body", "next")
+        live = source("live body", "in_progress")
+        self.addCleanup(snapshot.close)
+        self.addCleanup(live.close)
+
+        diagnostic = render_check._document_source_diagnostics(
+            snapshot,
+            live,
+            ["specs_sc/gateway-deployment.md", "roadmap_sc.md"],
+        )
+
+        self.assertEqual(
+            diagnostic.count("source rows for specs_sc/gateway-deployment.md"),
+            1,
+        )
+        self.assertNotIn("source rows for roadmap_sc.md", diagnostic)
+        self.assertIn('"roadmap_status": "next"', diagnostic)
+        self.assertIn('"roadmap_status": "in_progress"', diagnostic)
+        self.assertIn(
+            '"body_sha256": "'
+            + hashlib.sha256(b"snapshot body").hexdigest()
+            + '"',
+            diagnostic,
+        )
+        self.assertIn(
+            '"body_sha256": "' + hashlib.sha256(b"live body").hexdigest() + '"',
+            diagnostic,
+        )
+
+    def test_matching_source_rows_identify_a_stale_mirror(self):
+        snapshot = source("same body", "next")
+        live = source("same body", "next")
+        self.addCleanup(snapshot.close)
+        self.addCleanup(live.close)
+
+        diagnostic = render_check._document_source_diagnostics(
+            snapshot,
+            live,
+            ["specs_sc/gateway-deployment.md"],
+        )
+
+        self.assertIn(
+            "snapshot and live DB rows match; the active mirror is stale",
+            diagnostic,
+        )
+        self.assertNotIn("body_sha256", diagnostic)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- preserve the hermetic render-check verdict while reading the live DB only for drift diagnostics
- report the snapshot and live document source fields, including feature/status/frozen state and bounded body hashes
- distinguish source divergence from a stale active mirror
- share document path resolution between rendering and diagnostics

## Verification
- ./.subfloor/dev-kit test -q tests/test_render_check.py tests/test_artifact_policy.py tests/test_skill_retire.py tests/test_worktree_targets.py
- focused Ruff checks on changed implementation and tests
- Python 3.9 compile check

Closes #1283