### PR TITLE
Fix Sprint-aware Developer PR notifications

### DIFF
--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -139,9 +139,9 @@ sc sprint register-pr --sprint <id> --repository <owner/name> \
 ```
 
 After `register-pr` succeeds, retain ownership. Red/green/closed Re-enter wakes
-continue after the Sprint ends. Follow their context: in an armed/paused
-Sprint, fix red + pass green to review; outside an active Sprint, fix red only
-if needed + take no action on green. Planner/Reviewer get none.
+continue after the Sprint ends. Follow context: armed -> fix red + judge/pass
+green; paused -> wait for resume before fix/review; no active Sprint -> fix red
+only if needed + no action on green. Planner/Reviewer get none.
 
 If the same registered PR was externally closed, then reopened, rebased, and
 pushed, replay the exact `register-pr` command. Require `created: false`, which

--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -140,8 +140,9 @@ sc sprint register-pr --sprint <id> --repository <owner/name> \
 
 After `register-pr` succeeds, retain ownership. Red/green/closed Re-enter wakes
 continue after the Sprint ends. Follow context: armed -> fix red + judge/pass
-green; paused -> wait for resume before fix/review; no active Sprint -> fix red
-only if needed + no action on green. Planner/Reviewer get none.
+green; paused -> fix red now + judge green, review after resume;
+no active Sprint -> fix red if needed + no action on green. Planner/Reviewer get
+none.
 
 If the same registered PR was externally closed, then reopened, rebased, and
 pushed, replay the exact `register-pr` command. Require `created: false`, which

--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -138,10 +138,10 @@ sc sprint register-pr --sprint <id> --repository <owner/name> \
   --pr <number> --work-unit <id>
 ```
 
-After `register-pr` succeeds, retain ownership. Expect red/green/closed
-Re-enter wakes outside an armed Sprint. While the PR remains attached to an
-aborted Sprint, expect observation without a wake; reconciliation restores
-wakes. Fix red; judge green. Planner/Reviewer get none.
+After `register-pr` succeeds, retain ownership. Red/green/closed Re-enter wakes
+continue after the Sprint ends. Follow their context: in an armed/paused
+Sprint, fix red + pass green to review; outside an active Sprint, fix red only
+if needed + take no action on green. Planner/Reviewer get none.
 
 If the same registered PR was externally closed, then reopened, rebased, and
 pushed, replay the exact `register-pr` command. Require `created: false`, which

--- a/.super-coder/migrations/0233_reseed_sprint_aware_pr_notifications.sql
+++ b/.super-coder/migrations/0233_reseed_sprint_aware_pr_notifications.sql
@@ -10,9 +10,9 @@ Re-enter wakes outside an armed Sprint. While the PR remains attached to an
 aborted Sprint, expect observation without a wake; reconciliation restores
 wakes. Fix red; judge green. Planner/Reviewer get none.',
   'After `register-pr` succeeds, retain ownership. Red/green/closed Re-enter wakes
-continue after the Sprint ends. Follow their context: in an armed/paused
-Sprint, fix red + pass green to review; outside an active Sprint, fix red only
-if needed + take no action on green. Planner/Reviewer get none.'
+continue after the Sprint ends. Follow context: armed -> fix red + judge/pass
+green; paused -> wait for resume before fix/review; no active Sprint -> fix red
+only if needed + no action on green. Planner/Reviewer get none.'
 )
 WHERE name='sprint_dev';
 

--- a/.super-coder/migrations/0233_reseed_sprint_aware_pr_notifications.sql
+++ b/.super-coder/migrations/0233_reseed_sprint_aware_pr_notifications.sql
@@ -1,0 +1,19 @@
+-- 0233 — keep Developer PR notifications useful outside an active Sprint.
+
+BEGIN;
+
+UPDATE skills
+SET content=replace(
+  content,
+  'After `register-pr` succeeds, retain ownership. Expect red/green/closed
+Re-enter wakes outside an armed Sprint. While the PR remains attached to an
+aborted Sprint, expect observation without a wake; reconciliation restores
+wakes. Fix red; judge green. Planner/Reviewer get none.',
+  'After `register-pr` succeeds, retain ownership. Red/green/closed Re-enter wakes
+continue after the Sprint ends. Follow their context: in an armed/paused
+Sprint, fix red + pass green to review; outside an active Sprint, fix red only
+if needed + take no action on green. Planner/Reviewer get none.'
+)
+WHERE name='sprint_dev';
+
+COMMIT;

