### PR TITLE
fix(codex): reap failed app-server initialization

### DIFF
--- a/.super-coder/scripts/conversation_adapters/codex.py
+++ b/.super-coder/scripts/conversation_adapters/codex.py
@@ -86,18 +86,22 @@ class JsonLineRpcProcess:
             daemon=True,
         )
         self._reader.start()
-        self.request(
-            "initialize",
-            {
-                "clientInfo": {
-                    "name": "super-coder",
-                    "title": "super-coder conversation broker",
-                    "version": "1",
+        try:
+            self.request(
+                "initialize",
+                {
+                    "clientInfo": {
+                        "name": "super-coder",
+                        "title": "super-coder conversation broker",
+                        "version": "1",
+                    },
+                    "capabilities": {"experimentalApi": False},
                 },
-                "capabilities": {"experimentalApi": False},
-            },
-        )
-        self.notify("initialized", {})
+            )
+            self.notify("initialized", {})
+        except BaseException:
+            self.close()
+            raise
 
     def _drain_stderr(self) -> None:
         stderr = self.process.stderr

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -2232,6 +2232,40 @@ class ConversationAdapterTest(unittest.TestCase):
             process.pid,
         )
 
+    def test_codex_initialize_timeout_cleans_up_process_group(self) -> None:
+        process = mock.Mock()
+        process.pid = 4321
+        process.stdin = io.StringIO()
+        process.stdout = io.StringIO()
+        process.stderr = io.StringIO()
+        process.poll.return_value = None
+        timeout = AdapterError(
+            "HARNESS_TIMEOUT",
+            "Codex request timed out: initialize",
+            retryable=True,
+        )
+        with (
+            mock.patch(
+                "conversation_adapters.codex.subprocess.Popen",
+                return_value=process,
+            ),
+            mock.patch.object(
+                JsonLineRpcProcess,
+                "request",
+                side_effect=timeout,
+            ),
+            mock.patch(
+                "conversation_adapters.codex.cleanup_owned_process"
+            ) as cleanup,
+        ):
+            with self.assertRaisesRegex(
+                AdapterError,
+                "Codex request timed out: initialize",
+            ):
+                JsonLineRpcProcess(cwd=self.root, env={})
+
+        cleanup.assert_called_once_with(process, 5.0)
+
     def test_shared_runner_reaps_group_after_leader_exit(self) -> None:
         process = mock.Mock()
         process.pid = 4321


### PR DESCRIPTION
Closes #1294

Ensure constructor failures during the Codex app-server initialize handshake run the owned-process cleanup ladder before preserving the original adapter error.

Verification:
- .venv/bin/python -m pytest -q tests/test_conversation_adapters.py
- git diff --check