### PR TITLE
fix: stream typed OpenCode reasoning live

### DIFF
--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -407,6 +407,47 @@ class HttpTransport(Protocol):
     ) -> Iterable[Mapping[str, Any]]: ...
 
 
+class _SSEIterator:
+    """Decode one SSE response while allowing another thread to close it."""
+
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.lines = iter(response)
+        self.data: list[str] = []
+        self.closed = False
+
+    def __iter__(self) -> _SSEIterator:
+        return self
+
+    def __next__(self) -> Mapping[str, Any]:
+        while not self.closed:
+            raw_line = next(self.lines)
+            line = raw_line.decode("utf-8", "replace").rstrip("\r\n")
+            if line.startswith("data:"):
+                self.data.append(line[5:].lstrip())
+                continue
+            if line or not self.data:
+                continue
+            encoded = "\n".join(self.data)
+            self.data.clear()
+            try:
+                value = json.loads(encoded)
+            except json.JSONDecodeError as exc:
+                raise AdapterError(
+                    "HARNESS_PROTOCOL_ERROR",
+                    "SSE event contained invalid JSON",
+                ) from exc
+            if isinstance(value, dict):
+                return value
+        raise StopIteration
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        self.response.close()
+
+
 class UrlHttpTransport:
     """Small JSON + SSE transport for the loopback OpenCode server."""
 
@@ -506,32 +547,7 @@ class UrlHttpTransport:
                 retryable=True,
             ) from exc
 
-        return self._iter_sse(response)
-
-    @staticmethod
-    def _iter_sse(response: Any) -> Iterator[Mapping[str, Any]]:
-        data: list[str] = []
-        try:
-            for raw_line in response:
-                line = raw_line.decode("utf-8", "replace").rstrip("\r\n")
-                if line.startswith("data:"):
-                    data.append(line[5:].lstrip())
-                    continue
-                if line or not data:
-                    continue
-                encoded = "\n".join(data)
-                data.clear()
-                try:
-                    value = json.loads(encoded)
-                except json.JSONDecodeError as exc:
-                    raise AdapterError(
-                        "HARNESS_PROTOCOL_ERROR",
-                        "SSE event contained invalid JSON",
-                    ) from exc
-                if isinstance(value, dict):
-                    yield value
-        finally:
-            response.close()
+        return _SSEIterator(response)
 
 
 class ProcessRunner(Protocol):

--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -6,6 +6,7 @@ import atexit
 import hashlib
 import json
 import os
+import queue
 import secrets
 import shlex
 import shutil
@@ -49,6 +50,7 @@ SERVER_LOG = ENGINE / "logs" / "opencode-server.log"
 SERVER_STATE = ENGINE / "run" / "opencode-server.json"
 SHELL_RUNTIME_DIR = ENGINE / "run" / "opencode-shells"
 TURN_TIMEOUT_SECONDS = 5400.0
+TURN_CLEANUP_TIMEOUT_SECONDS = 10.0
 _SERVER_LOCK = threading.RLock()
 _SERVER_PROCESS: subprocess.Popen | None = None
 _SERVER_ENDPOINT = SERVER_ENDPOINT
@@ -59,6 +61,302 @@ MAX_CONNECTED_PROVIDERS = 256
 MAX_CONNECTED_MODELS = 2_000
 MAX_NATIVE_OPTIONS = 256
 MAX_NATIVE_IDENTIFIER_CHARS = 512
+
+
+class _OpenCodeProjection:
+    """Reduce one exact-session OpenCode typed-part stream."""
+
+    def __init__(self) -> None:
+        self.message_roles: dict[str, str] = {}
+        self.part_kinds: dict[str, str] = {}
+        self.part_messages: dict[str, str] = {}
+        self.part_text: dict[str, str] = {}
+        self.part_emitted: dict[str, str] = {}
+        self.tool_states: dict[str, str] = {}
+        self.run_started = False
+        self.last_usage: tuple[tuple[str, int | float], ...] | None = None
+
+    def _flush_text(self, part_id: str, native_type: str) -> list[NormalizedEvent]:
+        kind = self.part_kinds.get(part_id)
+        message_id = self.part_messages.get(part_id)
+        if kind not in {"text", "reasoning"} or not message_id:
+            return []
+        if self.message_roles.get(message_id) != "assistant":
+            return []
+        text = self.part_text.get(part_id, "")
+        emitted = self.part_emitted.get(part_id, "")
+        if not text.startswith(emitted):
+            raise AdapterError(
+                "HARNESS_PROTOCOL_ERROR",
+                f"OpenCode replaced emitted text for part {part_id}",
+            )
+        delta = text[len(emitted):]
+        if not delta:
+            return []
+        self.part_emitted[part_id] = text
+        return [
+            NormalizedEvent(
+                "assistant.delta",
+                {
+                    "text": delta,
+                    "segment": "reasoning" if kind == "reasoning" else "answer",
+                },
+                native_type,
+            )
+        ]
+
+    def _merge_full_text(self, part_id: str, text: str) -> None:
+        current = self.part_text.get(part_id, "")
+        if text.startswith(current):
+            self.part_text[part_id] = text
+            return
+        if current.startswith(text):
+            return
+        raise AdapterError(
+            "HARNESS_PROTOCOL_ERROR",
+            f"OpenCode returned irreconcilable text for part {part_id}",
+        )
+
+    def _tool_events(
+        self,
+        tool_ref: str,
+        name: str | None,
+        status: str,
+        native_type: str,
+    ) -> list[NormalizedEvent]:
+        previous = self.tool_states.get(tool_ref)
+        if status in {"pending", "running"}:
+            if previous is not None:
+                return []
+            self.tool_states[tool_ref] = "running"
+            return [
+                NormalizedEvent(
+                    "tool.started",
+                    {"tool_ref": tool_ref, "name": name},
+                    native_type,
+                )
+            ]
+        if status not in {"completed", "error"}:
+            return []
+        if previous in {"completed", "error"}:
+            return []
+        events = []
+        if previous is None:
+            events.append(
+                NormalizedEvent(
+                    "tool.started",
+                    {"tool_ref": tool_ref, "name": name},
+                    native_type,
+                )
+            )
+        self.tool_states[tool_ref] = status
+        events.append(
+            NormalizedEvent(
+                "tool.completed",
+                {
+                    "tool_ref": tool_ref,
+                    "status": "failed" if status == "error" else "completed",
+                },
+                native_type,
+            )
+        )
+        return events
+
+    def normalize(self, raw: Mapping[str, Any]) -> list[NormalizedEvent]:
+        event = OpenCodeAdapter._event_payload(raw)
+        native_type = event.get("type")
+        if not isinstance(native_type, str):
+            return []
+        props = event.get("properties")
+        props = props if isinstance(props, dict) else {}
+
+        if native_type == "session.status":
+            status = props.get("status")
+            status_type = status.get("type") if isinstance(status, dict) else status
+            if status_type != "busy" or self.run_started:
+                return []
+            self.run_started = True
+            return [
+                NormalizedEvent(
+                    "run.started", {"status": "running"}, native_type
+                )
+            ]
+        if native_type == "session.idle":
+            return [
+                NormalizedEvent(
+                    "run.completed", {"status": "completed"}, native_type
+                )
+            ]
+        if native_type == "session.error":
+            error = props.get("error")
+            name = OpenCodeAdapter._error_name(error)
+            interrupted = name == "MessageAbortedError"
+            return [
+                NormalizedEvent(
+                    "run.interrupted" if interrupted else "run.failed",
+                    {"error": name},
+                    native_type,
+                    "native" if interrupted else None,
+                )
+            ]
+        if native_type == "message.updated":
+            return self._message_updated(props, native_type)
+        if native_type == "message.part.delta":
+            return self._part_delta(props, native_type)
+        if native_type == "message.part.updated":
+            return self._part_updated(props, native_type)
+        if native_type in {"permission.asked", "permission.v2.asked"}:
+            return [
+                NormalizedEvent(
+                    "permission.requested",
+                    {
+                        "request_ref": props.get("id"),
+                        "action": props.get("permission") or props.get("action"),
+                        "resources": props.get("patterns") or props.get("resources", []),
+                    },
+                    native_type,
+                )
+            ]
+        if native_type in {"question.asked", "question.v2.asked"}:
+            return [
+                NormalizedEvent(
+                    "input.requested",
+                    {
+                        "request_ref": props.get("id"),
+                        "questions": props.get("questions", []),
+                    },
+                    native_type,
+                )
+            ]
+        if native_type in {
+            "session.next.tool.called",
+            "session.next.shell.started",
+        }:
+            tool_ref = props.get("callID") or props.get("id")
+            if not isinstance(tool_ref, str):
+                return []
+            return self._tool_events(
+                tool_ref,
+                props.get("tool") or ("bash" if props.get("command") else None),
+                "running",
+                native_type,
+            )
+        if native_type in {
+            "session.next.tool.success",
+            "session.next.tool.failed",
+            "session.next.shell.ended",
+        }:
+            tool_ref = props.get("callID") or props.get("id")
+            if not isinstance(tool_ref, str):
+                return []
+            return self._tool_events(
+                tool_ref,
+                None,
+                "error" if native_type.endswith("failed") else "completed",
+                native_type,
+            )
+        return []
+
+    def _message_updated(
+        self,
+        props: Mapping[str, Any],
+        native_type: str,
+    ) -> list[NormalizedEvent]:
+        info = props.get("info")
+        if not isinstance(info, dict):
+            return []
+        message_id = info.get("id")
+        role = info.get("role")
+        events: list[NormalizedEvent] = []
+        if isinstance(message_id, str) and isinstance(role, str):
+            self.message_roles[message_id] = role
+            for part_id, owner in tuple(self.part_messages.items()):
+                if owner == message_id:
+                    events.extend(self._flush_text(part_id, native_type))
+        if role != "assistant":
+            return events
+        tokens = info.get("tokens")
+        if not isinstance(tokens, dict):
+            return events
+        safe = {
+            key: value
+            for key, value in tokens.items()
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        }
+        if not safe or not any(safe.values()):
+            return events
+        usage = tuple(sorted(safe.items()))
+        if usage == self.last_usage:
+            return events
+        self.last_usage = usage
+        events.append(NormalizedEvent("usage", {"tokens": safe}, native_type))
+        return events
+
+    def _part_delta(
+        self,
+        props: Mapping[str, Any],
+        native_type: str,
+    ) -> list[NormalizedEvent]:
+        if props.get("field") != "text" or not isinstance(props.get("delta"), str):
+            return []
+        part_id = props.get("partID")
+        if not isinstance(part_id, str):
+            return []
+        message_id = props.get("messageID")
+        if isinstance(message_id, str):
+            self.part_messages[part_id] = message_id
+        self.part_text[part_id] = self.part_text.get(part_id, "") + props["delta"]
+        return self._flush_text(part_id, native_type)
+
+    def _part_updated(
+        self,
+        props: Mapping[str, Any],
+        native_type: str,
+    ) -> list[NormalizedEvent]:
+        part = props.get("part")
+        if not isinstance(part, dict):
+            return []
+        part_id = part.get("id")
+        kind = part.get("type")
+        if not isinstance(part_id, str) or not isinstance(kind, str):
+            return []
+        message_id = part.get("messageID")
+        if isinstance(message_id, str):
+            self.part_messages[part_id] = message_id
+        if kind in {"text", "reasoning"}:
+            self.part_kinds[part_id] = kind
+            text = part.get("text")
+            if isinstance(text, str):
+                self._merge_full_text(part_id, text)
+            return self._flush_text(part_id, native_type)
+        if kind != "tool":
+            return []
+        state = part.get("state")
+        status = state.get("status") if isinstance(state, dict) else None
+        tool_ref = part.get("callID") or part_id
+        if not isinstance(status, str) or not isinstance(tool_ref, str):
+            return []
+        name = part.get("tool")
+        return self._tool_events(
+            tool_ref,
+            name if isinstance(name, str) else None,
+            status,
+            native_type,
+        )
+
+    def reconcile_response(self, response: Any) -> list[NormalizedEvent]:
+        if not isinstance(response, dict):
+            return []
+        events: list[NormalizedEvent] = []
+        info = response.get("info")
+        if isinstance(info, dict):
+            events.extend(self._message_updated({"info": info}, "message.response"))
+        for part in response.get("parts") or []:
+            if isinstance(part, dict):
+                events.extend(
+                    self._part_updated({"part": part}, "message.response")
+                )
+        return events
 
 
 def _read_server_state() -> dict[str, Any] | None:
