### PR TITLE
test(messaging): inventory wake guidance

### DIFF
--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -130,7 +130,8 @@
     ".super-coder/migrations/0225_focused_dev_verification.sql",
     ".super-coder/migrations/0226_reseed_cartographer_workflow_hardening.sql",
     ".super-coder/migrations/0227_deepseek_controlled_route_binding.sql",
-    ".super-coder/migrations/0228_reseed_python_test_tooling.sql"
+    ".super-coder/migrations/0228_reseed_python_test_tooling.sql",
+    ".super-coder/migrations/0229_reseed_messaging_wake_guidance.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,
@@ -552,6 +553,11 @@
       "sc"
     ],
     "allowed_v2_authored_lines": {
+      ".super-coder/assets/skills/messaging/SKILL.md": [
+        "Engine-wide wakes need no Sprint. Sprint-scoped wakes deliver only while that",
+        "Sprint is armed; a producer may create delivery intent earlier and leave it",
+        "queued. Typed Sprint commands and engine producers return their durable"
+      ],
       ".super-coder/ui/app.js": [
         "\"Abort stops active work but retains the complete Sprint history and the Planner's durable abort-report request.\") : \"\",",
         "\"No Sprints yet\",",


### PR DESCRIPTION
## Summary
- inventory the messaging wake-guidance migration in the Sprint-removal fixture
- bind the three intentional Sprint-v2 lines in the messaging skill to exact allowed text

## Verification
- ./.subfloor/dev-kit test -q tests/test_sprint_removal_manifest.py
- python -m json.tool tests/fixtures/sprint_removal/manifest.json

Follow-up to #1284; clears the current main-suite regression blocking #1286 and #1288.