### PR TITLE
fix(sprint): support older gh PR base fields

### DIFF
--- a/.super-coder/scripts/github_pull_requests.py
+++ b/.super-coder/scripts/github_pull_requests.py
@@ -13,17 +13,22 @@ import os
 import signal
 import subprocess
 from collections.abc import Callable, Iterable
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any
 
 LIST_LIMIT = 300
 MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 GITHUB_TIMEOUT_SECONDS = 20.0
+_COMPAT_FIELDS = (
+    "number,headRefName,baseRefName,headRefOid,state,mergedAt,mergeCommit,"
+    "title,url,reviewDecision,statusCheckRollup"
+)
 _FIELDS = (
     "number,headRefName,baseRefName,baseRefOid,headRefOid,state,mergedAt,mergeCommit,"
     "title,url,reviewDecision,statusCheckRollup"
 )
+_BASE_REF_OID_SUPPORTED: bool | None = None
 _STATES = frozenset({"OPEN", "MERGED", "CLOSED"})
 _HEX = frozenset("0123456789abcdef")
 _FAILED_CHECKS = frozenset(
@@ -244,6 +249,9 @@ class GitHubPullRequestReader:
         self.runner = runner
         self.timeout = timeout
         self.max_response_bytes = max_response_bytes
+        self._base_ref_oid_supported = (
+            _BASE_REF_OID_SUPPORTED if runner is _run_read_process else None
+        )
 
     def _repo_args(self) -> list[str]:
         return ["--repo", self.repository] if self.repository else []
@@ -276,8 +284,53 @@ class GitHubPullRequestReader:
             raise GitHubReadError(_safe_error(result.stderr))
         return text
 
-    def list(self) -> list[PullRequest]:
+    def _remember_base_ref_oid_support(self, supported: bool) -> None:
+        global _BASE_REF_OID_SUPPORTED
+
+        self._base_ref_oid_supported = supported
+        if self.runner is _run_read_process:
+            _BASE_REF_OID_SUPPORTED = supported
+
+    @staticmethod
+    def _missing_base_ref_oid_field(exc: GitHubReadError) -> bool:
+        message = str(exc)
+        return "Unknown JSON field" in message and '"baseRefOid"' in message
+
+    def _run_pr_json(self, args: list[str]) -> tuple[str, bool]:
+        """Read PR JSON, falling back when an older gh lacks baseRefOid."""
+        include_base_sha = self._base_ref_oid_supported is not False
+        fields = _FIELDS if include_base_sha else _COMPAT_FIELDS
+        try:
+            raw = self._run([*args, "--json", fields, *self._repo_args()])
+        except GitHubReadError as exc:
+            if not include_base_sha or not self._missing_base_ref_oid_field(exc):
+                raise
+            self._remember_base_ref_oid_support(False)
+            raw = self._run(
+                [*args, "--json", _COMPAT_FIELDS, *self._repo_args()]
+            )
+            return raw, True
+        self._remember_base_ref_oid_support(include_base_sha)
+        return raw, not include_base_sha
+
+    def _read_base_sha(self, number: int) -> str:
+        repository = self.repository or "{owner}/{repo}"
         raw = self._run(
+            [
+                "gh",
+                "api",
+                f"repos/{repository}/pulls/{number}",
+                "--jq",
+                ".base.sha",
+            ]
+        )
+        base_sha = _sha_value(raw)
+        if base_sha is None:
+            raise GitHubReadError("GitHub PR response has no valid base commit SHA")
+        return base_sha
+
+    def list(self) -> list[PullRequest]:
+        raw, _ = self._run_pr_json(
             [
                 "gh",
                 "pr",
@@ -286,9 +339,6 @@ class GitHubPullRequestReader:
                 "all",
                 "--limit",
                 str(LIST_LIMIT),
-                "--json",
-                _FIELDS,
-                *self._repo_args(),
             ]
         )
         try:
@@ -304,9 +354,8 @@ class GitHubPullRequestReader:
     def get(self, number: int) -> PullRequest:
         if not isinstance(number, int) or number < 1:
             raise ValueError("PR number must be a positive integer")
-        raw = self._run(
-            ["gh", "pr", "view", str(number), "--json", _FIELDS,
-             *self._repo_args()]
+        raw, restore_base_sha = self._run_pr_json(
+            ["gh", "pr", "view", str(number)]
         )
         try:
             payload = json.loads(raw)
@@ -314,7 +363,12 @@ class GitHubPullRequestReader:
             raise GitHubReadError("GitHub PR read returned invalid JSON") from exc
         if not isinstance(payload, dict):
             raise GitHubReadError("GitHub PR read returned an invalid payload")
-        return normalize_pull_request(payload)
+        pull_request = normalize_pull_request(payload)
+        return (
+            replace(pull_request, base_sha=self._read_base_sha(number))
+            if restore_base_sha
+            else pull_request
+        )
 
     def patch(self, number: int) -> str:
         if not isinstance(number, int) or number < 1:

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1073,7 +1073,7 @@ class SprintPRWatcher:
                     continue
                 for row in repo_rows:
                     pull_request = listed.get(int(row["pr_number"]))
-                    if pull_request is None:
+                    if pull_request is None or pull_request.base_sha is None:
                         self._read_exact(reader, row, trigger)
                         continue
                     self._observe(row, pull_request, trigger)

--- a/.super-coder/scripts/sprint_recovery.py
+++ b/.super-coder/scripts/sprint_recovery.py
@@ -14,6 +14,7 @@ from sprint_domain import (
     LifecycleActor,
     PauseReceipt,
     ResumeReceipt,
+    SprintInvariantError,
     SprintLifecycleStore,
 )
 from sprint_pr_watcher import SprintPRWatcher
@@ -97,6 +98,11 @@ class SprintRecoveryCoordinator:
         )
         native_anomalies = self.native_reconciler(native_run_ids)
         observations, pr_anomalies = self._read_registered_prs(sprint_id)
+        if pr_anomalies:
+            raise SprintInvariantError(
+                "Sprint resume requires complete registered PR reconciliation: "
+                + "; ".join(pr_anomalies)
+            )
         anomalies = (*native_anomalies, *pr_anomalies)
         resolved_review_message_ids: list[int] = []
 

--- a/tests/fixtures/sprint_v2_acceptance.json
+++ b/tests/fixtures/sprint_v2_acceptance.json
@@ -74,7 +74,7 @@
     {
       "scenario": "Mid-Sprint spec edit is surfaced during resume",
       "file": "tests/test_sprint_recovery.py",
-      "test": "test_resume_records_drift_and_github_failure_without_blocking"
+      "test": "test_resume_records_drift_without_blocking"
     },
     {
       "scenario": "FnB authority can compile evidence when the Planner is unavailable",

--- a/tests/test_git_review.py
+++ b/tests/test_git_review.py
@@ -121,6 +121,45 @@ class GitHubReaderTest(unittest.TestCase):
         self.assertEqual(calls[0][:4], ["gh", "pr", "view", "823"])
         self.assertEqual(calls[1], ["gh", "pr", "diff", "823", "--patch"])
 
+    def test_old_gh_restores_base_sha_after_base_ref_oid_rejection(self) -> None:
+        payload = json.dumps(MockGitHub().pr(821)).encode()
+        base_sha = b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+        responses = [
+            SimpleNamespace(
+                returncode=1,
+                stdout=b"",
+                stderr=b'Unknown JSON field: "baseRefOid"\n',
+            ),
+            SimpleNamespace(returncode=0, stdout=payload, stderr=b""),
+            SimpleNamespace(returncode=0, stdout=base_sha, stderr=b""),
+        ]
+        calls = []
+
+        def runner(args, **kwargs):
+            calls.append(args)
+            return responses.pop(0)
+
+        reader = GitHubPullRequestReader(
+            "/tmp/repo", repository="acme/project", runner=runner
+        )
+
+        pull_request = reader.get(821)
+
+        self.assertEqual("b" * 40, pull_request.base_sha)
+        self.assertEqual([], responses)
+        self.assertIn("baseRefOid", calls[0][5])
+        self.assertNotIn("baseRefOid", calls[1][5])
+        self.assertEqual(
+            [
+                "gh",
+                "api",
+                "repos/acme/project/pulls/821",
+                "--jq",
+                ".base.sha",
+            ],
+            calls[2],
+        )
+
     def test_explicit_repository_scopes_every_read(self) -> None:
         payload = json.dumps(MockGitHub().pr(821)).encode()
         calls = []

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -52,6 +52,7 @@ class FakeReader:
     def __init__(self, current: PullRequest | Exception) -> None:
         self.current = current
         self.by_number: dict[int, PullRequest] = {}
+        self.listed_by_number: dict[int, PullRequest] | None = None
         self.get_calls: list[int] = []
         self.list_calls = 0
 
@@ -65,6 +66,8 @@ class FakeReader:
         self.list_calls += 1
         if isinstance(self.current, Exception):
             raise self.current
+        if self.listed_by_number is not None:
+            return list(self.listed_by_number.values())
         return list(self.by_number.values()) or [self.current]
 
 
@@ -2020,6 +2023,39 @@ class BatchAndNormalizationTest(SprintPRWatcherCase):
                     "FROM sprint_registered_prs p "
                     "JOIN sprint_pr_transitions t USING (registered_pr_id) "
                     "ORDER BY p.pr_number"
+                )
+            ],
+        )
+
+    def test_batch_read_restores_missing_base_sha_only_for_subscriptions(self):
+        self.reader.by_number = {
+            42: pull_request(number=42),
+            43: pull_request(number=43),
+        }
+        self.register(number=42)
+        self.register(number=43)
+        self.reader.listed_by_number = {
+            number: replace(item, base_sha=None)
+            for number, item in self.reader.by_number.items()
+        }
+        get_count = len(self.reader.get_calls)
+
+        self.assertTrue(self.watcher.poll_once())
+
+        self.assertEqual(1, self.reader.list_calls)
+        self.assertEqual([42, 43], self.reader.get_calls[get_count:])
+        self.assertEqual(
+            [(42, "c" * 40), (43, "c" * 40)],
+            [
+                (
+                    int(row["pr_number"]),
+                    json.loads(row["evidence"])["base_sha"],
+                )
+                for row in self.con.execute(
+                    "SELECT registered.pr_number,transition.evidence "
+                    "FROM sprint_registered_prs registered "
+                    "JOIN sprint_pr_transitions transition "
+                    "USING (registered_pr_id) ORDER BY registered.pr_number"
                 )
             ],
         )

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -2659,7 +2659,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ],
         )
 
