### PR TITLE
fix(logs): parse help before runtime dispatch

### DIFF
--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -1464,7 +1464,13 @@ case "$cmd" in
       *) echo "sc build: unknown argument '$1' (usage: ./sc build [--harnesses])" >&2; exit 2 ;;
     esac
     dbuild ;;
-  logs)         exec docker logs -f "$CNAME" ;;
+  logs)
+    if sc_help_form "$@"; then
+      echo "usage: ./sc logs"
+      echo "  Tail the managed server logs until interrupted."
+      exit 0
+    fi
+    exec docker logs -f "$CNAME" ;;
   verify)
     sc_refuse_linked verify "$DB"
     # Destructive by design: rebuild.py REPLACES the DB below. Say which DB and

--- a/tests/test_operator_surface.py
+++ b/tests/test_operator_surface.py
@@ -229,6 +229,32 @@ class EnterPreAttachPrintTest(unittest.TestCase):
 class HelpChartTest(unittest.TestCase):
     """A live verb absent from the chart is a verb its operator cannot find."""
 
+    def test_logs_help_does_not_select_the_docker_runtime(self):
+        with tempfile.TemporaryDirectory() as directory:
+            bin_dir = Path(directory)
+            marker = bin_dir / "docker-ran"
+            docker = bin_dir / "docker"
+            docker.write_text(
+                "#!/bin/sh\n"
+                f"touch {marker}\n"
+                "exit 99\n"
+            )
+            docker.chmod(docker.stat().st_mode | stat.S_IEXEC)
+
+            out = sc(
+                "logs",
+                "--help",
+                env={"PATH": f"{bin_dir}:{os.environ['PATH']}"},
+            )
+
+            self.assertEqual(out.returncode, 0, out.stderr)
+            self.assertEqual(
+                out.stdout,
+                "usage: ./sc logs\n"
+                "  Tail the managed server logs until interrupted.\n",
+            )
+            self.assertFalse(marker.exists())
+
     def test_update_help_matches_ff_only_runtime_contract(self):
         help_text = sc("help").stdout
         update_block = help_text.split("./sc update", 1)[1].split(


### PR DESCRIPTION
Closes #1295

Honor sc logs help before selecting the Docker runtime. This makes the reported bare-metal help invocation safe while preserving the existing Docker action and the fork-owned make dos-logs host seam.

Trade-off: this uses the issue's explicit help outcome instead of teaching the shared engine about sc-cachy's fork-local lifecycle wrapper.

Verification:
- .venv/bin/python -m pytest -q tests/test_operator_surface.py tests/test_host_runtime_contract.py
- SC_DISPATCH=<worktree dispatch> ./sc logs --help
- git diff --check