@@ -721,7 +1019,7 @@ class OpenCodeAdapter(ConversationAdapter):
         session_ref: str,
         context: ConversationContext,
         message: str,
-    ) -> None:
+    ) -> Any:
         body: dict[str, Any] = {
             "parts": [{"type": "text", "text": message}],
         }
@@ -746,7 +1044,7 @@ class OpenCodeAdapter(ConversationAdapter):
                 body["agent"] = opencode_config.route_agent_name(
                     context.binding_digest or ""
                 )
-        self.transport.request(
+        return self.transport.request(
             "POST",
             f"/session/{session_ref}/message",
             query=self._query(context.checked_worktree()),
@@ -790,6 +1088,7 @@ class OpenCodeAdapter(ConversationAdapter):
                 "message": message,
                 "dispatch_pending": True,
                 "interrupt_lock": threading.Lock(),
+                "interrupt_done": threading.Event(),
                 "resumed": resumed,
             },
         )
@@ -875,6 +1174,11 @@ class OpenCodeAdapter(ConversationAdapter):
             info = props.get("info")
             if isinstance(info, dict):
                 value = info.get("sessionID") or info.get("sessionId")
+                if isinstance(value, str):
+                    return value
+            part = props.get("part")
+            if isinstance(part, dict):
+                value = part.get("sessionID") or part.get("sessionId")
                 return value if isinstance(value, str) else None
         return None
 
@@ -893,136 +1197,80 @@ class OpenCodeAdapter(ConversationAdapter):
     def _normalize(
         self,
         raw: Mapping[str, Any],
+        projection: _OpenCodeProjection | None = None,
     ) -> list[NormalizedEvent]:
-        event = self._event_payload(raw)
-        native_type = event.get("type")
-        if not isinstance(native_type, str):
-            return []
-        props = event.get("properties")
-        props = props if isinstance(props, dict) else {}
+        return (projection or _OpenCodeProjection()).normalize(raw)
 