--- a/.super-coder/migrations/0233_reseed_sprint_aware_pr_notifications.sql
+++ b/.super-coder/migrations/0233_reseed_sprint_aware_pr_notifications.sql
@@ -11,8 +11,9 @@ aborted Sprint, expect observation without a wake; reconciliation restores
 wakes. Fix red; judge green. Planner/Reviewer get none.',
   'After `register-pr` succeeds, retain ownership. Red/green/closed Re-enter wakes
 continue after the Sprint ends. Follow context: armed -> fix red + judge/pass
-green; paused -> wait for resume before fix/review; no active Sprint -> fix red
-only if needed + no action on green. Planner/Reviewer get none.'
+green; paused -> fix red now + judge green, review after resume;
+no active Sprint -> fix red if needed + no action on green. Planner/Reviewer get
+none.'
 )
 WHERE name='sprint_dev';
 

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1404,6 +1404,10 @@ class SprintPRWatcher:
                 ),
             }
             if lifecycle == "paused":
+                instructions["red"] = (
+                    "Your paused Sprint PR went red; fix the failing checks now; "
+                    "do not wait for the Sprint to resume."
+                )
                 instructions["green"] = (
                     "Your paused Sprint PR is green; judge readiness and wait "
                     "for the Sprint to resume."

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1395,8 +1395,8 @@ class SprintPRWatcher:
             instructions = {
                 "red": "Your active Sprint PR went red; fix the failing checks.",
                 "green": (
-                    "Your active Sprint PR is green; pass the baton to review "
-                    "when ready."
+                    "Your active Sprint PR is green; judge readiness and pass "
+                    "the baton to review when ready."
                 ),
                 "closed": (
                     "Your active Sprint PR was closed without merge; tell the "

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1390,17 +1390,33 @@ class SprintPRWatcher:
                 ),
             )
 
-        if registered["lifecycle"] == "aborted":
-            return resolved_review_message_ids
-
-        instructions = {
-            "red": "Your PR went red; fix it.",
-            "green": "Your PR is green; judge readiness and pass the baton to review.",
-            "closed": (
-                "Your PR was closed without merge; judge it and inform the Planner "
-                "if this is a real problem."
-            ),
-        }
+        active_sprint = registered["lifecycle"] in {"armed", "paused"}
+        if active_sprint:
+            instructions = {
+                "red": "Your active Sprint PR went red; fix the failing checks.",
+                "green": (
+                    "Your active Sprint PR is green; pass the baton to review "
+                    "when ready."
+                ),
+                "closed": (
+                    "Your active Sprint PR was closed without merge; tell the "
+                    "Planner if this blocks the Sprint."
+                ),
+            }
+        else:
+            instructions = {
+                "red": (
+                    "Your PR went red outside an active Sprint; fix it if it still "
+                    "needs attention, otherwise no action is needed."
+                ),
+                "green": (
+                    "Your PR is green outside an active Sprint; no action is needed."
+                ),
+                "closed": (
+                    "Your PR was closed without merge outside an active Sprint; "
+                    "no action is needed unless the closure was unexpected."
+                ),
+            }
         if state in instructions:
             head = pull_request.head_sha or "unknown"
             owner_shell_id = int(registered["owner_shell_id"])

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1390,8 +1390,8 @@ class SprintPRWatcher:
                 ),
             )
 
-        active_sprint = registered["lifecycle"] in {"armed", "paused"}
-        if active_sprint:
+        lifecycle = registered["lifecycle"]
+        if lifecycle in {"armed", "paused"}:
             instructions = {
                 "red": "Your active Sprint PR went red; fix the failing checks.",
                 "green": (
@@ -1403,6 +1403,11 @@ class SprintPRWatcher:
                     "Planner if this blocks the Sprint."
                 ),
             }
