### PR TITLE
fix(sprint): silence PR wakes after abort

### DIFF
--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -138,11 +138,10 @@ sc sprint register-pr --sprint <id> --repository <owner/name> \
   --pr <number> --work-unit <id>
 ```
 
-After `register-pr` succeeds, retain ownership through green. The native
-registered-PR watcher creates your engine-wide subscription and sends
-self-describing red/green/externally-closed PR-event wakes as Re-enter, even
-outside an armed Sprint. Fix red; judge green. Planner and Reviewer receive no
-PR-event wakes.
+After `register-pr` succeeds, retain ownership. Expect red/green/closed
+Re-enter wakes outside an armed Sprint. While the PR remains attached to an
+aborted Sprint, expect observation without a wake; reconciliation restores
+wakes. Fix red; judge green. Planner/Reviewer get none.
 
 If the same registered PR was externally closed, then reopened, rebased, and
 pushed, replay the exact `register-pr` command. Require `created: false`, which

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -3856,11 +3856,10 @@ sc sprint register-pr --sprint <id> --repository <owner/name> \
   --pr <number> --work-unit <id>
 ```
 
-After `register-pr` succeeds, retain ownership through green. The native
-registered-PR watcher creates your engine-wide subscription and sends
-self-describing red/green/externally-closed PR-event wakes as Re-enter, even
-outside an armed Sprint. Fix red; judge green. Planner and Reviewer receive no
-PR-event wakes.
+After `register-pr` succeeds, retain ownership. Expect red/green/closed
+Re-enter wakes outside an armed Sprint. While the PR remains attached to an
+aborted Sprint, expect observation without a wake; reconciliation restores
+wakes. Fix red; judge green. Planner/Reviewer get none.
 
 If the same registered PR was externally closed, then reopened, rebased, and
 pushed, replay the exact `register-pr` command. Require `created: false`, which

--- a/.super-coder/migrations/0231_suppress_aborted_sprint_pr_wakes.sql
+++ b/.super-coder/migrations/0231_suppress_aborted_sprint_pr_wakes.sql
@@ -1,0 +1,20 @@
+-- 0231 — keep aborted-Sprint PR observation silent until ownership recovery.
+
+BEGIN;
+
+UPDATE skills
+SET content=replace(
+  content,
+  'After `register-pr` succeeds, retain ownership through green. The native
+registered-PR watcher creates your engine-wide subscription and sends
+self-describing red/green/externally-closed PR-event wakes as Re-enter, even
+outside an armed Sprint. Fix red; judge green. Planner and Reviewer receive no
+PR-event wakes.',
+  'After `register-pr` succeeds, retain ownership. Expect red/green/closed
+Re-enter wakes outside an armed Sprint. While the PR remains attached to an
+aborted Sprint, expect observation without a wake; reconciliation restores
+wakes. Fix red; judge green. Planner/Reviewer get none.'
+)
+WHERE name='sprint_dev';
+
+COMMIT;

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1390,6 +1390,9 @@ class SprintPRWatcher:
                 ),
             )
 