-        if native_type == "session.status":
-            status = props.get("status")
-            status_type = (
-                status.get("type") if isinstance(status, dict) else status
+    @staticmethod
+    def _close_stream(native_stream: Any) -> None:
+        close = getattr(native_stream, "close", None)
+        if not callable(close):
+            return
+        try:
+            close()
+        except (OSError, RuntimeError, ValueError):
+            pass
+
+    def _abort_once(
+        self,
+        turn: NativeTurn,
+        *,
+        operator: bool = False,
+    ) -> InterruptResult:
+        with self._interrupt_lock(turn):
+            if operator:
+                turn.metadata["interrupt_requested"] = True
+            if turn.metadata.get("abort_sent"):
+                return InterruptResult(
+                    bool(turn.metadata.get("interrupt_acknowledged"))
+                )
+            turn.metadata["abort_sent"] = True
+            pre_dispatch = bool(turn.metadata.get("dispatch_pending"))
+        try:
+            result = self.transport.request(
+                "POST",
+                f"/session/{turn.session_ref}/abort",
+                query=self._query(turn.worktree),
             )
-            if status_type == "busy":
-                return [
-                    NormalizedEvent(
-                        "run.started",
-                        {"status": "running"},
-                        native_type,
-                    )
-                ]
-            return []
-        if native_type == "session.idle":
-            return [
-                NormalizedEvent(
-                    "run.completed",
-                    {"status": "completed"},
-                    native_type,
-                )
-            ]
-        if native_type == "session.error":
-            error = props.get("error")
-            name = self._error_name(error)
-            interrupted = name == "MessageAbortedError"
-            return [
-                NormalizedEvent(
-                    "run.interrupted" if interrupted else "run.failed",
-                    {"error": name},
-                    native_type,
-                    "native" if interrupted else None,
-                )
-            ]
-        if native_type == "message.part.delta":
-            if props.get("field") == "text" and isinstance(
-                props.get("delta"), str
-            ):
-                return [
-                    NormalizedEvent(
-                        "assistant.delta",
-                        {"text": props["delta"]},
-                        native_type,
-                    )
-                ]
-            return []
-        if native_type in {
-            "permission.asked",
-            "permission.v2.asked",
-        }:
-            return [
-                NormalizedEvent(
-                    "permission.requested",
-                    {
-                        "request_ref": props.get("id"),
-                        "action": props.get("action"),
-                        "resources": props.get("resources", []),
-                    },
-                    native_type,
-                )
-            ]
-        if native_type in {"question.asked", "question.v2.asked"}:
-            return [
-                NormalizedEvent(
-                    "input.requested",
-                    {
-                        "request_ref": props.get("id"),
-                        "questions": props.get("questions", []),
-                    },
-                    native_type,
-                )
-            ]
-        if native_type in {
-            "session.next.tool.called",
-            "session.next.shell.started",
-        }:
-            return [
-                NormalizedEvent(
-                    "tool.started",
-                    {
-                        "tool_ref": props.get("id"),
-                        "name": props.get("tool") or props.get("command"),
-                    },
-                    native_type,
-                )
-            ]
-        if native_type in {
-            "session.next.tool.success",
-            "session.next.tool.failed",
-            "session.next.shell.ended",
-        }:
-            return [
-                NormalizedEvent(
-                    "tool.completed",
-                    {
-                        "tool_ref": props.get("id"),
-                        "status": (
-                            "failed" if native_type.endswith("failed") else "completed"
-                        ),
-                    },
-                    native_type,
-                )
-            ]
-        if native_type == "message.updated":
-            info = props.get("info")
-            if isinstance(info, dict) and info.get("role") == "assistant":
-                tokens = info.get("tokens")
-                if isinstance(tokens, dict):
-                    safe = {
-                        key: value
-                        for key, value in tokens.items()
-                        if isinstance(value, (int, float))
-                    }
-                    if safe:
-                        return [
-                            NormalizedEvent(
-                                "usage",
-                                {"tokens": safe},
-                                native_type,
-                            )
-                        ]
-        return []
+            acknowledged = bool(result) or pre_dispatch
+            with self._interrupt_lock(turn):
+                if operator:
+                    turn.metadata["interrupt_acknowledged"] = acknowledged
+        finally:
+            done = turn.metadata.get("interrupt_done")
+            if isinstance(done, threading.Event):
+                done.set()
+        return InterruptResult(acknowledged)
+
+    def _join_turn_workers(
+        self,
+        turn: NativeTurn,
+        native_stream: Any,
+        workers: tuple[threading.Thread, threading.Thread],
+        stop: threading.Event,
+        *,
+        abort_prompt: bool,
+    ) -> None:
+        stop.set()
+        if abort_prompt:
+            try:
+                self._abort_once(turn)
+            except AdapterError:
+                pass
+        self._close_stream(native_stream)
+        deadline = time.monotonic() + TURN_CLEANUP_TIMEOUT_SECONDS
+        for worker in workers:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            worker.join(remaining)
+        live = [worker.name for worker in workers if worker.is_alive()]
+        turn.metadata.pop("workers", None)
+        if live:
+            raise AdapterError(
+                "HARNESS_CLEANUP_FAILED",
+                "OpenCode turn workers did not stop: " + ", ".join(live),
+            )
 
     def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
         native_stream = turn.metadata.get("event_stream")
@@ -1058,6 +1306,7 @@ class OpenCodeAdapter(ConversationAdapter):
             else:
                 turn.metadata["dispatch_pending"] = False
         if interrupted_before_dispatch:
+            self._close_stream(native_stream)
             yield NormalizedEvent(
                 "run.interrupted",
                 {"status": "cancelled"},
@@ -1065,75 +1314,211 @@ class OpenCodeAdapter(ConversationAdapter):
                 "operator",
             )
             return
-        try:
-            self._prompt(turn.session_ref, context, message)
-        except AdapterError as exc:
-            if not isinstance(exc.__cause__, urllib.error.HTTPError):
-                raise
+
+        projection = _OpenCodeProjection()
+        coordination: queue.Queue[tuple[str, Any]] = queue.Queue()
+        stop = threading.Event()
+        sse_entered = threading.Event()
+        prompt_allowed = threading.Event()
+        prompt_state: dict[str, Any] = {}
+
+        def consume_sse() -> None:
+            sse_entered.set()
+            try:
+                for raw in native_stream:
+                    if stop.is_set():
+                        break
+                    coordination.put(("sse.raw", raw))
+            except BaseException as exc:  # noqa: BLE001 - cross-thread handoff
+                if not stop.is_set():
+                    coordination.put(("sse.error", exc))
+            finally:
+                coordination.put(("sse.end", None))
+
+        def dispatch_prompt() -> None:
+            prompt_allowed.wait()
+            if stop.is_set():
+                return
+            try:
+                prompt_state["response"] = self._prompt(
+                    turn.session_ref,
+                    context,
+                    message,
+                )
+                coordination.put(("prompt.done", None))
+            except BaseException as exc:  # noqa: BLE001 - cross-thread handoff
+                prompt_state["error"] = exc
+                coordination.put(("prompt.error", exc))
+
+        sse_worker = threading.Thread(
+            target=consume_sse,
+            name=f"opencode-turn-{turn.run_ref}-sse",
+        )
+        prompt_worker = threading.Thread(
+            target=dispatch_prompt,
+            name=f"opencode-turn-{turn.run_ref}-prompt",
+        )
+        workers = (sse_worker, prompt_worker)
+        turn.metadata["workers"] = workers
+        sse_worker.start()
+        if not sse_entered.wait(1):
+            stop.set()
+            self._close_stream(native_stream)
+            sse_worker.join(TURN_CLEANUP_TIMEOUT_SECONDS)
+            turn.metadata.pop("workers", None)
             raise AdapterError(
-                "HARNESS_SUBMISSION_FAILED",
-                exc.detail,
-                retryable=exc.retryable,
-            ) from exc
+                "HARNESS_CLEANUP_FAILED",
+                "OpenCode SSE consumer did not enter its read loop",
+            )
+        prompt_worker.start()
+        prompt_allowed.set()
+
         observed_activity = False
-        for raw in native_stream:
-            event_session = self._session_of(raw)
-            if event_session and event_session != turn.session_ref:
-                continue
-            for event in self._normalize(raw):
-                # Opening `/event` for an existing session can enqueue its
-                # current idle state before the message is dispatched. That
-                # idle belongs to the previous turn; accepting it would mark
-                # the new message complete without ever generating a reply.
-                if event.type == "run.completed" and not observed_activity:
+        prompt_done = False
+        terminal: NormalizedEvent | None = None
+        failure: BaseException | None = None
+        sse_ended = False
+        try:
+            while terminal is None and failure is None:
+                kind, value = coordination.get()
+                if kind == "prompt.done":
+                    prompt_done = True
                     continue
