### PR TITLE
feat: support moving active specs between features

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1699,6 +1699,83 @@ def patch_document(
         return False, str(exc)
 
 
+def move_spec_to_feature(con, document_id: int, target_feature_id: int):
+    """Move one active spec and its denormalized ownership links atomically."""
+    try:
+        with db_driver.write_transaction(con, "document.move_feature"):
+            document = con.execute(
+                "SELECT feature_id,kind,frozen FROM documents WHERE document_id=?",
+                (document_id,),
+            ).fetchone()
+            if document is None:
+                return None, 404, "no such document"
+            if document["kind"] != "spec":
+                return None, 409, "only spec documents can move between features"
+            if document["frozen"]:
+                return None, 409, "document is frozen — shipped history cannot move"
+            source_feature_id = document["feature_id"]
+            if source_feature_id is None:
+                return None, 409, "spec is not attached to a source feature"
+            if source_feature_id == target_feature_id:
+                return None, 409, "spec already belongs to the target feature"
+
+            target = con.execute(
+                "SELECT roadmap_status FROM roadmap WHERE feature_id=?",
+                (target_feature_id,),
+            ).fetchone()
+            if target is None:
+                return None, 404, "no such target feature"
+            if target["roadmap_status"] in {"shipped", "retired"}:
+                return (
+                    None,
+                    409,
+                    "target feature is terminal — choose an active roadmap feature",
+                )
+
+            sprint = con.execute(
+                "SELECT sprint_id FROM sprint_specs WHERE document_id=? "
+                "ORDER BY sprint_id LIMIT 1",
+                (document_id,),
+            ).fetchone()
+            if sprint is not None:
+                return (
+                    None,
+                    409,
+                    f"spec is bound to Sprint #{sprint['sprint_id']} and cannot move",
+                )
+
+            target_seq = int(
+                con.execute(
+                    "SELECT COALESCE(MAX(seq),0)+1 FROM documents "
+                    "WHERE feature_id=? AND kind='spec'",
+                    (target_feature_id,),
+                ).fetchone()[0]
+            )
+            con.execute(
+                "UPDATE documents SET feature_id=?,seq=?,updated_at=datetime('now') "
+                "WHERE document_id=?",
+                (target_feature_id, target_seq, document_id),
+            )
+            tasks = con.execute(
+                "UPDATE spec_tasks SET feature_id=? WHERE document_id=?",
+                (target_feature_id, document_id),
+            ).rowcount
+            decisions = con.execute(
+                "UPDATE shell_decisions SET feature_id=? WHERE document_id=?",
+                (target_feature_id, document_id),
+            ).rowcount
+            return {
+                "document_id": document_id,
+                "source_feature_id": source_feature_id,
+                "target_feature_id": target_feature_id,
+                "target_seq": target_seq,
+                "tasks_moved": tasks,
+                "decisions_moved": decisions,
+            }, 200, None
+    except db_driver.IntegrityError as exc:
+        return None, 409, str(exc)
+
+
 def create_flag(con, body):
     if not body.get("description"):
         return None, "description required"
@@ -4363,6 +4440,27 @@ class Handler(BaseHTTPRequestHandler):
                                         body, {"status", "title", "description",
                                                "completed_date", "resolution_notes"})
                 return self._send(200 if ok else 400, {"ok": ok, "error": err})
+
+            # PATCH /_sc/mem/docs/{id}/feature — move one active spec while
+            # preserving its identity and plan. This must precede the bare
+            # /docs/{id} check.
+            if len(parts) == 5 and parts[2] == "docs" and parts[4] == "feature":
+                did = int(parts[3])
+                target = body.get("feature_id")
+                if target is None:
+                    return self._send(400, {"error": "feature_id required"})
+                try:
+                    target = int(target)
+                except (TypeError, ValueError):
+                    return self._send(400, {"error": "feature_id must be an integer"})
+                result, status, error = move_spec_to_feature(con, did, target)
+                if error:
+                    return self._send(status, {"ok": False, "error": error})
+                return self._send(200, {
+                    "ok": True,
+                    **result,
+                    "serialize": serialize_doc_write(),
+                })
 
             # PATCH /_sc/mem/docs/{id}/freeze — must precede the bare /docs/{id} check
             # Shared: specs/docs are collaborative (matches the fleet-wide GET