+            if lifecycle == "paused":
+                instructions["green"] = (
+                    "Your paused Sprint PR is green; judge readiness and wait "
+                    "for the Sprint to resume."
+                )
         else:
             instructions = {
                 "red": (

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -148,9 +148,10 @@ Planner Re-enters become fresh ticket chats); FnB pause/resume returns to
 supervise, while automatic pauses preserve the dial. Developer-owned PR
 subscriptions emit self-describing red/green/closed Re-enter wakes throughout
 ownership, including after a Sprint ends. Wake text distinguishes an
-armed/paused Sprint from no active Sprint; Planner and Reviewer receive no
-PR-event wakes. Arming validates all recorded role harness/model/effort
-selections before publishing work; defaults satisfy the gate.
+armed Sprint, a paused Sprint, and no active Sprint; Planner and Reviewer
+receive no PR-event wakes. Arming validates all recorded role
+harness/model/effort selections before publishing work;
+defaults satisfy the gate.
 
 ---
 

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -146,11 +146,11 @@ are New; Developer/Reviewer→Planner and Reviewer→Developer are Re-enter. FnB
 can close the Planner chat during an armed Sprint to set coordinate mode (idle
 Planner Re-enters become fresh ticket chats); FnB pause/resume returns to
 supervise, while automatic pauses preserve the dial. Developer-owned PR
-subscriptions emit self-describing red/green/closed Re-enter wakes even outside
-an armed Sprint, except while the registration remains attached to an aborted
-Sprint; Planner and Reviewer receive no PR-event wakes. Arming validates all
-recorded role harness/model/effort selections before publishing work;
-defaults satisfy the gate.
+subscriptions emit self-describing red/green/closed Re-enter wakes throughout
+ownership, including after a Sprint ends. Wake text distinguishes an
+armed/paused Sprint from no active Sprint; Planner and Reviewer receive no
+PR-event wakes. Arming validates all recorded role harness/model/effort
+selections before publishing work; defaults satisfy the gate.
 
 ---
 

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -134,7 +134,8 @@
     ".super-coder/migrations/0227_deepseek_controlled_route_binding.sql",
     ".super-coder/migrations/0228_reseed_python_test_tooling.sql",
     ".super-coder/migrations/0229_reseed_messaging_wake_guidance.sql",
-    ".super-coder/migrations/0231_suppress_aborted_sprint_pr_wakes.sql"
+    ".super-coder/migrations/0231_suppress_aborted_sprint_pr_wakes.sql",
+    ".super-coder/migrations/0233_reseed_sprint_aware_pr_notifications.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_focused_dev_verification.py
+++ b/tests/test_focused_dev_verification.py
@@ -14,6 +14,7 @@ ASSETS = ENGINE / "assets" / "skills"
 MIGRATIONS = (
     ENGINE / "migrations" / "0225_focused_dev_verification.sql",
     ENGINE / "migrations" / "0231_suppress_aborted_sprint_pr_wakes.sql",
+    ENGINE / "migrations" / "0233_reseed_sprint_aware_pr_notifications.sql",
 )
 sys.path.insert(0, str(ENGINE / "scripts"))
 

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -434,8 +434,8 @@ class RegistrationTest(SprintPRWatcherCase):
                     "re-enter",
                     "GitHub PR event: repository=acme/repo, number=42, head_sha="
                     + reopened_head
-                    + ", event=green. Your active Sprint PR is green; pass the "
-                    "baton to review when ready.",
+                    + ", event=green. Your active Sprint PR is green; judge "
+                    "readiness and pass the baton to review when ready.",
                 ),
             ],
             [
@@ -1289,8 +1289,8 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         self.assertEqual(
             "GitHub PR event: repository=acme/repo, number=42, head_sha="
             + "a" * 40
-            + ", event=green. Your active Sprint PR is green; pass the baton "
-            "to review when ready.",
+            + ", event=green. Your active Sprint PR is green; judge readiness "
+            "and pass the baton to review when ready.",
             paused_message["body"],
         )
 

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -1270,6 +1270,7 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         self.assertEqual(before, after)
 
     def test_paused_change_is_observed_immediately_and_deduplicated(self):
+        self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
         self.register()
         lifecycle = sprint_domain.SprintLifecycleStore(self.con)
         lifecycle.transition(
@@ -1278,9 +1279,25 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
             sprint_domain.LifecycleActor("participant", 1),
             reason="test",
         )
+        self.reader.current = pull_request()
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual(["green", "red"], self._states())
+        paused_red_message = self.con.execute(
+            "SELECT body FROM wake_message "
+            "WHERE idempotency_key LIKE 'pr-transition:%' "
+            "ORDER BY message_id DESC LIMIT 1"
+        ).fetchone()
+        self.assertEqual(
+            "GitHub PR event: repository=acme/repo, number=42, head_sha="
+            + "a" * 40
+            + ", event=red. Your paused Sprint PR went red; fix the failing "
+            "checks now; do not wait for the Sprint to resume.",
+            paused_red_message["body"],
+        )
+
         self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
         self.assertTrue(self.watcher.poll_once())
-        self.assertEqual(["red", "green"], self._states())
+        self.assertEqual(["green", "red", "green"], self._states())
         paused_message = self.con.execute(
             "SELECT body FROM wake_message "
             "WHERE idempotency_key LIKE 'pr-transition:%' "
@@ -1301,9 +1318,9 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
             sprint_domain.LifecycleActor("planner", 3),
         )
         self.assertTrue(self.watcher.poll_once())
-        self.assertEqual(["red", "green"], self._states())
+        self.assertEqual(["green", "red", "green"], self._states())
         self.assertTrue(self.watcher.poll_once())
-        self.assertEqual(["red", "green"], self._states())
+        self.assertEqual(["green", "red", "green"], self._states())
 
     def test_completed_sprint_does_not_gate_an_active_subscription(self):
         self.register()

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -424,8 +424,8 @@ class RegistrationTest(SprintPRWatcherCase):
                     "re-enter",
                     "GitHub PR event: repository=acme/repo, number=42, head_sha="
                     + "a" * 40
-                    + ", event=closed. Your PR was closed without merge; judge it "
-                    "and inform the Planner if this is a real problem.",
+                    + ", event=closed. Your active Sprint PR was closed without "
+                    "merge; tell the Planner if this blocks the Sprint.",
                 ),
                 (
                     1,
@@ -434,8 +434,8 @@ class RegistrationTest(SprintPRWatcherCase):
                     "re-enter",
                     "GitHub PR event: repository=acme/repo, number=42, head_sha="
                     + reopened_head
-                    + ", event=green. Your PR is green; judge readiness and pass "
-                    "the baton to review.",
+                    + ", event=green. Your active Sprint PR is green; pass the "
+                    "baton to review when ready.",
                 ),
             ],
             [
@@ -1058,7 +1058,8 @@ class TransitionRoutingTest(SprintPRWatcherCase):
             {
                 "GitHub PR event: repository=acme/repo, number=42, head_sha="
                 + "a" * 40
-                + ", event=red. Your PR went red; fix it."
+                + ", event=red. Your active Sprint PR went red; fix the failing "
+                "checks."
             },
             {str(row["body"]) for row in routed},
         )