-                if event.type == "run.completed":
-                    with self._interrupt_lock(turn):
-                        if turn.metadata.get("interrupt_acknowledged"):
-                            event = NormalizedEvent(
-                                "run.interrupted",
-                                {"status": "cancelled"},
-                                event.native_type,
-                                "operator",
+                if kind == "prompt.error":
+                    failure = value
+                    continue
+                if kind == "sse.error":
+                    failure = value
+                    continue
+                if kind == "sse.end":
+                    sse_ended = True
+                    if terminal is None:
+                        if not observed_activity:
+                            prompt_worker.join(
+                                min(0.2, TURN_CLEANUP_TIMEOUT_SECONDS)
                             )
-                if event.type in {
-                    "run.started",
-                    "assistant.delta",
-                    "tool.started",
-                    "tool.completed",
-                    "permission.requested",
-                    "input.requested",
-                }:
-                    observed_activity = True
-                if event.type in TERMINAL_EVENTS:
-                    turn.metadata["terminal"] = event.type
-                    if event.interrupt_evidence:
-                        turn.metadata["interrupt_evidence"] = (
-                            event.interrupt_evidence
+                        if prompt_state.get("error") is not None:
+                            failure = prompt_state["error"]
+                        elif not observed_activity and "response" in prompt_state:
+                            failure = AdapterError(
+                                "HARNESS_SUBMISSION_UNOBSERVED",
+                                "OpenCode accepted the synchronous prompt request "
+                                "but reported no activity or terminal event for "
+                                f"{turn.session_ref}",
+                            )
+                        else:
+                            failure = AdapterError(
+                                "HARNESS_STREAM_LOST",
+                                "OpenCode event stream ended without a terminal event",
+                                retryable=True,
+                            )
+                    continue
+                if kind != "sse.raw" or not isinstance(value, Mapping):
+                    continue
+                event_session = self._session_of(value)
+                if event_session and event_session != turn.session_ref:
+                    continue
+                for event in self._normalize(value, projection):
+                    if event.type == "run.completed" and not observed_activity:
+                        continue
+                    if event.type == "run.completed":
+                        done = turn.metadata.get("interrupt_done")
+                        with self._interrupt_lock(turn):
+                            interrupt_pending = bool(
+                                turn.metadata.get("interrupt_requested")
+                                and not turn.metadata.get(
+                                    "interrupt_acknowledged"
+                                )
+                            )
+                        if interrupt_pending and isinstance(
+                            done, threading.Event
+                        ):
+                            done.wait(TURN_CLEANUP_TIMEOUT_SECONDS)
+                        with self._interrupt_lock(turn):
+                            if turn.metadata.get("interrupt_acknowledged"):
+                                event = NormalizedEvent(
+                                    "run.interrupted",
+                                    {"status": "cancelled"},
+                                    event.native_type,
+                                    "operator",
+                                )
+                    if event.type in {
+                        "run.started",
+                        "assistant.delta",
+                        "tool.started",
+                        "tool.completed",
+                        "permission.requested",
+                        "input.requested",
+                    }:
+                        observed_activity = True
+                    if event.type in TERMINAL_EVENTS:
+                        if (
+                            prompt_state.get("error") is None
+                            and prompt_worker.is_alive()
+                        ):
+                            prompt_worker.join(
+                                min(0.2, TURN_CLEANUP_TIMEOUT_SECONDS)
+                            )
+                        if prompt_state.get("error") is not None:
+                            failure = prompt_state["error"]
+                        else:
+                            terminal = event
+                        break
+                    yield event
+        finally:
+            if terminal is not None and prompt_worker.is_alive():
+                prompt_worker.join(min(0.2, TURN_CLEANUP_TIMEOUT_SECONDS))
+            self._join_turn_workers(
+                turn,
+                native_stream,
+                workers,
+                stop,
+                abort_prompt=(
+                    prompt_worker.is_alive()
+                    or (
+                        failure is not None
+                        and not (
+                            isinstance(failure, AdapterError)
+                            and isinstance(
+                                failure.__cause__, urllib.error.HTTPError
+                            )
                         )
-                yield event
-                if event.type in TERMINAL_EVENTS:
-                    return
-        if not observed_activity:
-            raise AdapterError(
-                "HARNESS_SUBMISSION_UNOBSERVED",
-                "OpenCode accepted the synchronous prompt request but "
-                f"reported no activity or terminal event for {turn.session_ref}",
+                    )
+                    or (failure is None and terminal is None)
+                ),
             )
 
+        if failure is not None:
+            if isinstance(failure, AdapterError):
+                if isinstance(failure.__cause__, urllib.error.HTTPError):
+                    raise AdapterError(
+                        "HARNESS_SUBMISSION_FAILED",
+                        failure.detail,
+                        retryable=failure.retryable,
+                    ) from failure
+                raise failure
+            raise failure
+        if terminal is None:
+            if sse_ended and not observed_activity and prompt_done:
+                raise AdapterError(
+                    "HARNESS_SUBMISSION_UNOBSERVED",
+                    "OpenCode accepted the synchronous prompt request but "
+                    f"reported no activity or terminal event for {turn.session_ref}",
+                )
+            raise AdapterError(
+                "HARNESS_STREAM_LOST",
+                "OpenCode turn ended without a terminal event",
+                retryable=True,
+            )
+        for event in projection.reconcile_response(prompt_state.get("response")):
+            yield event
+        turn.metadata["terminal"] = terminal.type
+        if terminal.interrupt_evidence:
+            turn.metadata["interrupt_evidence"] = terminal.interrupt_evidence
+        yield terminal
+
     def interrupt(self, turn: NativeTurn) -> InterruptResult:
-        with self._interrupt_lock(turn):
-            turn.metadata["interrupt_requested"] = True
-            result = self.transport.request(
-                "POST",
-                f"/session/{turn.session_ref}/abort",
-                query=self._query(turn.worktree),
-            )
-            acknowledged = bool(result) or bool(
-                turn.metadata.get("dispatch_pending")
-            )
-            turn.metadata["interrupt_acknowledged"] = acknowledged
-        return InterruptResult(acknowledged)
+        return self._abort_once(turn, operator=True)
 
     def inspect(
         self,

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3154,25 +3154,34 @@ function chatBubble(
   segment = "answer",
 ) {
   const bubble = el("article", { className: `chat-bubble chat-${kind}` });
-  if (kind === "assistant" && segment === "reasoning")
+  const isReasoning = kind === "assistant" && segment === "reasoning";
+  if (isReasoning)
     bubble.classList.add("chat-reasoning");
-  const header = el("div", { className: "chat-bubble-head" },
-    el("div", { className: "chat-who" },
-      kind === "user" ? "You"
-        : kind === "assistant" && segment === "reasoning" ? "Reasoning"
-        : kind === "assistant" ? chatShellLabel(conversation)
-        : "Activity"));
+  const label = kind === "user" ? "You"
+    : isReasoning ? "Reasoning"
+    : kind === "assistant" ? chatShellLabel(conversation)
+    : "Activity";
   const time = chatMessageTimeLabel(createdAt);
-  if (time) header.append(el("time", {
+  const timeNode = () => el("time", {
     className: "chat-message-time",
     dateTime: String(createdAt),
-  }, time));
-  bubble.append(header);
+  }, time);
   const content = kind === "activity"
     ? el("div", { className: "chat-activity-text" }, body)
     : mdBlock(body);
   if (kind === "assistant") content.classList.add("chat-assistant-body");
-  bubble.append(content);
+  if (isReasoning) {
+    const disclosure = el("details", { className: "chat-reasoning-disclosure" });
+    const summary = el("summary", {}, "Reasoning");
+    if (time) summary.append(timeNode());
+    disclosure.append(summary, content);
+    bubble.append(disclosure);
+  } else {
+    const header = el("div", { className: "chat-bubble-head" },
+      el("div", { className: "chat-who" }, label));
+    if (time) header.append(timeNode());
+    bubble.append(header, content);
+  }
   if (meta) bubble.append(el("div", { className: "chat-meta" }, meta));
   if (kind === "assistant") {
     const tokenLabel = chatContextTokenLabel(contextTokens);

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -472,6 +472,13 @@ body.interface-view main {
   background: color-mix(in srgb, var(--panel) 88%, var(--accent));
   border-style: dashed; color: var(--dim);
 }
+.chat-reasoning-disclosure { min-width: min(600px, 62vw); }
+.chat-reasoning-disclosure > summary {
+  display: flex; align-items: baseline; justify-content: space-between; gap: .8rem;
+  cursor: pointer; color: var(--dim); font-size: calc(.62rem + 1px);
+  text-transform: uppercase; letter-spacing: .12em;
+}
+.chat-reasoning-disclosure[open] > summary { margin-bottom: .45rem; }
 .chat-bubble.chat-activity {
   align-self: flex-start; background: transparent; border-style: dashed;
   color: var(--dim); font-size: .78rem; padding: .4rem .65rem;

--- a/tests/fixtures/conversations/opencode/1.18.23-typed-turn.json
+++ b/tests/fixtures/conversations/opencode/1.18.23-typed-turn.json
@@ -1,0 +1,226 @@
+{
+  "cli_version": "1.18.23",
+  "source": "sanitized live /event capture plus exact-tag tool state shape",
+  "session_ref": "ses_exact",
+  "events": [
+    {
+      "type": "session.idle",
+      "properties": {"sessionID": "ses_exact"}
+    },
+    {
+      "type": "message.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "info": {"id": "msg_user", "sessionID": "ses_exact", "role": "user"}
+      }
+    },
+    {
+      "type": "message.part.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "part": {
+          "id": "prt_user",
+          "messageID": "msg_user",
+          "sessionID": "ses_exact",
+          "type": "text",
+          "text": "must not project"
+        }
+      }
+    },
+    {
+      "type": "session.status",
+      "properties": {"sessionID": "ses_exact", "status": {"type": "busy"}}
+    },
+    {
+      "type": "session.status",
+      "properties": {"sessionID": "ses_exact", "status": {"type": "busy"}}
+    },
+    {
+      "type": "message.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "info": {
+          "id": "msg_assistant",
+          "sessionID": "ses_exact",
+          "role": "assistant",
+          "tokens": {"input": 0, "output": 0, "reasoning": 0}
+        }
+      }
+    },
+    {
+      "type": "message.part.delta",
+      "properties": {
+        "sessionID": "ses_exact",
+        "messageID": "msg_assistant",
+        "partID": "prt_reasoning",
+        "field": "text",
+        "delta": "think"
+      }
+    },
+    {
+      "type": "message.part.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "part": {
+          "id": "prt_reasoning",
+          "messageID": "msg_assistant",
+          "sessionID": "ses_exact",
+          "type": "reasoning",
+          "text": ""
+        }
+      }
+    },
+    {
+      "type": "message.part.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "part": {
+          "id": "prt_reasoning",
+          "messageID": "msg_assistant",
+          "sessionID": "ses_exact",
+          "type": "reasoning",
+          "text": "thinking",
+          "time": {"start": 1, "end": 2}
+        }
+      }
+    },
+    {
+      "type": "message.part.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "part": {
+          "id": "prt_answer",
+          "messageID": "msg_assistant",
+          "sessionID": "ses_exact",
+          "type": "text",
+          "text": ""
+        }
+      }
+    },
+    {
+      "type": "message.part.delta",
+      "properties": {
+        "sessionID": "ses_exact",
+        "messageID": "msg_assistant",
+        "partID": "prt_answer",
+        "field": "text",
+        "delta": "OK"
+      }
+    },
+    {
+      "type": "message.part.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "part": {
+          "id": "prt_answer",
+          "messageID": "msg_assistant",
+          "sessionID": "ses_exact",
+          "type": "text",
+          "text": "OK",
+          "time": {"start": 2, "end": 3}
+        }
+      }
+    },
+    {
+      "type": "message.part.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "part": {
+          "id": "prt_tool",
+          "messageID": "msg_assistant",
+          "sessionID": "ses_exact",
+          "type": "tool",
+          "callID": "call_1",
+          "tool": "bash",
+          "state": {"status": "running", "input": {"command": "pwd"}}
+        }
+      }
+    },
+    {
+      "type": "message.part.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "part": {
+          "id": "prt_tool",
+          "messageID": "msg_assistant",
+          "sessionID": "ses_exact",
+          "type": "tool",
+          "callID": "call_1",
+          "tool": "bash",
+          "state": {"status": "running", "input": {"command": "pwd"}}
+        }
+      }
+    },
+    {
+      "type": "message.part.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "part": {
+          "id": "prt_tool",
+          "messageID": "msg_assistant",
+          "sessionID": "ses_exact",
+          "type": "tool",
+          "callID": "call_1",
+          "tool": "bash",
+          "state": {"status": "completed", "output": "/tmp"}
+        }
+      }
+    },
+    {
+      "type": "message.part.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "part": {
+          "id": "prt_tool",
+          "messageID": "msg_assistant",
+          "sessionID": "ses_exact",
+          "type": "tool",
+          "callID": "call_1",
+          "tool": "bash",
+          "state": {"status": "completed", "output": "/tmp"}
+        }
+      }
+    },
+    {
+      "type": "message.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "info": {
+          "id": "msg_assistant",
+          "sessionID": "ses_exact",
+          "role": "assistant",
+          "tokens": {"input": 8602, "output": 31, "reasoning": 0}
+        }
+      }
+    },
+    {
+      "type": "message.updated",
+      "properties": {
+        "sessionID": "ses_exact",
+        "info": {
+          "id": "msg_assistant",
+          "sessionID": "ses_exact",
+          "role": "assistant",
+          "tokens": {"input": 8602, "output": 31, "reasoning": 0}
+        }
+      }
+    },
+    {
+      "type": "session.idle",
+      "properties": {"sessionID": "ses_exact"}
+    }
+  ],
+  "response": {
+    "info": {
+      "id": "msg_assistant",
+      "sessionID": "ses_exact",
+      "role": "assistant",
+      "tokens": {"input": 8602, "output": 31, "reasoning": 0}
+    },
+    "parts": [
+      {"id": "prt_reasoning", "messageID": "msg_assistant", "sessionID": "ses_exact", "type": "reasoning", "text": "thinking"},
+      {"id": "prt_answer", "messageID": "msg_assistant", "sessionID": "ses_exact", "type": "text", "text": "OK"},
+      {"id": "prt_tool", "messageID": "msg_assistant", "sessionID": "ses_exact", "type": "tool", "callID": "call_1", "tool": "bash", "state": {"status": "completed", "output": "/tmp"}}
+    ]
+  }
+}

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -43,6 +43,8 @@ from conversation_adapters.base import SubprocessRunner
 
 KIMI_FIXTURES = ROOT / "tests" / "fixtures" / "conversations" / "kimi"
 KIMI_V2_STATE = KIMI_FIXTURES / "state-v2.json"