--- a/.super-coder/assets/skills/db_map/SKILL.md
+++ b/.super-coder/assets/skills/db_map/SKILL.md
@@ -58,6 +58,7 @@ sc mem roadmap depends <feature_id> [--on <feature_id>]…
 
 sc mem doc add "…" --kind <spec|doc> --feature <id> --body-file <path> --render-path <path>
 sc mem doc freeze <document_id>
+sc mem doc move <document_id> --feature <target_feature_id>
 sc mem task add "…" --feature <id> --doc <id> --seq <n> [--desc "…"]
 sc mem task start <task_id>
 sc mem task done <task_id>
@@ -77,7 +78,10 @@ Load the owning skill before a governed write: `memory` for state/identity,
 `spec` for roadmap tasks, `docs` for documents, `flags` for blockers, and
 `messaging` for shell coordination. Frozen documents require a new document
 revision; decisions are superseded with `--parent`; seed entries are retired
-rather than rewritten.
+rather than rewritten. `doc move` preserves one unfrozen spec's identity,
+tasks, and document-linked decisions while reassigning them atomically to an
+active feature; it refuses frozen, ordinary-doc, terminal-target, and
+Sprint-bound moves.
 
 ## Failure behavior
 

--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -23,9 +23,11 @@ copy to `specs_sc/` / `docs_sc/`; the GUI opens it rendered in md-converter.
 Feature = the `roadmap` row; exists from `brainstorm` onward, before any spec.
 Specs hang off the feature, not off each other: several unfrozen specs per
 feature, each a `documents (kind='spec')` row, ordered by `seq`. No
-feature-to-feature links; no second roadmap row for related work — related
-work = another spec under the same feature. Freeze = the ship-time record of
-what was built to; it never gates the feature's other specs.
+feature-to-feature links; related work within one mental model is another spec
+under the same feature. A genuinely new era may split into a fresh feature by
+moving its unfrozen active spec through the guarded workflow below. Freeze =
+the ship-time record of what was built to; it never gates the feature's other
+specs.
 
 | state | test | meaning |
 |---|---|---|
@@ -36,6 +38,25 @@ what was built to; it never gates the feature's other specs.
 The **doc** (`kind='doc'`) = the feature's readable face — write it when the
 first spec ships, under the same `feature_id`. Sibling of the specs, not a
 parent.
+
+## Split an active era from feature history
+
+When accumulated history makes a feature's active context misleading or a new
+era has become a separate mental model, preserve the old feature as history and
+move the existing unfrozen active spec intact:
+
+1. Create the fresh feature with its correct work-stream, status, and summary.
+2. Run `sc mem doc move <document_id> --feature <target_feature_id>`.
+3. Re-read the document and task ledger under the target feature; the same ids,
+   task states, and document-linked decisions must now project there.
+4. Edit the historical feature's title/summary to name the split, then set its
+   truthful terminal status (`shipped` for delivered history, `retired` for
+   abandoned history).
+
+The move assigns the spec's next target-feature sequence and is atomic across
+the document, its tasks, and document-linked decisions. It refuses frozen
+specs, ordinary docs, terminal targets, and any spec already bound to a Sprint.
+Do not duplicate the spec or cancel/recreate its tasks when this move applies.
 
 ## Assess the work-stream on every feature
 

--- a/.super-coder/assets/skills/spec/SKILL.md
+++ b/.super-coder/assets/skills/spec/SKILL.md
@@ -94,12 +94,8 @@ sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"
 sc mem state "[<feature>] — last: <last_done>. next: <next_up>."
 ```
 
-Cancellation applies when work is copied or replanned into a different spec.
-When the existing unfrozen spec itself starts a fresh feature era, use
-`sc mem doc move <document_id> --feature <target_feature_id>` instead: the
-document, its task ledger, and its document-linked decisions move atomically,
-so their identities and statuses remain intact. Follow the `docs` split
-workflow to verify the target and annotate the historical feature.
+Intact spec move: `sc mem doc move <document_id> --feature <target_feature_id>`
+(see `docs`).
 
 Final Verification follows the boot `TESTING POSTURE`. Complete code; run every
 available focused proof; use observed registered-PR checks only for an

--- a/.super-coder/assets/skills/spec/SKILL.md
+++ b/.super-coder/assets/skills/spec/SKILL.md
@@ -94,6 +94,13 @@ sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"
 sc mem state "[<feature>] — last: <last_done>. next: <next_up>."
 ```
 