+        if registered["lifecycle"] == "aborted":
+            return resolved_review_message_ids
+
         instructions = {
             "red": "Your PR went red; fix it.",
             "green": "Your PR is green; judge readiness and pass the baton to review.",

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -147,9 +147,10 @@ can close the Planner chat during an armed Sprint to set coordinate mode (idle
 Planner Re-enters become fresh ticket chats); FnB pause/resume returns to
 supervise, while automatic pauses preserve the dial. Developer-owned PR
 subscriptions emit self-describing red/green/closed Re-enter wakes even outside
-an armed Sprint; Planner and Reviewer receive no PR-event wakes. Arming
-validates all recorded role harness/model/effort selections before publishing
-work; defaults satisfy the gate.
+an armed Sprint, except while the registration remains attached to an aborted
+Sprint; Planner and Reviewer receive no PR-event wakes. Arming validates all
+recorded role harness/model/effort selections before publishing work;
+defaults satisfy the gate.
 
 ---
 

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -133,7 +133,8 @@
     ".super-coder/migrations/0226_reseed_cartographer_workflow_hardening.sql",
     ".super-coder/migrations/0227_deepseek_controlled_route_binding.sql",
     ".super-coder/migrations/0228_reseed_python_test_tooling.sql",
-    ".super-coder/migrations/0229_reseed_messaging_wake_guidance.sql"
+    ".super-coder/migrations/0229_reseed_messaging_wake_guidance.sql",
+    ".super-coder/migrations/0231_suppress_aborted_sprint_pr_wakes.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_focused_dev_verification.py
+++ b/tests/test_focused_dev_verification.py
@@ -11,7 +11,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
 ASSETS = ENGINE / "assets" / "skills"
-MIGRATION = ENGINE / "migrations" / "0225_focused_dev_verification.sql"
+MIGRATIONS = (
+    ENGINE / "migrations" / "0225_focused_dev_verification.sql",
+    ENGINE / "migrations" / "0231_suppress_aborted_sprint_pr_wakes.sql",
+)
 sys.path.insert(0, str(ENGINE / "scripts"))
 
 import seed_skills  # noqa: E402
@@ -105,7 +108,7 @@ class FocusedDeveloperVerificationMigrationTest(unittest.TestCase):
         original_planner = self.con.execute(
             "SELECT system_prompt FROM shells WHERE shell_id=3"
         ).fetchone()[0]
-        migration = MIGRATION.read_text()
+        migration = "\n".join(path.read_text() for path in MIGRATIONS)
 
         self.con.executescript(migration)
         first_prompts = dict(

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -1291,7 +1291,7 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         self.assertTrue(self.watcher.poll_once())
         self.assertEqual(["red", "green"], self._states())
 
-    def test_terminal_sprint_does_not_gate_an_active_subscription(self):
+    def test_completed_sprint_does_not_gate_an_active_subscription(self):
         self.register()
         self.con.execute(
             "UPDATE sprint_work_units SET disposition='completed',"
@@ -1311,6 +1311,57 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         self.assertTrue(self.watcher.poll_once())
         self.assertEqual(calls + 1, len(self.reader.get_calls))
         self.assertEqual(0, self.reader.list_calls)
+
+    def test_aborted_sprint_observes_pr_without_waking_its_former_developer(self):
+        self.register()
+        self.con.execute(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (4,'FnB','FNB','admin','prompt',1)"
+        )
+        self.con.commit()
+        sprint_domain.SprintLifecycleStore(self.con).abort(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("fnb", 4),
+            reason="the implementation was abandoned",
+            terminal_outcome="cancelled",
+        )
+        wake_count = self.con.execute(
+            "SELECT COUNT(*) FROM wake_message "
+            "WHERE idempotency_key LIKE 'pr-transition:%'"
+        ).fetchone()[0]
+        self.reader.current = pull_request(
+            state="CLOSED", checks=None, checks_failed=False
+        )
+
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(["red", "closed"], self._states())
+        self.assertEqual(
+            ["red", "closed"],
+            [
+                str(row[0])
+                for row in self.con.execute(
+                    "SELECT normalized_state FROM pr_subscription_transitions "
+                    "ORDER BY transition_id"
+                )
+            ],
+        )
+        self.assertEqual(
+            wake_count,
+            self.con.execute(
+                "SELECT COUNT(*) FROM wake_message "
+                "WHERE idempotency_key LIKE 'pr-transition:%'"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM wake_message "
+                "WHERE idempotency_key LIKE 'pr-transition:%' "
+                "AND body LIKE '%event=closed%'"
+            ).fetchone()[0],
+        )
 
     def test_failure_is_durable_backs_off_and_never_invents_state(self):
         self.reader.current = GitHubReadError("rate limit reached")

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -1663,7 +1663,11 @@ class SprintSkillTest(unittest.TestCase):
         developer = bodies["sprint_dev"]
         reviewer = bodies["sprint_rev"]
         planner = bodies["sprint_pln"]
+        normalized_developer = " ".join(developer.split())
         self.assertIn("outside an armed Sprint", developer)
+        self.assertIn("attached to an aborted Sprint", normalized_developer)
+        self.assertIn("observation without a wake", normalized_developer)
+        self.assertIn("reconciliation restores wakes", normalized_developer)
         self.assertIn("Reviewer decides", developer)
         self.assertIn("recalling unreleased work", " ".join(reviewer.split()))
         self.assertIn("Compile the bounded evidence packet first", reviewer)


### PR DESCRIPTION
## Summary
- keep engine-wide PR observation and transition evidence after Sprint abort
- suppress developer PR-event wakes while ownership remains attached to the aborted Sprint
- restore wake routing automatically when ownership is reconciled to a replacement Sprint
- update boot/Developer guidance and the convergent skill migration

## Verification
- 129 focused tests passed
- 131 focused subtests passed
- git diff --check passed

## Trade-off
Observation remains lifecycle-independent for recovery and auditability; only routing is silenced during aborted ownership.