-    def test_resume_records_drift_and_github_failure_without_blocking(self):
+    def test_resume_stays_paused_when_registered_pr_read_fails(self):
         self.register()
         coordinator = self.coordinator()
         coordinator.pause(
@@ -2679,44 +2679,53 @@ class SprintRecoveryCase(SprintPRWatcherCase):
         )
         self.con.commit()
         self.reader.current = GitHubReadError("github unavailable")
+        transition_count = self.con.execute(
+            "SELECT COUNT(*) FROM sprint_pr_transitions"
+        ).fetchone()[0]
 
-        receipt = coordinator.resume(
-            self.sprint_id,
-            sprint_domain.LifecycleActor("planner", 3),
-        )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError,
+            "complete registered PR reconciliation: acme/repo#42 "
+            "reconciliation failed: github unavailable",
+        ):
+            coordinator.resume(
+                self.sprint_id,
+                sprint_domain.LifecycleActor("planner", 3),
+            )
 
-        self.assertTrue(receipt.changed)
-        self.assertEqual((document_id,), receipt.spec_drift_document_ids)
         self.assertEqual(
-            ("acme/repo#42 reconciliation failed: github unavailable",),
-            receipt.anomalies,
-        )
-        self.assertEqual(
-            "armed",
+            "paused",
             self.con.execute(
                 "SELECT lifecycle FROM sprints WHERE sprint_id=?",
                 (self.sprint_id,),
             ).fetchone()[0],
         )
