### PR TITLE
fix(deepseek): list Web entry in harness picker

### DIFF
--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -184,6 +184,27 @@ sc_open_browser() {
   return 1
 }
 
+sc_enter_with_browser_handoff() {
+  sc_handoff_id="$$"
+  sc_handoff_path="$ROOT/.sc-state/local/run/browser-handoff-$sc_handoff_id"
+  rm -f "$sc_handoff_path"
+  if docker exec -it -e "SC_BROWSER_HANDOFF_ID=$sc_handoff_id" \
+      "$CNAME" ./sc boot "$@"; then
+    sc_enter_rc=0
+  else
+    sc_enter_rc=$?
+  fi
+  if [ "$sc_enter_rc" -eq 0 ] && [ -f "$sc_handoff_path" ]; then
+    rm -f "$sc_handoff_path"
+    sc_deepseek_url="http://127.0.0.1:$(deepseekhostport)"
+    echo "  DeepSeek Web  $sc_deepseek_url"
+    sc_open_browser "$sc_deepseek_url" || true
+  else
+    rm -f "$sc_handoff_path"
+  fi
+  return "$sc_enter_rc"
+}
+
 # The two localhost URLs an operator needs, derived from this fork's ports —
 # never a fixed 8800, because every fork lands on its own offset (ports.py).
 # One printer, three callers (`url`, `enter`, `enter-<shortname>`): entry
@@ -1372,7 +1393,7 @@ case "$cmd" in
       sc_open_browser "$sc_deepseek_url" || true
       exit 0
     fi
-    exec docker exec -it "$CNAME" ./sc boot "$@" ;;
+    sc_enter_with_browser_handoff "$@" ;;
   enter-*)
     if [ "${1:-}" = "--devkit-repair" ]; then
       echo "sc ${cmd}: repair posture is available only as ./sc enter --devkit-repair" >&2
@@ -1385,7 +1406,7 @@ case "$cmd" in
       exit 1
     }
     sc_urls || true
-    exec docker exec -it "$CNAME" ./sc boot "${cmd#enter-}" "$@" ;;
+    sc_enter_with_browser_handoff "${cmd#enter-}" "$@" ;;
   down)         docker rm -f "$CNAME" >/dev/null 2>&1 && echo "→ sandbox stopped" || echo "→ not running"
                 sc_vm_broker_down
                 sc_ts_broker_down

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -286,6 +286,20 @@ def require_local_web_surface(adapter: dict) -> None:
         raise ValueError(f"harness '{harness}' does not support local Web entry")
 
 
+def interactive_launch(adapter: dict) -> dict | None:
+    """Return the adapter's supported interactive launch contract."""
+    surfaces = adapter.get("surfaces") or {}
+    if surfaces.get("terminal") is True:
+        return {
+            "kind": "terminal",
+            "launch": adapter.get("launch") or [adapter.get("harness", "unknown")],
+        }
+    interactive = adapter.get("interactive")
+    if isinstance(interactive, dict) and interactive.get("kind") == "local_web":
+        return interactive
+    return None
+
+
 def linked_vm_configured() -> bool:
     """Match ``sc_vm_broker_configured``: a truthy persisted vm block."""
     return bool(ports_mod.resolve(persist=False).get("vm"))
@@ -680,10 +694,11 @@ def ensure_harness_path() -> None:
 
 
 def detect_harnesses() -> list[str]:
-    """Harnesses installable RIGHT NOW: an adapter dir with adapter.json whose
-    launch command is also on PATH (after ensure_harness_path() has folded in
-    the installer bin dirs). Adapter-dir order. Drives the launch-time picker —
-    we only offer a harness the host can actually exec."""
+    """Interactive harnesses installable right now, in adapter-dir order.
+
+    Terminal adapters use their ordinary launch command. Browser-backed
+    adapters use the command from their explicit interactive contract.
+    """
     if not ADAPTERS.exists():
         return []
     found = []
@@ -695,13 +710,26 @@ def detect_harnesses() -> list[str]:
             adapter = json.loads(cfg.read_text())
         except (json.JSONDecodeError, OSError):
             continue
-        surfaces = adapter.get("surfaces") or {}
-        if surfaces.get("terminal") is not True:
+        interactive = interactive_launch(adapter)
+        if interactive is None:
             continue
-        cmd = (adapter.get("launch") or [d.name])[0]
+        cmd = (interactive.get("launch") or [d.name])[0]
         if shutil.which(cmd):
             found.append(adapter.get("harness", d.name))
     return found
