### PR TITLE
Fix Admin update floor-crossing defects

### DIFF
--- a/.super-coder/Dockerfile
+++ b/.super-coder/Dockerfile
@@ -181,8 +181,12 @@ ARG SC_HARNESS_EPOCH=0
 # would let the mount shadow the baked binary with an incompatible host binary.
 # KIMI_NO_MODIFY_PATH skips its shell-rc edit.
 RUN echo "harness epoch: ${SC_HARNESS_EPOCH}" \
- && curl -fsSL https://code.kimi.com/kimi-code/install.sh \
-      | env KIMI_INSTALL_DIR=/usr/local KIMI_NO_MODIFY_PATH=1 bash
+ && curl -fsSL --connect-timeout 15 --max-time 60 \
+      -o /tmp/kimi-install.sh https://code.kimi.com/kimi-code/install.sh \
+ && timeout --signal=TERM --kill-after=10s 180s \
+      env KIMI_INSTALL_DIR=/usr/local KIMI_NO_MODIFY_PATH=1 \
+      bash /tmp/kimi-install.sh \
+ && rm -f /tmp/kimi-install.sh
 
 # A user matching the host uid/gid so bind-mounted files aren't root-owned.
 # A host GID or UID may already exist in the base image — sudo builds pass

--- a/.super-coder/assets/skills/admin_git/SKILL.md
+++ b/.super-coder/assets/skills/admin_git/SKILL.md
@@ -48,8 +48,13 @@ gitignored. After `self_update` succeeds, stage only the durable public update:
 ```bash
 git add .sc-state/engine.ref
 git status --short
-git commit -m "chore: update super-coder engine pin"
+SC_SHELL_FLAVOR=admin git commit -m "chore: update super-coder engine pin"
 ```
+
+Set the marker on this commit command even inside an Admin shell. The update
+may have replaced the pre-commit hook during a session launched by the old
+floor, whose inherited environment cannot contain the new Admin exemption.
+The marker makes that one post-update handoff explicit without bypassing hooks.
 
 Add the root `sc` dispatcher or another public file only when the update
 deliberately changed it. Never force-add `.super-coder/`, local snapshots,

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -56,8 +56,13 @@ gitignored. After `self_update` succeeds, stage only the durable public update:
 ```bash
 git add .sc-state/engine.ref
 git status --short
-git commit -m "chore: update super-coder engine pin"
+SC_SHELL_FLAVOR=admin git commit -m "chore: update super-coder engine pin"
 ```
+
+Set the marker on this commit command even inside an Admin shell. The update
+may have replaced the pre-commit hook during a session launched by the old
+floor, whose inherited environment cannot contain the new Admin exemption.
+The marker makes that one post-update handoff explicit without bypassing hooks.
 
 Add the root `sc` dispatcher or another public file only when the update
 deliberately changed it. Never force-add `.super-coder/`, local snapshots,

--- a/.super-coder/migrations/0244_admin_update_floor_crossing.sql
+++ b/.super-coder/migrations/0244_admin_update_floor_crossing.sql
@@ -1,0 +1,28 @@
+-- 0244 — keep Admin maintenance governed across an in-session floor update.
+
+BEGIN;
+
+UPDATE skills SET content=REPLACE(
+  content,
+  'git commit -m "chore: update super-coder engine pin"
+```
+
+Add the root `sc` dispatcher',
+  'SC_SHELL_FLAVOR=admin git commit -m "chore: update super-coder engine pin"
+```
+
+Set the marker on this commit command even inside an Admin shell. The update
+may have replaced the pre-commit hook during a session launched by the old
+floor, whose inherited environment cannot contain the new Admin exemption.
+The marker makes that one post-update handoff explicit without bypassing hooks.
+
+Add the root `sc` dispatcher'
+)
+WHERE name='admin_git';
+
+INSERT OR IGNORE INTO flavor_skills (flavor, skill_id)
+SELECT 'admin', skill_id
+FROM skills
+WHERE name='flags' AND is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/instance_state.py
+++ b/.super-coder/scripts/instance_state.py
@@ -292,8 +292,25 @@ def _instance_id_lock(config_path: Path, owner_uid: int):
         directory_info.st_mode
     ):
         raise InstanceStateError("refusing unsafe instance identity lock directory")
-    if directory_info.st_uid != owner_uid or stat.S_IMODE(directory_info.st_mode) & 0o022:
+    if directory_info.st_uid != owner_uid:
         raise InstanceStateError("refusing foreign instance identity lock directory")
+    if stat.S_IMODE(directory_info.st_mode) != PRIVATE_DIRECTORY_MODE:
+        try:
+            os.chmod(lock_directory, PRIVATE_DIRECTORY_MODE)
+            directory_info = lock_directory.lstat()
+        except OSError as exc:
+            raise InstanceStateError(
+                f"cannot secure instance identity lock directory: {exc}"
+            ) from exc
+        if (
+            stat.S_ISLNK(directory_info.st_mode)
+            or not stat.S_ISDIR(directory_info.st_mode)
+            or directory_info.st_uid != owner_uid
+            or stat.S_IMODE(directory_info.st_mode) != PRIVATE_DIRECTORY_MODE
+        ):
+            raise InstanceStateError(
+                "refusing unsafe instance identity lock directory"
+            )
     lock_path = lock_directory / "instance-id.lock"
     flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
     try:

