### PR TITLE
Validate worktree virtualenvs before PATH injection

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -78,6 +78,17 @@ PROC_SELF_STAT = Path("/proc/self/stat")   # H-25: our own start ticks, pre-exec
 
 DEFAULT_HEADLESS_PROMPT = "Check your inbox and act on your unread messages."
 SESSION_OPEN_RETRY_DELAYS_S = (0.1, 0.3)
+VENV_PROBE_TIMEOUT_S = 3
+VENV_PROBE_SCRIPT = (
+    "import json, sys; "
+    "print(json.dumps({'version': list(sys.version_info[:2]), "
+    "'prefix': sys.prefix, 'base_prefix': sys.base_prefix}))"
+)
+
+
+class VenvEligibility(NamedTuple):
+    bin_dir: Path | None
+    failure: str | None
 
 
 def _headless_effort_args(hcfg: dict, effort: "str | None",
@@ -1259,12 +1270,105 @@ def _cli_version(binary: str) -> "str | None":
     return lines[0].strip() if lines else None
 
 
+def _probe_worktree_venv(work_dir: Path) -> VenvEligibility:
+    """Read-only proof that the assigned worktree owns a viable Python 3.14 venv."""
+    venv = work_dir / ".venv"
+    project_bin = venv / "bin"
+    if not project_bin.exists() and not project_bin.is_symlink():
+        return VenvEligibility(None, None)
+    if not project_bin.is_dir():
+        return VenvEligibility(None, ".venv/bin is not a directory")
+
+    python = project_bin / "python"
+    try:
+        executable = python.resolve(strict=True)
+    except FileNotFoundError:
+        condition = (
+            "dangling .venv/bin/python symlink"
+            if python.is_symlink()
+            else "missing .venv/bin/python"
+        )
+        return VenvEligibility(None, condition)
+    except (OSError, RuntimeError) as exc:
+        return VenvEligibility(
+            None, f"unresolvable .venv/bin/python ({exc})"
+        )
+
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        return VenvEligibility(
+            None, ".venv/bin/python is not an executable regular file"
+        )
+
+    try:
+        completed = subprocess.run(
+            [str(python), "-I", "-S", "-c", VENV_PROBE_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=VENV_PROBE_TIMEOUT_S,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return VenvEligibility(
+            None, f"Python probe timed out after {VENV_PROBE_TIMEOUT_S} seconds"
+        )
+    except OSError as exc:
+        return VenvEligibility(None, f"Python probe could not execute ({exc})")
+
+    if completed.returncode != 0:
+        return VenvEligibility(
+            None, f"Python probe exited {completed.returncode}"
+        )
+    try:
+        report = json.loads(completed.stdout)
+        version = report["version"]
+        prefix = report["prefix"]
+        base_prefix = report["base_prefix"]
+        if (
+            not isinstance(version, list)
+            or len(version) != 2
+            or not all(isinstance(part, int) for part in version)
+            or not isinstance(prefix, str)
+            or not isinstance(base_prefix, str)
+        ):
+            raise ValueError
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return VenvEligibility(None, "Python probe returned an invalid report")
+
+    if version != [3, 14]:
+        return VenvEligibility(
+            None, f"Python 3.14 is required; found {version[0]}.{version[1]}"
+        )
+
+    try:
+        selected_prefix = venv.resolve()
+        reported_prefix = Path(prefix).resolve()
+    except (OSError, RuntimeError):
+        return VenvEligibility(
+            None, f"Python reported foreign prefix {prefix}"
+        )
+    if reported_prefix != selected_prefix:
+        return VenvEligibility(
+            None, f"Python reported foreign prefix {prefix}"
+        )
+    if base_prefix == prefix:
+        return VenvEligibility(None, "Python reported no virtual environment")
+
+    return VenvEligibility(project_bin, None)
+
+
 def _shell_path(work_dir: Path, inherited: str) -> str:
-    """Put this shell's existing project environment ahead of baseline tools."""
+    """Put a proven project environment ahead of baseline tools."""
     entries = [str(REPO_ROOT)]
-    project_bin = work_dir / ".venv" / "bin"
-    if project_bin.is_dir():
-        entries.append(str(project_bin))
+    eligibility = _probe_worktree_venv(work_dir)
+    if eligibility.bin_dir is not None:
+        entries.append(str(eligibility.bin_dir))
+    elif eligibility.failure is not None:
+        print(
+            f"WARNING: {work_dir}: ignoring unusable .venv: "
+            f"{eligibility.failure}; run `sc deps` from this worktree to "
+            "rebuild its fork-owned environment.",
+            file=sys.stderr,
+        )
     if inherited:
         entries.append(inherited)
     return os.pathsep.join(entries)

--- a/tests/test_conversation_launch.py
+++ b/tests/test_conversation_launch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 import sys
 import tempfile
+import venv
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -198,6 +199,8 @@ def test_deepseek_managed_browser_launch_does_not_probe_cli(
     launch_case, monkeypatch
 ) -> None:
     db_path, worktree = launch_case
+    project_venv = worktree / ".venv"
+    venv.EnvBuilder(with_pip=False).create(project_venv)
 
     def connect():
         con = sqlite3.connect(db_path)
@@ -258,6 +261,10 @@ def test_deepseek_managed_browser_launch_does_not_probe_cli(
         ),
     )
     assert prepared.argv == []
+    assert prepared.env["PATH"].split(run_mod.os.pathsep)[:2] == [
+        str(run_mod.REPO_ROOT),
+        str(project_venv / "bin"),
+    ]
 
 
 @pytest.fixture

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -2,15 +2,19 @@
 """Regression tests for atomic, contention-safe launcher session opening."""
 from __future__ import annotations
 
+import io
+import json
 import os
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import threading
 import unittest
-from contextlib import contextmanager
-from types import SimpleNamespace
+import venv
+from contextlib import contextmanager, nullcontext, redirect_stderr
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parents[1] / ".super-coder" / "scripts"
@@ -109,29 +113,187 @@ class ShellPathTest(unittest.TestCase):
         self.root_patch.start()
         self.addCleanup(self.root_patch.stop)
 
-    def test_existing_project_environment_precedes_inherited_tools(self) -> None:
+    def _python(self, *, executable: bool = True) -> Path:
         project_bin = self.worktree / ".venv" / "bin"
         project_bin.mkdir(parents=True)
+        python = project_bin / "python"
+        python.write_text("probe fixture")
+        python.chmod(0o755 if executable else 0o644)
+        return python
 
-        path = run._shell_path(self.worktree, "/usr/local/bin:/usr/bin")
+    def _completed_probe(
+        self,
+        *,
+        version: tuple[int, int] = (3, 14),
+        prefix: Path | None = None,
+        base_prefix: Path | None = None,
+        returncode: int = 0,
+    ) -> subprocess.CompletedProcess:
+        prefix = prefix or self.worktree / ".venv"
+        base_prefix = base_prefix or self.root / "baseline-python"
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=returncode,
+            stdout=json.dumps({
+                "version": list(version),
+                "prefix": str(prefix),
+                "base_prefix": str(base_prefix),
+            }),
+            stderr="",
+        )
+
+    def _path_and_warning(self, completed=None) -> tuple[str, str]:
+        stderr = io.StringIO()
+        patcher = (
+            mock.patch.object(run.subprocess, "run", return_value=completed)
+            if completed is not None
+            else nullcontext()
+        )
+        with patcher, redirect_stderr(stderr):
+            path = run._shell_path(self.worktree, "/usr/local/bin:/usr/bin")
+        return path, stderr.getvalue()
+
+    def test_python_314_virtualenv_precedes_inherited_tools(self) -> None:
+        python = self._python()
+        completed = self._completed_probe()
+
+        with mock.patch.object(
+            run.subprocess, "run", return_value=completed
+        ) as probe:
+            path = run._shell_path(
+                self.worktree, "/usr/local/bin:/usr/bin"
+            )
 
         self.assertEqual(
             path,
-            f"{self.root}:{project_bin}:/usr/local/bin:/usr/bin",
+            f"{self.root}:{python.parent}:/usr/local/bin:/usr/bin",
+        )
+        probe.assert_called_once_with(
+            [
+                str(python),
+                "-I",
+                "-S",
+                "-c",
+                run.VENV_PROBE_SCRIPT,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
         )
 
-    def test_absent_or_non_directory_environment_is_not_injected(self) -> None:
+    def test_real_python_314_virtualenv_is_admitted(self) -> None:
+        project_venv = self.worktree / ".venv"
+        venv.EnvBuilder(with_pip=False).create(project_venv)
+
+        path, warning = self._path_and_warning()
+
         self.assertEqual(
-            run._shell_path(self.worktree, "/usr/bin"),
-            f"{self.root}:/usr/bin",
+            path,
+            f"{self.root}:{project_venv / 'bin'}:/usr/local/bin:/usr/bin",
         )
+        self.assertEqual(warning, "")
+
+    def test_absent_environment_is_omitted_without_warning(self) -> None:
+        path, warning = self._path_and_warning()
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertEqual(warning, "")
+
+    def test_non_directory_bin_is_omitted_with_remedy(self) -> None:
         project_bin = self.worktree / ".venv" / "bin"
         project_bin.parent.mkdir(parents=True)
         project_bin.write_text("not a directory")
-        self.assertEqual(
-            run._shell_path(self.worktree, "/usr/bin"),
-            f"{self.root}:/usr/bin",
+        path, warning = self._path_and_warning()
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn(str(self.worktree), warning)
+        self.assertIn(".venv/bin is not a directory", warning)
+        self.assertIn("run `sc deps`", warning)
+
+    def test_missing_interpreter_is_omitted_with_remedy(self) -> None:
+        (self.worktree / ".venv" / "bin").mkdir(parents=True)
+        path, warning = self._path_and_warning()
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn("missing .venv/bin/python", warning)
+        self.assertIn("run `sc deps`", warning)
+
+    def test_dangling_interpreter_is_omitted_with_remedy(self) -> None:
+        project_bin = self.worktree / ".venv" / "bin"
+        project_bin.mkdir(parents=True)
+        (project_bin / "python").symlink_to(self.root / "missing-python")
+        path, warning = self._path_and_warning()
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn("dangling .venv/bin/python symlink", warning)
+        self.assertTrue((project_bin / "python").is_symlink())
+
+    def test_non_executable_interpreter_is_omitted_with_remedy(self) -> None:
+        python = self._python(executable=False)
+        path, warning = self._path_and_warning()
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn("not an executable regular file", warning)
+        self.assertEqual(python.stat().st_mode & 0o777, 0o644)
+
+    def test_timed_out_probe_is_omitted_with_remedy(self) -> None:
+        self._python()
+        stderr = io.StringIO()
+        with mock.patch.object(
+            run.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired("python", 3),
+        ), redirect_stderr(stderr):
+            path = run._shell_path(self.worktree, "/usr/bin")
+        self.assertEqual(path, f"{self.root}:/usr/bin")
+        self.assertIn("Python probe timed out after 3 seconds", stderr.getvalue())
+
+    def test_foreign_prefix_is_omitted_with_remedy(self) -> None:
+        self._python()
+        foreign = self.root / "other-worktree" / ".venv"
+        path, warning = self._path_and_warning(
+            self._completed_probe(prefix=foreign)
         )
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn(f"Python reported foreign prefix {foreign}", warning)
+
+    def test_python_313_environment_is_omitted_with_remedy(self) -> None:
+        self._python()
+        path, warning = self._path_and_warning(
+            self._completed_probe(version=(3, 13))
+        )
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn("Python 3.14 is required; found 3.13", warning)
+
+    def test_python_315_environment_is_omitted_with_remedy(self) -> None:
+        self._python()
+        path, warning = self._path_and_warning(
+            self._completed_probe(version=(3, 15))
+        )
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn("Python 3.14 is required; found 3.15", warning)
+
+    def test_nonzero_probe_is_omitted_with_remedy(self) -> None:
+        self._python()
+        path, warning = self._path_and_warning(
+            self._completed_probe(returncode=9)
+        )
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn("Python probe exited 9", warning)
+
+    def test_invalid_probe_report_is_omitted_with_remedy(self) -> None:
+        self._python()
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="not-json", stderr=""
+        )
+        path, warning = self._path_and_warning(completed)
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn("Python probe returned an invalid report", warning)
+
+    def test_non_virtual_prefix_is_omitted_with_remedy(self) -> None:
+        self._python()
+        prefix = self.worktree / ".venv"
+        path, warning = self._path_and_warning(
+            self._completed_probe(prefix=prefix, base_prefix=prefix)
+        )
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn("Python reported no virtual environment", warning)
 
     def test_interactive_and_prepared_launches_share_the_path_builder(self) -> None:
         source = (SCRIPTS / "run.py").read_text()


### PR DESCRIPTION
Implements Feature #40 / Spec #171 task #624 only.

Summary:
- add one read-only, three-second isolated Python probe for the assigned worktree .venv
- admit only executable Python 3.14 virtualenvs whose reported prefix matches the selected environment
- preserve repository-root precedence and use the same PATH builder for interactive and prepared/headless launches
- omit invalid environments with a worktree-specific sc deps remedy; keep absent environments silent
- cover valid, absent, non-directory, missing, dangling, non-executable, timeout, nonzero, malformed, non-virtual, foreign-prefix, Python 3.13, and Python 3.15 cases

Checks:
- python3 -m py_compile .super-coder/scripts/run.py tests/test_run_session.py tests/test_conversation_launch.py
- python3 -m unittest tests.test_run_session -v (33 passed)
- python3 -m pytest -q tests/test_conversation_launch.py (14 passed)
- git diff --check

Base: edf51f5341d658acf8c3aedf18dfd1b204c19d0d
Departures: none. Tasks #625 and #626 are untouched.