+OPENCODE_FIXTURES = ROOT / "tests" / "fixtures" / "conversations" / "opencode"
+OPENCODE_TYPED_TURN = OPENCODE_FIXTURES / "1.18.23-typed-turn.json"
 
 
 def v2_context(
@@ -239,34 +241,90 @@ class FakeOpenCode:
                     },
                 },
                 {
-                    "type": "message.part.delta",
+                    "type": "message.updated",
                     "properties": {
                         "sessionID": self.session_ref,
-                        "field": "reasoning",
-                        "delta": "secret reasoning",
+                        "info": {
+                            "id": "msg-assistant",
+                            "sessionID": self.session_ref,
+                            "role": "assistant",
+                        },
+                    },
+                },
+                {
+                    "type": "message.part.updated",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "part": {
+                            "id": "reasoning-1",
+                            "messageID": "msg-assistant",
+                            "sessionID": self.session_ref,
+                            "type": "reasoning",
+                            "text": "",
+                        },
                     },
                 },
                 {
                     "type": "message.part.delta",
                     "properties": {
                         "sessionID": self.session_ref,
+                        "messageID": "msg-assistant",
+                        "partID": "reasoning-1",
+                        "field": "text",
+                        "delta": "secret reasoning",
+                    },
+                },
+                {
+                    "type": "message.part.updated",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "part": {
+                            "id": "text-1",
+                            "messageID": "msg-assistant",
+                            "sessionID": self.session_ref,
+                            "type": "text",
+                            "text": "",
+                        },
+                    },
+                },
+                {
+                    "type": "message.part.delta",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "messageID": "msg-assistant",
+                        "partID": "text-1",
                         "field": "text",
                         "delta": "hello",
                     },
                 },
                 {
-                    "type": "session.next.tool.called",
+                    "type": "message.part.updated",
                     "properties": {
                         "sessionID": self.session_ref,
-                        "id": "tool-1",
-                        "tool": "bash",
+                        "part": {
+                            "id": "tool-1",
+                            "messageID": "msg-assistant",
+                            "sessionID": self.session_ref,
+                            "type": "tool",
+                            "callID": "call-1",
+                            "tool": "bash",
+                            "state": {"status": "running", "input": {}},
+                        },
                     },
                 },
                 {
-                    "type": "session.next.tool.success",
+                    "type": "message.part.updated",
                     "properties": {
                         "sessionID": self.session_ref,
-                        "id": "tool-1",
+                        "part": {
+                            "id": "tool-1",
+                            "messageID": "msg-assistant",
+                            "sessionID": self.session_ref,
+                            "type": "tool",
+                            "callID": "call-1",
+                            "tool": "bash",
+                            "state": {"status": "completed", "output": "ok"},
+                        },
                     },
                 },
                 {
@@ -284,6 +342,98 @@ class FakeOpenCode:
                 },
             ]
         )
