### PR TITLE
fix(ui): hide model support confidence

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3240,9 +3240,7 @@ function chatModelOptions(select, catalog, harness, defaultModel) {
     textContent: "Use harness default",
   }));
   for (const model of available) {
-    const support = model.harness_support_state
-      ? ` — ${model.harness_support_state}` : "";
-    select.append(el("option", { value: model.id, textContent: model.id + support }));
+    select.append(el("option", { value: model.id, textContent: model.id }));
   }
   if (!select.options.length) {
     select.append(el("option", {

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -302,6 +302,30 @@ def test_start_chat_has_default_and_configured_paths_without_terminal_controls()
     assert "attach" not in interface.lower()
 
 
+def test_model_picker_labels_do_not_expose_harness_support_confidence():
+    options = APP[
+        APP.index("function chatModelOptions"):
+        APP.index("function chatCreateConversation")
+    ]
+    script = r"""
+const CHAT_HARNESS_DEFAULT_VALUE = "__sc_harness_default__";
+const el = (tag, props) => ({tag, ...props});
+const select = {options: [], replaceChildren() { this.options = []; },
+  append(option) { this.options.push(option); }};
+""" + options + r"""
+chatModelOptions(select, {harnesses: {codex: {models: [
+  {id: "gpt-5.6-sol", availability: "available", harness_support_state: "best-effort"},
+  {id: "gpt-hidden", availability: "unavailable", harness_support_state: "tested"},
+]}}}, "codex", "gpt-5.6-sol");
+console.log(JSON.stringify(select.options));
+"""
+    assert run_js(script) == [
+        {"tag": "option", "value": "", "textContent": "Use shell default — gpt-5.6-sol"},
+        {"tag": "option", "value": "__sc_harness_default__", "textContent": "Use harness default"},
+        {"tag": "option", "value": "gpt-5.6-sol", "textContent": "gpt-5.6-sol"},
+    ]
+
+
 @pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
 def test_missing_retained_harness_status_disables_composer():
     availability = APP[


### PR DESCRIPTION
## Summary
- show model names without harness support-confidence suffixes in the chat configuration picker
- retain model IDs and thinking-level behavior unchanged
- cover the picker labels with a browser-native regression test

## Verification
- ============================= test session starts ==============================
platform linux -- Python 3.14.7, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/j3d1/Repos/sc-cachy/.sc-worktrees/dev3
plugins: anyio-4.14.2
collected 41 items

tests/test_conversation_ui.py .........................................  [100%]

============================== 41 passed in 0.30s ==============================
- 
- F841 Local variable `interface` is assigned to but never used
  --> tests/test_conversation_ui.py:75:5
   |
74 | def test_sprint_badge_enters_the_current_conversation_without_a_wake():
75 |     interface = APP[APP.index("async function renderInterface"):
   |     ^^^^^^^^^
76 |                     APP.index("// ── Tabs + boot")]
77 |     badge = APP[APP.index("function chatSprintBadge"):
   |
help: Remove assignment to unused variable `interface`

Found 1 error.
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option). *(blocked by pre-existing F841 at tests/test_conversation_ui.py:75)*