--- a/.super-coder/templates/shells/admin.json
+++ b/.super-coder/templates/shells/admin.json
@@ -4,5 +4,5 @@
   "role": "Admin shell",
   "mandate": "Own {{repo}}'s super-coder infrastructure — keep the engine current, skills healthy, and DB schema sound. You maintain `main` directly; no other shell touches the substrate or the default branch. You own the floor.",
   "focus": "You are the fork's infrastructure owner and the ONLY shell that works in the repo root on `main` — every other shell operates from an isolated worktree and lands changes via PRs. You maintain the engine floor: updates, rollbacks, schema migrations, root-checkout reconciliation, approved merges, diagnosis, and recovery. Recovery work takes precedence over unrelated cleanup. Run `git_cleanup` and capability changes only when requested or relevant to the maintenance objective; there is no standing every-session sweep. Preserve foreign worktrees and never broaden host authority into product feature work or DevOps-owned runtime work.",
-  "skills": ["admin_git", "git_cleanup", "engine_database", "engine_migrations", "self_update", "snapshot"]
+  "skills": ["admin_git", "git_cleanup", "engine_database", "engine_migrations", "flags", "self_update", "snapshot"]
 }

--- a/tests/test_branch_guard.py
+++ b/tests/test_branch_guard.py
@@ -114,6 +114,11 @@ class BranchGuardTest(unittest.TestCase):
                 self.assertIn("Create a feature branch first", result.stderr)
                 self.assertNotIn("no-verify", result.stderr)
 
+    def test_explicit_admin_marker_allows_default_branch_commit(self):
+        result = self.pre_commit(SC_SHELL_FLAVOR="admin")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_exact_operator_install_and_update_commits_bypass_the_hook(self):
         repo = Path(tempfile.mkdtemp(prefix="sc-bg-bypass-", dir=Path.home()))
         self.addCleanup(shutil.rmtree, repo, ignore_errors=True)

--- a/tests/test_docker_build_context.py
+++ b/tests/test_docker_build_context.py
@@ -29,3 +29,14 @@ def test_sandbox_dockerfile_copies_no_repository_paths() -> None:
 
     assert "COPY" not in instructions
     assert "ADD" not in instructions
+
+
+def test_kimi_installer_has_a_bounded_network_window() -> None:
+    dockerfile = (ROOT / ".super-coder" / "Dockerfile").read_text()
+    kimi_install = dockerfile.split("# Kimi Code", 1)[1].split(
+        "# A user matching", 1
+    )[0]
+
+    assert "--connect-timeout" in kimi_install
+    assert "--max-time" in kimi_install
+    assert "timeout --signal=TERM --kill-after=" in kimi_install

--- a/tests/test_flavor_skill_packs.py
+++ b/tests/test_flavor_skill_packs.py
@@ -20,6 +20,7 @@ RATIFIED_OPT_INS = {
         "admin_git",
         "engine_database",
         "engine_migrations",
+        "flags",
         "git_cleanup",
         "self_update",
         "snapshot",
@@ -183,6 +184,7 @@ class HardCutoverMigrationTest(unittest.TestCase):
         ):
             self.assertIn(section, body)
         self.assertIn("git pull --ff-only origin main", body)
+        self.assertIn("SC_SHELL_FLAVOR=admin git commit", body)
         self.assertIn("Never switch its branch, stash,", body)
         self.assertNotIn("git checkout -b", body)
 
@@ -284,6 +286,8 @@ class HardCutoverMigrationTest(unittest.TestCase):
             # 0241 predates the Admin-only engine_database skill introduced by
             # 0243; this fixture proves the historical migration in isolation.
             expected_at_0241 = expected - {"engine_database"}
+            if flavor == "admin":
+                expected_at_0241 -= {"flags"}
             expected_with_local = expected_at_0241 | (
                 {"fork_testing_seat"} if flavor == "dev" else set()
             )

--- a/tests/test_instance_state.py
+++ b/tests/test_instance_state.py
@@ -338,6 +338,17 @@ class InstanceStateResolverTests(unittest.TestCase):
         ):
             self.resolve()
 
+    def test_normalizes_owner_owned_identity_lock_directory_permissions(self):
+        self.config.write_text(json.dumps({"port": 8837}) + "\n")
+        lock_directory = self.engine / "run"
+        lock_directory.mkdir(mode=0o775)
+        os.chmod(lock_directory, 0o775)
+
+        resolved = self.resolve()
+
+        self.assertEqual(resolved.instance_id, self.fixed_id)
+        self.assertEqual(stat.S_IMODE(lock_directory.stat().st_mode), 0o700)
+
     def test_refuses_symlinked_private_directory(self):
         foreign = self.base / "foreign-state"
         foreign.mkdir()


### PR DESCRIPTION
Fixes #1450
Fixes #1451
Fixes #1452
Fixes #1453

## Changes
- normalize an owner-owned legacy engine run directory to mode 0700 before identity locking
- make the post-update Admin pin commit carry its explicit branch-guard marker
- bound both the Kimi installer-script fetch and the complete installer execution
- restore Admin access to the governed `flags` write procedure while retaining Planner-only `flag_sweep`

## Verification
- 154 affected tests passed
- focused Ruff lint passed
- mypy passed for `instance_state.py`
- JSON, Python syntax, and `git diff --check` passed
- `docker buildx build --check` passed with no warnings