### PR TITLE
fix(ui): make reasoning disclosure behavior obvious

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3149,6 +3149,15 @@ function chatUpdateContextTokens(node, value) {
   label.textContent = text;
 }
 
+function chatCollapseOtherReasoning(disclosure) {
+  if (!disclosure.open) return;
+  for (const other of document.querySelectorAll(
+    ".chat-reasoning-disclosure[open]",
+  )) {
+    if (other !== disclosure) other.open = false;
+  }
+}
+
 function chatBubble(
   kind, body, meta = "", conversation = null, createdAt = "", contextTokens = null,
   segment = "answer",
@@ -3173,6 +3182,7 @@ function chatBubble(
   if (isReasoning) {
     const disclosure = el("details", { className: "chat-reasoning-disclosure" });
     const summary = el("summary", {}, "Reasoning");
+    disclosure.ontoggle = () => chatCollapseOtherReasoning(disclosure);
     if (time) summary.append(timeNode());
     disclosure.append(summary, content);
     bubble.append(disclosure);

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -474,10 +474,16 @@ body.interface-view main {
 }
 .chat-reasoning-disclosure { min-width: min(600px, 62vw); }
 .chat-reasoning-disclosure > summary {
-  display: flex; align-items: baseline; justify-content: space-between; gap: .8rem;
+  display: flex; align-items: baseline; gap: .45rem; list-style: none;
   cursor: pointer; color: var(--dim); font-size: calc(.62rem + 1px);
   text-transform: uppercase; letter-spacing: .12em;
 }
+.chat-reasoning-disclosure > summary::-webkit-details-marker { display: none; }
+.chat-reasoning-disclosure > summary::before {
+  content: "▸"; flex: none; transition: transform .12s;
+}
+.chat-reasoning-disclosure > summary > .chat-message-time { margin-left: auto; }
+.chat-reasoning-disclosure[open] > summary::before { transform: rotate(90deg); }
 .chat-reasoning-disclosure[open] > summary { margin-bottom: .45rem; }
 .chat-bubble.chat-activity {
   align-self: flex-start; background: transparent; border-style: dashed;

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -407,6 +407,14 @@ def test_reasoning_streams_as_distinct_assistant_segments_without_approval_ui():
     assert "disclosure.ontoggle = () => chatCollapseOtherReasoning(disclosure)" in interface
     assert ".chat-bubble.chat-assistant.chat-reasoning" in STYLE
     assert ".chat-reasoning-disclosure" in STYLE
+    reasoning_style = STYLE[
+        STYLE.index(".chat-reasoning-disclosure {"):
+        STYLE.index(".chat-bubble.chat-activity")
+    ]
+    assert 'content: "▸"' in reasoning_style
+    assert "summary::-webkit-details-marker" in reasoning_style
+    assert ".chat-reasoning-disclosure[open] > summary::before" in reasoning_style
+    assert "transform: rotate(90deg)" in reasoning_style
     assert "approval control" not in interface.lower()
     assert "approval button" not in interface.lower()
 

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -403,10 +403,47 @@ def test_reasoning_streams_as_distinct_assistant_segments_without_approval_ui():
     assert 'isReasoning ? "Reasoning"' in interface
     assert 'el("details", { className: "chat-reasoning-disclosure" }' in interface
     assert 'el("summary", {}, "Reasoning")' in interface
+    assert "disclosure.append(summary, content)" in interface
+    assert "disclosure.ontoggle = () => chatCollapseOtherReasoning(disclosure)" in interface
     assert ".chat-bubble.chat-assistant.chat-reasoning" in STYLE
     assert ".chat-reasoning-disclosure" in STYLE
     assert "approval control" not in interface.lower()
     assert "approval button" not in interface.lower()
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_reasoning_disclosures_allow_only_one_open_section():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    helper = interface[
+        interface.index("function chatCollapseOtherReasoning"):
+        interface.index("function chatBubble")
+    ]
+    script = r"""
+const first = {open: true};
+const second = {open: true};
+let queries = 0;
+global.document = {
+  querySelectorAll(selector) {
+    if (selector !== ".chat-reasoning-disclosure[open]") throw new Error(selector);
+    queries += 1;
+    return [first, second];
+  },
+};
+""" + helper + r"""
+chatCollapseOtherReasoning(second);
+const openingSecond = {first: first.open, second: second.open, queries};
+first.open = true;
+second.open = false;
+chatCollapseOtherReasoning(second);
+console.log(JSON.stringify({openingSecond, closingSecond: {
+  first: first.open, second: second.open, queries,
+}}));
+"""
+    assert run_js(script) == {
+        "openingSecond": {"first": False, "second": True, "queries": 1},
+        "closingSecond": {"first": True, "second": False, "queries": 1},
+    }
 
 
 def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():


### PR DESCRIPTION
Follow-up to #1412.

## Summary

- keep reasoning sections default-closed and natively clickable
- close the previously open reasoning section when another opens
- show a persistent chevron and rotate it for the expanded state
- leave complete answer bubbles outside the disclosure behavior

## Verification

- `./sc test tests/test_conversation_ui.py` — 42 passed
- `./sc typecheck tests/test_conversation_ui.py` — pass
- `node --check .super-coder/ui/app.js` — pass
- `git diff --check` — pass

Repository-wide baseline gates remain separately tracked: lint #1206 and typecheck #1416. PR CI is the authoritative full-suite proof.