+Cancellation applies when work is copied or replanned into a different spec.
+When the existing unfrozen spec itself starts a fresh feature era, use
+`sc mem doc move <document_id> --feature <target_feature_id>` instead: the
+document, its task ledger, and its document-linked decisions move atomically,
+so their identities and statuses remain intact. Follow the `docs` split
+workflow to verify the target and annotate the historical feature.
+
 Final Verification follows the boot `TESTING POSTURE`. Complete code; run every
 available focused proof; use observed registered-PR checks only for an
 unavailable local gate: pending -> wait, red -> fix, green -> review. No checks

--- a/.super-coder/migrations/0245_reseed_spec_feature_reassignment.sql
+++ b/.super-coder/migrations/0245_reseed_spec_feature_reassignment.sql
@@ -1,0 +1,104 @@
+-- 0245 — teach shells the supported active-spec feature split workflow.
+-- The API/CLI implementation needs no schema change: documents, spec_tasks,
+-- and document-linked decisions already carry the ownership columns. These
+-- idempotent replacements run after 0243's full-body skill publication, so the
+-- old text is a stable migration input on every upgrade path.
+
+BEGIN;
+
+UPDATE skills SET content=REPLACE(
+  content,
+  'sc mem doc add "…" --kind <spec|doc> --feature <id> --body-file <path> --render-path <path>
+sc mem doc freeze <document_id>
+sc mem task add "…" --feature <id> --doc <id> --seq <n> [--desc "…"]',
+  'sc mem doc add "…" --kind <spec|doc> --feature <id> --body-file <path> --render-path <path>
+sc mem doc freeze <document_id>
+sc mem doc move <document_id> --feature <target_feature_id>
+sc mem task add "…" --feature <id> --doc <id> --seq <n> [--desc "…"]'
+)
+WHERE name='db_map';
+
+UPDATE skills SET content=REPLACE(
+  content,
+  'revision; decisions are superseded with `--parent`; seed entries are retired
+rather than rewritten.',
+  'revision; decisions are superseded with `--parent`; seed entries are retired
+rather than rewritten. `doc move` preserves one unfrozen spec''s identity,
+tasks, and document-linked decisions while reassigning them atomically to an
+active feature; it refuses frozen, ordinary-doc, terminal-target, and
+Sprint-bound moves.'
+)
+WHERE name='db_map';
+
+UPDATE skills SET content=REPLACE(
+  content,
+  'feature, each a `documents (kind=''spec'')` row, ordered by `seq`. No
+feature-to-feature links; no second roadmap row for related work — related
+work = another spec under the same feature. Freeze = the ship-time record of
+what was built to; it never gates the feature''s other specs.',
+  'feature, each a `documents (kind=''spec'')` row, ordered by `seq`. No
+feature-to-feature links; related work within one mental model is another spec
+under the same feature. A genuinely new era may split into a fresh feature by
+moving its unfrozen active spec through the guarded workflow below. Freeze =
+the ship-time record of what was built to; it never gates the feature''s other
+specs.'
+)
+WHERE name='docs';
+
+UPDATE skills SET content=REPLACE(
+  content,
+  'The **doc** (`kind=''doc''`) = the feature''s readable face — write it when the
+first spec ships, under the same `feature_id`. Sibling of the specs, not a
+parent.
+
+## Assess the work-stream on every feature',
+  'The **doc** (`kind=''doc''`) = the feature''s readable face — write it when the
+first spec ships, under the same `feature_id`. Sibling of the specs, not a
+parent.
+
+## Split an active era from feature history
+
+When accumulated history makes a feature''s active context misleading or a new
+era has become a separate mental model, preserve the old feature as history and
+move the existing unfrozen active spec intact:
+
+1. Create the fresh feature with its correct work-stream, status, and summary.
+2. Run `sc mem doc move <document_id> --feature <target_feature_id>`.
+3. Re-read the document and task ledger under the target feature; the same ids,
+   task states, and document-linked decisions must now project there.
+4. Edit the historical feature''s title/summary to name the split, then set its
+   truthful terminal status (`shipped` for delivered history, `retired` for
+   abandoned history).
+
+The move assigns the spec''s next target-feature sequence and is atomic across
+the document, its tasks, and document-linked decisions. It refuses frozen
+specs, ordinary docs, terminal targets, and any spec already bound to a Sprint.
+Do not duplicate the spec or cancel/recreate its tasks when this move applies.
+
+## Assess the work-stream on every feature'
+)
+WHERE name='docs';
+
+UPDATE skills SET content=REPLACE(
+  content,
+  'sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"
+sc mem state "[<feature>] — last: <last_done>. next: <next_up>."
+```
+
+Final Verification follows',
+  'sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"
+sc mem state "[<feature>] — last: <last_done>. next: <next_up>."
+```
+
+Cancellation applies when work is copied or replanned into a different spec.
+When the existing unfrozen spec itself starts a fresh feature era, use
+`sc mem doc move <document_id> --feature <target_feature_id>` instead: the
+document, its task ledger, and its document-linked decisions move atomically,
+so their identities and statuses remain intact. Follow the `docs` split
+workflow to verify the target and annotate the historical feature.
+
+Final Verification follows'
+)
+WHERE name='spec';
+
+COMMIT;