+
+
+def signal_browser_handoff(handoff_id: str | None) -> None:
+    """Tell the host dispatcher that a picker-selected local Web app is ready."""
+    if not handoff_id or not handoff_id.isascii() or not handoff_id.isdigit():
+        return
+    path = REPO_ROOT / ".sc-state" / "local" / "run" / f"browser-handoff-{handoff_id}"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("deepseek\n")
+    except OSError:
+        # The ready URL is already printed; browser opening remains best-effort.
+        return
 
 
 def pick_harness(detected: list[str], default: str, first: bool) -> str | None:
@@ -1783,6 +1811,9 @@ def main() -> None:
     flavor_model = fdef["models"].get(harness) if fdef else None
     flavor_effort = (fdef.get("efforts") or {}).get(harness) if fdef else None
     adapter = load_adapter(harness)
+    launch_contract = interactive_launch(adapter)
+    if not local_web and not headless and not host_admin and launch_contract:
+        local_web = launch_contract["kind"] == "local_web"
     try:
         if local_web:
             require_local_web_surface(adapter)
@@ -2083,6 +2114,7 @@ def main() -> None:
         action = "reused" if service["reused"] else "started"
         print(f"→ DeepSeek Web: {action} for {work_dir}")
         print(f"→ DeepSeek Web URL: {service['url']}")
+        signal_browser_handoff(os.environ.get("SC_BROWSER_HANDOFF_ID"))
         return
 
     # --name labels the session in the harness prompt box, resume picker, and

--- a/tests/test_harness_surfaces.py
+++ b/tests/test_harness_surfaces.py
@@ -107,16 +107,22 @@ class HarnessSurfaceProjectionTest(unittest.TestCase):
             "retired-harness", harness_surfaces.known_terminal_harnesses()
         )
 
