### PR TITLE
fix: contain worktree virtualenv paths

### DIFF
--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -1274,10 +1274,29 @@ def _probe_worktree_venv(work_dir: Path) -> VenvEligibility:
     """Read-only proof that the assigned worktree owns a viable Python 3.14 venv."""
     venv = work_dir / ".venv"
     project_bin = venv / "bin"
+    if venv.is_symlink():
+        return VenvEligibility(None, "symlinked .venv root")
     if not project_bin.exists() and not project_bin.is_symlink():
         return VenvEligibility(None, None)
     if not project_bin.is_dir():
         return VenvEligibility(None, ".venv/bin is not a directory")
+
+    try:
+        assigned_root = work_dir.resolve(strict=True)
+        selected_venv = venv.resolve(strict=True)
+        selected_bin = project_bin.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        return VenvEligibility(
+            None, f"unresolvable .venv containment ({exc})"
+        )
+    if selected_venv != assigned_root / ".venv":
+        return VenvEligibility(
+            None, ".venv resolves outside assigned worktree"
+        )
+    if selected_bin != selected_venv / "bin":
+        return VenvEligibility(
+            None, ".venv/bin resolves outside assigned .venv"
+        )
 
     python = project_bin / "python"
     try:

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -194,6 +194,60 @@ class ShellPathTest(unittest.TestCase):
         )
         self.assertEqual(warning, "")
 
+    def test_sibling_worktree_symlinked_environment_is_omitted(self) -> None:
+        sibling_venv = self.root / ".sc-worktrees" / "dev2" / ".venv"
+        sibling_bin = sibling_venv / "bin"
+        sibling_bin.mkdir(parents=True)
+        sibling_python = sibling_bin / "python"
+        sibling_python.write_text("probe fixture")
+        sibling_python.chmod(0o755)
+        (self.worktree / ".venv").symlink_to(
+            Path("..") / "dev2" / ".venv"
+        )
+        stderr = io.StringIO()
+
+        with mock.patch.object(
+            run.subprocess,
+            "run",
+            return_value=self._completed_probe(prefix=sibling_venv),
+        ) as probe, redirect_stderr(stderr):
+            path = run._shell_path(
+                self.worktree, "/usr/local/bin:/usr/bin"
+            )
+
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        self.assertIn("symlinked .venv root", stderr.getvalue())
+        self.assertIn("run `sc deps`", stderr.getvalue())
+        probe.assert_not_called()
+
+    def test_symlinked_bin_escape_is_omitted(self) -> None:
+        project_venv = self.worktree / ".venv"
+        project_venv.mkdir()
+        sibling_bin = (
+            self.root / ".sc-worktrees" / "dev2" / ".venv" / "bin"
+        )
+        sibling_bin.mkdir(parents=True)
+        sibling_python = sibling_bin / "python"
+        sibling_python.write_text("probe fixture")
+        sibling_python.chmod(0o755)
+        (project_venv / "bin").symlink_to(sibling_bin)
+        stderr = io.StringIO()
+
+        with mock.patch.object(
+            run.subprocess,
+            "run",
+            return_value=self._completed_probe(prefix=project_venv),
+        ) as probe, redirect_stderr(stderr):
+            path = run._shell_path(
+                self.worktree, "/usr/local/bin:/usr/bin"
+            )
+
+        self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")
+        warning = stderr.getvalue()
+        self.assertIn(".venv/bin resolves outside assigned .venv", warning)
+        self.assertIn("run `sc deps`", warning)
+        probe.assert_not_called()
+
     def test_absent_environment_is_omitted_without_warning(self) -> None:
         path, warning = self._path_and_warning()
         self.assertEqual(path, f"{self.root}:/usr/local/bin:/usr/bin")


### PR DESCRIPTION
## Summary
- reject symlinked assigned-worktree `.venv` roots before probing
- reject `.venv/bin` path components that resolve outside the assigned environment
- preserve real Python 3.14 virtualenvs and the shared interactive/prepared PATH builder
- add sibling-worktree root and bin-escape regressions

## Verification
- `python3 -m py_compile .super-coder/scripts/run.py tests/test_run_session.py`
- `python3 -m unittest tests.test_run_session` (35 passed)
- `git diff --check`

Repairs Feature #40 / Spec #171 task #647 and SC-1335 (flag #507). Task and flag remain open pending renewed REV2 review and merge.

Trade-off: terminal `python` symlinks to the host interpreter remain valid because standard virtualenvs use them; containment applies to the owned `.venv` root and PATH-bearing `bin` directory.