### PR TITLE
fix(map): decouple refresh from private engine state

### DIFF
--- a/.super-coder/scripts/map_db.py
+++ b/.super-coder/scripts/map_db.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Resolve, open, and seed the map DB — the repo catalogue (dr_*).
 
 The map is a derived cache of the host repo, owned by the cartographer. It lives
@@ -32,7 +31,6 @@ REPO_ROOT = ENGINE.parent
 MAP_DB_PATH = artifact_policy.map_db_path()
 MAP_SCHEMA = ENGINE / "map_schema.sql"
 MAP_CONTENT = artifact_policy.map_content_path()
-ENGINE_DB = instance_state.active_database_path(ENGINE)
 
 
 def ensure_schema(con: sqlite3.Connection) -> None:
@@ -64,10 +62,18 @@ def seed_authored(con: sqlite3.Connection) -> None:
         con.commit()
         return
     # Transition: lift dr_section out of the pre-split engine DB if it still has it.
-    if not ENGINE_DB.exists():
+    # Resolve this optional source only after the durable map sources miss. In
+    # downstream sandboxes the owner-private engine namespace is intentionally
+    # unreadable; that boundary must not block an independent derived-map refresh.
+    try:
+        engine_db = instance_state.active_database_path(ENGINE)
+    except instance_state.InstanceStateError as exc:
+        print(f"map_db: legacy section import unavailable ({exc}) — continuing")
+        return
+    if not engine_db.exists():
         return
     try:
-        eng = sqlite3.connect(f"file:{ENGINE_DB}?mode=ro", uri=True)
+        eng = sqlite3.connect(f"file:{engine_db}?mode=ro", uri=True)
     except sqlite3.OperationalError:
         return
     try:
@@ -100,7 +106,7 @@ def connect(*, seed: bool = True) -> sqlite3.Connection:
     return con
 
 
-def open_ro() -> "sqlite3.Connection | None":
+def open_ro() -> sqlite3.Connection | None:
     """Open the map DB read-only for rendering. None if it doesn't exist yet
     (a fork that hasn't mapped) — callers degrade to 'not mapped'."""
     if not MAP_DB_PATH.exists():

