### PR TITLE
fix: recover DeepSeek model and Sprint execution

### DIFF
--- a/.super-coder/scripts/conversation_adapters/deepseek.py
+++ b/.super-coder/scripts/conversation_adapters/deepseek.py
@@ -31,6 +31,7 @@ from .base import (
 SESSION_REF = re.compile(r"^sc-[0-9a-f]{32}$")
 RUN_REF_PREFIX = "deepseek-host-run-v1:"
 MAX_UNKNOWN_EVENTS = 24
+MANAGED_IDENTITY_WAIT_SECONDS = 5400.0
 SENSITIVE_KEY = re.compile(
     r"(?:key|token|secret|password|credential|authorization)", re.I
 )
@@ -148,7 +149,10 @@ class DeepSeekAdapter(ConversationAdapter):
                 "DeepSeek conversation preparation omitted canonical shell identity",
             )
         try:
-            self._shell_lease = deepseek_web.acquire_shell_identity(env=env)
+            self._shell_lease = deepseek_web.acquire_shell_identity(
+                env=env,
+                wait_seconds=MANAGED_IDENTITY_WAIT_SECONDS,
+            )
             deepseek_web.ensure(
                 context.checked_worktree(),
                 env=env,

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -247,7 +247,7 @@ def ensure_server(*, timeout: float = 10.0) -> tuple[str, str | None]:
                     and installed_version != server_version
                     and _pid_is_opencode_serve(state_pid)
                 ):
-                    # A healthy orphan is still the wrong Browser/Sprint
+                    # A healthy orphan is still the wrong managed-conversation
                     # execution seat after the CLI is upgraded. Rotate it only
                     # at first adoption, before this process can hand the
                     # endpoint to an active conversation.

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -21,6 +21,7 @@ from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import Any
 
+import harness_versions
 import opencode_config
 import route_transport
 
@@ -178,6 +179,20 @@ def _server_healthy(endpoint: str, password: str | None) -> bool:
     )
 
 
+def _server_version(endpoint: str, password: str | None) -> str | None:
+    """Read the exact version of one healthy managed execution seat."""
+    try:
+        health = UrlHttpTransport(
+            endpoint,
+            password=password,
+            timeout=1.0,
+        ).request("GET", "/global/health")
+    except AdapterError:
+        return None
+    version = health.get("version") if isinstance(health, dict) else None
+    return version if isinstance(version, str) and version else None
+
+
 def ensure_server(*, timeout: float = 10.0) -> tuple[str, str | None]:
     """Return the endpoint and credential for a healthy ``opencode serve``.
 
@@ -207,6 +222,39 @@ def ensure_server(*, timeout: float = 10.0) -> tuple[str, str | None]:
                 candidates.append(candidate)
         for endpoint, password in candidates:
             if _server_healthy(endpoint, password):
+                first_orphan_adoption = bool(
+                    state
+                    and state_pid is not None
+                    and endpoint == state_endpoint
+                    and password == state["password"]
+                    and _SERVER_PROCESS is None
+                    and (_SERVER_ENDPOINT, _SERVER_PASSWORD)
+                    != (state_endpoint, state["password"])
+                )
+                installed_version = (
+                    harness_versions.probe("opencode")
+                    if first_orphan_adoption
+                    else None
+                )
+                server_version = (
+                    _server_version(endpoint, password)
+                    if installed_version is not None
+                    else None
+                )
+                if (
+                    installed_version is not None
+                    and server_version is not None
+                    and installed_version != server_version
+                    and _pid_is_opencode_serve(state_pid)
+                ):
+                    # A healthy orphan is still the wrong Browser/Sprint
+                    # execution seat after the CLI is upgraded. Rotate it only
+                    # at first adoption, before this process can hand the
+                    # endpoint to an active conversation.
+                    _clear_server_state()
+                    _reap_orphan_server(state_pid)
+                    state_pid = None
+                    break
                 _SERVER_ENDPOINT = endpoint
                 _SERVER_PASSWORD = password
                 return endpoint, password

--- a/.super-coder/scripts/deepseek_web.py
+++ b/.super-coder/scripts/deepseek_web.py
@@ -199,20 +199,37 @@ def _clear_terminal_unproven(env: Mapping[str, str]) -> None:
         pass
 
 
-def acquire_shell_identity(*, env: Mapping[str, str]) -> ShellIdentityLease:
-    """Acquire the full-lifetime Host identity lease or refuse before mutation."""
+def acquire_shell_identity(
+    *,
+    env: Mapping[str, str],
+    wait_seconds: float = 0.0,
+) -> ShellIdentityLease:
+    """Acquire the full-lifetime Host identity lease before any mutation.
+
+    Native Web and one-shot callers retain the fail-fast default. Managed
+    Browser/Sprint turns may opt into a bounded wait so simultaneous wake
+    turns serialize at the shared stock Host identity boundary.
+    """
+    if wait_seconds < 0:
+        raise ValueError("DeepSeek identity wait must be non-negative")
     path = _identity_lock_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     handle = path.open("a+")
     os.chmod(path, 0o600)
-    try:
-        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError as exc:
-        handle.close()
-        raise DeepSeekWebError(
-            "HARNESS_SHELL_IDENTITY_BUSY",
-            "another DeepSeek execution owns the shared Host credential",
-        ) from exc
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            break
+        except BlockingIOError as exc:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                handle.close()
+                raise DeepSeekWebError(
+                    "HARNESS_SHELL_IDENTITY_BUSY",
+                    "another DeepSeek execution owns the shared Host credential",
+                ) from exc
+            time.sleep(min(0.05, remaining))
     try:
         _clear_terminal_unproven(env)
     except Exception:

--- a/.super-coder/scripts/deepseek_web.py
+++ b/.super-coder/scripts/deepseek_web.py
@@ -207,7 +207,7 @@ def acquire_shell_identity(
     """Acquire the full-lifetime Host identity lease before any mutation.
 
     Native Web and one-shot callers retain the fail-fast default. Managed
