### PR TITLE
Fix paused Sprint governing-spec rebinding

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2795,6 +2795,21 @@ class Handler(BaseHTTPRequestHandler):
                     for document_id, selected in selected_specs.items()
                 ),
             )
+            con.execute(
+                "INSERT INTO sprint_spec_revision_history "
+                "(sprint_id,document_id,generation,bound_revision_sha256,"
+                "bound_revision_body,bound_revision_legacy,approval_id,"
+                "actor_kind,actor_shell_id,reason,created_at) "
+                "SELECT sprint_id,document_id,1,bound_revision_sha256,"
+                "bound_revision_body,bound_revision_legacy,approval_id,?,?,"
+                "'binding declared',included_at FROM sprint_specs "
+                "WHERE sprint_id=?",
+                (
+                    "fnb" if caller["flavor"] == "admin" else "planner",
+                    shell_id,
+                    sprint_id,
+                ),
+            )
             con.executemany(
                 "INSERT INTO sprint_participants "
                 "(sprint_id,shell_id,role,harness,model,effort,route) "
@@ -3031,6 +3046,28 @@ class Handler(BaseHTTPRequestHandler):
                     "conformance_reviewer_shell_id": int(owner[0]),
                     "conformance_owner_generation": int(owner[1]),
                     "participant_bindings": bindings,
+                })
+            if path == "/_sc/sprint/rebind-spec":
+                receipt = sprint_domain.SprintSpecRevisionStore(con).rebind(
+                    sprint_id,
+                    self._sprint_integer(body, "document_id"),
+                    self._sprint_actor(con, sprint_id, shell_id),
+                    expected_revision_sha256=(
+                        self._sprint_optional_text(
+                            body, "expected_revision_sha256"
+                        )
+                        or ""
+                    ),
+                    reason=self._sprint_optional_text(body, "reason") or "",
+                )
+                return self._send(200, {
+                    "sprint_id": receipt.sprint_id,
+                    "document_id": receipt.document_id,
+                    "old_revision_sha256": receipt.old_revision_sha256,
+                    "new_revision_sha256": receipt.new_revision_sha256,
+                    "revision_id": receipt.revision_id,
+                    "generation": receipt.generation,
+                    "changed": receipt.changed,
                 })
             if path == "/_sc/sprint/replan-unit":
                 planner_shell_id = self._sprint_planner_proxy(

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -70,17 +70,16 @@ cleanup authority. An unproved postcondition stops.
   Reviewers own verdicts/conformance; do not proxy handoffs/judgments.
 - Record Reviewer decision id + exact action + receipt; never rewrite rationale
   as Planner judgment.
-- Mid-Sprint spec edits require owning Planner/FnB + durable Reviewer decision.
-  Record old/new revision hashes; binding changes only when the decision says so.
+- Reviewer-approved Planner/FnB spec rebind:
+  pause -> `sc mem doc edit` -> `sc sprint rebind-spec --sprint <id>
+  --document <id> --expected-revision <old-sha256> --reason <decision>` ->
+  replan -> resume. Pass = old/new hashes + changed boolean; conflict -> reread.
 - Use native wakes. Start no recurring loop, scheduled job, manual participant
-  boot, or external watcher. One stalled-gate inspection is allowed:
+  boot, or external watcher. Do not repeat a stalled-gate inspection:
 
 ```text
 sc sprint watcher-state --sprint <id>
 ```
-
-Do not repeat this read as a polling loop. Act on its bounded watcher evidence,
-then return to native delivery.
 
 ## Relay contract
 

--- a/.super-coder/migrations/0239_sprint_spec_rebinding.sql
+++ b/.super-coder/migrations/0239_sprint_spec_rebinding.sql
@@ -1,0 +1,123 @@
+-- Permit one audited governing-spec rebind while a Sprint is paused.
+
+BEGIN;
+
+CREATE TABLE sprint_spec_revision_history (
+    revision_id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    sprint_id              INTEGER NOT NULL,
+    document_id            INTEGER NOT NULL,
+    generation             INTEGER NOT NULL CHECK (generation > 0),
+    bound_revision_sha256  TEXT NOT NULL
+                           CHECK (
+                             length(bound_revision_sha256)=64
+                             AND bound_revision_sha256 NOT GLOB '*[^0-9a-f]*'
+                           ),
+    bound_revision_body    TEXT,
+    bound_revision_legacy  INTEGER NOT NULL CHECK (bound_revision_legacy IN (0,1)),
+    approval_id            INTEGER REFERENCES sprint_spec_approvals(approval_id),
+    actor_kind             TEXT NOT NULL
+                           CHECK (actor_kind IN ('planner','fnb','system')),
+    actor_shell_id         INTEGER REFERENCES shells(shell_id),
+    reason                 TEXT NOT NULL CHECK (trim(reason)<>''),
+    created_at             TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK (bound_revision_legacy=1 OR bound_revision_body IS NOT NULL),
+    CHECK (
+      (actor_kind='system' AND actor_shell_id IS NULL)
+      OR (actor_kind IN ('planner','fnb') AND actor_shell_id IS NOT NULL)
+    ),
+    UNIQUE (sprint_id, document_id, generation),
+    FOREIGN KEY (sprint_id) REFERENCES sprints(sprint_id),
+    FOREIGN KEY (document_id) REFERENCES documents(document_id)
+);
+CREATE INDEX idx_sprint_spec_revision_history_binding
+    ON sprint_spec_revision_history(sprint_id, document_id, revision_id);
+
+INSERT INTO sprint_spec_revision_history (
+    sprint_id,
+    document_id,
+    generation,
+    bound_revision_sha256,
+    bound_revision_body,
+    bound_revision_legacy,
+    approval_id,
+    actor_kind,
+    reason,
+    created_at
+)
+SELECT sprint_id,
+       document_id,
+       1,
+       bound_revision_sha256,
+       bound_revision_body,
+       bound_revision_legacy,
+       approval_id,
+       'system',
+       'binding history initialized',
+       included_at
+FROM sprint_specs;
+
+CREATE TABLE governing_revision_rebind_permits (
+    sprint_id              INTEGER NOT NULL,
+    document_id            INTEGER NOT NULL,
+    old_revision_sha256    TEXT NOT NULL,
+    new_revision_id        INTEGER NOT NULL
+                           REFERENCES sprint_spec_revision_history(revision_id)
+                           ON DELETE CASCADE,
+    PRIMARY KEY (sprint_id, document_id),
+    FOREIGN KEY (sprint_id, document_id)
+        REFERENCES sprint_specs(sprint_id, document_id) ON DELETE CASCADE
+);
+
+DROP TRIGGER trg_sprint_specs_bound_revision_immutable;
+CREATE TRIGGER trg_sprint_specs_bound_revision_immutable
+BEFORE UPDATE OF
+  bound_revision_sha256, bound_revision_body, bound_revision_legacy
+ON sprint_specs
+WHEN NOT (
+   OLD.bound_revision_legacy=1
+   AND OLD.bound_revision_body IS NULL
+   AND NEW.bound_revision_legacy=1
+   AND NEW.bound_revision_sha256 IS OLD.bound_revision_sha256
+   AND NEW.bound_revision_body IS NOT NULL
+   AND EXISTS (
+     SELECT 1 FROM governing_revision_backfill_permits p
+     WHERE p.sprint_id=OLD.sprint_id AND p.document_id=OLD.document_id
+   )
+ )
+ AND NOT EXISTS (
+   SELECT 1
+   FROM governing_revision_rebind_permits permit
+   JOIN sprint_spec_revision_history revision
+     ON revision.revision_id=permit.new_revision_id
+   WHERE permit.sprint_id=OLD.sprint_id
+     AND permit.document_id=OLD.document_id
+     AND permit.old_revision_sha256=OLD.bound_revision_sha256
+     AND revision.sprint_id=OLD.sprint_id
+     AND revision.document_id=OLD.document_id
+     AND revision.bound_revision_sha256=NEW.bound_revision_sha256
+     AND revision.bound_revision_body IS NEW.bound_revision_body
+     AND revision.bound_revision_legacy=NEW.bound_revision_legacy
+     AND revision.bound_revision_legacy=0
+ )
+ AND (
+   NEW.bound_revision_sha256 IS NOT OLD.bound_revision_sha256
+   OR NEW.bound_revision_body IS NOT OLD.bound_revision_body
+   OR NEW.bound_revision_legacy IS NOT OLD.bound_revision_legacy
+ )
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint governing revisions are immutable');
+END;
+
+CREATE TRIGGER trg_sprint_spec_revision_history_append_only_update
+BEFORE UPDATE ON sprint_spec_revision_history
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint governing revision history is append-only');
+END;
+
+CREATE TRIGGER trg_sprint_spec_revision_history_append_only_delete
+BEFORE DELETE ON sprint_spec_revision_history
+BEGIN
+  SELECT RAISE(ABORT, 'Sprint governing revision history is append-only');
+END;
+
+COMMIT;

--- a/.super-coder/migrations/0240_reseed_sprint_spec_rebinding.sql
+++ b/.super-coder/migrations/0240_reseed_sprint_spec_rebinding.sql
@@ -1,0 +1,34 @@
+-- Teach Planners the supported paused-Sprint governing-spec rebind control.
+
+BEGIN;
+
+UPDATE skills
+SET content=replace(
+  replace(
+    content,
+    '- Mid-Sprint spec edits require owning Planner/FnB + durable Reviewer decision.
+  Record old/new revision hashes; binding changes only when the decision says so.',
+    '- Reviewer-approved Planner/FnB spec rebind:
+  pause -> `sc mem doc edit` -> `sc sprint rebind-spec --sprint <id>
+  --document <id> --expected-revision <old-sha256> --reason <decision>` ->
+  replan -> resume. Pass = old/new hashes + changed boolean; conflict -> reread.'
+  ),
+  '- Use native wakes. Start no recurring loop, scheduled job, manual participant
+  boot, or external watcher. One stalled-gate inspection is allowed:
+
+```text
+sc sprint watcher-state --sprint <id>
+```
+
+Do not repeat this read as a polling loop. Act on its bounded watcher evidence,
+then return to native delivery.',
+  '- Use native wakes. Start no recurring loop, scheduled job, manual participant
+  boot, or external watcher. Do not repeat a stalled-gate inspection:
+
+```text
+sc sprint watcher-state --sprint <id>
+```'
+)
+WHERE name='sprint_pln';
+
+COMMIT;

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -49,6 +49,7 @@ SPRINT_INSTANCE_TABLES = [
     "sprint_spec_approvals",
     "sprints",
     "sprint_specs",
+    "sprint_spec_revision_history",
     # Bindings load before participants because the latter's active-pointer
     # ownership trigger must be able to see the referenced immutable row.
     # Snapshot load has foreign_keys disabled, so the binding's participant FK

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -247,6 +247,16 @@ _EVENT_FIELDS = {
             "notification_state",
         }
     ),
+    "spec.rebound": frozenset(
+        {
+            "document_id",
+            "old_revision_sha256",
+            "new_revision_sha256",
+            "revision_id",
+            "generation",
+            "reason",
+        }
+    ),
     "spec.edit_notification_unavailable": frozenset(
         {"document_id", "edit_event_id", "planner_shell_id"}
     ),

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -175,6 +175,21 @@ def cmd_spec_revision(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_rebind_spec(args: argparse.Namespace) -> int:
+    result = _post(
+        "/_sc/sprint/rebind-spec",
+        {
+            "sprint_id": args.sprint,
+            "document_id": args.document,
+            "expected_revision_sha256": args.expected_revision,
+            "reason": args.reason,
+        },
+        idempotent=True,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
 def cmd_send(args: argparse.Namespace) -> int:
     result = _post(
         "/_sc/sprint/send",
@@ -611,6 +626,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--body-only", action="store_true", help="write the exact body only"
     )
     spec_revision.set_defaults(fn=cmd_spec_revision)
+
+    rebind_spec = sub.add_parser(
+        "rebind-spec",
+        help="Planner or FnB binds one paused Sprint spec to its current body",
+    )
+    rebind_spec.add_argument("--sprint", type=int, required=True)
+    rebind_spec.add_argument("--document", type=int, required=True)
+    rebind_spec.add_argument("--expected-revision", required=True)
+    rebind_spec.add_argument("--reason", required=True)
+    rebind_spec.set_defaults(fn=cmd_rebind_spec)
 
     send = sub.add_parser(
         "send", help="Send one typed relay to another Sprint participant"

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -191,6 +191,17 @@ class SpecApprovalReceipt:
 
 
 @dataclass(frozen=True)
+class SpecRebindReceipt:
+    sprint_id: int
+    document_id: int
+    old_revision_sha256: str
+    new_revision_sha256: str
+    revision_id: int
+    generation: int
+    changed: bool
+
+
+@dataclass(frozen=True)
 class WorkUnitCompletionReceipt:
     sprint_id: int
     work_unit_id: int
@@ -534,6 +545,212 @@ class SprintSpecRevisionStore:
             "availability": "available",
             "body": str(bound_body),
         }
+
+    def rebind(
+        self,
+        sprint_id: int,
+        document_id: int,
+        actor: LifecycleActor,
+        *,
+        expected_revision_sha256: str,
+        reason: str,
+    ) -> SpecRebindReceipt:
+        """Replace one paused binding while retaining exact revision history."""
+        if len(expected_revision_sha256) != 64 or any(
+            char not in "0123456789abcdef" for char in expected_revision_sha256
+        ):
+            raise ValueError("expected revision must be one lowercase SHA-256")
+        reason = reason.strip()
+        if not reason:
+            raise ValueError("spec rebind reason is required")
+        if len(reason) > 2000:
+            raise ValueError("spec rebind reason exceeds 2000 characters")
+        if actor.kind not in {"planner", "fnb"}:
+            raise SprintAuthorityError(
+                "only the originating Planner or FnB may rebind a Sprint spec"
+            )
+        if actor.shell_id is None:
+            raise SprintAuthorityError("spec rebind authority requires a shell identity")
+
+        with db_driver.write_transaction(self.con, "sprint.spec.rebind"):
+            sprint = self.con.execute(
+                "SELECT feature_id,originating_planner_shell_id,lifecycle "
+                "FROM sprints WHERE sprint_id=?",
+                (sprint_id,),
+            ).fetchone()
+            if sprint is None:
+                raise KeyError(f"unknown Sprint: {sprint_id}")
+            if sprint["lifecycle"] != "paused":
+                raise SprintInvariantError(
+                    "governing specs may be rebound only while the Sprint is paused"
+                )
+            if actor.kind == "planner" and actor.shell_id != sprint[
+                "originating_planner_shell_id"
+            ]:
+                raise SprintAuthorityError(
+                    "only the originating Planner may rebind this Sprint spec"
+                )
+
+            binding = self.con.execute(
+                "SELECT ss.bound_revision_sha256,ss.bound_revision_body,"
+                "d.kind,d.feature_id,d.body "
+                "FROM sprint_specs ss JOIN documents d USING (document_id) "
+                "WHERE ss.sprint_id=? AND ss.document_id=?",
+                (sprint_id, document_id),
+            ).fetchone()
+            if binding is None:
+                raise KeyError(
+                    f"document {document_id} is not bound to Sprint {sprint_id}"
+                )
+            if (
+                binding["kind"] != "spec"
+                or binding["feature_id"] is None
+                or int(binding["feature_id"]) != int(sprint["feature_id"])
+            ):
+                raise SprintInvariantError(
+                    "rebind requires a governing spec for the Sprint feature"
+                )
+            current_body = binding["body"]
+            if not isinstance(current_body, str) or not current_body.strip():
+                raise SprintInvariantError(
+                    "rebind requires a non-empty current governing spec"
+                )
+            new_revision = hashlib.sha256(current_body.encode()).hexdigest()
+            old_revision = str(binding["bound_revision_sha256"])
+            history = self.con.execute(
+                "SELECT revision_id,generation,bound_revision_sha256,actor_kind,"
+                "actor_shell_id,reason FROM sprint_spec_revision_history "
+                "WHERE sprint_id=? AND document_id=? "
+                "ORDER BY generation DESC LIMIT 2",
+                (sprint_id, document_id),
+            ).fetchall()
+            if not history:
+                raise SprintInvariantError(
+                    "governing spec binding has no revision history"
+                )
+            latest = history[0]
+            if old_revision != latest["bound_revision_sha256"]:
+                raise SprintInvariantError(
+                    "active governing spec does not match its revision history"
+                )
+
+            if expected_revision_sha256 != old_revision:
+                replay = (
+                    new_revision == old_revision
+                    and len(history) == 2
+                    and history[1]["bound_revision_sha256"]
+                    == expected_revision_sha256
+                    and history[0]["actor_kind"] == actor.kind
+                    and history[0]["actor_shell_id"] == actor.shell_id
+                    and history[0]["reason"] == reason
+                )
+                if replay:
+                    return SpecRebindReceipt(
+                        sprint_id,
+                        document_id,
+                        expected_revision_sha256,
+                        old_revision,
+                        int(latest["revision_id"]),
+                        int(latest["generation"]),
+                        False,
+                    )
+                raise SprintConflictError(
+                    "governing spec binding changed; read the active revision and retry",
+                    {
+                        "code": "spec_revision_changed",
+                        "expected_revision_sha256": expected_revision_sha256,
+                        "active_revision_sha256": old_revision,
+                    },
+                )
+            if new_revision == old_revision:
+                return SpecRebindReceipt(
+                    sprint_id,
+                    document_id,
+                    old_revision,
+                    new_revision,
+                    int(latest["revision_id"]),
+                    int(latest["generation"]),
+                    False,
+                )
+
+            generation = int(latest["generation"]) + 1
+            revision_id = int(
+                self.con.execute(
+                    "INSERT INTO sprint_spec_revision_history "
+                    "(sprint_id,document_id,generation,bound_revision_sha256,"
+                    "bound_revision_body,bound_revision_legacy,actor_kind,"
+                    "actor_shell_id,reason) VALUES (?,?,?,?,?,0,?,?,?)",
+                    (
+                        sprint_id,
+                        document_id,
+                        generation,
+                        new_revision,
+                        current_body,
+                        actor.kind,
+                        actor.shell_id,
+                        reason,
+                    ),
+                ).lastrowid
+            )
+            self.con.execute(
+                "INSERT INTO governing_revision_rebind_permits "
+                "(sprint_id,document_id,old_revision_sha256,new_revision_id) "
+                "VALUES (?,?,?,?)",
+                (sprint_id, document_id, old_revision, revision_id),
+            )
+            changed = self.con.execute(
+                "UPDATE sprint_specs SET bound_revision_sha256=?,"
+                "bound_revision_body=?,bound_revision_legacy=0,approval_id=NULL "
+                "WHERE sprint_id=? AND document_id=? "
+                "AND bound_revision_sha256=?",
+                (
+                    new_revision,
+                    current_body,
+                    sprint_id,
+                    document_id,
+                    old_revision,
+                ),
+            ).rowcount
+            if changed != 1:
+                raise SprintConflictError(
+                    "governing spec binding changed during rebind",
+                    {"code": "spec_revision_changed"},
+                )
+            self.con.execute(
+                "DELETE FROM governing_revision_rebind_permits "
+                "WHERE sprint_id=? AND document_id=?",
+                (sprint_id, document_id),
+            )
+            self.con.execute(
+                "INSERT INTO sprint_events "
+                "(sprint_id,event_type,actor_kind,actor_shell_id,payload) "
+                "VALUES (?,'spec.rebound',?,?,?)",
+                (
+                    sprint_id,
+                    actor.kind,
+                    actor.shell_id,
+                    json.dumps(
+                        {
+                            "document_id": document_id,
+                            "old_revision_sha256": old_revision,
+                            "new_revision_sha256": new_revision,
+                            "revision_id": revision_id,
+                            "generation": generation,
+                            "reason": reason,
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+        return SpecRebindReceipt(
+            sprint_id,
+            document_id,
+            old_revision,
+            new_revision,
+            revision_id,
+            generation,
+            True,
+        )
 
 
 class SprintLifecycleStore:

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -135,7 +135,9 @@
     ".super-coder/migrations/0233_reseed_sprint_aware_pr_notifications.sql",
     ".super-coder/migrations/0234_reseed_ci_fallback_authority.sql",
     ".super-coder/migrations/0238_final_schema_rebaseline.sql",
-    "docs/deepseek-harness-removal.md"
+    "docs/deepseek-harness-removal.md",
+    ".super-coder/migrations/0239_sprint_spec_rebinding.sql",
+    ".super-coder/migrations/0240_reseed_sprint_spec_rebinding.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_focused_dev_verification.py
+++ b/tests/test_focused_dev_verification.py
@@ -16,6 +16,7 @@ MIGRATIONS = (
     ENGINE / "migrations" / "0231_suppress_aborted_sprint_pr_wakes.sql",
     ENGINE / "migrations" / "0233_reseed_sprint_aware_pr_notifications.sql",
     ENGINE / "migrations" / "0234_reseed_ci_fallback_authority.sql",
+    ENGINE / "migrations" / "0240_reseed_sprint_spec_rebinding.sql",
 )
 sys.path.insert(0, str(ENGINE / "scripts"))
 

--- a/tests/test_sprint_board_api.py
+++ b/tests/test_sprint_board_api.py
@@ -1134,21 +1134,34 @@ class SprintBoardApiCase(unittest.TestCase):
 
     def test_browser_bound_revision_reports_legacy_unavailability(self):
         current_body = "legacy current body must remain unavailable"
+        bound_revision = hashlib.sha256(b"body").hexdigest()
         with self.connect() as con:
-            con.execute(
-                "UPDATE sprint_specs SET bound_revision_body=NULL "
-                "WHERE sprint_id=? AND document_id=?",
-                (self.ids["sprint_id"], self.ids["document_id"]),
+            legacy_document_id = int(
+                con.execute(
+                    "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                    "VALUES (?,'spec',98,'Legacy bound spec',?)",
+                    (self.ids["feature_id"], current_body),
+                ).lastrowid
             )
             con.execute(
-                "UPDATE documents SET body=? WHERE document_id=?",
-                (current_body, self.ids["document_id"]),
+                "INSERT INTO sprint_specs "
+                "(sprint_id,document_id,bound_revision_sha256,"
+                "bound_revision_body,bound_revision_legacy) "
+                "VALUES (?,?,?,NULL,1)",
+                (self.ids["sprint_id"], legacy_document_id, bound_revision),
+            )
+            con.execute(
+                "INSERT INTO sprint_spec_revision_history "
+                "(sprint_id,document_id,generation,bound_revision_sha256,"
+                "bound_revision_body,bound_revision_legacy,actor_kind,reason) "
+                "VALUES (?,?,1,?,NULL,1,'system','legacy browser fixture')",
+                (self.ids["sprint_id"], legacy_document_id, bound_revision),
             )
             con.commit()
         status, _, body = self.request(
             "GET",
             f"/api/sprints/{self.ids['sprint_id']}/spec-revisions/"
-            f"{self.ids['document_id']}",
+            f"{legacy_document_id}",
         )
         self.assertEqual(409, status, body)
         error = body["error"]
@@ -1160,8 +1173,8 @@ class SprintBoardApiCase(unittest.TestCase):
         self.assertEqual(
             {
                 "sprint_id": self.ids["sprint_id"],
-                "document_id": self.ids["document_id"],
-                "bound_revision_sha256": hashlib.sha256(b"body").hexdigest(),
+                "document_id": legacy_document_id,
+                "bound_revision_sha256": bound_revision,
                 "current_revision_sha256": hashlib.sha256(
                     current_body.encode()
                 ).hexdigest(),

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -70,6 +70,52 @@ class SprintCliDispatcherTest(unittest.TestCase):
         self.assertEqual(0, completed.returncode, completed.stderr)
         self.assertIn("cleanup-status", completed.stdout)
         self.assertIn("cleanup", completed.stdout)
+        self.assertIn("rebind-spec", completed.stdout)
+
+    def test_rebind_spec_posts_expected_revision_and_reason_idempotently(self):
+        output = io.StringIO()
+        response = {
+            "sprint_id": 29,
+            "document_id": 178,
+            "old_revision_sha256": "a" * 64,
+            "new_revision_sha256": "b" * 64,
+            "revision_id": 2,
+            "generation": 2,
+            "changed": True,
+        }
+        with (
+            mock.patch.object(mem, "_api", return_value=response) as api,
+            contextlib.redirect_stdout(output),
+        ):
+            self.assertEqual(
+                0,
+                sprint_cli.main(
+                    [
+                        "rebind-spec",
+                        "--sprint",
+                        "29",
+                        "--document",
+                        "178",
+                        "--expected-revision",
+                        "a" * 64,
+                        "--reason",
+                        "Reviewer decision 1667",
+                    ]
+                ),
+            )
+
+        api.assert_called_once_with(
+            "POST",
+            "/_sc/sprint/rebind-spec",
+            {
+                "sprint_id": 29,
+                "document_id": 178,
+                "expected_revision_sha256": "a" * 64,
+                "reason": "Reviewer decision 1667",
+            },
+            idempotent=True,
+        )
+        self.assertEqual(response, json.loads(output.getvalue()))
 
     def test_cleanup_commands_use_bounded_get_and_idempotent_post(self):
         output = io.StringIO()
@@ -1101,6 +1147,113 @@ class SprintCliApiTest(unittest.TestCase):
             )
             self.assertEqual([document_id], payload["spec_document_ids"])
             self.assertNotIn("spec_approval_ids", payload)
+        finally:
+            con.close()
+
+    def test_paused_spec_rebind_is_end_to_end_and_preserves_history(self):
+        self.use_isolated_db()
+        con = sqlite3.connect(self.db)
+        try:
+            feature_id = int(
+                con.execute(
+                    "INSERT INTO roadmap (title,roadmap_status) "
+                    "VALUES ('Rebind declaration','in_progress')"
+                ).lastrowid
+            )
+            original = "original governing body"
+            document_id = int(
+                con.execute(
+                    "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                    "VALUES (?,'spec',1,'Rebind spec',?)",
+                    (feature_id, original),
+                ).lastrowid
+            )
+            con.commit()
+        finally:
+            con.close()
+
+        sprint_id = self.run_cli(
+            TOKENS["planner"],
+            "declare",
+            "--feature",
+            str(feature_id),
+            "--spec",
+            str(document_id),
+            "--participants-file",
+            self.participants_file(),
+            "--merge-grant",
+        )["sprint_id"]
+        replacement = "reviewer-approved governing body"
+        old_revision = hashlib.sha256(original.encode()).hexdigest()
+        new_revision = hashlib.sha256(replacement.encode()).hexdigest()
+        con = sqlite3.connect(self.db)
+        try:
+            con.execute(
+                "UPDATE sprints SET lifecycle='armed',armed_at=datetime('now'),"
+                "conformance_reviewer_shell_id=2,"
+                "conformance_owner_generation=1 "
+                "WHERE sprint_id=?",
+                (sprint_id,),
+            )
+            con.execute(
+                "UPDATE sprints SET lifecycle='paused',paused_at=datetime('now') "
+                "WHERE sprint_id=?",
+                (sprint_id,),
+            )
+            con.execute(
+                "UPDATE documents SET body=? WHERE document_id=?",
+                (replacement, document_id),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+        argv = (
+            "rebind-spec",
+            "--sprint",
+            str(sprint_id),
+            "--document",
+            str(document_id),
+            "--expected-revision",
+            old_revision,
+            "--reason",
+            "Reviewer decision message 77",
+        )
+        receipt = self.run_cli(TOKENS["planner"], *argv)
+        self.assertEqual(old_revision, receipt["old_revision_sha256"])
+        self.assertEqual(new_revision, receipt["new_revision_sha256"])
+        self.assertTrue(receipt["changed"])
+        retry = self.run_cli(TOKENS["planner"], *argv)
+        self.assertFalse(retry["changed"])
+        self.assertEqual(receipt["revision_id"], retry["revision_id"])
+
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                (new_revision, replacement, None),
+                con.execute(
+                    "SELECT bound_revision_sha256,bound_revision_body,approval_id "
+                    "FROM sprint_specs WHERE sprint_id=? AND document_id=?",
+                    (sprint_id, document_id),
+                ).fetchone(),
+            )
+            self.assertEqual(
+                [(1, old_revision), (2, new_revision)],
+                con.execute(
+                    "SELECT generation,bound_revision_sha256 "
+                    "FROM sprint_spec_revision_history WHERE sprint_id=? "
+                    "ORDER BY generation",
+                    (sprint_id,),
+                ).fetchall(),
+            )
+            self.assertEqual(
+                1,
+                con.execute(
+                    "SELECT COUNT(*) FROM sprint_events "
+                    "WHERE sprint_id=? AND event_type='spec.rebound'",
+                    (sprint_id,),
+                ).fetchone()[0],
+            )
         finally:
             con.close()
 

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -1439,6 +1439,7 @@ class SprintSkillTest(unittest.TestCase):
             "arm",
             "inbox",
             "spec-revision",
+            "rebind-spec",
             "send",
             "accept",
             "decline",

--- a/tests/test_sprint_snapshot_rebuild.py
+++ b/tests/test_sprint_snapshot_rebuild.py
@@ -107,6 +107,16 @@ def seed_prepared(
             "VALUES (?,?,?,?)",
             (sprint_id, document_id, revision, approval_id),
         )
+    if snapshot.table_exists(con, "sprint_spec_revision_history"):
+        con.execute(
+            "INSERT INTO sprint_spec_revision_history "
+            "(sprint_id,document_id,generation,bound_revision_sha256,"
+            "bound_revision_body,bound_revision_legacy,approval_id,actor_kind,reason) "
+            "SELECT sprint_id,document_id,1,bound_revision_sha256,"
+            "bound_revision_body,bound_revision_legacy,approval_id,'system',"
+            "'snapshot fixture' FROM sprint_specs WHERE sprint_id=?",
+            (sprint_id,),
+        )
     con.executemany(
         "INSERT INTO sprint_participants "
         "(participant_id,sprint_id,shell_id,role,harness,model,effort,route) "

--- a/tests/test_sprint_spec_revisions.py
+++ b/tests/test_sprint_spec_revisions.py
@@ -68,6 +68,14 @@ class GoverningRevisionCase(unittest.TestCase):
             ).lastrowid
         )
         revision = hashlib.sha256(self.original.encode()).hexdigest()
+        self.approval_id = int(
+            self.con.execute(
+                "INSERT INTO sprint_spec_approvals "
+                "(document_id,revision_sha256,reviewer_shell_id,verdict) "
+                "VALUES (?,?,3,'pass')",
+                (self.document_id, revision),
+            ).lastrowid
+        )
         self.sprint_id = int(
             self.con.execute(
                 "INSERT INTO sprints "
@@ -79,8 +87,27 @@ class GoverningRevisionCase(unittest.TestCase):
         self.con.execute(
             "INSERT INTO sprint_specs "
             "(sprint_id,document_id,bound_revision_sha256,bound_revision_body,"
-            "bound_revision_legacy) VALUES (?,?,?,?,0)",
-            (self.sprint_id, self.document_id, revision, self.original),
+            "bound_revision_legacy,approval_id) VALUES (?,?,?,?,0,?)",
+            (
+                self.sprint_id,
+                self.document_id,
+                revision,
+                self.original,
+                self.approval_id,
+            ),
+        )
+        self.con.execute(
+            "INSERT INTO sprint_spec_revision_history "
+            "(sprint_id,document_id,generation,bound_revision_sha256,"
+            "bound_revision_body,bound_revision_legacy,approval_id,actor_kind,"
+            "reason) VALUES (?,?,1,?,?,0,?,'system','test binding')",
+            (
+                self.sprint_id,
+                self.document_id,
+                revision,
+                self.original,
+                self.approval_id,
+            ),
         )
         self.con.executemany(
             "INSERT INTO sprint_participants (sprint_id,shell_id,role,harness) "
@@ -98,6 +125,243 @@ class GoverningRevisionCase(unittest.TestCase):
             (self.sprint_id,),
         )
         self.con.commit()
+
+    def test_paused_rebind_preserves_history_and_exact_retry_is_idempotent(self) -> None:
+        replacement = "# Revised governing bytes\n\nApproved correction.\n"
+        old_revision = hashlib.sha256(self.original.encode()).hexdigest()
+        new_revision = hashlib.sha256(replacement.encode()).hexdigest()
+        self.con.execute(
+            "UPDATE sprints SET lifecycle='paused',paused_at=datetime('now') "
+            "WHERE sprint_id=?",
+            (self.sprint_id,),
+        )
+        self.con.execute(
+            "UPDATE documents SET body=? WHERE document_id=?",
+            (replacement, self.document_id),
+        )
+        self.con.commit()
+        actor = sprint_domain.LifecycleActor("planner", 1)
+        store = sprint_domain.SprintSpecRevisionStore(self.con)
+
+        receipt = store.rebind(
+            self.sprint_id,
+            self.document_id,
+            actor,
+            expected_revision_sha256=old_revision,
+            reason="Reviewer decision message 77",
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual(old_revision, receipt.old_revision_sha256)
+        self.assertEqual(new_revision, receipt.new_revision_sha256)
+        self.assertEqual(2, receipt.generation)
+        self.assertEqual(
+            (new_revision, replacement, 0, None),
+            tuple(
+                self.con.execute(
+                    "SELECT bound_revision_sha256,bound_revision_body,"
+                    "bound_revision_legacy,approval_id FROM sprint_specs "
+                    "WHERE sprint_id=?",
+                    (self.sprint_id,),
+                ).fetchone()
+            ),
+        )
+        history = [
+            tuple(row)
+            for row in self.con.execute(
+                "SELECT generation,bound_revision_sha256,bound_revision_body,"
+                "approval_id,actor_kind,actor_shell_id,reason "
+                "FROM sprint_spec_revision_history WHERE sprint_id=? "
+                "ORDER BY generation",
+                (self.sprint_id,),
+            )
+        ]
+        self.assertEqual(
+            [
+                (
+                    1,
+                    old_revision,
+                    self.original,
+                    self.approval_id,
+                    "system",
+                    None,
+                    "test binding",
+                ),
+                (
+                    2,
+                    new_revision,
+                    replacement,
+                    None,
+                    "planner",
+                    1,
+                    "Reviewer decision message 77",
+                ),
+            ],
+            history,
+        )
+        event = self.con.execute(
+            "SELECT payload FROM sprint_events WHERE event_type='spec.rebound'"
+        ).fetchone()
+        self.assertEqual(
+            {
+                "document_id": self.document_id,
+                "generation": 2,
+                "new_revision_sha256": new_revision,
+                "old_revision_sha256": old_revision,
+                "reason": "Reviewer decision message 77",
+                "revision_id": receipt.revision_id,
+            },
+            json.loads(event[0]),
+        )
+        self.assertNotIn(replacement, event[0])
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM governing_revision_rebind_permits"
+            ).fetchone()[0],
+        )
+
+        replay = store.rebind(
+            self.sprint_id,
+            self.document_id,
+            actor,
+            expected_revision_sha256=old_revision,
+            reason="Reviewer decision message 77",
+        )
+        self.assertFalse(replay.changed)
+        self.assertEqual(receipt.revision_id, replay.revision_id)
+        self.assertEqual(
+            2,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_spec_revision_history "
+                "WHERE sprint_id=?",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events WHERE event_type='spec.rebound'"
+            ).fetchone()[0],
+        )
+
+    def test_rebind_rejects_stale_expected_revision_without_effects(self) -> None:
+        self.con.execute(
+            "UPDATE sprints SET lifecycle='paused' WHERE sprint_id=?",
+            (self.sprint_id,),
+        )
+        self.con.execute(
+            "UPDATE documents SET body='new contract' WHERE document_id=?",
+            (self.document_id,),
+        )
+        self.con.commit()
+        with self.assertRaisesRegex(
+            sprint_domain.SprintConflictError, "binding changed"
+        ) as raised:
+            sprint_domain.SprintSpecRevisionStore(self.con).rebind(
+                self.sprint_id,
+                self.document_id,
+                sprint_domain.LifecycleActor("planner", 1),
+                expected_revision_sha256="0" * 64,
+                reason="stale caller",
+            )
+        self.assertEqual("spec_revision_changed", raised.exception.details["code"])
+        self.assertEqual(
+            (hashlib.sha256(self.original.encode()).hexdigest(), self.original),
+            tuple(
+                self.con.execute(
+                    "SELECT bound_revision_sha256,bound_revision_body "
+                    "FROM sprint_specs WHERE sprint_id=?",
+                    (self.sprint_id,),
+                ).fetchone()
+            ),
+        )
+        self.assertEqual(
+            (1, 0),
+            (
+                self.con.execute(
+                    "SELECT COUNT(*) FROM sprint_spec_revision_history"
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT COUNT(*) FROM sprint_events WHERE event_type='spec.rebound'"
+                ).fetchone()[0],
+            ),
+        )
+
+    def test_rebind_requires_paused_lifecycle_and_owner_authority(self) -> None:
+        old_revision = hashlib.sha256(self.original.encode()).hexdigest()
+        self.con.execute(
+            "UPDATE documents SET body='new contract' WHERE document_id=?",
+            (self.document_id,),
+        )
+        self.con.commit()
+        store = sprint_domain.SprintSpecRevisionStore(self.con)
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "only while the Sprint is paused"
+        ):
+            store.rebind(
+                self.sprint_id,
+                self.document_id,
+                sprint_domain.LifecycleActor("planner", 1),
+                expected_revision_sha256=old_revision,
+                reason="too early",
+            )
+        self.con.execute(
+            "UPDATE sprints SET lifecycle='paused' WHERE sprint_id=?",
+            (self.sprint_id,),
+        )
+        self.con.commit()
+        with self.assertRaisesRegex(
+            sprint_domain.SprintAuthorityError, "originating Planner or FnB"
+        ):
+            store.rebind(
+                self.sprint_id,
+                self.document_id,
+                sprint_domain.LifecycleActor("participant", 2),
+                expected_revision_sha256=old_revision,
+                reason="wrong actor",
+            )
+        self.assertEqual(
+            (1, 0),
+            (
+                self.con.execute(
+                    "SELECT COUNT(*) FROM sprint_spec_revision_history"
+                ).fetchone()[0],
+                self.con.execute(
+                    "SELECT COUNT(*) FROM sprint_events WHERE event_type='spec.rebound'"
+                ).fetchone()[0],
+            ),
+        )
+
+    def test_rebind_history_and_active_projection_reject_untracked_rewrites(self) -> None:
+        with self.assertRaisesRegex(sqlite3.IntegrityError, "immutable"):
+            self.con.execute(
+                "UPDATE sprint_specs SET bound_revision_body='invented' "
+                "WHERE sprint_id=?",
+                (self.sprint_id,),
+            )
+        with self.assertRaisesRegex(sqlite3.IntegrityError, "append-only"):
+            self.con.execute(
+                "UPDATE sprint_spec_revision_history SET reason='invented' "
+                "WHERE sprint_id=?",
+                (self.sprint_id,),
+            )
+        with self.assertRaisesRegex(sqlite3.IntegrityError, "append-only"):
+            self.con.execute(
+                "DELETE FROM sprint_spec_revision_history WHERE sprint_id=?",
+                (self.sprint_id,),
+            )
+        self.assertEqual(
+            (self.original, "test binding"),
+            tuple(
+                self.con.execute(
+                    "SELECT ss.bound_revision_body,h.reason FROM sprint_specs ss "
+                    "JOIN sprint_spec_revision_history h USING (sprint_id,document_id) "
+                    "WHERE ss.sprint_id=?",
+                    (self.sprint_id,),
+                ).fetchone()
+            ),
+        )
 
     def test_exact_bound_body_survives_drift_and_is_participant_scoped(self) -> None:
         self.con.execute(
@@ -119,17 +383,30 @@ class GoverningRevisionCase(unittest.TestCase):
             )
 
     def test_legacy_mismatch_is_explicit_and_never_returns_current_text(self) -> None:
+        legacy_document_id = int(
+            self.con.execute(
+                "INSERT INTO documents (feature_id,kind,seq,title,body) "
+                "VALUES (?,'spec',2,'Legacy governing spec','untrusted current text')",
+                (self.feature_id,),
+            ).lastrowid
+        )
+        revision = hashlib.sha256(self.original.encode()).hexdigest()
         self.con.execute(
-            "UPDATE sprint_specs SET bound_revision_body=NULL WHERE sprint_id=?",
-            (self.sprint_id,),
+            "INSERT INTO sprint_specs "
+            "(sprint_id,document_id,bound_revision_sha256,bound_revision_body,"
+            "bound_revision_legacy) VALUES (?,?,?,NULL,1)",
+            (self.sprint_id, legacy_document_id, revision),
         )
         self.con.execute(
-            "UPDATE documents SET body='untrusted current text' WHERE document_id=?",
-            (self.document_id,),
+            "INSERT INTO sprint_spec_revision_history "
+            "(sprint_id,document_id,generation,bound_revision_sha256,"
+            "bound_revision_body,bound_revision_legacy,actor_kind,reason) "
+            "VALUES (?,?,1,?,NULL,1,'system','legacy test binding')",
+            (self.sprint_id, legacy_document_id, revision),
         )
         with self.assertRaises(sprint_domain.BoundRevisionUnavailable) as raised:
             sprint_domain.SprintSpecRevisionStore(self.con).read(
-                self.sprint_id, self.document_id, caller_shell_id=2
+                self.sprint_id, legacy_document_id, caller_shell_id=2
             )
         self.assertEqual("bound_revision_unavailable", raised.exception.details["code"])
         self.assertEqual(


### PR DESCRIPTION
Fixes #1396.

Adds the missing paused-Sprint control for atomically rebinding one governing spec to its exact current digest/body. The control is restricted to the originating Planner or FnB, uses an expected revision for conflict detection, preserves append-only revision history, records an old/new event, and is retry-safe.

Also wires the control through the authenticated API/CLI, snapshot catalogue, board evidence, and Planner guidance. Historical QA approval remains attached only to the old revision rather than being misrepresented as approval of the replacement bytes.

Verification:
- 618 Sprint tests + 259 subtests
- 56 migration/manifest/schema-guard tests + 192 subtests
- 8 public skill freshness tests
- Python compilation and `git diff --check`