-        payload = json.loads(
+        self.assertEqual(
+            transition_count,
             self.con.execute(
-                "SELECT payload FROM sprint_events WHERE sprint_id=? "
-                "AND event_type='lifecycle.reconciled'",
-                (self.sprint_id,),
+                "SELECT COUNT(*) FROM sprint_pr_transitions"
             ).fetchone()[0]
         )
-        self.assertEqual([str(document_id)], sorted(payload["spec_drift"]))
-        self.assertEqual(list(receipt.anomalies), payload["anomalies"])
         self.assertEqual(
-            [(None, 3, 0)],
-            [
-                tuple(row)
-                for row in self.con.execute(
-                    "SELECT to_participant_id,receiver_shell_id,actionable "
-                    "FROM wake_message "
-                    "WHERE idempotency_key LIKE 'sprint-resume:%'"
-                )
-            ],
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='lifecycle.reconciled'",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM wake_message "
+                "WHERE idempotency_key LIKE 'sprint-resume:%'"
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            "edited while paused",
+            self.con.execute(
+                "SELECT body FROM documents WHERE document_id=?", (document_id,)
+            ).fetchone()[0],
         )
 
     def test_resume_surfaces_native_and_capacity_anomalies_without_blocking(self):

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -2659,7 +2659,7 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             ],
         )
 