--- a/.super-coder/migrations/0245_reseed_spec_feature_reassignment.sql
+++ b/.super-coder/migrations/0245_reseed_spec_feature_reassignment.sql
@@ -90,12 +90,8 @@ Final Verification follows',
 sc mem state "[<feature>] — last: <last_done>. next: <next_up>."
 ```
 
-Cancellation applies when work is copied or replanned into a different spec.
-When the existing unfrozen spec itself starts a fresh feature era, use
-`sc mem doc move <document_id> --feature <target_feature_id>` instead: the
-document, its task ledger, and its document-linked decisions move atomically,
-so their identities and statuses remain intact. Follow the `docs` split
-workflow to verify the target and annotate the historical feature.
+Intact spec move: `sc mem doc move <document_id> --feature <target_feature_id>`
+(see `docs`).
 
 Final Verification follows'
 )

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -63,6 +63,7 @@ Run from the repo root, like every engine command:
     ./sc mem oriented                # mark first-run complete (bootstrapped=1)
     ./sc mem doc add "<title>" --body-file PATH [--feature ID] [--kind spec|doc] [--seq N]
     ./sc mem doc edit <document_id>  [--title "…"] [--body-file PATH] [--render-path …]   # unfrozen only
+    ./sc mem doc move <document_id>  --feature <target_feature_id>   # unfrozen spec + plan, atomic
     ./sc mem doc freeze <document_id>
     ./sc mem doc qaqc <spec_document_id> --verdict approved|changes_requested [--findings-doc ID]
     ./sc mem narrative "<line>"
@@ -831,6 +832,20 @@ def cmd_oriented(args) -> int:
 
 
 def cmd_doc(args) -> int:
+    if args.doc_cmd == "move":
+        r = _api(
+            "PATCH",
+            f"/_sc/mem/docs/{args.document_id}/feature",
+            {"feature_id": args.feature},
+            timeout=_DOC_WRITE_TIMEOUT,
+        )
+        rc = _finish_api(
+            f"mem: spec document #{args.document_id} moved "
+            f"feature #{r['source_feature_id']} → #{r['target_feature_id']} "
+            f"as spec seq {r['target_seq']} "
+            f"({r['tasks_moved']} task(s), {r['decisions_moved']} decision(s))"
+        )
+        return _note_serialize(r) or rc
     if args.doc_cmd == "qaqc":
         payload = {
             "document_id": args.document_id,
@@ -1118,7 +1133,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("oriented", help="mark this shell oriented (bootstrapped=1)") \
        .set_defaults(fn=cmd_oriented)
 
-    sp = sub.add_parser("doc", help="add, edit, or freeze a spec/doc document")
+    sp = sub.add_parser("doc", help="add, edit, move, or freeze a spec/doc document")
     dsub = sp.add_subparsers(dest="doc_cmd", required=True)
     da = dsub.add_parser("add")
     da.add_argument("title")
@@ -1132,6 +1147,12 @@ def build_parser() -> argparse.ArgumentParser:
     de.add_argument("--title")
     de.add_argument("--body-file", dest="body_file")
     de.add_argument("--render-path", dest="render_path")
+    dm = dsub.add_parser(
+        "move",
+        help="move an unfrozen spec and its plan to another active feature",
+    )
+    dm.add_argument("document_id", type=int)
+    dm.add_argument("--feature", type=int, required=True, help="target feature id")
     df = dsub.add_parser("freeze")
     df.add_argument("document_id", type=int)
     dq = dsub.add_parser(

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -162,6 +162,7 @@
     ".super-coder/api/sprint_routes.py",
     ".super-coder/api/transport.py",
     ".super-coder/assets/skills/authoring_syntax/SKILL.md",
+    ".super-coder/assets/skills/db_map/SKILL.md",
     ".super-coder/assets/skills/docs/SKILL.md",
     ".super-coder/assets/skills/git/SKILL.md",
     ".super-coder/assets/skills/memory/SKILL.md",

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -142,7 +142,8 @@
     ".super-coder/migrations/0239_sprint_spec_rebinding.sql",
     ".super-coder/migrations/0240_reseed_sprint_spec_rebinding.sql",
     ".super-coder/migrations/0242_reseed_flag_sweep_delivery_audit.sql",
-    ".super-coder/migrations/0243_role_aware_boot_contract.sql"
+    ".super-coder/migrations/0243_role_aware_boot_contract.sql",
+    ".super-coder/migrations/0245_reseed_spec_feature_reassignment.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -822,6 +822,205 @@ class ApiMemTest(unittest.TestCase):
             server.run_snapshot_render = real_rsr
             server.serialize_doc_write = lambda: {"ok": True, "output": "(test stub)"}
 
+    def test_move_spec_to_feature_preserves_identity_and_plan(self):
+        self.run_mem("roadmap", "add", "split source")
+        self.run_mem("roadmap", "add", "split target")
+        source = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='split source'"
+        )[0]
+        target = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='split target'"
+        )[0]
+        self.write(
+            "INSERT INTO documents (feature_id,kind,seq,title) "
+            "VALUES (?,'spec',1,'existing target spec')",
+            target,
+        )
+        did = self.write(
+            "INSERT INTO documents (feature_id,kind,seq,title) "
+            "VALUES (?,'spec',7,'active v2 spec')",
+            source,
+        )
+        tid = self.write(
+            "INSERT INTO spec_tasks "
+            "(feature_id,document_id,seq,title,status,shell_id) "
+            "VALUES (?,?,0,'Preparation','in_progress',1)",
+            source,
+            did,
+        )
+        decision_id = self.write(
+            "INSERT INTO shell_decisions "
+            "(shell_id,decision_date,decision,rationale,feature_id,document_id) "
+            "VALUES (1,'2026-09-01','move with the spec','why',?,?)",
+            source,
+            did,
+        )
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.assertEqual(
+                self.run_mem(
+                    "doc", "move", str(did), "--feature", str(target)
+                ),
+                0,
+            )
+        self.assertIn(f"feature #{source} → #{target}", output.getvalue())
+        self.assertIn("as spec seq 2 (1 task(s), 1 decision(s))", output.getvalue())
+        self.assertIn("local snapshot + flat render refreshed", output.getvalue())
+        document = self.q(
+            "SELECT feature_id,seq,title FROM documents WHERE document_id=?", did
+        )
+        self.assertEqual((target, 2, "active v2 spec"), tuple(document))
+        self.assertEqual(
+            tuple(
+                self.q(
+                    "SELECT feature_id,status FROM spec_tasks WHERE task_id=?", tid
+                )
+            ),
+            (target, "in_progress"),
+        )
+        self.assertEqual(
+            self.q(
+                "SELECT feature_id FROM shell_decisions WHERE decision_id=?",
+                decision_id,
+            )[0],
+            target,
+        )
+
+    def test_move_spec_to_feature_refuses_ineligible_history(self):
+        self.run_mem("roadmap", "add", "move refusal source")
+        self.run_mem("roadmap", "add", "move refusal target")
+        self.run_mem(
+            "roadmap", "add", "move terminal target", "--status", "shipped"
+        )
+        source = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='move refusal source'"
+        )[0]
+        target = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='move refusal target'"
+        )[0]
+        terminal = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='move terminal target'"
+        )[0]
+        frozen = self.write(
+            "INSERT INTO documents (feature_id,kind,seq,title,frozen) "
+            "VALUES (?,'spec',1,'frozen history',1)",
+            source,
+        )
+        ordinary = self.write(
+            "INSERT INTO documents (feature_id,kind,seq,title) "
+            "VALUES (?,'doc',1,'ordinary doc')",
+            source,
+        )
+        terminal_bound = self.write(
+            "INSERT INTO documents (feature_id,kind,seq,title) "
+            "VALUES (?,'spec',2,'terminal target candidate')",
+            source,
+        )
+        sprint_bound = self.write(
+            "INSERT INTO documents (feature_id,kind,seq,title) "
+            "VALUES (?,'spec',3,'sprint history')",
+            source,
+        )
+        sprint_id = self.write(
+            "INSERT INTO sprints (feature_id,originating_planner_shell_id) "
+            "VALUES (?,4)",
+            source,
+        )
+        self.write(
+            "INSERT INTO sprint_specs "
+            "(sprint_id,document_id,bound_revision_sha256) VALUES (?,?,?)",
+            sprint_id,
+            sprint_bound,
+            "a" * 64,
+        )
+
+        refused = (
+            (frozen, target, "frozen"),
+            (ordinary, target, "only spec"),
+            (terminal_bound, terminal, "terminal"),
+            (sprint_bound, target, f"Sprint #{sprint_id}"),
+            (terminal_bound, source, "already belongs"),
+        )
+        for did, feature_id, message in refused:
+            with self.subTest(document_id=did, message=message):
+                with self.assertRaises(SystemExit) as caught:
+                    mem._api(
+                        "PATCH",
+                        f"/_sc/mem/docs/{did}/feature",
+                        {"feature_id": feature_id},
+                    )
+                self.assertIn("409", str(caught.exception))
+                self.assertIn(message, str(caught.exception))
+                self.assertEqual(
+                    self.q(
+                        "SELECT feature_id FROM documents WHERE document_id=?", did
+                    )[0],
+                    source,
+                )
+
+    def test_move_spec_to_feature_rolls_back_related_rows(self):
+        self.run_mem("roadmap", "add", "atomic move source")
+        self.run_mem("roadmap", "add", "atomic move target")
+        source = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='atomic move source'"
+        )[0]
+        target = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='atomic move target'"
+        )[0]
+        did = self.write(
+            "INSERT INTO documents (feature_id,kind,seq,title) "
+            "VALUES (?,'spec',1,'atomic move spec')",
+            source,
+        )
+        tid = self.write(
+            "INSERT INTO spec_tasks (feature_id,document_id,seq,title,shell_id) "
+            "VALUES (?,?,0,'Preparation',1)",
+            source,
+            did,
+        )
+        self.write(
+            "CREATE TRIGGER fail_atomic_spec_move "
+            "BEFORE UPDATE OF feature_id ON spec_tasks "
+            f"WHEN OLD.task_id={tid} BEGIN "
+            "SELECT RAISE(ABORT,'forced move failure'); END"
+        )
+        try:
+            with self.assertRaises(SystemExit) as caught:
+                mem._api(
+                    "PATCH",
+                    f"/_sc/mem/docs/{did}/feature",
+                    {"feature_id": target},
+                )
+            self.assertIn("409", str(caught.exception))
+            self.assertIn("forced move failure", str(caught.exception))
+            self.assertEqual(
+                self.q(
+                    "SELECT feature_id FROM documents WHERE document_id=?", did
+                )[0],
+                source,
+            )
+            self.assertEqual(
+                self.q("SELECT feature_id FROM spec_tasks WHERE task_id=?", tid)[0],
+                source,
+            )
+        finally:
+            self.write("DROP TRIGGER fail_atomic_spec_move")
+
+    def test_feature_move_guidance_is_seeded_for_shells(self):
+        for skill in ("db_map", "docs", "spec"):
+            with self.subTest(skill=skill):
+                content = self.q(
+                    "SELECT content FROM skills WHERE name=? AND is_deleted=0",
+                    skill,
+                )[0]
+                self.assertIn(
+                    "sc mem doc move <document_id> --feature <target_feature_id>",
+                    content,
+                )
+        docs = self.q("SELECT content FROM skills WHERE name='docs'")[0]
+        self.assertIn("Split an active era from feature history", docs)
+
     # ── doc write vs local save — ONE shared serialization boundary ───────────
     def test_doc_write_and_snapshot_share_one_lock(self):
         # Doc-write serialize and /api/snapshot both write the same non-atomic


### PR DESCRIPTION
## Summary

- add an atomic API operation and `sc mem doc move` CLI for moving one unfrozen active spec to another active feature
- preserve document, task, and decision identities while resequencing the spec in its target feature
- refuse frozen, ordinary-doc, terminal-target, same-feature, and Sprint-bound moves
- publish the feature-split workflow to db_map, docs, and spec skills through migration 0245

## Design trade-off

Feature creation and the old feature's title, summary, project, dependencies, and terminal status remain explicit existing roadmap operations. The move primitive handles only the relational migration; this keeps editorial policy out of the database API and makes the consequential row updates atomic.

## Verification

- 75 affected tests pass: test_mem, test_skills_freshness, test_migration_management
- Python compilation and git diff checks pass
- migration/render reconstruction applied all 188 migrations including 0245 successfully
- local render comparison then found the active generated mirror stale against the current source floor; this is runtime mirror state, not a migration failure
- repository lint/typecheck hooks remain red on established baseline findings; changed-line Ruff filtering is clean
