### PR TITLE
fix(analytics): clarify Kimi quota remaining

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2485,11 +2485,11 @@ const AN_PROVIDER_LABEL = { anthropic: "Claude", openai: "Codex", moonshot: "Kim
 // stops at "how much is left" — the FnB's ruling that retired account identity
 // rests on the provider's own page being one click away, so the link is part of
 // the design and not a convenience. Each URL is taken from the harness CLI's own
-// binary rather than guessed; Kimi links to its Code usage console.
+// binary rather than guessed; Kimi links straight to its membership quota tab.
 const AN_PROVIDER_USAGE_URL = {
   anthropic: "https://claude.ai/settings/usage",
   openai: "https://chatgpt.com/codex/settings/usage",
-  moonshot: "https://www.kimi.com/code/console",
+  moonshot: "https://www.kimi.ai/membership/subscription?tab=quota",
 };
 // Display order for a card's windows. Unrecognized kinds sort last rather than
 // being dropped — the probe stores a window it could not map under its raw
@@ -2536,23 +2536,33 @@ function anAge(iso) {
   return ms <= 0 ? "just now" : anDuration(ms) + " ago";
 }
 
-function anWindowRow(w) {
+function anWindowRow(w, provider) {
   const pct = w.used_percent;
+  // Kimi's own usage surface presents quota remaining. Its endpoint commonly
+  // normalizes limit/used to a 100-point scale, so rendering `28 / 100` looks
+  // like an absolute request allowance and inverts the 72%-left figure the
+  // operator sees on Kimi. Keep used_percent as the threshold source, but make
+  // Kimi's presentation match the provider: remaining bar + explicit label,
+  // and no count-like rendering of percentage-normalized values.
+  const isKimi = provider === "moonshot";
+  const displayPct = isKimi && pct != null
+    ? Math.max(0, Math.min(100, 100 - pct)) : pct;
+  const pctText = isKimi && pct != null ? anPct(displayPct) + " left" : anPct(pct);
   const row = el("div", { className: "an-win" });
   row.append(el("div", { className: "an-win-head" },
     el("span", { className: "an-win-name" }, anWindowName(w)),
-    el("span", { className: "an-win-pct" + anQuotaClass(pct) }, anPct(pct))));
+    el("span", { className: "an-win-pct" + anQuotaClass(pct) }, pctText)));
   const meter = el("div", { className: "an-meter" });
   if (pct != null) {
     // Clamped: a provider reporting over 100 fills the track, it does not
     // overflow it. NULL draws no fill at all — an empty track is honest.
     const fill = el("div", { className: "an-meter-fill" + anQuotaClass(pct) });
-    fill.style.width = Math.max(0, Math.min(100, pct)) + "%";
+    fill.style.width = Math.max(0, Math.min(100, displayPct)) + "%";
     meter.append(fill);
   }
   row.append(meter);
   const meta = [];
-  if (w.used != null || w.limit_value != null)
+  if (!isKimi && (w.used != null || w.limit_value != null))
     meta.push(["used", (w.used == null ? "—" : fmt(w.used))
       + " / " + (w.limit_value == null ? "—" : fmt(w.limit_value))]);
   meta.push(["resets", anCountdown(w.resets_at)]);
@@ -2617,7 +2627,7 @@ function anProviderCard(prov) {
   if (!wins.length)
     card.append(el("div", { className: "muted" },
       prov.status === "ok" ? "no windows reported" : "no reading yet"));
-  for (const w of wins) card.append(anWindowRow(w));
+  for (const w of wins) card.append(anWindowRow(w, prov.provider));
 
   const foot = el("div", { className: "an-acct-foot" });
   // THE AGE IS NEVER OMITTED AND NEVER SOFTENED. It is the whole of the

--- a/tests/mutations/u4_quota_accounts_ui.py
+++ b/tests/mutations/u4_quota_accounts_ui.py
@@ -96,17 +96,18 @@ MUTATIONS = [
         "M5 the meter is unclamped — a provider reporting over 100 overflows "
         "the track instead of filling it",
         "threshold_driven",
-        "    fill.style.width = Math.max(0, Math.min(100, pct)) + \"%\";",
-        "    fill.style.width = pct + \"%\";",
+        "    fill.style.width = Math.max(0, Math.min(100, displayPct)) + \"%\";",
+        "    fill.style.width = displayPct + \"%\";",
     ),
     (
         "M6 COLOUR IS TAKEN FROM THE PROVIDER'S STATUS instead of used_percent "
         "— openai's limit_reached painted red at 22%. Every consistent fixture "
         "stays green under this; only the contradictory card reddens",
         "provider_status_never_decides_colour",
-        "  for (const w of wins) card.append(anWindowRow(w));",
+        "  for (const w of wins) card.append(anWindowRow(w, prov.provider));",
         "  for (const w of wins) card.append(anWindowRow("
-        "status === \"error\" ? { ...w, used_percent: 100 } : w));",
+        "status === \"error\" ? { ...w, used_percent: 100 } : w, "
+        "prov.provider));",
     ),
     (
         "M7 the accounts array drives provider state — the status list is "

--- a/tests/test_quota_accounts_ui.py
+++ b/tests/test_quota_accounts_ui.py
@@ -388,6 +388,30 @@ def test_a_real_zero_percent_still_draws_a_measured_zero():
     assert r["pct"] == ["0%"] and r["width"] == "0%"
 
 
+def test_kimi_matches_provider_remaining_quota_without_fake_absolute_counts():
+    """Kimi's official usage UI reports quota remaining, while its endpoint
+    commonly normalizes limit/used onto a 100-point scale. The card must match
+    that direction and must not present 28/100 as an absolute request budget.
+
+    The fill and label are both asserted so the display cannot say 72% left
+    while drawing the inverse 28% bar. The source used_percent stays intact for
+    the provider-blind warning threshold, pinned by the red class at 96% used.
+    """
+    r = run_js("""
+      const r0 = root(); anDrawQuota(r0, PAYLOAD);
+      const card = byClass(r0, "an-acct")[0];
+      out({ pct: texts(byClass(card, "an-win-pct")),
+            width: byClass(card, "an-meter-fill")[0].style.width,
+            tone: cls(byClass(card, "an-win-pct")[0]),
+            body: card.textContent });
+    """, payload([provider("moonshot", windows=[
+        window(pct=96.0, used=96, limit_value=100)])]))
+    assert r["pct"] == ["4% left"]
+    assert r["width"] == "4%"
+    assert "red" in r["tone"], "warning colour still follows 96% used"
+    assert "96 / 100" not in r["body"]
+
+
 # ── one card per provider, never hidden ──────────────────────────────────────
 
 def test_every_provider_renders_a_card_including_the_unconfigured_ones():
@@ -562,7 +586,7 @@ def test_each_card_links_out_to_its_own_providers_usage_page():
     """, payload(all_three()))
     assert r["hrefs"] == ["https://claude.ai/settings/usage",
                           "https://chatgpt.com/codex/settings/usage",
-                          "https://www.kimi.com/code/console"]
+                          "https://www.kimi.ai/membership/subscription?tab=quota"]
 
 
 def test_refresh_forces_a_probe_and_redraws_from_its_response():


### PR DESCRIPTION
## Summary

- render Kimi quota as an explicit remaining percentage, matching Kimi’s own usage surface
- omit Kimi’s normalized 100-point values from the absolute-count row
- link directly to the Kimi membership quota tab
- retain used-percent thresholds plus stale-reading status and age

## Verification

- `pytest -q tests/test_quota_probes.py tests/test_quota_accounts_api.py tests/test_quota_accounts_ui.py` — 120 passed, 12 subtests passed
- `pytest -q tests/test_quota_gate.py` — 19 passed, 3 subtests passed
- `node --check .super-coder/ui/app.js`
- `git diff --check`

## Trade-off

The stored API contract remains `used_percent`; only Kimi’s rendering is inverted to remaining quota. This preserves provider-blind warning thresholds while matching the provider’s own presentation and avoids claiming that the common 100-point response is an absolute request allowance.

## Follow-up

The legacy Provider Quota UI mutation driver has 19 pre-existing stale anchors from the prior simplification. Internal flag `quota-ui-mutation-driver-stale` (#503) tracks that separate cleanup.