-    Browser/Sprint turns may opt into a bounded wait so simultaneous wake
+    Managed conversation turns may opt into a bounded wait so simultaneous wake
     turns serialize at the shared stock Host identity boundary.
     """
     if wait_seconds < 0:

--- a/.super-coder/scripts/opencode_config.py
+++ b/.super-coder/scripts/opencode_config.py
@@ -33,7 +33,14 @@ def canonical_variant_options(
         ):
             return None
         if value.get("reasoningEffort") not in {
-            None, "none", "minimal", "low", "medium", "high", "xhigh",
+            None,
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
         }:
             return None
         if value.get("reasoningSummary") not in {

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -25,7 +25,11 @@ from conversation_adapters.base import (  # noqa: E402
     ConversationContext,
     NativeTurn,
 )
-from conversation_adapters.deepseek import DeepSeekAdapter, _run_ref  # noqa: E402
+from conversation_adapters.deepseek import (  # noqa: E402
+    MANAGED_IDENTITY_WAIT_SECONDS,
+    DeepSeekAdapter,
+    _run_ref,
+)
 
 REAL_RESERVE_MANAGED_SESSION = deepseek_web.reserve_managed_session
 REAL_RELEASE_MANAGED_SESSION = deepseek_web.release_managed_session
@@ -538,6 +542,28 @@ def test_browser_start_stream_and_exact_call_order(tmp_path: Path) -> None:
         for method, payload in live.calls
     )
     assert live.streams[0].closed
+
+
+def test_managed_browser_queues_for_the_shared_host_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[float] = []
+
+    class Lease:
+        def close(self) -> None:
+            return None
+
+    def acquire(**kwargs):
+        captured.append(kwargs["wait_seconds"])
+        return Lease()
+
+    monkeypatch.setattr(deepseek_web, "acquire_shell_identity", acquire)
+    live = FakeHost()
+    adapter = DeepSeekAdapter(client_factory=lambda: live)
+    adapter._managed_client(context(tmp_path, live))
+    adapter.close()
+
+    assert captured == [MANAGED_IDENTITY_WAIT_SECONDS]
 
 
 def test_start_reserves_the_deterministic_session_before_host_publication(

--- a/tests/test_deepseek_web.py
+++ b/tests/test_deepseek_web.py
@@ -9,6 +9,8 @@ import json
 import socket
 import sys
 import tempfile
+import threading
+import time
 from contextlib import suppress
 from pathlib import Path
 from unittest import mock
@@ -548,6 +550,31 @@ def test_shell_identity_lease_refuses_an_overlapping_owner() -> None:
 
         second = deepseek_web.acquire_shell_identity(env=env)
         second.close()
+
+
+def test_managed_identity_wait_queues_until_overlapping_owner_releases() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        env = {**service_env(Path(raw))}
+        first = deepseek_web.acquire_shell_identity(env=env)
+        acquired = threading.Event()
+        second: list[deepseek_web.ShellIdentityLease] = []
+
+        def wait_for_identity() -> None:
+            second.append(
+                deepseek_web.acquire_shell_identity(env=env, wait_seconds=1.0)
+            )
+            acquired.set()
+
+        worker = threading.Thread(target=wait_for_identity)
+        worker.start()
+        time.sleep(0.1)
+        assert not acquired.is_set()
+        first.close()
+        worker.join(timeout=2)
+
+        assert acquired.is_set()
+        assert len(second) == 1
+        second[0].close()
 
 
 def test_two_canonical_shells_refuse_before_host_or_workflow_side_effects() -> None:

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1297,13 +1297,14 @@ class BuildTest(NoCLI):
     def test_opencode_live_overlay_preserves_admitted_variant_evidence(self):
         connected = mc.opencode_connected_models({
             "_sc_cli_version": "1.18.9",
-            "connected": ["openai"],
+            "connected": ["ollama-cloud"],
             "all": [{
-                "id": "openai",
-                "npm": "@ai-sdk/openai",
-                "models": {"gpt-connected": {
+                "id": "ollama-cloud",
+                "npm": "@ai-sdk/openai-compatible",
+                "models": {"deepseek-v4-pro": {
                     "variants": {
                         "high": {"reasoningEffort": "high"},
+                        "max": {"reasoningEffort": "max"},
                     }
                 }},
             }],
@@ -1315,12 +1316,18 @@ class BuildTest(NoCLI):
             )
 
         model = got["harnesses"]["opencode"]["models"][0]
-        self.assertEqual(model["supported_efforts"], ["high"])
+        self.assertEqual(model["id"], "ollama-cloud/deepseek-v4-pro")
+        self.assertEqual(model["supported_efforts"], ["high", "max"])
         self.assertEqual(model["default_effort"], "high")
-        self.assertEqual(model["native_variant_ids"], {"high": "high"})
+        self.assertEqual(
+            model["native_variant_ids"], {"high": "high", "max": "max"}
+        )
         self.assertEqual(
             model["adapter_metadata"]["variant_options_by_effort"],
-            {"high": {"reasoningEffort": "high"}},
+            {
+                "high": {"reasoningEffort": "high"},
+                "max": {"reasoningEffort": "max"},
+            },
         )
 
     def test_all_sources_down_raises(self):

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -60,6 +60,11 @@ class OpenCodeServerTest(unittest.TestCase):
         opencode._SERVER_ENDPOINT = opencode.SERVER_ENDPOINT
         opencode._SERVER_PASSWORD = None
         opencode._SERVER_LOG_HANDLE = None
+        self.probe_patch = mock.patch.object(
+            opencode.harness_versions, "probe", return_value=None
+        )
+        self.probe_patch.start()
+        self.addCleanup(self.probe_patch.stop)
         self.addCleanup(opencode.stop_server)
 
     def test_healthy_existing_server_is_reused_without_spawning(self):
@@ -135,6 +140,81 @@ class OpenCodeServerTest(unittest.TestCase):
         spawn.assert_not_called()
         reap.assert_not_called()
         self.assertTrue(self.state_path.exists())
+
+    def test_version_mismatched_managed_orphan_is_rotated_before_adoption(self):
+        self.state_path.write_text(json.dumps({
+            "pid": 4322,
+            "password": "stale-secret",
+            "port": 43212,
+        }))
+        process = FakeProcess(pid=9999)
+        with mock.patch.dict(os.environ, {}, clear=False), \
+                mock.patch.object(
+                    opencode,
+                    "_server_healthy",
+                    side_effect=lambda endpoint, password: (
+                        (endpoint, password)
+                        in {
+                            ("http://127.0.0.1:43212", "stale-secret"),
+                            ("http://127.0.0.1:43213", "fresh-secret"),
+                        }
+                    ),
+                ), mock.patch.object(
+                    opencode, "_server_version", return_value="1.18.18"
+                ), mock.patch.object(
+                    opencode.harness_versions, "probe", return_value="1.18.22"
+                ), mock.patch.object(
+                    opencode, "_pid_is_opencode_serve", return_value=True
+                ), mock.patch.object(
+                    opencode, "_reap_orphan_server"
+                ) as reap, mock.patch.object(
+                    opencode.shutil, "which", return_value="/bin/opencode"
+                ), mock.patch.object(
+                    opencode.secrets, "token_urlsafe", return_value="fresh-secret"
+                ), mock.patch.object(
+                    opencode, "_available_loopback_port", return_value=43213
+                ), mock.patch.object(
+                    opencode.subprocess, "Popen", return_value=process
+                ):
+            os.environ.pop("OPENCODE_SERVER_PASSWORD", None)
+            endpoint, password = opencode.ensure_server(timeout=1)
+
+        self.assertEqual(endpoint, "http://127.0.0.1:43213")
+        self.assertEqual(password, "fresh-secret")
+        reap.assert_called_once_with(4322)
+        self.assertEqual(
+            json.loads(self.state_path.read_text()),
+            {"pid": 9999, "password": "fresh-secret", "port": 43213},
+        )
+
+    def test_version_mismatch_never_reaps_unverified_recorded_process(self):
+        self.state_path.write_text(json.dumps({
+            "pid": 4322,
+            "password": "recorded-secret",
+            "port": 43212,
+        }))
+        with mock.patch.object(
+            opencode,
+            "_server_healthy",
+            side_effect=lambda endpoint, password: (
+                (endpoint, password)
+                == ("http://127.0.0.1:43212", "recorded-secret")
+            ),
+        ), mock.patch.object(
+            opencode, "_server_version", return_value="1.18.18"
+        ), mock.patch.object(
+            opencode.harness_versions, "probe", return_value="1.18.22"
+        ), mock.patch.object(
+            opencode, "_pid_is_opencode_serve", return_value=False
+        ), mock.patch.object(
+            opencode, "_reap_orphan_server"
+        ) as reap, mock.patch.object(opencode.subprocess, "Popen") as spawn:
+            endpoint, password = opencode.ensure_server()
+
+        self.assertEqual(endpoint, "http://127.0.0.1:43212")
+        self.assertEqual(password, "recorded-secret")
+        reap.assert_not_called()
+        spawn.assert_not_called()
 
     def test_unreachable_orphan_is_reaped_then_respawned(self):
         self.state_path.write_text(
@@ -236,6 +316,7 @@ class OpenCodeServerTest(unittest.TestCase):
                                 "reasoningEffort": "high",
                                 "reasoningSummary": "detailed",
                             },
+                            "max": {"reasoningEffort": "max"},
                         },
                     }
                 },
@@ -244,10 +325,10 @@ class OpenCodeServerTest(unittest.TestCase):
 
         self.assertEqual(len(got), 1)
         model = got[0]
-        self.assertEqual(model["supported_efforts"], ["low", "high"])
+        self.assertEqual(model["supported_efforts"], ["low", "high", "max"])
         self.assertEqual(model["default_effort"], "high")
         self.assertEqual(model["native_variant_ids"], {
-            "low": "low", "high": "high",
+            "low": "low", "high": "high", "max": "max",
         })
         self.assertEqual(
             model["adapter_metadata"]["variant_options_by_effort"],
@@ -257,6 +338,7 @@ class OpenCodeServerTest(unittest.TestCase):
                     "reasoningEffort": "high",
                     "reasoningSummary": "detailed",
                 },
+                "max": {"reasoningEffort": "max"},
             },
         )
         self.assertEqual(model["cli_version"], "1.18.9")


### PR DESCRIPTION
## Summary

- admit OpenCode exact OpenAI-compatible reasoningEffort=max variants and bind catalogue evidence to the managed server execution seat
- rotate a verified version-skewed managed OpenCode orphan before first adoption, while preserving unverified/external process ownership
- serialize managed DeepSeek Browser/Sprint turns at the stock Host identity lease so simultaneous Planner and Developer arm wakes cannot strand one pickup
- keep native Web and one-shot DeepSeek identity acquisition fail-fast

## Root causes

OpenCode reused a healthy 1.18.18 sidecar while the installed CLI and compatibility evidence were 1.18.22, and its closed variant sanitizer rejected the exact max overlay advertised for ollama-cloud/deepseek-v4-pro.

Sprint arming emits Planner and Developer wakes together. Stock DSH has one fork-scoped shell credential, so fail-fast managed acquisition made one ordinary concurrent wake fail before activation.

## Verification

- 39 focused OpenCode/model/route tests passed
- 120 focused DeepSeek/Sprint/launch tests passed
- pinned stock-DSH cross-surface production gate passed
- git diff --check passed

Decisions: #248 (OpenCode execution seat), #250 (managed DeepSeek serialization). Specs: #149 and #170 follow-up ledgers complete.