@@ -1280,6 +1281,18 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
         self.assertTrue(self.watcher.poll_once())
         self.assertEqual(["red", "green"], self._states())
+        paused_message = self.con.execute(
+            "SELECT body FROM wake_message "
+            "WHERE idempotency_key LIKE 'pr-transition:%' "
+            "ORDER BY message_id DESC LIMIT 1"
+        ).fetchone()
+        self.assertEqual(
+            "GitHub PR event: repository=acme/repo, number=42, head_sha="
+            + "a" * 40
+            + ", event=green. Your active Sprint PR is green; pass the baton "
+            "to review when ready.",
+            paused_message["body"],
+        )
 
         lifecycle.transition(
             self.sprint_id,
@@ -1307,12 +1320,25 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
             terminal_outcome="delivered",
         )
         calls = len(self.reader.get_calls)
+        self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
 
         self.assertTrue(self.watcher.poll_once())
         self.assertEqual(calls + 1, len(self.reader.get_calls))
         self.assertEqual(0, self.reader.list_calls)
+        message = self.con.execute(
+            "SELECT body FROM wake_message "
+            "WHERE idempotency_key LIKE 'pr-transition:%' "
+            "ORDER BY message_id DESC LIMIT 1"
+        ).fetchone()
+        self.assertEqual(
+            "GitHub PR event: repository=acme/repo, number=42, head_sha="
+            + "a" * 40
+            + ", event=green. Your PR is green outside an active Sprint; "
+            "no action is needed.",
+            message["body"],
+        )
 
