### PR TITLE
ci: prove Docker sandbox lifecycle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,7 +143,8 @@ jobs:
                       remaining = deadline - time.monotonic()
                       if remaining <= 0:
                           continue
-                      url = f"http://127.0.0.1:{port_result.stdout.strip()}/api/health"
+                      port = json.loads(port_result.stdout)["port"]
+                      url = f"http://127.0.0.1:{port}/api/health"
                       with urllib.request.urlopen(
                           url,
                           timeout=min(5, remaining),

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,3 +83,144 @@ jobs:
           python-version: '3.14'
       - name: Rebuild + render + headless boot
         run: ./sc verify
+
+  docker-sandbox-lifecycle:
+    name: Docker sandbox lifecycle
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      SC_CI_CONTAINER: sc-${{ github.event.repository.name }}
+      SC_CI_SIDECAR: sc-pg-${{ github.event.repository.name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # A launch may forward explicitly configured host GitHub auth. Keep
+          # the job token out of git config so the disposable sandbox receives
+          # no repository credential.
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+      - name: Bootstrap the fresh checkout
+        run: ./sc verify
+      - name: Build and launch the default sandbox
+        run: ./sc launch
+      - name: Reach the sandbox health endpoint within 90 seconds
+        run: |-
+          python3 - <<'PY'
+          import json
+          import subprocess
+          import time
+          import urllib.request
+
+          deadline = time.monotonic() + 90
+          last_evidence = "no health response"
+          while (remaining := deadline - time.monotonic()) > 0:
+              try:
+                  result = subprocess.run(
+                      ["./sc", "health"],
+                      capture_output=True,
+                      text=True,
+                      timeout=min(5, remaining),
+                      check=False,
+                  )
+                  last_evidence = (
+                      f"exit={result.returncode} stdout={result.stdout!r} "
+                      f"stderr={result.stderr!r}"
+                  )
+                  payload = json.loads(result.stdout) if result.returncode == 0 else {}
+                  if payload.get("ok") is True:
+                      remaining = deadline - time.monotonic()
+                      if remaining <= 0:
+                          continue
+                      port_result = subprocess.run(
+                          ["./sc", "ports", "port"],
+                          capture_output=True,
+                          text=True,
+                          timeout=min(5, remaining),
+                          check=True,
+                      )
+                      remaining = deadline - time.monotonic()
+                      if remaining <= 0:
+                          continue
+                      url = f"http://127.0.0.1:{port_result.stdout.strip()}/api/health"
+                      with urllib.request.urlopen(
+                          url,
+                          timeout=min(5, remaining),
+                      ) as response:
+                          direct_payload = json.load(response)
+                          if response.status == 200 and direct_payload.get("ok") is True:
+                              print(json.dumps(direct_payload, sort_keys=True))
+                              raise SystemExit(0)
+              except (json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
+                  last_evidence = repr(exc)
+              time.sleep(min(2, max(0, deadline - time.monotonic())))
+
+          raise SystemExit(f"sandbox health did not become ready within 90 seconds: {last_evidence}")
+          PY
+      - name: Prove the running engine uses Python 3.14
+        run: |-
+          docker exec -i "$SC_CI_CONTAINER" python3 - <<'PY'
+          import json
+          import os
+          import platform
+          import sys
+          from pathlib import Path
+
+          servers = []
+          for process in Path("/proc").iterdir():
+              if not process.name.isdecimal():
+                  continue
+              try:
+                  command = (process / "cmdline").read_bytes()
+              except OSError:
+                  continue
+              if b".super-coder/api/server.py" in command:
+                  servers.append(process)
+
+          if len(servers) != 1:
+              raise SystemExit(f"expected one running engine server, found {len(servers)}")
+          server_executable = Path(os.readlink(servers[0] / "exe")).resolve()
+          selected_executable = Path(sys.executable).resolve()
+          evidence = {
+              "python": platform.python_version(),
+              "running_engine_executable": str(server_executable),
+              "selected_executable": str(selected_executable),
+          }
+          print(json.dumps(evidence, sort_keys=True))
+          if server_executable != selected_executable:
+              raise SystemExit("running engine and selected Python executables differ")
+          if sys.version_info[:2] != (3, 14):
+              raise SystemExit(f"running engine uses unsupported Python {platform.python_version()}")
+          PY
+      - name: Capture Docker failure evidence
+        if: failure()
+        run: |-
+          set +e
+          docker ps -a --no-trunc
+          docker inspect "$SC_CI_CONTAINER"
+          docker logs "$SC_CI_CONTAINER"
+          docker exec "$SC_CI_CONTAINER" python3 -VV
+          python3 -VV
+          epoch="$(python3 .super-coder/scripts/install.py --harness-epoch 2>/dev/null)"
+          selected_image="$(python3 .super-coder/scripts/sandbox_devkit.py image-name \
+            "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/.super-coder" "$epoch" \
+            "$(id -un)" "$(id -u)" "$(id -g)" 2>/dev/null)"
+          echo "selected image: ${selected_image:-unresolved}"
+          test -z "$selected_image" || docker image inspect "$selected_image"
+          docker image ls --all --no-trunc
+      - name: Stop the managed sandbox
+        if: always()
+        run: ./sc down
+      - name: Assert no managed container residue
+        if: always()
+        run: |-
+          residue=0
+          for container in "$SC_CI_CONTAINER" "$SC_CI_SIDECAR"; do
+            if docker container inspect "$container" >/dev/null 2>&1; then
+              echo "managed container remains after ./sc down: $container" >&2
+              docker inspect "$container"
+              residue=1
+            fi
+          done
+          test "$residue" -eq 0

--- a/tests/test_docker_lifecycle_workflow.py
+++ b/tests/test_docker_lifecycle_workflow.py
@@ -41,6 +41,7 @@ class DockerLifecycleWorkflowTest(unittest.TestCase):
         self.assertLess(bootstrap, launch)
         self.assertNotIn("./sc launch --no-build", self.job)
         self.assertIn('["./sc", "health"]', self.job)
+        self.assertIn('json.loads(port_result.stdout)["port"]', self.job)
         self.assertIn("time.monotonic() + 90", self.job)
         self.assertIn('response.status == 200 and direct_payload.get("ok") is True', self.job)
 

--- a/tests/test_docker_lifecycle_workflow.py
+++ b/tests/test_docker_lifecycle_workflow.py
@@ -1,0 +1,80 @@
+"""Contract coverage for the disposable default-sandbox CI gate."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "tests.yml"
+
+
+def job_block(job: str) -> str:
+    text = WORKFLOW.read_text()
+    match = re.search(
+        rf"(?ms)^  {re.escape(job)}:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)",
+        text,
+    )
+    if match is None:
+        raise AssertionError(f"workflow job {job!r} is missing")
+    return match.group(0)
+
+
+class DockerLifecycleWorkflowTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.job = job_block("docker-sandbox-lifecycle")
+
+    def test_job_has_stable_disposable_runtime_contract(self) -> None:
+        self.assertIn("name: Docker sandbox lifecycle", self.job)
+        self.assertIn("runs-on: ubuntu-24.04", self.job)
+        self.assertRegex(self.job, r"(?m)^    timeout-minutes: [1-9][0-9]*$")
+        self.assertIn("python-version: '3.14'", self.job)
+        self.assertIn("persist-credentials: false", self.job)
+        self.assertIn("SC_CI_CONTAINER: sc-${{ github.event.repository.name }}", self.job)
+        self.assertIn("SC_CI_SIDECAR: sc-pg-${{ github.event.repository.name }}", self.job)
+
+    def test_job_uses_supported_bootstrap_and_real_launch(self) -> None:
+        bootstrap = self.job.index("run: ./sc verify")
+        launch = self.job.index("run: ./sc launch")
+
+        self.assertLess(bootstrap, launch)
+        self.assertNotIn("./sc launch --no-build", self.job)
+        self.assertIn('["./sc", "health"]', self.job)
+        self.assertIn("time.monotonic() + 90", self.job)
+        self.assertIn('response.status == 200 and direct_payload.get("ok") is True', self.job)
+
+    def test_runtime_proof_targets_the_live_api_server(self) -> None:
+        self.assertIn('b".super-coder/api/server.py"', self.job)
+        self.assertIn('os.readlink(servers[0] / "exe")', self.job)
+        self.assertIn("server_executable != selected_executable", self.job)
+        self.assertIn("sys.version_info[:2] != (3, 14)", self.job)
+
+    def test_failure_evidence_and_unconditional_cleanup_are_required(self) -> None:
+        self.assertRegex(
+            self.job,
+            r"(?s)- name: Capture Docker failure evidence\n        if: failure\(\).*?"
+            r"docker ps -a --no-trunc.*?docker logs.*?docker image inspect.*?"
+            r"docker image ls --all --no-trunc",
+        )
+        self.assertRegex(
+            self.job,
+            r"(?s)- name: Stop the managed sandbox\n        if: always\(\)\n"
+            r"        run: \./sc down",
+        )
+        self.assertRegex(
+            self.job,
+            r"(?s)- name: Assert no managed container residue\n        if: always\(\).*?"
+            r'for container in "\$SC_CI_CONTAINER" "\$SC_CI_SIDECAR".*?'
+            r'test "\$residue" -eq 0',
+        )
+
+    def test_job_has_no_secret_or_browser_execution_surface(self) -> None:
+        lowered = self.job.lower()
+        self.assertNotIn("secrets.", lowered)
+        self.assertNotIn("playwright", lowered)
+        self.assertNotIn("chromium", lowered)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_host_runtime_contract.py
+++ b/tests/test_host_runtime_contract.py
@@ -548,7 +548,7 @@ class Python314SourceContractTest(unittest.TestCase):
             selectors,
             {
                 ".github/workflows/render-check.yml": ["3.14"],
-                ".github/workflows/tests.yml": ["3.14", "3.14", "3.14"],
+                ".github/workflows/tests.yml": ["3.14", "3.14", "3.14", "3.14"],
                 ".super-coder/templates/fork/subfloor-visual-qa.yml": ["3.14"],
             },
         )


### PR DESCRIPTION
## Summary

- add the stable GitHub-hosted Docker sandbox lifecycle job for Feature #40 task #626
- bootstrap through ./sc verify, run the real ./sc launch build/start path, bound health to 90 seconds, and prove the live API server uses Python 3.14
- capture Docker failure evidence and always run ./sc down plus managed-container and sidecar residue assertions
- keep checkout credentials, Chromium, and Playwright out of the sandbox gate

## Local verification

- ./sc test tests/test_docker_lifecycle_workflow.py tests/test_host_runtime_contract.py -q (23 passed, 61 subtests passed)
- ruff check tests/test_docker_lifecycle_workflow.py
- workflow YAML parsed with PyYAML
- git diff --check

## CI-only gate

The real Docker build/launch/health/down path is intentionally exercised by the new disposable GitHub-hosted job. This linked development worktree cannot run that branch-local lifecycle because ./sc resolves lifecycle operations against the shared live checkout.