-    def test_resume_stays_paused_when_registered_pr_read_fails(self):
+    def test_resume_records_drift_without_blocking(self):
         self.register()
         coordinator = self.coordinator()
         coordinator.pause(
@@ -2678,6 +2678,51 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             (document_id,),
         )
         self.con.commit()
+
+        receipt = coordinator.resume(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual((document_id,), receipt.spec_drift_document_ids)
+        self.assertEqual((), receipt.anomalies)
+        self.assertEqual(
+            "armed",
+            self.con.execute(
+                "SELECT lifecycle FROM sprints WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+        payload = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='lifecycle.reconciled'",
+                (self.sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual([str(document_id)], sorted(payload["spec_drift"]))
+        self.assertEqual([], payload["anomalies"])
+        self.assertEqual(
+            [(None, 3, 0)],
+            [
+                tuple(row)
+                for row in self.con.execute(
+                    "SELECT to_participant_id,receiver_shell_id,actionable "
+                    "FROM wake_message "
+                    "WHERE idempotency_key LIKE 'sprint-resume:%'"
+                )
+            ],
+        )
+
+    def test_resume_stays_paused_when_registered_pr_read_fails(self):
+        self.register()
+        coordinator = self.coordinator()
+        coordinator.pause(
+            self.sprint_id,
+            sprint_domain.LifecycleActor("participant", 1),
+            reason="GitHub unavailable during resume",
+        )
         self.reader.current = GitHubReadError("github unavailable")
         transition_count = self.con.execute(
             "SELECT COUNT(*) FROM sprint_pr_transitions"
@@ -2719,12 +2764,6 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             self.con.execute(
                 "SELECT COUNT(*) FROM wake_message "
                 "WHERE idempotency_key LIKE 'sprint-resume:%'"
-            ).fetchone()[0],
-        )
-        self.assertEqual(
-            "edited while paused",
-            self.con.execute(
-                "SELECT body FROM documents WHERE document_id=?", (document_id,)
             ).fetchone()[0],
         )
 


### PR DESCRIPTION
## Summary

- fall back when older GitHub CLI builds reject `baseRefOid`
- restore the exact PR base SHA through the stable REST projection so merge-base safety remains enforced
- bound fallback reads to registered subscriptions and keep Sprint resume paused when registered PR reconciliation is incomplete

Closes #1377

## Verification

- `python -m pytest -q tests/test_sprint_recovery.py tests/test_sprint_live_proof.py tests/test_git_review.py tests/test_sprint_pr_watcher.py tests/test_sprint_review_loop.py tests/test_sprint_cli.py`
- 190 passed, 69 subtests passed
- `git diff --check`