-    def test_aborted_sprint_observes_pr_without_waking_its_former_developer(self):
+    def test_aborted_sprint_uses_non_sprint_notification_policy(self):
         self.register()
         self.con.execute(
             "INSERT INTO shells "
@@ -1348,19 +1374,23 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
             ],
         )
         self.assertEqual(
-            wake_count,
+            wake_count + 1,
             self.con.execute(
                 "SELECT COUNT(*) FROM wake_message "
                 "WHERE idempotency_key LIKE 'pr-transition:%'"
             ).fetchone()[0],
         )
+        message = self.con.execute(
+            "SELECT body FROM wake_message "
+            "WHERE idempotency_key LIKE 'pr-transition:%' "
+            "ORDER BY message_id DESC LIMIT 1"
+        ).fetchone()
         self.assertEqual(
-            0,
-            self.con.execute(
-                "SELECT COUNT(*) FROM wake_message "
-                "WHERE idempotency_key LIKE 'pr-transition:%' "
-                "AND body LIKE '%event=closed%'"
-            ).fetchone()[0],
+            "GitHub PR event: repository=acme/repo, number=42, head_sha="
+            + "a" * 40
+            + ", event=closed. Your PR was closed without merge outside an "
+            "active Sprint; no action is needed unless the closure was unexpected.",
+            message["body"],
         )
 
     def test_failure_is_durable_backs_off_and_never_invents_state(self):
@@ -1709,8 +1739,13 @@ class EngineWideSubscriptionTest(SprintPRWatcherCase):
             (1, None, None, "re-enter"),
             tuple(message)[:4],
         )
-        self.assertIn("repository=acme/repo, number=42", message["body"])
-        self.assertIn("head_sha=" + "a" * 40 + ", event=red", message["body"])
+        self.assertEqual(
+            "GitHub PR event: repository=acme/repo, number=42, head_sha="
+            + "a" * 40
+            + ", event=red. Your PR went red outside an active Sprint; fix it if "
+            "it still needs attention, otherwise no action is needed.",
+            message["body"],
+        )
 
     def test_no_subscriptions_performs_zero_github_calls(self):
         self.assertFalse(self.watcher.poll_once())

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -1289,10 +1289,11 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         self.assertEqual(
             "GitHub PR event: repository=acme/repo, number=42, head_sha="
             + "a" * 40
-            + ", event=green. Your active Sprint PR is green; judge readiness "
-            "and pass the baton to review when ready.",
+            + ", event=green. Your paused Sprint PR is green; judge readiness "
+            "and wait for the Sprint to resume.",
             paused_message["body"],
         )