--- a/tests/test_map_db.py
+++ b/tests/test_map_db.py
@@ -1,0 +1,130 @@
+"""Regression coverage for map DB independence from private engine state."""
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+SCRIPTS = ENGINE / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import instance_state
+import map_db
+
+
+def section_connection() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.execute(
+        "CREATE TABLE dr_section ("
+        "name TEXT PRIMARY KEY, path_prefix TEXT, description TEXT, sort_order INTEGER)"
+    )
+    return con
+
+
+class PrivateStateIndependenceTests(unittest.TestCase):
+    def test_import_does_not_resolve_engine_database(self) -> None:
+        spec = importlib.util.spec_from_file_location(
+            "map_db_import_probe", SCRIPTS / "map_db.py"
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+
+        with mock.patch.object(
+            instance_state,
+            "active_database_path",
+            side_effect=AssertionError("must not resolve private state at import"),
+        ):
+            spec.loader.exec_module(module)
+
+    def test_existing_sections_do_not_resolve_engine_database(self) -> None:
+        con = section_connection()
+        self.addCleanup(con.close)
+        con.execute("INSERT INTO dr_section VALUES ('Code', 'src/', 'code', 10)")
+
+        with mock.patch.object(
+            map_db.instance_state,
+            "active_database_path",
+            side_effect=AssertionError("must not resolve private state"),
+        ) as resolve:
+            map_db.seed_authored(con)
+
+        resolve.assert_not_called()
+
+    def test_snapshot_does_not_resolve_engine_database(self) -> None:
+        con = section_connection()
+        self.addCleanup(con.close)
+        with tempfile.TemporaryDirectory() as td:
+            snapshot = Path(td) / "content.sql"
+            snapshot.write_text(
+                "INSERT INTO dr_section VALUES ('Docs', 'docs/', 'docs', 20);\n"
+            )
+            with mock.patch.object(map_db, "MAP_CONTENT", snapshot), mock.patch.object(
+                map_db.instance_state,
+                "active_database_path",
+                side_effect=AssertionError("must not resolve private state"),
+            ) as resolve:
+                map_db.seed_authored(con)
+
+        resolve.assert_not_called()
+        self.assertEqual(
+            con.execute("SELECT name FROM dr_section").fetchone()[0], "Docs"
+        )
+
+    def test_inaccessible_legacy_source_does_not_block_fresh_map(self) -> None:
+        con = section_connection()
+        self.addCleanup(con.close)
+        with tempfile.TemporaryDirectory() as td, mock.patch.object(
+            map_db, "MAP_CONTENT", Path(td) / "missing.sql"
+        ), mock.patch.object(
+            map_db.instance_state,
+            "active_database_path",
+            side_effect=instance_state.InstanceStateError(
+                "cannot read private state owner metadata: permission denied"
+            ),
+        ):
+            map_db.seed_authored(con)
+
+        self.assertEqual(
+            con.execute("SELECT COUNT(*) FROM dr_section").fetchone()[0], 0
+        )
+
+    def test_readable_legacy_source_still_imports_sections(self) -> None:
+        con = section_connection()
+        self.addCleanup(con.close)
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            legacy = base / "shell_db.db"
+            source = sqlite3.connect(legacy)
+            source.execute(
+                "CREATE TABLE dr_section ("
+                "name TEXT, path_prefix TEXT, description TEXT, sort_order INTEGER)"
+            )
+            source.execute(
+                "INSERT INTO dr_section VALUES ('Tests', 'tests/', 'tests', 30)"
+            )
+            source.commit()
+            source.close()
+
+            with mock.patch.object(
+                map_db, "MAP_CONTENT", base / "missing.sql"
+            ), mock.patch.object(
+                map_db.instance_state, "active_database_path", return_value=legacy
+            ):
+                map_db.seed_authored(con)
+
+        self.assertEqual(
+            con.execute(
+                "SELECT name, path_prefix FROM dr_section"
+            ).fetchone(),
+            ("Tests", "tests/"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_map_db.py
+++ b/tests/test_map_db.py
@@ -14,7 +14,6 @@ ENGINE = ROOT / ".super-coder"
 SCRIPTS = ENGINE / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-import instance_state
 import map_db
 
 
@@ -36,7 +35,7 @@ class PrivateStateIndependenceTests(unittest.TestCase):
         module = importlib.util.module_from_spec(spec)
 
         with mock.patch.object(
-            instance_state,
+            map_db.instance_state,
             "active_database_path",
             side_effect=AssertionError("must not resolve private state at import"),
         ):
@@ -84,7 +83,7 @@ class PrivateStateIndependenceTests(unittest.TestCase):
         ), mock.patch.object(
             map_db.instance_state,
             "active_database_path",
-            side_effect=instance_state.InstanceStateError(
+            side_effect=map_db.instance_state.InstanceStateError(
                 "cannot read private state owner metadata: permission denied"
             ),
         ):


### PR DESCRIPTION
Closes #1454

## Summary
- defer private engine DB resolution until the optional legacy section fallback is actually needed
- allow inaccessible owner-private state to fall through to normal fresh-map seeding
- cover import, existing-map, snapshot, inaccessible-state, and readable-legacy paths

## Verification
- `./sc test tests/test_map_db.py tests/test_map_repo.py tests/test_map_setup.py tests/test_instance_state.py` (44 passed)
- `./sc lint .super-coder/scripts/map_db.py tests/test_map_db.py`
- `./sc typecheck .super-coder/scripts/map_db.py tests/test_map_db.py`

## Trade-off
A downstream sandbox that has neither authored map content nor readable legacy engine state starts from normal derived section seeding instead of blocking the entire map refresh. The legacy import remains intact wherever the engine state is readable.