+
+
+class SynchronizedTypedOpenCode(FakeOpenCode):
+    """Replay 1.18.23 typed SSE while the synchronous prompt is blocked."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        fixture = json.loads(OPENCODE_TYPED_TURN.read_text())
+        self.session_ref = fixture["session_ref"]
+        self.events = fixture["events"]
+        self.response = fixture["response"]
+        self.message_started = threading.Event()
+        self.progress_sent = threading.Event()
+        self.release_message = threading.Event()
+
+    def request(self, method, path, *, query=None, body=None):
+        if method == "POST" and path.endswith("/message"):
+            self.requests.append((method, path, dict(query or {}), body))
+            self.message_started.set()
+            if not self.release_message.wait(2):
+                raise AssertionError("test did not release synchronous prompt")
+            return self.response
+        return super().request(method, path, query=query, body=body)
+
+    def stream(self, path, *, query=None):
+        self.stream_calls.append((path, dict(query or {})))
+
+        def replay():
+            yield self.events[0]
+            if not self.message_started.wait(2):
+                raise AssertionError("SSE consumer started no prompt worker")
+            for event in self.events[1:-1]:
+                yield event
+            self.progress_sent.set()
+            if not self.release_message.wait(2):
+                raise AssertionError("test did not release terminal SSE")
+            yield self.events[-1]
+
+        return replay()
+
+
+class CloseableBlockingStream:
+    def __init__(self, session_ref: str) -> None:
+        self.session_ref = session_ref
+        self.closed = threading.Event()
+        self.started = threading.Event()
+        self._first = True
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.started.set()
+        if self._first:
+            self._first = False
+            return {
+                "type": "session.status",
+                "properties": {
+                    "sessionID": self.session_ref,
+                    "status": {"type": "busy"},
+                },
+            }
+        self.closed.wait(2)
+        raise StopIteration
+
+    def close(self) -> None:
+        self.closed.set()
+
+
+class FailingPromptOpenCode(FakeOpenCode):
+    def __init__(self) -> None:
+        super().__init__()
+        self.event_stream = CloseableBlockingStream(self.session_ref)
+        self.abort_count = 0
+
+    def request(self, method, path, *, query=None, body=None):
+        if method == "POST" and path.endswith("/message"):
+            self.requests.append((method, path, dict(query or {}), body))
+            raise AdapterError(
+                "HARNESS_UNAVAILABLE",
+                "POST /message failed: connection reset",
+                retryable=True,
+            )
+        if method == "POST" and path.endswith("/abort"):
+            self.requests.append((method, path, dict(query or {}), body))
+            self.abort_count += 1
+            return True
+        return super().request(method, path, query=query, body=body)
+
+    def stream(self, path, *, query=None):
+        self.stream_calls.append((path, dict(query or {})))
+        return self.event_stream
 
 
 class FakeClaudeProcess:
@@ -1071,7 +1221,24 @@ class ConversationAdapterTest(unittest.TestCase):
                 self.assertIn("tool.started", types)
                 self.assertIn("tool.completed", types)
                 self.assertIn("run.completed", types)
-                self.assertNotIn("secret reasoning", repr(events))
+                if harness == "opencode":
+                    reasoning = [
+                        event for event in events
+                        if event.type == "assistant.delta"
+                        and event.payload.get("segment") == "reasoning"
+                    ]
+                    answers = [
+                        event for event in events
+                        if event.type == "assistant.delta"
+                        and event.payload.get("segment") != "reasoning"
+                    ]
+                    self.assertEqual(
+                        [event.payload["text"] for event in reasoning],
+                        ["secret reasoning"],
+                    )
+                    self.assertNotIn("secret reasoning", repr(answers))
+                else:
+                    self.assertNotIn("secret reasoning", repr(events))
                 self.assertEqual(
                     adapter.reconcile(turn, self.context).outcome,
                     "succeeded",
@@ -1555,6 +1722,201 @@ class ConversationAdapterTest(unittest.TestCase):
             )]),
             1,
         )
+
+    def test_opencode_streams_typed_progress_before_sync_response(self):
+        native = SynchronizedTypedOpenCode()
+        adapter = OpenCodeAdapter(
+            transport=native,
+            shell_runtime_dir=self.root / "runtime-shells",
+        )
+        turn = adapter.start(self.context, "typed progress")
+        events: list[NormalizedEvent] = []
+        progress_observed = threading.Event()
+        errors: list[BaseException] = []
+
+        def consume() -> None:
+            try:
+                for event in adapter.stream(turn):
+                    events.append(event)
+                    if event.type == "tool.completed":
+                        progress_observed.set()
+            except BaseException as exc:  # noqa: BLE001 - asserted below
+                errors.append(exc)
+
+        worker = threading.Thread(target=consume)
+        worker.start()
+        self.assertTrue(native.message_started.wait(1))
+        self.assertTrue(native.progress_sent.wait(1))
+        self.assertTrue(
+            progress_observed.wait(1),
+            "typed progress remained buffered behind synchronous /message",
+        )
+        self.assertTrue(worker.is_alive())
+
+        progress = list(events)
+        self.assertEqual(
+            [event.type for event in progress].count("run.started"),
+            1,
+        )
+        self.assertEqual(
+            [
+                (event.payload["text"], event.payload.get("segment"))
+                for event in progress
+                if event.type == "assistant.delta"
+            ],
+            [
+                ("think", "reasoning"),
+                ("ing", "reasoning"),
+                ("OK", "answer"),
+            ],
+        )
+        self.assertNotIn("must not project", repr(progress))
+        self.assertEqual(
+            [event.type for event in progress].count("tool.started"),
+            1,
+        )
+        self.assertEqual(
+            [event.type for event in progress].count("tool.completed"),
+            1,
+        )
+        usage = [event for event in progress if event.type == "usage"]
+        self.assertEqual(len(usage), 1)
+        self.assertEqual(
+            usage[0].payload["tokens"],
+            {"input": 8602, "output": 31, "reasoning": 0},
+        )
+
+        native.release_message.set()
+        worker.join(2)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(events[-1].type, "run.completed")
+        self.assertEqual(
+            [event.type for event in events].count("run.completed"),
+            1,
+        )
+        self.assertEqual(
+            len([
+                request for request in native.requests
+                if request[1].endswith("/message")
+            ]),
+            1,
+        )
+
+    def test_opencode_prompt_failure_closes_stream_and_joins_workers(self):
+        native = FailingPromptOpenCode()
+        adapter = OpenCodeAdapter(
+            transport=native,
+            shell_runtime_dir=self.root / "runtime-shells",
+        )
+        turn = adapter.start(self.context, "fail once")
+
+        with self.assertRaises(AdapterError) as caught:
+            list(adapter.stream(turn))
+
+        self.assertEqual(caught.exception.code, "HARNESS_UNAVAILABLE")
+        self.assertTrue(native.event_stream.started.is_set())
+        self.assertTrue(native.event_stream.closed.is_set())
+        self.assertEqual(native.abort_count, 1)
+        self.assertEqual(
+            [
+                thread.name for thread in threading.enumerate()
+                if turn.run_ref in thread.name
+            ],
+            [],
+        )
+
+    def test_opencode_repeated_interrupt_aborts_exact_session_once(self):
+        adapter, native = self.build("opencode")
+        turn = adapter.start(self.context, "interrupt once")
+
+        self.assertTrue(adapter.interrupt(turn).acknowledged)
+        self.assertTrue(adapter.interrupt(turn).acknowledged)
+
+        aborts = [
+            request for request in native.requests
+            if request[:2] == (
+                "POST", f"/session/{native.session_ref}/abort"
+            )
+        ]
+        self.assertEqual(len(aborts), 1)
+
+    def test_opencode_typed_tool_error_is_one_failed_lifecycle(self):
+        adapter, _native = self.build("opencode")
+        projection = opencode_adapter._OpenCodeProjection()
+        raw = {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "ses_exact",
+                "part": {
+                    "id": "prt_failed",
+                    "messageID": "msg_assistant",
+                    "sessionID": "ses_exact",
+                    "type": "tool",
+                    "callID": "call_failed",
+                    "tool": "bash",
+                    "state": {"status": "error", "error": "denied"},
+                },
+            },
+        }
+
+        events = adapter._normalize(raw, projection)
+
+        self.assertEqual([event.type for event in events], [
+            "tool.started", "tool.completed"
+        ])
+        self.assertEqual(events[0].payload, {
+            "tool_ref": "call_failed", "name": "bash"
+        })
+        self.assertEqual(events[1].payload, {
+            "tool_ref": "call_failed", "status": "failed"
+        })
+        self.assertEqual(adapter._normalize(raw, projection), [])
+
+    def test_opencode_rejects_irreconcilable_completed_part_text(self):
+        adapter, _native = self.build("opencode")
+        projection = opencode_adapter._OpenCodeProjection()
+        adapter._normalize({
+            "type": "message.updated",
+            "properties": {
+                "sessionID": "ses_exact",
+                "info": {
+                    "id": "msg_assistant",
+                    "sessionID": "ses_exact",
+                    "role": "assistant",
+                },
+            },
+        }, projection)
+        adapter._normalize({
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "ses_exact",
+                "part": {
+                    "id": "prt_answer",
+                    "messageID": "msg_assistant",
+                    "sessionID": "ses_exact",
+                    "type": "text",
+                    "text": "first",
+                },
+            },
+        }, projection)
+
+        with self.assertRaisesRegex(
+            AdapterError, "irreconcilable text for part prt_answer"
+        ):
+            adapter._normalize({
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": "ses_exact",
+                    "part": {
+                        "id": "prt_answer",
+                        "messageID": "msg_assistant",
+                        "sessionID": "ses_exact",
+                        "type": "text",
+                        "text": "replacement",
+                    },
+                },
+            }, projection)
 
     def test_opencode_exact_resources_filtering_and_unknown_recovery(
         self,

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -300,10 +300,151 @@ class BlockingOpenCodeTransport:
         return events()
 
 
+class ProgressiveOpenCodeTransport:
+    """Emit typed 1.18.23 progress while synchronous /message is blocked."""
+
+    def __init__(self) -> None:
+        self.session_ref = "ses_progressive"
+        self.message_started = threading.Event()
+        self.progress_sent = threading.Event()
+        self.release_message = threading.Event()
+        self.requests: list[tuple[str, str]] = []
+
+    def request(self, method: str, path: str, *, query=None, body=None):
+        self.requests.append((method, path))
+        if method == "POST" and path == "/session":
+            return {"id": self.session_ref}
+        if method == "POST" and path.endswith("/message"):
+            self.message_started.set()
+            if not self.release_message.wait(2):
+                raise AssertionError("test did not release OpenCode message")
+            return {
+                "info": {
+                    "id": "msg_assistant",
+                    "sessionID": self.session_ref,
+                    "role": "assistant",
+                },
+                "parts": [
+                    {
+                        "id": "prt_reasoning",
+                        "messageID": "msg_assistant",
+                        "sessionID": self.session_ref,
+                        "type": "reasoning",
+                        "text": "thinking",
+                    },
+                    {
+                        "id": "prt_answer",
+                        "messageID": "msg_assistant",
+                        "sessionID": self.session_ref,
+                        "type": "text",
+                        "text": "answer",
+                    },
+                ],
+            }
+        if method == "POST" and path.endswith("/abort"):
+            self.release_message.set()
+            return True
+        raise AssertionError(f"unexpected OpenCode request: {method} {path}")
+
+    def stream(self, path: str, *, query=None):
+        def events():
+            yield {
+                "type": "session.idle",
+                "properties": {"sessionID": self.session_ref},
+            }
+            if not self.message_started.wait(2):
+                raise AssertionError("OpenCode prompt worker never started")
+            yield {
+                "type": "session.status",
+                "properties": {
+                    "sessionID": self.session_ref,
+                    "status": {"type": "busy"},
+                },
+            }
+            yield {
+                "type": "message.updated",
+                "properties": {
+                    "sessionID": self.session_ref,
+                    "info": {
+                        "id": "msg_assistant",
+                        "sessionID": self.session_ref,
+                        "role": "assistant",
+                    },
+                },
+            }
+            for part_id, part_type, text in (
+                ("prt_reasoning", "reasoning", "thinking"),
+                ("prt_answer", "text", "answer"),
+            ):
+                yield {
+                    "type": "message.part.updated",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "part": {
+                            "id": part_id,
+                            "messageID": "msg_assistant",
+                            "sessionID": self.session_ref,
+                            "type": part_type,
+                            "text": "",
+                        },
+                    },
+                }
+                yield {
+                    "type": "message.part.delta",
+                    "properties": {
+                        "sessionID": self.session_ref,
+                        "messageID": "msg_assistant",
+                        "partID": part_id,
+                        "field": "text",
+                        "delta": text,
+                    },
+                }
+            yield {
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": self.session_ref,
+                    "part": {
+                        "id": "prt_tool",
+                        "messageID": "msg_assistant",
+                        "sessionID": self.session_ref,
+                        "type": "tool",
+                        "callID": "call_1",
+                        "tool": "bash",
+                        "state": {"status": "running", "input": {}},
+                    },
+                },
+            }
+            self.progress_sent.set()
+            if not self.release_message.wait(2):
+                raise AssertionError("test did not release terminal SSE")
+            yield {
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": self.session_ref,
+                    "part": {
+                        "id": "prt_tool",
+                        "messageID": "msg_assistant",
+                        "sessionID": self.session_ref,
+                        "type": "tool",
+                        "callID": "call_1",
+                        "tool": "bash",
+                        "state": {"status": "completed", "output": "ok"},
+                    },
+                },
+            }
+            yield {
+                "type": "session.idle",
+                "properties": {"sessionID": self.session_ref},
+            }
+
+        return events()
+
+
 class StubUrlResponse:
     def __init__(self, payload: bytes = b"", *, lines=()) -> None:
         self.payload = payload
         self.lines = tuple(lines)
+        self.closed = False
 
     def __enter__(self):
         return self
@@ -318,7 +459,7 @@ class StubUrlResponse:
         return iter(self.lines)
 
     def close(self) -> None:
-        pass
+        self.closed = True
 
 
 class RejectingOpenCodeFirstTurnEndpoint:
@@ -1956,6 +2097,79 @@ class ServiceContractTest(ConversationBrokerCase):
         )
         self.assertEqual(transport.message_count, 3)
 
+    def test_opencode_typed_progress_is_durable_before_message_returns(
+        self,
+    ) -> None:
+        transport = ProgressiveOpenCodeTransport()
+        self.addCleanup(transport.release_message.set)
+        adapter = OpenCodeAdapter(
+            transport=transport,
+            shell_runtime_dir=self.root / "opencode-shells",
+        )
+        broker = self.start_broker(
+            lambda harness: adapter if harness == "opencode" else None
+        )
+        conversation_id = self.add_conversation(harness="opencode")
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+        self.assertTrue(transport.message_started.wait(1))
+        self.assertTrue(transport.progress_sent.wait(1))
+
+        deadline = time.monotonic() + 2
+        run_id = None
+        projected: list[tuple[str, dict]] = []
+        while time.monotonic() < deadline:
+            con = self.connect()
+            run = con.execute(
+                "SELECT run_id,state FROM conversation_runs "
+                "WHERE trigger_message_id=?",
+                (message_id,),
+            ).fetchone()
+            if run is not None:
+                run_id = int(run["run_id"])
+                projected = [
+                    (row["event_type"], json.loads(row["payload"]))
+                    for row in con.execute(
+                        "SELECT event_type,payload FROM conversation_events "
+                        "WHERE run_id=? ORDER BY sequence",
+                        (run_id,),
+                    )
+                ]
+            con.close()
+            if any(event_type == "tool.started" for event_type, _ in projected):
+                break
+            time.sleep(0.01)
+
+        self.assertIsNotNone(run_id)
+        assistant = [
+            (payload["text"], payload["segment"])
+            for event_type, payload in projected
+            if event_type == "assistant.delta"
+        ]
+        self.assertEqual(
+            assistant,
+            [("thinking", "reasoning"), ("answer", "answer")],
+        )
+        self.assertEqual(
+            [event_type for event_type, _ in projected].count("tool.started"),
+            1,
+        )
+        self.assertNotIn("run.completed", [item[0] for item in projected])
+
+        transport.release_message.set()
+        self.wait_run_state(run_id, "succeeded")
+        con = self.connect()
+        terminals = con.execute(
+            "SELECT event_type FROM conversation_events "
+            "WHERE run_id=? AND event_type IN "
+            "('run.completed','run.failed','run.interrupted')",
+            (run_id,),
+        ).fetchall()
+        con.close()
+        self.assertEqual([row["event_type"] for row in terminals], [
+            "run.completed"
+        ])
+
     def test_opencode_first_turn_submission_failure_is_not_reclassified_idle(
         self,
     ) -> None:
@@ -2022,6 +2236,25 @@ class ServiceContractTest(ConversationBrokerCase):
                 ).fetchone()[0],
                 1,
             )
+
+    def test_opencode_sse_handle_closes_the_owned_http_response(self) -> None:
+        response = StubUrlResponse(lines=(
+            b'data: {"type":"session.idle","properties":{}}\n',
+            b"\n",
+        ))
+        transport = base_adapter.UrlHttpTransport("http://opencode.test")
+        with mock.patch.object(
+            base_adapter.urllib.request,
+            "urlopen",
+            return_value=response,
+        ):
+            stream = transport.stream("/event")
+
+        self.assertEqual(next(iter(stream))["type"], "session.idle")
+        stream.close()
+        self.assertTrue(response.closed)
+        with self.assertRaises(StopIteration):
+            next(iter(stream))
 
     def test_starting_crash_without_exact_identity_becomes_unknown(self) -> None:
         _conversation, _message, run_id = self.add_live_run(state="starting")

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -400,8 +400,11 @@ def test_reasoning_streams_as_distinct_assistant_segments_without_approval_ui():
     assert "anchor = sequence" in reducer
     assert "assistantSegments.delete(event.run_id)" in reducer
     assert 'bubble.classList.add("chat-reasoning")' in interface
-    assert 'segment === "reasoning" ? "Reasoning"' in interface
+    assert 'isReasoning ? "Reasoning"' in interface
+    assert 'el("details", { className: "chat-reasoning-disclosure" }' in interface
+    assert 'el("summary", {}, "Reasoning")' in interface
     assert ".chat-bubble.chat-assistant.chat-reasoning" in STYLE
+    assert ".chat-reasoning-disclosure" in STYLE
     assert "approval control" not in interface.lower()
     assert "approval button" not in interface.lower()
 

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -771,9 +771,33 @@ class SprintBoundRouteDispatchProof(unittest.TestCase):
                         },
                     },
                     {
+                        "type": "message.updated",
+                        "properties": {
+                            "info": {
+                                "id": "msg_sprint_exact_null_default",
+                                "role": "assistant",
+                                "sessionID": self.session_ref,
+                            },
+                        },
+                    },
+                    {
+                        "type": "message.part.updated",
+                        "properties": {
+                            "part": {
+                                "id": "part_sprint_exact_null_default",
+                                "messageID": "msg_sprint_exact_null_default",
+                                "sessionID": self.session_ref,
+                                "type": "text",
+                                "text": "",
+                            },
+                        },
+                    },
+                    {
                         "type": "message.part.delta",
                         "properties": {
                             "sessionID": self.session_ref,
+                            "messageID": "msg_sprint_exact_null_default",
+                            "partID": "part_sprint_exact_null_default",
                             "field": "text",
                             "delta": "done",
                         },

--- a/tests/test_supervision_sc.py
+++ b/tests/test_supervision_sc.py
@@ -67,7 +67,12 @@ class SupervisionFixture:
         (self.engine / "Dockerfile").write_text("FROM scratch\n")
         (self.root / ".sc-state").mkdir()
         (self.root / ".sc-state" / "engine.ref").write_text("a" * 40 + "\n")
-        (self.root / ".gitignore").write_text("/.sc-state/local/\n")
+        (self.root / ".gitignore").write_text(
+            "/.sc-state/local/\n"
+            "/.super-coder/shell_db.db\n"
+            "/.super-coder/shell_db.db-wal\n"
+            "/.super-coder/shell_db.db-shm\n"
+        )
         subprocess.run(("git", "init", "-q", str(self.root)), check=True)
         self._write_scripts()
         self._write_fake_commands()
@@ -362,7 +367,12 @@ class SupervisionFixture:
             "hooks": {"deps": {"argv": ["./.subfloor/provision"]}},
             "provision": {"hook": "deps", "inputs": []},
         }))
-        (self.root / ".gitignore").write_text("/.sc-state/local/\n")
+        (self.root / ".gitignore").write_text(
+            "/.sc-state/local/\n"
+            "/.super-coder/shell_db.db\n"
+            "/.super-coder/shell_db.db-wal\n"
+            "/.super-coder/shell_db.db-shm\n"
+        )
         subprocess.run(("git", "init", "-q", str(self.root)), check=True)
         subprocess.run(("git", "-C", str(self.root), "add", "."), check=True)
         subprocess.run(
@@ -378,6 +388,17 @@ class SupervisionFixture:
         return (
             self.docker_state / f"{self.env['SC_TEST_PG_NAME']}.id"
         ).read_text().strip()
+
+    def tracked_status(self) -> str:
+        return subprocess.run(
+            (
+                "git", "-C", str(self.root), "status", "--short",
+                "--untracked-files=no",
+            ),
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout
 
 
 class RestrictedLaunchTests(unittest.TestCase):
@@ -430,11 +451,16 @@ class RestrictedLaunchTests(unittest.TestCase):
 
     def test_successful_provision_reports_hook_output_and_ready_state(self):
         self.fx.configure_provision()
+        self.assertEqual(self.fx.tracked_status(), "")
         self.fx.env["SC_TEST_PROVISION_OUTPUT"] = "dependencies installed"
 
         result = self.fx.run("launch", "--no-build")
 
-        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"{result.stderr}\ntracked status:\n{self.fx.tracked_status()}",
+        )
         self.assertIn("dependencies installed", result.stdout)
         self.assertIn("provision state: ready", result.stdout)
         self.assertNotIn("container-1", result.stdout)


### PR DESCRIPTION
## Outcome

OpenCode browser turns now consume SSE while the synchronous `/message` request is in flight. Native 1.18.23 typed parts keep reasoning, answer text, and tool lifecycle separate; reasoning renders in a collapsed disclosure instead of flooding the answer bubble.

## Changes

- coordinate one prompt worker and one SSE worker per exact native turn
- preserve one synchronous prompt, exact session resume, model/variant pass-through, and shared-server ownership
- classify `message.part.updated` text, reasoning, and tool parts by `partID`
- buffer delta-before-type ordering and reconcile completed full-part text without duplication
- deduplicate busy, usage, and tool lifecycle projections
- close the owned SSE response and join turn workers within the bounded cleanup path
- preserve prompt-rejection, ambiguous transport, terminal, and interrupt precedence
- render reasoning through the existing transcript segment as collapsed-by-default
- add a sanitized OpenCode 1.18.23 typed-wire fixture

Spec: Feature #24 / document #169  
Follow-up flag resolved by this head: SC-1412 / flag #567

## Native evidence

- observed runtime: OpenCode `1.18.23` on the host seat
- connected route: `ollama-cloud/glm-5.3-flash`, variant `high`
- exact `/event` capture confirmed reasoning and answer both use `field: text`, distinguished by typed `partID` updates
- exact-session abort released a live bash-tool prompt in 5.7 seconds
- maintained baseline remains 1.18.9; this PR does not claim a full harness promotion

## Verification

- `./sc test tests/test_conversation_adapters.py tests/test_conversation_broker.py -q` — 108 passed, 36 subtests
- affected conversation files — 228 passed, 52 subtests
- harness/model contracts — 130 passed, 110 subtests
- API — 76 passed, 16 subtests
- release gate — 5 passed
- UI — 41 passed
- optional Playwright segmented journey — skipped on unavailable host browser capability
- `git diff --check` — clean

The declared lint and typecheck hooks still report their pre-existing baseline findings; neither reports a finding in the new implementation lines. Required PR CI remains the repository-wide authoritative gate.