+        self.assertNotIn("pass the baton", paused_message["body"])
 
         lifecycle.transition(
             self.sprint_id,

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -1667,22 +1667,31 @@ class SprintSkillTest(unittest.TestCase):
         self.assertIn(
             "Red/green/closed Re-enter wakes continue", normalized_developer
         )
-        self.assertIn("in an armed/paused Sprint", normalized_developer)
-        self.assertIn("outside an active Sprint", normalized_developer)
-        self.assertIn("take no action on green", normalized_developer)
+        self.assertIn("armed -> fix red + judge/pass green", normalized_developer)
+        self.assertIn(
+            "paused -> wait for resume before fix/review", normalized_developer
+        )
+        self.assertIn(
+            "no active Sprint -> fix red only if needed", normalized_developer
+        )
+        self.assertIn("no action on green", normalized_developer)
         self.assertIn("Reviewer decides", developer)
         self.assertIn("recalling unreleased work", " ".join(reviewer.split()))
         self.assertIn("Compile the bounded evidence packet first", reviewer)
         self.assertIn("Developer-owned subscriptions", planner)
 
         boot = (ENGINE / "templates" / "boot.md").read_text()
+        normalized_boot = " ".join(boot.split())
         self.assertIn("## ACTIVE CHAT DELIVERY", boot)
         self.assertIn("Every `wake_message` creates durable delivery intent", boot)
         self.assertIn("verified live turn", boot)
         self.assertIn("coordinate mode", boot)
         self.assertIn("reaper", boot)
         self.assertIn("including after a Sprint ends", boot)
-        self.assertIn("armed/paused Sprint from no active Sprint", boot)
+        self.assertIn(
+            "an armed Sprint, a paused Sprint, and no active Sprint",
+            normalized_boot,
+        )
         self.assertIn("defaults satisfy the gate", boot)
 
     def test_force_new_and_blind_review_contracts_are_folded_into_roles(self):

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -1669,10 +1669,11 @@ class SprintSkillTest(unittest.TestCase):
         )
         self.assertIn("armed -> fix red + judge/pass green", normalized_developer)
         self.assertIn(
-            "paused -> wait for resume before fix/review", normalized_developer
+            "paused -> fix red now + judge green, review after resume",
+            normalized_developer,
         )
         self.assertIn(
-            "no active Sprint -> fix red only if needed", normalized_developer
+            "no active Sprint -> fix red if needed", normalized_developer
         )
         self.assertIn("no action on green", normalized_developer)
         self.assertIn("Reviewer decides", developer)

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -1664,10 +1664,12 @@ class SprintSkillTest(unittest.TestCase):
         reviewer = bodies["sprint_rev"]
         planner = bodies["sprint_pln"]
         normalized_developer = " ".join(developer.split())
-        self.assertIn("outside an armed Sprint", developer)
-        self.assertIn("attached to an aborted Sprint", normalized_developer)
-        self.assertIn("observation without a wake", normalized_developer)
-        self.assertIn("reconciliation restores wakes", normalized_developer)
+        self.assertIn(
+            "Red/green/closed Re-enter wakes continue", normalized_developer
+        )
+        self.assertIn("in an armed/paused Sprint", normalized_developer)
+        self.assertIn("outside an active Sprint", normalized_developer)
+        self.assertIn("take no action on green", normalized_developer)
         self.assertIn("Reviewer decides", developer)
         self.assertIn("recalling unreleased work", " ".join(reviewer.split()))
         self.assertIn("Compile the bounded evidence packet first", reviewer)
@@ -1679,6 +1681,8 @@ class SprintSkillTest(unittest.TestCase):
         self.assertIn("verified live turn", boot)
         self.assertIn("coordinate mode", boot)
         self.assertIn("reaper", boot)
+        self.assertIn("including after a Sprint ends", boot)
+        self.assertIn("armed/paused Sprint from no active Sprint", boot)
         self.assertIn("defaults satisfy the gate", boot)
 
     def test_force_new_and_blind_review_contracts_are_folded_into_roles(self):


### PR DESCRIPTION
## Summary
- keep Developer-owned PR subscriptions active after Sprints end
- render active-Sprint instructions only for armed/paused Sprints
- render ordinary fix/no-action instructions for completed, aborted, prepared, or unlinked subscriptions
- reseed the Developer skill and align boot guidance

## Verification
- `pytest -q tests/test_sprint_pr_watcher.py tests/test_sprint_skills.py tests/test_focused_dev_verification.py tests/test_sprint_removal_manifest.py tests/test_skills_freshness.py`
- 120 passed, 131 subtests passed
- `git diff --check`

## Trade-off
The watcher remains engine-wide and persistent by design; lifecycle affects only the instruction policy, so useful red alerts survive Sprint termination without presenting a terminal Sprint as active.