### PR TITLE
fix(update): preserve admin and owner identity

### DIFF
--- a/.super-coder/scripts/instance_state.py
+++ b/.super-coder/scripts/instance_state.py
@@ -513,10 +513,14 @@ def _ensure_private_root(
     if metadata.exists() or metadata.is_symlink():
         _lstat_owned_regular(metadata, "private state owner metadata", owner_uid)
         payload = _load_json_object(metadata, "private state owner metadata")
-        metadata_owner_uid = _namespace_host_uid(owner_uid)
+        # Filesystem ownership is reported in this process's UID namespace,
+        # while owner metadata may have been created from either that visible
+        # UID or its parent-namespace mapping.  Accept only those two proven
+        # representations of the already-validated filesystem owner.
+        accepted_owner_uids = {owner_uid, _namespace_host_uid(owner_uid)}
         if (
             payload.get(INSTANCE_ID_KEY) != instance_id
-            or payload.get("owner_uid") != metadata_owner_uid
+            or payload.get("owner_uid") not in accepted_owner_uids
         ):
             raise InstanceStateError("refusing foreign private instance state")
         return

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -131,7 +131,18 @@ def snapshot_under_cutover() -> None:
     """Snapshot in-process so the parent update retains its exclusive lease."""
     import snapshot as snapshot_mod
 
-    snapshot_mod.main(lease_held=True)
+    # The subprocess path establishes update's Admin authority in run_script().
+    # Keep the same narrow authorization boundary now that snapshot runs in
+    # this process, and do not leak it into the caller's ambient environment.
+    previous_admin = os.environ.get("SC_ADMIN")
+    os.environ["SC_ADMIN"] = "1"
+    try:
+        snapshot_mod.main(lease_held=True)
+    finally:
+        if previous_admin is None:
+            os.environ.pop("SC_ADMIN", None)
+        else:
+            os.environ["SC_ADMIN"] = previous_admin
 
 
 def bind_cutover_state(database: Path) -> None:

--- a/tests/test_instance_state.py
+++ b/tests/test_instance_state.py
@@ -395,10 +395,35 @@ class InstanceStateResolverTests(unittest.TestCase):
         ):
             self.assertEqual(self.resolve(create=False), resolved)
 
+    def test_accepts_visible_owner_uid_when_mapping_uses_another_domain(self):
+        resolved = self.resolve()
+
+        with mock.patch.object(
+            instance_state, "_namespace_host_uid", return_value=0
+        ):
+            self.assertEqual(self.resolve(create=False), resolved)
+
+    def test_refuses_owner_uid_outside_visible_and_mapped_domains(self):
+        resolved = self.resolve()
+        metadata = resolved.root / "owner.json"
+        payload = json.loads(metadata.read_text())
+        payload["owner_uid"] = 2000
+        metadata.write_text(json.dumps(payload))
+
+        with mock.patch.object(
+            instance_state, "_namespace_host_uid", return_value=1000
+        ), self.assertRaisesRegex(
+            instance_state.InstanceStateError, "foreign private instance state"
+        ):
+            self.resolve(create=False)
+
     def test_uid_mapping_fails_closed_when_owner_is_not_mapped(self):
         uid_map = self.base / "uid_map"
         uid_map.write_text("0 1000 1\n1 100000 65536\n")
         self.assertEqual(instance_state._namespace_host_uid(0, uid_map), 1000)
+
+        uid_map.write_text("1000 0 1\n")
+        self.assertEqual(instance_state._namespace_host_uid(1000, uid_map), 0)
 
         uid_map.write_text("1 100000 65536\nmalformed\n")
         self.assertEqual(instance_state._namespace_host_uid(0, uid_map), 0)

--- a/tests/test_update_service_cutover.py
+++ b/tests/test_update_service_cutover.py
@@ -22,6 +22,30 @@ class Stop(Exception):
 
 
 class UpdateServiceCutoverTest(unittest.TestCase):
+    def test_in_process_snapshot_uses_scoped_update_admin_authority(self):
+        observed_admin = []
+
+        def snapshot(*, lease_held):
+            snapshot_mod.require_admin("snapshot")
+            observed_admin.append((lease_held, os.environ.get("SC_ADMIN")))
+
+        with mock.patch.dict(os.environ, {}, clear=False), mock.patch.object(
+            snapshot_mod, "main", side_effect=snapshot
+        ):
+            os.environ.pop("SC_ADMIN", None)
+            update.snapshot_under_cutover()
+            self.assertNotIn("SC_ADMIN", os.environ)
+
+        self.assertEqual(observed_admin, [(True, "1")])
+
+    def test_in_process_snapshot_restores_admin_environment_after_failure(self):
+        with mock.patch.dict(os.environ, {"SC_ADMIN": "caller"}), mock.patch.object(
+            snapshot_mod, "main", side_effect=SystemExit("snapshot failed")
+        ):
+            with self.assertRaisesRegex(SystemExit, "snapshot failed"):
+                update.snapshot_under_cutover()
+            self.assertEqual(os.environ.get("SC_ADMIN"), "caller")
+
     def assert_restart_failure_stops_all(
         self,
         *,
@@ -169,6 +193,7 @@ class UpdateServiceCutoverTest(unittest.TestCase):
                 migration_targets.append(update.DB_PATH)
 
             def snapshot_body():
+                self.assertEqual(os.environ.get("SC_ADMIN"), "1")
                 snapshot_targets.append(
                     (snapshot_mod.DB_PATH, snapshot_mod.OUT_PATH)
                 )


### PR DESCRIPTION
Fixes #1436 and #1437.

Summary:
- establish update-owned Admin authority around the in-process snapshot and restore the caller environment afterward
- accept owner metadata in either the process-visible UID domain or its parent-namespace mapping while preserving filesystem ownership and fail-closed checks
- cover the reported reverse UID map, foreign UID rejection, scoped snapshot authority, environment restoration, and runtime relaunch path

Verification:
- python3 -m unittest tests.test_update_service_cutover
- python3 -m unittest tests.test_instance_state tests.test_engine_sql
- python3 -m unittest tests.test_update_materialize tests.test_update_legacy_compat tests.test_update_broker_refresh
- python3 -m unittest tests.test_update_source_sync tests.test_update_worktree_repair
- python3 -m py_compile .super-coder/scripts/update.py .super-coder/scripts/instance_state.py tests/test_instance_state.py tests/test_update_service_cutover.py
- git diff --check

Known repository baseline:
- ./sc lint: pre-existing 1,229 findings across unrelated generated and source files
- ./sc typecheck: pre-existing 675 errors across unrelated files