### PR TITLE
fix(models): include DeepSeek in Default Models

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -477,8 +477,13 @@ def get_model_routes(con, *, harness: str | None = None,
 
 
 def known_harnesses() -> list[str]:
-    """Harnesses eligible for flavor-level launch and model defaults."""
+    """Harnesses visible in the flavor-level model-defaults matrix."""
     return harness_surfaces.known_runnable_harnesses()
+
+
+def known_default_harnesses() -> list[str]:
+    """Harnesses eligible for the flavor-level interactive launch star."""
+    return harness_surfaces.known_interactive_harnesses()
 
 
 def _historical_harnesses(con) -> set[str]:
@@ -512,11 +517,13 @@ def _historical_harnesses(con) -> set[str]:
 
 
 def get_flavor_defaults(con) -> dict:
-    """The launch-defaults matrix for the Default Models sub-tab: per flavor,
-    a model per harness + one starred default harness (flavor_defaults rows —
-    the exact table run.py's picker resolves at launch). Template flavors with
-    no rows yet are included empty so the GUI matrix is complete; missing
-    cells are created on first write (see set_flavor_default)."""
+    """The model matrix and interactive launch defaults for each flavor.
+
+    Every model-capable harness is visible, while only harnesses with a proven
+    terminal or local-Web launch contract may receive the star consumed by
+    run.py. Template flavors with no rows yet are included empty; missing cells
+    are created on first write (see set_flavor_default).
+    """
     flavors: dict[str, list] = {}
     route_rows = {
         (r["harness"], r["selector"]): r
@@ -577,6 +584,7 @@ def get_flavor_defaults(con) -> dict:
     return {
         "flavors": flavors,
         "harnesses": known_harnesses(),
+        "default_harnesses": known_default_harnesses(),
         "harness_status": harness_surfaces.project(_historical_harnesses(con)),
     }
 
@@ -664,6 +672,12 @@ def set_flavor_default(con, body) -> tuple[bool, dict | None]:
     if harness not in known_harnesses():
         return False, _flavor_default_error(
             "validation_error", f"unknown harness '{harness}'")
+    if body.get("is_default") and harness not in known_default_harnesses():
+        return False, _flavor_default_error(
+            "validation_error",
+            f"harness '{harness}' has no interactive launch surface and "
+            "cannot be the flavor default",
+        )
     known_flavors = {t.get("flavor") for t in shell_factory.flavors()} | {
         r[0] for r in con.execute("SELECT DISTINCT flavor FROM flavor_defaults")}
     if flavor not in known_flavors:

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -477,8 +477,8 @@ def get_model_routes(con, *, harness: str | None = None,
 
 
 def known_harnesses() -> list[str]:
-    """Compatibility string roster for terminal/default-model callers."""
-    return harness_surfaces.known_terminal_harnesses()
+    """Harnesses eligible for flavor-level launch and model defaults."""
+    return harness_surfaces.known_runnable_harnesses()
 
 
 def _historical_harnesses(con) -> set[str]:

--- a/.super-coder/scripts/harness_surfaces.py
+++ b/.super-coder/scripts/harness_surfaces.py
@@ -82,6 +82,15 @@ def _proven_surfaces(
     }
 
 
+def _local_web_launch_proven(manifest: Mapping[str, object]) -> bool:
+    """Return whether the adapter has an engine-managed local-Web entry."""
+    interactive = manifest.get("interactive")
+    return (
+        isinstance(interactive, dict)
+        and interactive.get("kind") == "local_web"
+    )
+
+
 def _runtime_command(harness: str, manifest: Mapping[str, object]) -> str:
     runtime = manifest.get("runtime")
     if isinstance(runtime, dict) and isinstance(runtime.get("command"), str):
@@ -123,13 +132,31 @@ def known_terminal_harnesses() -> list[str]:
 
 
 def known_runnable_harnesses() -> list[str]:
-    """Return shipped harnesses with at least one proven execution surface."""
+    """Return shipped harnesses visible in the model-defaults matrix."""
     found = []
     for harness, path in _manifest_paths().items():
         try:
             manifest = json.loads(path.read_text())
             declared = _declared_surfaces(manifest)
-            if any(_proven_surfaces(harness, manifest, declared).values()):
+            if (
+                any(_proven_surfaces(harness, manifest, declared).values())
+                or _local_web_launch_proven(manifest)
+            ):
+                found.append(harness)
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+    return sorted(found)
+
+
+def known_interactive_harnesses() -> list[str]:
+    """Return shipped harnesses eligible for the flavor launch-default star."""
+    found = []
+    for harness, path in _manifest_paths().items():
+        try:
+            manifest = json.loads(path.read_text())
+            declared = _declared_surfaces(manifest)
+            terminal = _proven_surfaces(harness, manifest, declared)["terminal"]
+            if terminal or _local_web_launch_proven(manifest):
                 found.append(harness)
         except (OSError, json.JSONDecodeError, ValueError):
             continue

--- a/.super-coder/scripts/harness_surfaces.py
+++ b/.super-coder/scripts/harness_surfaces.py
@@ -122,6 +122,20 @@ def known_terminal_harnesses() -> list[str]:
     return sorted(found)
 
 
+def known_runnable_harnesses() -> list[str]:
+    """Return shipped harnesses with at least one proven execution surface."""
+    found = []
+    for harness, path in _manifest_paths().items():
+        try:
+            manifest = json.loads(path.read_text())
+            declared = _declared_surfaces(manifest)
+            if any(_proven_surfaces(harness, manifest, declared).values()):
+                found.append(harness)
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+    return sorted(found)
+
+
 def project(
     historical_harnesses: Iterable[str] = (),
     *,

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -690,6 +690,7 @@ async function renderDefaultModels(root, s, catalogOverride = null) {
   // emphasis — the shell header above is inert on this tab), one card per
   // flavor with docs-style separation between cards.
   const flavors = Object.keys(fd.flavors).sort();
+  const defaultHarnesses = new Set(fd.default_harnesses || fd.harnesses || []);
   for (const flavor of flavors) {
     const byHarness = Object.fromEntries((fd.flavors[flavor] || []).map((r) => [r.harness, r]));
     const panel = el("div", { className: "vpanel dm-card" });
@@ -699,6 +700,10 @@ async function renderDefaultModels(root, s, catalogOverride = null) {
       const star = el("input", { type: "radio", name: "dm-star-" + flavor,
                                  title: "star = default harness at launch" });
       star.checked = row.is_default;
+      star.disabled = !defaultHarnesses.has(h);
+      if (star.disabled) {
+        star.title = "model configuration only — no interactive launch surface";
+      }
       star.onchange = async () => {
         try {
           await api("/flavor-defaults", "POST", { flavor, harness: h, is_default: true });

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -754,6 +754,10 @@ class FlavorDefaultsTest(unittest.TestCase):
             got["harnesses"],
             ["claude", "codex", "deepseek", "kimi", "opencode", "vibe"],
         )
+        self.assertEqual(
+            got["default_harnesses"],
+            ["claude", "codex", "deepseek", "kimi", "opencode", "vibe"],
+        )
         self.assertIn("deepseek", got["harness_status"])
         self.assertEqual(got["harness_status"]["deepseek"]["surfaces"], {
             "terminal": False,
@@ -958,13 +962,42 @@ class FlavorDefaultsTest(unittest.TestCase):
 
         ok, err = server.set_flavor_default(
             self.con,
-            {"flavor": "planner", "harness": "deepseek", "model": None},
+            {"flavor": "planner", "harness": "deepseek", "model": None,
+             "is_default": True},
         )
 
         self.assertTrue(ok, err)
         row = self._row("planner", "deepseek")
         self.assertEqual((row["model"], row["effort"], row["is_default"]),
-                         (None, None, 0))
+                         (None, None, 1))
+
+    def test_noninteractive_harness_is_configurable_but_not_starrable(self) -> None:
+        with mock.patch.object(
+            server, "known_harnesses", return_value=["one-shot-only"]
+        ), mock.patch.object(server, "known_default_harnesses", return_value=[]):
+            ok, err = server.set_flavor_default(
+                self.con,
+                {"flavor": "planner", "harness": "one-shot-only", "model": None},
+            )
+            self.assertTrue(ok, err)
+            row = self._row("planner", "one-shot-only")
+            self.assertEqual((row["model"], row["effort"], row["is_default"]),
+                             (None, None, 0))
+
+            ok, err = server.set_flavor_default(
+                self.con,
+                {"flavor": "planner", "harness": "one-shot-only",
+                 "is_default": True},
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(err, {
+            "code": "validation_error",
+            "message": "harness 'one-shot-only' has no interactive launch "
+                       "surface and cannot be the flavor default",
+            "details": {},
+        })
+        self.assertEqual(self._row("planner", "one-shot-only")["is_default"], 0)
 
     def test_unknown_harness_remains_unsettable(self) -> None:
         ok, err = server.set_flavor_default(

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -751,10 +751,10 @@ class FlavorDefaultsTest(unittest.TestCase):
         self.assertIn("planner", got["flavors"])
         self.assertIn("admin", got["flavors"], "template flavors appear even unseeded")
         self.assertEqual(
-            got["harnesses"], ["claude", "codex", "kimi", "opencode", "vibe"]
+            got["harnesses"],
+            ["claude", "codex", "deepseek", "kimi", "opencode", "vibe"],
         )
         self.assertIn("deepseek", got["harness_status"])
-        self.assertNotIn("deepseek", got["harnesses"])
         self.assertEqual(got["harness_status"]["deepseek"]["surfaces"], {
             "terminal": False,
             "one_shot": True,
@@ -952,6 +952,33 @@ class FlavorDefaultsTest(unittest.TestCase):
         row = self._row("planner", "vibe")
         self.assertEqual(row["model"], "devstral-latest")
         self.assertEqual(row["is_default"], 1)
+
+    def test_deepseek_harness_default_is_settable(self) -> None:
+        self.assertIsNone(self._row("planner", "deepseek"))
+
+        ok, err = server.set_flavor_default(
+            self.con,
+            {"flavor": "planner", "harness": "deepseek", "model": None},
+        )
+
+        self.assertTrue(ok, err)
+        row = self._row("planner", "deepseek")
+        self.assertEqual((row["model"], row["effort"], row["is_default"]),
+                         (None, None, 0))
+
+    def test_unknown_harness_remains_unsettable(self) -> None:
+        ok, err = server.set_flavor_default(
+            self.con,
+            {"flavor": "planner", "harness": "removed-harness", "model": None},
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(err, {
+            "code": "validation_error",
+            "message": "unknown harness 'removed-harness'",
+            "details": {},
+        })
+        self.assertIsNone(self._row("planner", "removed-harness"))
 
     def test_empty_model_clears_to_null(self) -> None:
         self._route("claude", "opus")

--- a/tests/test_harness_surfaces.py
+++ b/tests/test_harness_surfaces.py
@@ -1,6 +1,7 @@
 """Authoritative harness surface/status projection contracts."""
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import unittest
@@ -32,6 +33,10 @@ class HarnessSurfaceProjectionTest(unittest.TestCase):
         )
         self.assertEqual(
             harness_surfaces.known_runnable_harnesses(),
+            ["claude", "codex", "deepseek", "kimi", "opencode", "vibe"],
+        )
+        self.assertEqual(
+            harness_surfaces.known_interactive_harnesses(),
             ["claude", "codex", "deepseek", "kimi", "opencode", "vibe"],
         )
         for harness in ("claude", "codex", "kimi", "opencode"):
@@ -113,6 +118,61 @@ class HarnessSurfaceProjectionTest(unittest.TestCase):
         self.assertNotIn(
             "retired-harness", harness_surfaces.known_runnable_harnesses()
         )
+
+    def test_model_visibility_is_separate_from_launch_default_eligibility(self) -> None:
+        manifests = {
+            "one-shot-only": {
+                "harness": "one-shot-only",
+                "surfaces": {
+                    "terminal": False,
+                    "one_shot": True,
+                    "browser": False,
+                    "sprint": False,
+                },
+                "headless": {"launch": ["one-shot"]},
+            },
+            "browser-only": {
+                "harness": "browser-only",
+                "surfaces": {
+                    "terminal": False,
+                    "one_shot": False,
+                    "browser": True,
+                    "sprint": False,
+                },
+            },
+            "local-web-only": {
+                "harness": "local-web-only",
+                "surfaces": {
+                    "terminal": False,
+                    "one_shot": False,
+                    "browser": False,
+                    "sprint": False,
+                },
+                "interactive": {
+                    "kind": "local_web",
+                    "launch": ["local-web"],
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            adapters = Path(tmp)
+            for harness, manifest in manifests.items():
+                path = adapters / harness / "adapter.json"
+                path.parent.mkdir()
+                path.write_text(json.dumps(manifest))
+            with mock.patch.object(harness_surfaces, "ADAPTERS", adapters), \
+                    mock.patch.object(
+                        harness_surfaces,
+                        "_browser_contract_proven",
+                        side_effect=lambda harness: harness == "browser-only",
+                    ):
+                visible = harness_surfaces.known_runnable_harnesses()
+                defaults = harness_surfaces.known_interactive_harnesses()
+
+        self.assertEqual(
+            visible, ["browser-only", "local-web-only", "one-shot-only"]
+        )
+        self.assertEqual(defaults, ["local-web-only"])
 
     def test_interactive_detection_includes_terminal_and_local_web_harnesses(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_harness_surfaces.py
+++ b/tests/test_harness_surfaces.py
@@ -30,6 +30,10 @@ class HarnessSurfaceProjectionTest(unittest.TestCase):
             harness_surfaces.known_terminal_harnesses(),
             ["claude", "codex", "kimi", "opencode", "vibe"],
         )
+        self.assertEqual(
+            harness_surfaces.known_runnable_harnesses(),
+            ["claude", "codex", "deepseek", "kimi", "opencode", "vibe"],
+        )
         for harness in ("claude", "codex", "kimi", "opencode"):
             with self.subTest(harness=harness):
                 self.assertEqual(projection[harness]["surfaces"], {
@@ -105,6 +109,9 @@ class HarnessSurfaceProjectionTest(unittest.TestCase):
         })
         self.assertNotIn(
             "retired-harness", harness_surfaces.known_terminal_harnesses()
+        )
+        self.assertNotIn(
+            "retired-harness", harness_surfaces.known_runnable_harnesses()
         )
 
     def test_interactive_detection_includes_terminal_and_local_web_harnesses(self) -> None:

--- a/tests/test_shells_ui_contract.py
+++ b/tests/test_shells_ui_contract.py
@@ -92,6 +92,8 @@ def test_default_models_saves_model_and_effort_atomically():
     assert 'row.effort_state = "selection-required"' in DEFAULT_MODELS
     assert 'ariaLabel: `Thinking level for ${flavor} ${h}`' in DEFAULT_MODELS
     assert "m.harness_support_state" in DEFAULT_MODELS
+    assert "new Set(fd.default_harnesses || fd.harnesses || [])" in DEFAULT_MODELS
+    assert "star.disabled = !defaultHarnesses.has(h)" in DEFAULT_MODELS
 
 
 def test_skills_is_nested_under_shells_instead_of_global_navigation():


### PR DESCRIPTION
## Summary
- add a runnable-harness roster for flavor-level launch and model defaults
- include DeepSeek because it has proven one-shot, Browser, and Sprint surfaces while preserving the terminal-only roster
- verify DeepSeek defaults are writable and unknown harnesses remain rejected

The roster uses any proven execution surface rather than only interactive surfaces because flavor defaults also feed one-shot, Browser, and Sprint execution. This aligns the API with Decision #232, which makes DeepSeek first-class across those surfaces.

## Tests
- 69 passed, 6 subtests passed: tests/test_harness_surfaces.py tests/test_api_endpoints.py
- 10 passed, 6 subtests passed: new focused regression and negative cases