### PR TITLE
fix(render): prune stale document mirrors

### DIFF
--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -106,7 +106,8 @@ def _render_documents(con, written, skipped, root: Path) -> None:
     """specs (kind='spec') → specs_sc/, docs (kind='doc') → docs_sc/.
 
     The document's own `render_path` is authoritative when set; otherwise we
-    derive a stable path from kind + title.
+    derive a stable path from kind + title. Files without a current source row
+    are removed so both managed directories remain exact DB projections.
     """
     rows = con.execute(
         "SELECT d.feature_id, d.kind, d.seq, d.title, d.body, d.render_path, "
@@ -114,10 +115,13 @@ def _render_documents(con, written, skipped, root: Path) -> None:
         "LEFT JOIN roadmap r ON r.feature_id = d.feature_id "
         "ORDER BY d.feature_id, d.kind, d.seq"
     ).fetchall()
+    expected: set[Path] = set()
     for r in rows:
         if not r["body"]:
             continue
         rel = document_rel_path(r)
+        target = _document_target(root, rel, r["kind"])
+        expected.add(target)
         # Per-document metadata into the rendered frontmatter — where the
         # feature sits in the plan + whether this spec is frozen.
         extra = [
@@ -125,9 +129,16 @@ def _render_documents(con, written, skipped, root: Path) -> None:
             f"roadmap_status: {r['roadmap_status'] or ''}",
             f"frozen: {'true' if r['frozen'] else 'false'}",
         ]
-        _write_if_changed(_document_target(root, rel, r["kind"]),
-                          with_banner(r["body"], extra),
-                          written, skipped)
+        _write_if_changed(target, with_banner(r["body"], extra), written, skipped)
+
+    for dirname in ("specs_sc", "docs_sc"):
+        managed_root = root / dirname
+        if not managed_root.exists():
+            continue
+        for path in sorted(managed_root.rglob("*")):
+            if path.is_file() and path not in expected:
+                path.unlink()
+                written.append(path)
 
 
 # Board order: delivered first, then the committed funnel backward, with

--- a/tests/test_flat_render.py
+++ b/tests/test_flat_render.py
@@ -1,0 +1,113 @@
+"""Flat document mirrors converge when document sources move or disappear."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from contextlib import closing
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RENDER = ROOT / ".super-coder" / "render"
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path[:0] = [str(RENDER), str(SCRIPTS)]
+
+import flat  # noqa: E402
+
+
+SCHEMA = """
+CREATE TABLE roadmap (
+    feature_id INTEGER PRIMARY KEY,
+    title TEXT,
+    roadmap_status TEXT
+);
+CREATE TABLE documents (
+    feature_id INTEGER,
+    kind TEXT,
+    seq INTEGER,
+    title TEXT,
+    body TEXT,
+    render_path TEXT,
+    frozen INTEGER
+);
+"""
+
+
+class FlatDocumentReconciliationTest(unittest.TestCase):
+    def test_render_replaces_a_document_at_its_new_path(self):
+        with tempfile.TemporaryDirectory() as td, closing(
+            sqlite3.connect(":memory:")
+        ) as con:
+            root = Path(td)
+            con.row_factory = sqlite3.Row
+            con.executescript(SCHEMA)
+            con.execute("INSERT INTO roadmap VALUES (7, 'Gateway', 'next')")
+            con.execute(
+                "INSERT INTO documents VALUES "
+                "(7, 'spec', 1, 'Gateway', 'Current body', "
+                "'specs_sc/current.md', 0)"
+            )
+            current = root / "specs_sc" / "current.md"
+            stale = root / "specs_sc" / "old-name.md"
+            stale.parent.mkdir()
+            current.write_text(
+                "---\n"
+                "rendered_by: super-coder\n"
+                "source: db\n"
+                "edit: changes here are overwritten — author via the shell or localhost GUI\n"
+                "feature: Gateway\n"
+                "roadmap_status: next\n"
+                "frozen: false\n"
+                "---\n\n"
+                "Current body\n"
+            )
+            stale.write_text("stale body\n")
+
+            written: list[Path] = []
+            skipped: list[Path] = []
+            flat._render_documents(con, written, skipped, root)
+
+            self.assertEqual([stale], written)
+            self.assertEqual([current], skipped)
+            self.assertEqual(
+                "---\n"
+                "rendered_by: super-coder\n"
+                "source: db\n"
+                "edit: changes here are overwritten — author via the shell or localhost GUI\n"
+                "feature: Gateway\n"
+                "roadmap_status: next\n"
+                "frozen: false\n"
+                "---\n\n"
+                "Current body\n",
+                current.read_text(),
+            )
+            self.assertFalse(stale.exists())
+
+    def test_render_removes_orphans_only_from_managed_document_roots(self):
+        with tempfile.TemporaryDirectory() as td, closing(
+            sqlite3.connect(":memory:")
+        ) as con:
+            root = Path(td)
+            con.row_factory = sqlite3.Row
+            con.executescript(SCHEMA)
+            stale_spec = root / "specs_sc" / "retired.md"
+            stale_doc = root / "docs_sc" / "nested" / "retired.md"
+            outside = root / "notes" / "keep.md"
+            for path in (stale_spec, stale_doc, outside):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(f"{path.name}\n")
+
+            written: list[Path] = []
+            skipped: list[Path] = []
+            flat._render_documents(con, written, skipped, root)
+
+            self.assertEqual({stale_spec, stale_doc}, set(written))
+            self.assertEqual([], skipped)
+            self.assertFalse(stale_spec.exists())
+            self.assertFalse(stale_doc.exists())
+            self.assertEqual("keep.md\n", outside.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- make specs_sc and docs_sc exact projections of current document rows
- remove orphaned managed files after rendering current document paths
- report removals through the existing changed-file summary
- cover renamed and removed document sources without touching files outside managed roots

## Verification
- python3 -m unittest tests.test_flat_render tests.test_render_check tests.test_skill_convergence_release_gate tests.test_update_legacy_compat -v
- python3 -m compileall -q .super-coder/render/flat.py tests/test_flat_render.py tests/test_render_check.py
- git diff --check

Closes #1283