-    def test_terminal_detection_excludes_shipped_non_terminal_harness(self) -> None:
+    def test_interactive_detection_includes_terminal_and_local_web_harnesses(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             adapters = Path(tmp)
             terminal = adapters / "terminal" / "adapter.json"
+            local_web = adapters / "local-web" / "adapter.json"
             browser_only = adapters / "browser-only" / "adapter.json"
             terminal.parent.mkdir()
+            local_web.parent.mkdir()
             browser_only.parent.mkdir()
             terminal.write_text(
                 '{"harness":"terminal","launch":["terminal"],'
                 '"surfaces":{"terminal":true}}'
+            )
+            local_web.write_text(
+                '{"harness":"local-web","surfaces":{"terminal":false},'
+                '"interactive":{"kind":"local_web","launch":["web-cli","web"]}}'
             )
             browser_only.write_text(
                 '{"harness":"browser-only","runtime":{"command":"browser"},'
@@ -127,8 +133,76 @@ class HarnessSurfaceProjectionTest(unittest.TestCase):
             ):
                 detected = run.detect_harnesses()
 
-        self.assertEqual(detected, ["terminal"])
+        self.assertEqual(detected, ["local-web", "terminal"])
         self.assertNotIn("browser-only", detected)
+
+    def test_picker_selected_local_web_signals_the_host_dispatcher(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            run, "REPO_ROOT", Path(tmp)
+        ):
+            run.signal_browser_handoff("31415")
+            marker = (
+                Path(tmp)
+                / ".sc-state"
+                / "local"
+                / "run"
+                / "browser-handoff-31415"
+            )
+            self.assertEqual(marker.read_text(), "deepseek\n")
+
+            run.signal_browser_handoff("../../outside")
+            self.assertFalse((Path(tmp) / "outside").exists())
+
+    def test_selected_local_web_uses_web_validation_in_the_boot_path(self) -> None:
+        class StopAfterSelection(RuntimeError):
+            pass
+
+        con = mock.Mock()
+        chosen = {"shell_id": 5, "shortname": "DEV3", "flavor": "dev"}
+        adapter = {
+            "harness": "deepseek",
+            "surfaces": {"terminal": False},
+            "interactive": {"kind": "local_web", "launch": ["dsh", "web"]},
+        }
+        local_web_gate = mock.Mock(wraps=run.require_local_web_surface)
+        terminal_gate = mock.Mock(wraps=run.require_harness_surface)
+
+        with mock.patch.dict(run.os.environ, {"RENDER_ONLY": "1"}, clear=True), \
+                mock.patch.object(
+                    run.sys,
+                    "argv",
+                    ["run.py", "DEV3", "--harness", "deepseek"],
+                ), \
+                mock.patch.object(run.sys.stdin, "isatty", return_value=False), \
+                mock.patch.object(run, "open_db", return_value=con), \
+                mock.patch.object(run, "authenticate", return_value={"user_id": 1}), \
+                mock.patch.object(
+                    run,
+                    "flavor_defaults",
+                    return_value={
+                        "dev": {
+                            "default_harness": "claude",
+                            "models": {"deepseek": None},
+                        }
+                    },
+                ), \
+                mock.patch.object(run, "list_shells", return_value=[chosen]), \
+                mock.patch.object(run, "pick_shell", return_value=chosen), \
+                mock.patch.object(run, "browser_conversation_active", return_value=False), \
+                mock.patch.object(run, "confirm_live", return_value=True), \
+                mock.patch.object(run, "ensure_harness_path"), \
+                mock.patch.object(run, "load_adapter", return_value=adapter), \
+                mock.patch.object(run, "require_local_web_surface", local_web_gate), \
+                mock.patch.object(run, "require_harness_surface", terminal_gate), \
+                mock.patch.object(run, "cleanup_before_launch"), \
+                mock.patch.object(
+                    run, "open_session", side_effect=StopAfterSelection
+                ), \
+                self.assertRaises(StopAfterSelection):
+            run.main()
+
+        local_web_gate.assert_called_once_with(adapter)
+        terminal_gate.assert_not_called()
 
     def test_explicit_unsupported_terminal_and_one_shot_requests_fail_early(self) -> None:
         adapter = {

--- a/tests/test_operator_surface.py
+++ b/tests/test_operator_surface.py
@@ -121,6 +121,12 @@ class EnterPreAttachPrintTest(unittest.TestCase):
             "docker",
             "#!/bin/sh\n"
             "[ -n \"$SC_DOCKER_LOG\" ] && printf '%s\\n' \"$*\" > \"$SC_DOCKER_LOG\"\n"
+            "if [ -n \"$SC_DOCKER_HANDOFF\" ]; then\n"
+            "  id=$(printf '%s\\n' \"$*\" | sed -n 's/.*SC_BROWSER_HANDOFF_ID=\\([0-9][0-9]*\\).*/\\1/p')\n"
+            "  root=$(cd \"$(git rev-parse --git-common-dir)/..\" && pwd)\n"
+            "  mkdir -p \"$root/.sc-state/local/run\"\n"
+            "  printf 'deepseek\\n' > \"$root/.sc-state/local/run/browser-handoff-$id\"\n"
+            "fi\n"
             "exit 0\n",
         )
         self._stub(
@@ -196,6 +202,36 @@ class EnterPreAttachPrintTest(unittest.TestCase):
         expected = "http://127.0.0.1:8942"
         self.assertIn(expected, out.stdout)
         self.assertEqual(browser_log.read_text().strip(), expected)
+
+    def test_picker_selected_deepseek_hands_browser_opening_to_the_host(self):
+        log = self.bin / "docker.log"
+        browser_log = self.bin / "browser.log"
+        out = sc(
+            "enter",
+            env=self._env(
+                SC_DOCKER_LOG=str(log),
+                SC_DOCKER_HANDOFF="1",
+                SC_BROWSER_LOG=str(browser_log),
+                SC_PYTHON=str(self.bin / "deepseek-python"),
+            ),
+        )
+
+        self.assertEqual(out.returncode, 0, out.stderr)
+        self.assertIn("SC_BROWSER_HANDOFF_ID=", log.read_text())
+        expected = "http://127.0.0.1:8942"
+        self.assertIn(expected, out.stdout)
+        self.assertEqual(browser_log.read_text().strip(), expected)
+
+    def test_terminal_selection_without_handoff_does_not_open_a_browser(self):
+        browser_log = self.bin / "browser.log"
+        out = sc(
+            "enter",
+            env=self._env(SC_BROWSER_LOG=str(browser_log)),
+        )
+
+        self.assertEqual(out.returncode, 0, out.stderr)
+        self.assertFalse(browser_log.exists())
+        self.assertNotIn("DeepSeek Web", out.stdout)
 
     def test_launch_publishes_deepseek_relay_to_host_loopback_only(self):
         source = (ROOT / ".super-coder" / "scripts" / "dispatch.sh").read_text()


### PR DESCRIPTION
## Summary
- include installed local-Web adapters such as DeepSeek in the interactive `make dos-e` harness picker
- infer DeepSeek Web launch after picker selection and hand browser opening back to the host dispatcher
- preserve direct `./sc enter deepseek`, terminal harness selection, loopback-only URL derivation, and printed fallback

## Verification
- `sh -n .super-coder/scripts/dispatch.sh`
- `./sc test tests/test_harness_surfaces.py tests/test_operator_surface.py tests/test_run_session.py` (43 passed)
- actual worktree detection: `claude, codex, deepseek, kimi, opencode, vibe`
- declared whole-file lint remains non-green on 85 pre-existing violations; no diagnostic lands on changed lines

## Trade-off
The host dispatcher now waits for interactive Docker entry instead of replacing itself, allowing a successful local-Web selection to return one readiness marker. Terminal harnesses still retain the same attached PTY and exit status.