### PR TITLE
fix(update): unblock recovery and verification

### DIFF
--- a/.super-coder/adapters/codex/README.md
+++ b/.super-coder/adapters/codex/README.md
@@ -32,9 +32,12 @@ Codex reads project-local hooks from `<repo>/.codex/hooks.json`. The hook is a
 `PreToolUse` matcher on `^apply_patch$` (codex's file-edit tool) that runs the
 shared `.super-coder/scripts/branch-guard.sh` and denies the edit (exit 2) while a
 protected default branch is in play. `.codex/hooks.json` is emitted (gitignored)
-each launch. Codex only delivers the apply_patch *patch text* (`tool_input.command`),
-not a file path, so the guard uses its cwd-branch check (not the target-file check
-claude/opencode get).
+each launch. Codex delivers the apply_patch text in `tool_input.command`; the
+guard extracts Add/Update/Delete targets from its patch headers before applying
+the same target-file check used for other harnesses. Scratch-only patches under
+`/tmp`, `/var/tmp`, `/dev/shm`, or `$TMPDIR` remain available even when the cwd
+is a protected Admin checkout. A payload without a usable target falls back to
+the cwd-branch check.
 
 **Two things gate whether this hook actually enforces — both verified empirically:**
 

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -96,6 +96,8 @@ from quota_probes import dispatch as quota_dispatch  # noqa: E402  (account quot
 import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
 import ts as ts_mod  # noqa: E402  (tailnet — config + live checks)
 import pm2 as pm2_mod  # noqa: E402  (host pm2 stack — config + live checks)
+sys.path.insert(0, str(ENGINE / "render"))
+import flat as flat_render  # noqa: E402  (document render-path ownership)
 
 # Startup validates ``instance_state.active_database_path`` in ``main`` before
 # this recovery-safe target is opened by any route or daemon.
@@ -1553,6 +1555,33 @@ def patch_shell(con, shell_id, body):
                          SHELL_EDITABLE)
 
 
+def document_render_path_conflict(
+    con,
+    candidate: dict,
+    *,
+    exclude_document_id: int | None = None,
+) -> str | None:
+    """Return a stable ownership error when a populated document path collides."""
+    if not candidate.get("body"):
+        return None
+    candidate_path = Path(flat_render.document_rel_path(candidate))
+    rows = con.execute(
+        "SELECT document_id,feature_id,kind,seq,title,body,render_path "
+        "FROM documents WHERE body IS NOT NULL AND body != '' "
+        "ORDER BY document_id"
+    ).fetchall()
+    for row in rows:
+        if exclude_document_id is not None and row["document_id"] == exclude_document_id:
+            continue
+        if Path(flat_render.document_rel_path(row)) == candidate_path:
+            owner = candidate.get("document_id") or "new document"
+            return (
+                f"duplicate document render path {str(candidate_path)!r}: "
+                f"document IDs {row['document_id']} and {owner}"
+            )
+    return None
+
+
 def patch_document(
     con,
     doc_id,
@@ -1573,7 +1602,8 @@ def patch_document(
     try:
         with db_driver.write_transaction(con, "document.edit"):
             document = con.execute(
-                "SELECT feature_id,frozen,body FROM documents WHERE document_id=?",
+                "SELECT document_id,feature_id,kind,seq,title,body,render_path,frozen "
+                "FROM documents WHERE document_id=?",
                 (doc_id,),
             ).fetchone()
             if document is None:
@@ -1583,6 +1613,14 @@ def patch_document(
                     False,
                     "document is frozen — open the next spec, don't edit this one",
                 )
+
+            candidate = dict(document)
+            candidate.update({column: body[column] for column in cols})
+            conflict = document_render_path_conflict(
+                con, candidate, exclude_document_id=doc_id
+            )
+            if conflict is not None:
+                return False, conflict
 
             before_body = document["body"] or ""
             body_changed = "body" in body and body["body"] != document["body"]
@@ -1896,7 +1934,7 @@ _SCRIPTS = {
     "snapshot": ("Snapshot", f"Serialize the per-instance tables → {_ARTIFACT_DEST} "
                  "(deterministic, idempotent). Run after editing identity, roadmap, "
                  "docs, or flags so the change survives a rebuild.",
-                 [_PY, str(ENGINE / "scripts/snapshot.py")], False),
+                 [_PY, str(ENGINE / "scripts/snapshot.py"), "--runtime-owned"], False),
     "render": ("Render flat", "Regenerate the flat _sc files under the active artifact root "
                "(specs_sc / docs_sc / skills_sc / roadmap_sc.md) from the DB. Incremental.",
                [_PY, str(ENGINE / "scripts/render.py"), "flat"], False),
@@ -4173,23 +4211,49 @@ class Handler(BaseHTTPRequestHandler):
                 fid = body.get("feature_id")
                 fid = int(fid) if fid is not None else None
                 kind = body.get("kind") or "spec"
-                seq = body.get("seq")
-                if seq is None:  # next seq for this (feature, kind) — mirrors the old CLI
-                    seq = con.execute(
-                        "SELECT COALESCE(MAX(seq),0)+1 FROM documents "
-                        "WHERE feature_id IS ? AND kind=?", (fid, kind)).fetchone()[0]
-                cur = con.execute(
-                    "INSERT INTO documents (feature_id, kind, seq, title, body, render_path) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (fid,
-                     kind,
-                     seq,
-                     (body.get("title") or "").strip() or None,
-                     body.get("body") or None,
-                     body.get("render_path") or None))
-                con.commit()
-                return self._send(201, {"document_id": cur.lastrowid,
-                                        "serialize": serialize_doc_write()})
+                conflict_error = None
+                document_id = None
+                with db_driver.write_transaction(con, "document.add"):
+                    seq = body.get("seq")
+                    if seq is None:
+                        seq = con.execute(
+                            "SELECT COALESCE(MAX(seq),0)+1 FROM documents "
+                            "WHERE feature_id IS ? AND kind=?",
+                            (fid, kind),
+                        ).fetchone()[0]
+                    candidate = {
+                        "document_id": None,
+                        "feature_id": fid,
+                        "kind": kind,
+                        "seq": seq,
+                        "title": (body.get("title") or "").strip() or None,
+                        "body": body.get("body") or None,
+                        "render_path": body.get("render_path") or None,
+                    }
+                    conflict = document_render_path_conflict(con, candidate)
+                    if conflict is not None:
+                        conflict_error = conflict
+                    else:
+                        cur = con.execute(
+                            "INSERT INTO documents "
+                            "(feature_id, kind, seq, title, body, render_path) "
+                            "VALUES (?, ?, ?, ?, ?, ?)",
+                            (
+                                fid,
+                                kind,
+                                seq,
+                                candidate["title"],
+                                candidate["body"],
+                                candidate["render_path"],
+                            ),
+                        )
+                        document_id = cur.lastrowid
+                if conflict_error is not None:
+                    return self._send(409, {"error": conflict_error})
+                return self._send(201, {
+                    "document_id": document_id,
+                    "serialize": serialize_doc_write(),
+                })
 
             if path == "/_sc/mem/narrative":
                 text = (body.get("text") or "").strip()
@@ -4909,7 +4973,12 @@ class Handler(BaseHTTPRequestHandler):
                     }
                 })
             if path.startswith("/api/scripts/"):
-                r = run_script(path.rsplit("/", 1)[1])
+                script_key = path.rsplit("/", 1)[1]
+                if script_key == "snapshot":
+                    with _CONTENT_WRITE_LOCK, artifact_policy.content_write_lock():
+                        r = run_script(script_key)
+                else:
+                    r = run_script(script_key)
                 if r is None:
                     return self._send(404, {"error": "no such script"})
                 return self._send(200 if r["ok"] else 500, r)

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -110,11 +110,25 @@ def _render_documents(con, written, skipped, root: Path) -> None:
     are removed so both managed directories remain exact DB projections.
     """
     rows = con.execute(
-        "SELECT d.feature_id, d.kind, d.seq, d.title, d.body, d.render_path, "
+        "SELECT d.document_id, d.feature_id, d.kind, d.seq, d.title, d.body, d.render_path, "
         "d.frozen, r.roadmap_status, r.title AS feature_title FROM documents d "
         "LEFT JOIN roadmap r ON r.feature_id = d.feature_id "
         "ORDER BY d.feature_id, d.kind, d.seq"
     ).fetchall()
+    owners: dict[Path, tuple[int, str]] = {}
+    for row in rows:
+        if not row["body"]:
+            continue
+        rel = document_rel_path(row)
+        target = _document_target(root, rel, row["kind"])
+        previous = owners.get(target)
+        if previous is not None:
+            raise ValueError(
+                f"duplicate document render path {rel!r}: "
+                f"document IDs {previous[0]} and {row['document_id']}"
+            )
+        owners[target] = (row["document_id"], rel)
+
     expected: set[Path] = set()
     for r in rows:
         if not r["body"]:

--- a/.super-coder/scripts/branch-guard.sh
+++ b/.super-coder/scripts/branch-guard.sh
@@ -16,15 +16,14 @@
 # commit and prints it.
 #
 # TWO checks, in order of authority:
-#   1. TARGET FILE (claude + opencode) — the edited path arrives as $1 (opencode
-#      plugin) or in claude's PreToolUse JSON on stdin. We resolve the branch of
+#   1. TARGET FILE (claude + opencode + codex) — the edited path arrives as $1
+#      (opencode), a structured claude field, or codex apply_patch text. We resolve the branch of
 #      the repo that OWNS that file and block if it is protected. This catches the
 #      foot-gun a cwd-only check misses: a worktree shell editing files in the
 #      stale main checkout (a DIFFERENT repo dir on `main`) — the cwd is a clean
 #      feature branch, so the old cwd check waved it through. If the target is
 #      outside the shell's own worktree but NOT on a protected branch, we ALLOW
-#      but emit a loud warning (claude additionalContext + stderr). codex's
-#      apply_patch hook supplies no usable target → it uses Check 2 only.
+#      but emit a loud warning (claude additionalContext + stderr).
 #   2. CWD (all consumers, and the fallback when there is no target) — the
 #      original behavior: block if HEAD of the cwd's repo is a protected branch.
 #
@@ -102,18 +101,34 @@ feature_branch_hint() {
 #   1. an explicit $1 arg — the opencode plugin extracts the path from the tool
 #      args and passes it here (it has the path structured; nothing to pipe).
 #   2. a PreToolUse JSON payload on stdin — claude pipes tool_input.file_path /
-#      notebook_path. (codex's apply_patch hook pipes no usable target, so it
-#      falls through to the cwd check — see the codex adapter README.)
+#      notebook_path; codex pipes the patch text in tool_input.command.
 #   3. neither → empty → fall through to the cwd check (Check 2).
 target="${1:-}"
 if [ -z "$target" ]; then
   payload="$(cat 2>/dev/null || true)"
   if [ -n "$payload" ] && command -v python3 >/dev/null 2>&1; then
     target="$(printf '%s' "$payload" | python3 -c '
-import sys, json
+import os, re, sys, json
 try:
     ti = (json.load(sys.stdin).get("tool_input") or {})
-    print(ti.get("file_path") or ti.get("notebook_path") or "")
+    direct = ti.get("file_path") or ti.get("notebook_path")
+    if direct:
+        print(direct)
+    else:
+        paths = re.findall(
+            r"^\*\*\* (?:Add|Update|Delete) File: (.+)$",
+            ti.get("command") or "",
+            re.MULTILINE,
+        )
+        scratch = ["/tmp/", "/var/tmp/", "/dev/shm/"]
+        tmpdir = os.environ.get("TMPDIR", "").rstrip("/")
+        if tmpdir:
+            scratch.append(tmpdir + "/")
+        non_scratch = [
+            path for path in paths
+            if not any(path.startswith(root) for root in scratch)
+        ]
+        print((non_scratch or paths or [""])[0])
 except Exception:
     print("")
 ' 2>/dev/null || echo "")"
@@ -126,8 +141,7 @@ fi
 # files, and without this such a write falls through to the cwd-branch check
 # (Check 2) and is blocked whenever the shell's cwd happens to sit on a protected
 # branch — a pure false positive. Exempt the standard scratch roots up front.
-# Only applies when we HAVE a resolved target: a no-target call (codex
-# apply_patch) carries no path and still uses the cwd check.
+# Only applies when we HAVE a resolved target.
 if [ -n "$target" ]; then
   case "$target" in
     /tmp/* | /var/tmp/* | /dev/shm/* ) exit 0 ;;
@@ -144,7 +158,7 @@ fi
 # worktree — host-level shared folders used for handoffs, screenshots, drafts.
 # Set SC_SHARED_DIRS to a space-separated list of absolute paths in the launch
 # environment; run.py passes it through unchanged. Only applies when we have a
-# resolved target (no-target callers like codex apply_patch still use Check 2).
+# resolved target.
 if [ -n "$target" ] && [ -n "${SC_SHARED_DIRS:-}" ]; then
   abs_target="$(realpath -m "$target" 2>/dev/null || echo "$target")"
   for _sd in $SC_SHARED_DIRS; do

--- a/.super-coder/scripts/engine_sql.py
+++ b/.super-coder/scripts/engine_sql.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import NoReturn
 
 import instance_state
+import mem
 
 ENGINE = Path(__file__).resolve().parents[1]
 ERROR_CODE = "admin_only_engine_state"
@@ -61,7 +62,10 @@ def _admin_token() -> str:
         return token
 
     if not token:
-        refuse()
+        mem._PROG = "sc sql"
+        if not mem._discover_runtime_credential():
+            refuse()
+        token = mem.SC_API_TOKEN
     return token
 
 

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -1123,6 +1123,11 @@ def authenticate(con, interactive: bool = True):
     return row
 
 
+def interactive_authentication(*, headless: bool, render_only: bool) -> bool:
+    """Whether this launch may ask for user credentials."""
+    return not headless and not render_only
+
+
 # ── Shell selection ─────────────────────────────────────────────────────────
 
 def list_shells(con, user_id: int) -> list:
@@ -2149,7 +2154,13 @@ def main() -> None:
                 pass
             heal_note = None
 
-    user = authenticate(con, interactive=not headless)
+    user = authenticate(
+        con,
+        interactive=interactive_authentication(
+            headless=headless,
+            render_only=bool(os.environ.get("RENDER_ONLY")),
+        ),
+    )
     fdefaults = flavor_defaults(con)
     # Liveness snapshot for the interactive picker: one /proc pass (ms) so the
     # boot list can show shell status — BROWSER / Busy / Orphaned /

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -22,13 +22,19 @@ Usage:
 """
 from __future__ import annotations
 
+import json
+import os
 import sqlite3  # kept for map.db (which stays SQLite)
+import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import artifact_policy
 import db_driver
 import instance_state
 import map_db
+import ports
 import seed_skills
 import state_relocation
 from _serialize_guard import require_admin
@@ -586,8 +592,80 @@ def _main_under_lease() -> int:
     return 0
 
 
-def main(*, lease_held: bool = False) -> int:
+def _main_runtime_owned() -> int:
+    """Serialize a coherent read view while the healthy API owns the runtime."""
+    copied = artifact_policy.prepare_local_state()
+    if copied:
+        print(f"snapshot: localized {len(copied)} existing artifact(s)")
+    if not DB_PATH.exists():
+        raise SystemExit(f"snapshot: no live DB at {DB_PATH} — run `./sc rebuild` first.")
+    con = db_driver.connect(DB_PATH)
+    try:
+        persist_instance(con)
+    finally:
+        con.close()
+    try:
+        displayed = OUT_PATH.relative_to(REPO_ROOT)
+    except ValueError:
+        displayed = OUT_PATH
+    print(f"snapshot: wrote {displayed}")
+    snapshot_map()
+    return 0
+
+
+def _snapshot_via_runtime_api() -> str | None:
+    """Ask a healthy runtime to serialize; return None only when it is absent."""
+    base = os.environ.get("SC_API_BASE", "").rstrip("/")
+    if not base:
+        port = ports.resolve(persist=False).get("port")
+        if not isinstance(port, int):
+            return None
+        base = f"http://127.0.0.1:{port}"
+    request = urllib.request.Request(
+        base + "/api/scripts/snapshot", data=b"", method="POST"
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=185) as response:
+            raw_payload = response.read()
+    except urllib.error.HTTPError as exc:
+        try:
+            payload = json.loads(exc.read())
+            detail = payload.get("output") or payload.get("error") or str(exc)
+        except (ValueError, AttributeError):
+            detail = str(exc)
+        raise SystemExit(f"snapshot: runtime-owned serialization failed: {detail}") from exc
+    except urllib.error.URLError as exc:
+        if isinstance(exc.reason, ConnectionRefusedError):
+            return None
+        raise SystemExit(
+            f"snapshot: runtime API request failed: {exc.reason}"
+        ) from exc
+    except ConnectionRefusedError:
+        return None
+    except OSError as exc:
+        raise SystemExit(f"snapshot: runtime API request failed: {exc}") from exc
+    try:
+        payload = json.loads(raw_payload)
+    except (ValueError, TypeError) as exc:
+        raise SystemExit("snapshot: runtime API returned an invalid response") from exc
+    if not payload.get("ok"):
+        raise SystemExit(
+            "snapshot: runtime-owned serialization failed: "
+            + str(payload.get("output") or "unknown API failure")
+        )
+    return str(payload.get("output") or "snapshot: runtime-owned serialization complete")
+
+
+def main(*, lease_held: bool = False, runtime_owned: bool = False) -> int:
     instance_state.active_database_path(ENGINE)
+    require_admin("snapshot")
+    if runtime_owned:
+        return _main_runtime_owned()
+    if not lease_held:
+        runtime_output = _snapshot_via_runtime_api()
+        if runtime_output is not None:
+            print(runtime_output)
+            return 0
     state = instance_state.maintenance_state(ENGINE)
     if lease_held:
         state_relocation.refuse_live_database_owners(DB_PATH)
@@ -600,4 +678,11 @@ def main(*, lease_held: bool = False) -> int:
 if __name__ == "__main__":
     from cli_entry import run_cli
 
-    raise SystemExit(run_cli(main))
+    def cli_main(argv: list[str]) -> int:
+        if argv == ["--runtime-owned"]:
+            return main(runtime_owned=True)
+        if argv:
+            raise SystemExit("usage: snapshot.py")
+        return main()
+
+    raise SystemExit(run_cli(cli_main, sys.argv[1:]))

--- a/.super-coder/scripts/state_relocation.py
+++ b/.super-coder/scripts/state_relocation.py
@@ -467,8 +467,6 @@ def relocate_legacy_state(
         if receipt is not None and receipt["status"] == "private":
             if not resolved.database.exists():
                 raise RelocationError("relocation receipt exists but private DB is missing")
-            if database_fingerprint(resolved.database) != receipt.get("database"):
-                raise RelocationError("private database conflicts with relocation receipt")
             if legacy.exists():
                 if database_fingerprint(legacy) != receipt.get("database"):
                     raise RelocationError("conflicting complete legacy and private databases")

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import ast
 import importlib
 import importlib.util
+import json
 import os
 import re
 import shutil
@@ -1180,10 +1181,26 @@ def start_docker_review_server(service: tuple[str, str] | None) -> None:
         [docker, "start", container], capture_output=True, text=True, check=False
     )
     if started.returncode != 0:
-        sys.exit(
-            f"update: DB maintenance succeeded but Docker runtime {container} "
-            "could not start:\n" + (started.stderr or started.stdout).strip()
+        detail = (started.stderr or started.stdout).strip()
+        if "no such" not in detail.lower():
+            sys.exit(
+                f"update: DB maintenance succeeded but Docker runtime {container} "
+                f"could not start:\n{detail}"
+            )
+        recreated = subprocess.run(
+            [str(REPO_ROOT / "sc"), "launch", "--no-build"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
         )
+        if recreated.returncode != 0:
+            recreate_detail = (recreated.stderr or recreated.stdout).strip()
+            sys.exit(
+                f"update: DB maintenance succeeded but absent Docker runtime "
+                f"{container} could not be recreated:\n{recreate_detail}"
+            )
+        print(f"→ recreated Docker runtime {container} after DB maintenance")
     ready = subprocess.run(
         [docker, "inspect", "-f", "{{.State.Running}}", container],
         capture_output=True,
@@ -1195,6 +1212,70 @@ def start_docker_review_server(service: tuple[str, str] | None) -> None:
             f"update: Docker runtime {container} did not become ready after start"
         )
     print(f"→ started Docker runtime {container} after DB maintenance")
+
+
+def _runtime_intent_path(state: instance_state.InstanceState) -> Path:
+    return state.root / "update-runtime-intent.json"
+
+
+def _load_runtime_intent(state: instance_state.InstanceState) -> set[str]:
+    path = _runtime_intent_path(state)
+    if not path.exists() and not path.is_symlink():
+        return set()
+    try:
+        instance_state._lstat_owned_regular(
+            path, "update runtime intent", os.geteuid()
+        )
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError, instance_state.InstanceStateError) as exc:
+        raise state_relocation.RelocationError(
+            f"update runtime intent is unreadable: {exc}"
+        ) from exc
+    if payload.get("version") != 1 or not isinstance(payload.get("runtimes"), list):
+        raise state_relocation.RelocationError("update runtime intent is invalid")
+    runtimes = set(payload["runtimes"])
+    if not runtimes.issubset({"docker", "pm2"}):
+        raise state_relocation.RelocationError("update runtime intent is invalid")
+    return runtimes
+
+
+def _write_runtime_intent(
+    state: instance_state.InstanceState, runtimes: set[str]
+) -> None:
+    if not runtimes:
+        return
+    path = _runtime_intent_path(state)
+    instance_state._atomic_write_json(
+        path,
+        {"version": 1, "runtimes": sorted(runtimes)},
+        os.geteuid(),
+        label="update runtime intent",
+    )
+
+
+def _clear_runtime_intent(state: instance_state.InstanceState) -> None:
+    _runtime_intent_path(state).unlink(missing_ok=True)
+
+
+def _service_targets_from_intent(
+    runtimes: set[str],
+    pm2_service: tuple[str, str] | None,
+    docker_service: tuple[str, str] | None,
+) -> tuple[tuple[str, str] | None, tuple[str, str] | None]:
+    if pm2_service is None and "pm2" in runtimes:
+        pm2_bin = shutil.which("pm2")
+        if pm2_bin is None:
+            raise SystemExit("update: retained PM2 relaunch intent but pm2 is unavailable")
+        process = f"sc-{ports.resolve(persist=False).get('repo', REPO_ROOT.name)}"
+        pm2_service = (pm2_bin, process)
+    if docker_service is None and "docker" in runtimes:
+        docker = shutil.which("docker")
+        if docker is None:
+            raise SystemExit(
+                "update: retained Docker relaunch intent but docker is unavailable"
+            )
+        docker_service = (docker, f"sc-{REPO_ROOT.name}")
+    return pm2_service, docker_service
 
 
 def require_restarted_runtime_health() -> None:
@@ -1268,11 +1349,24 @@ def restart_review_servers(
 
 def migrate_with_service_cutover(*, backup: bool = True, reconcile=None) -> None:
     """Run all update reconciliation under one stopped-runtime lease."""
+    state = instance_state.resolve(instance_config=ENGINE / "instance.json")
+    try:
+        runtime_intent = _load_runtime_intent(state)
+    except state_relocation.RelocationError as exc:
+        sys.exit(
+            "update: runtime relaunch intent refused before shutdown: "
+            f"{exc}\n  inspect: ./sc health\n  recover: ./sc rollback"
+        )
     docker_service = stop_docker_review_server()
+    if docker_service is not None:
+        runtime_intent.add("docker")
+        _write_runtime_intent(state, runtime_intent)
     service = stop_pm2_review_server()
+    if service is not None:
+        runtime_intent.add("pm2")
+        _write_runtime_intent(state, runtime_intent)
     legacy_was_present = instance_state.legacy_database_path(ENGINE).exists()
     try:
-        state = instance_state.resolve(instance_config=ENGINE / "instance.json")
         with state_relocation.exclusive_maintenance(state, command="update"):
             relocation = state_relocation.relocate_legacy_state(
                 ENGINE,
@@ -1308,7 +1402,11 @@ def migrate_with_service_cutover(*, backup: bool = True, reconcile=None) -> None
     # Deliberately not in finally: a failed destructive migration must leave
     # the old server stopped instead of restarting code against a changed or
     # incompatible floor.
+    service, docker_service = _service_targets_from_intent(
+        runtime_intent, service, docker_service
+    )
     restart_review_servers(service, docker_service)
+    _clear_runtime_intent(state)
 
 
 def sync_skills() -> None:

--- a/tests/test_branch_guard.py
+++ b/tests/test_branch_guard.py
@@ -64,6 +64,15 @@ class BranchGuardTest(unittest.TestCase):
                               cwd=self.repo, env=env, capture_output=True,
                               check=False)
 
+    def guard_codex_patch(self, patch: str) -> subprocess.CompletedProcess:
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("SC_SHELL_FLAVOR", "SC_SHARED_DIRS", "TMPDIR",
+                            "SC_PROTECTED_BRANCHES", "SC_SHELL_WORKTREE")}
+        payload = json.dumps({"tool_input": {"command": patch}})
+        return subprocess.run(["bash", str(GUARD)], input=payload, text=True,
+                              cwd=self.repo, env=env, capture_output=True,
+                              check=False)
+
     def pre_commit(self, **markers: str) -> subprocess.CompletedProcess:
         """Run the universal commit backstop with an explicit caller context."""
         env = {
@@ -84,6 +93,22 @@ class BranchGuardTest(unittest.TestCase):
 
     def test_tracked_area_target_blocked_on_protected_branch(self):
         r = self.guard(str(self.repo / "src" / "new_module.py"))
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("protected branch 'main'", r.stderr)
+
+    def test_codex_tmp_patch_allowed_on_protected_branch(self):
+        r = self.guard_codex_patch(
+            "*** Begin Patch\n*** Add File: /tmp/recovery.py\n+repair\n*** End Patch"
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_codex_mixed_patch_still_blocks_repository_target(self):
+        r = self.guard_codex_patch(
+            "*** Begin Patch\n"
+            "*** Add File: /tmp/recovery.py\n+repair\n"
+            f"*** Add File: {self.repo / 'src' / 'change.py'}\n+change\n"
+            "*** End Patch"
+        )
         self.assertEqual(r.returncode, 2)
         self.assertIn("protected branch 'main'", r.stderr)
 

--- a/tests/test_engine_sql.py
+++ b/tests/test_engine_sql.py
@@ -1,6 +1,7 @@
 """Authorization contract for Admin-only general engine SQL."""
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import sys
@@ -54,6 +55,52 @@ class EngineSqlTest(unittest.TestCase):
              mock.patch.object(engine_sql.shutil, "which", return_value="/bin/sqlite3"), \
              mock.patch.object(engine_sql.subprocess, "run", return_value=completed) as run:
             self.assertEqual(engine_sql.main(["read-only", "SELECT 1;"]), 0)
+        self.assertEqual(
+            run.call_args.args[0],
+            ["/bin/sqlite3", "-readonly", str(self.db), "SELECT 1;"],
+        )
+
+    def test_api_down_host_admin_discovers_owner_only_runtime_credential(self):
+        credential_dir = Path(self.tmp.name) / "credentials"
+        credential_dir.mkdir()
+        artifact = credential_dir / "admin.json"
+        artifact.write_text(json.dumps({
+            "shell_id": 1,
+            "shortname": "admin",
+            "api_base": "http://127.0.0.1:1",
+            "token": "admin-token",
+        }))
+        artifact.chmod(0o600)
+        completed = mock.Mock(returncode=0)
+        saved = (
+            engine_sql.mem._CRED_DIR,
+            engine_sql.mem.SC_API_TOKEN,
+            engine_sql.mem.SC_API_BASE,
+            engine_sql.mem._DISCOVERED_FROM,
+        )
+        self.addCleanup(
+            setattr, engine_sql.mem, "_CRED_DIR", saved[0]
+        )
+        self.addCleanup(
+            setattr, engine_sql.mem, "SC_API_TOKEN", saved[1]
+        )
+        self.addCleanup(
+            setattr, engine_sql.mem, "SC_API_BASE", saved[2]
+        )
+        self.addCleanup(
+            setattr, engine_sql.mem, "_DISCOVERED_FROM", saved[3]
+        )
+        engine_sql.mem._CRED_DIR = credential_dir
+        engine_sql.mem.SC_API_TOKEN = ""
+        engine_sql.mem.SC_API_BASE = ""
+        engine_sql.mem._DISCOVERED_FROM = None
+
+        with mock.patch.dict(os.environ, {}, clear=True), self._path(), \
+             mock.patch.object(engine_sql, "_api_flavor", return_value=None), \
+             mock.patch.object(engine_sql.shutil, "which", return_value="/bin/sqlite3"), \
+             mock.patch.object(engine_sql.subprocess, "run", return_value=completed) as run:
+            self.assertEqual(engine_sql.main(["read-only", "SELECT 1;"]), 0)
+
         self.assertEqual(
             run.call_args.args[0],
             ["/bin/sqlite3", "-readonly", str(self.db), "SELECT 1;"],

--- a/tests/test_flat_render.py
+++ b/tests/test_flat_render.py
@@ -23,6 +23,7 @@ CREATE TABLE roadmap (
     roadmap_status TEXT
 );
 CREATE TABLE documents (
+    document_id INTEGER PRIMARY KEY,
     feature_id INTEGER,
     kind TEXT,
     seq INTEGER,
@@ -45,7 +46,7 @@ class FlatDocumentReconciliationTest(unittest.TestCase):
             con.execute("INSERT INTO roadmap VALUES (7, 'Gateway', 'next')")
             con.execute(
                 "INSERT INTO documents VALUES "
-                "(7, 'spec', 1, 'Gateway', 'Current body', "
+                "(11, 7, 'spec', 1, 'Gateway', 'Current body', "
                 "'specs_sc/current.md', 0)"
             )
             current = root / "specs_sc" / "current.md"
@@ -107,6 +108,40 @@ class FlatDocumentReconciliationTest(unittest.TestCase):
             self.assertFalse(stale_spec.exists())
             self.assertFalse(stale_doc.exists())
             self.assertEqual("keep.md\n", outside.read_text())
+
+    def test_duplicate_document_targets_fail_before_any_write(self):
+        with tempfile.TemporaryDirectory() as td, closing(
+            sqlite3.connect(":memory:")
+        ) as con:
+            root = Path(td)
+            con.row_factory = sqlite3.Row
+            con.executescript(SCHEMA)
+            con.execute("INSERT INTO roadmap VALUES (7, 'Gateway', 'next')")
+            con.execute(
+                "INSERT INTO documents VALUES "
+                "(11, 7, 'spec', 1, 'First', 'First body', "
+                "'specs_sc/shared.md', 0)"
+            )
+            con.execute(
+                "INSERT INTO documents VALUES "
+                "(12, 7, 'spec', 2, 'Second', 'Second body', "
+                "'specs_sc//shared.md', 0)"
+            )
+            target = root / "specs_sc" / "shared.md"
+            target.parent.mkdir()
+            target.write_text("preserved\n")
+            written: list[Path] = []
+            skipped: list[Path] = []
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "duplicate document render path.*document IDs 11 and 12",
+            ):
+                flat._render_documents(con, written, skipped, root)
+
+            self.assertEqual(target.read_text(), "preserved\n")
+            self.assertEqual(written, [])
+            self.assertEqual(skipped, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -1258,6 +1258,101 @@ class ApiMemTest(unittest.TestCase):
         self.assertEqual(self.q("SELECT render_path FROM documents "
                                 "WHERE document_id=?", did)[0], "docs_sc/pathless.md")
 
+    def test_doc_add_rejects_duplicate_render_path(self):
+        body = self.tmp / "duplicate-add.md"
+        body.write_text("# duplicate\n")
+        self.run_mem("roadmap", "add", "duplicate add feature")
+        feature_id = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='duplicate add feature'"
+        )[0]
+        self.assertEqual(
+            self.run_mem(
+                "doc", "add", "render owner", "--kind", "doc",
+                "--body-file", str(body), "--render-path", "docs_sc/owned.md",
+                "--feature", str(feature_id),
+            ),
+            0,
+        )
+        with self.assertRaises(SystemExit) as caught:
+            self.run_mem(
+                "doc", "add", "render intruder", "--kind", "doc",
+                "--body-file", str(body), "--render-path", "docs_sc//owned.md",
+                "--feature", str(feature_id),
+            )
+        self.assertIn("document IDs", str(caught.exception))
+        self.assertIsNone(
+            self.q("SELECT document_id FROM documents WHERE title='render intruder'")
+        )
+
+    def test_doc_edit_rejects_derived_render_path_collision(self):
+        body = self.tmp / "duplicate-edit.md"
+        body.write_text("# duplicate\n")
+        self.run_mem("roadmap", "add", "duplicate edit feature")
+        feature_id = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='duplicate edit feature'"
+        )[0]
+        self.run_mem(
+            "doc", "add", "derived owner", "--kind", "doc",
+            "--body-file", str(body), "--feature", str(feature_id),
+        )
+        self.run_mem(
+            "doc", "add", "derived candidate", "--kind", "doc",
+            "--body-file", str(body), "--feature", str(feature_id),
+        )
+        candidate = self.q(
+            "SELECT document_id FROM documents WHERE title='derived candidate'"
+        )[0]
+
+        with self.assertRaises(SystemExit) as caught:
+            self.run_mem("doc", "edit", str(candidate), "--title", "derived owner")
+
+        self.assertIn("document IDs", str(caught.exception))
+        self.assertEqual(
+            self.q("SELECT title FROM documents WHERE document_id=?", candidate)[0],
+            "derived candidate",
+        )
+
+    def test_concurrent_doc_adds_cannot_claim_one_render_path(self):
+        self.run_mem("roadmap", "add", "concurrent render owners")
+        feature_id = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='concurrent render owners'"
+        )[0]
+        barrier = threading.Barrier(2)
+        outcomes = []
+
+        def add(title):
+            barrier.wait()
+            try:
+                mem._api("POST", "/_sc/mem/docs", {
+                    "feature_id": feature_id,
+                    "kind": "doc",
+                    "title": title,
+                    "body": "# concurrent\n",
+                    "render_path": "docs_sc/concurrent-owner.md",
+                })
+                outcomes.append("created")
+            except SystemExit as exc:
+                outcomes.append(str(exc))
+
+        threads = [
+            threading.Thread(target=add, args=("concurrent owner A",)),
+            threading.Thread(target=add, args=("concurrent owner B",)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(10)
+
+        self.assertEqual(sum(outcome == "created" for outcome in outcomes), 1)
+        self.assertTrue(any("409" in outcome for outcome in outcomes))
+        self.assertEqual(
+            self.q(
+                "SELECT COUNT(*) FROM documents WHERE render_path=?",
+                "docs_sc/concurrent-owner.md",
+            )[0],
+            1,
+        )
+
     # ── decision guard: a bare sibling verb is a guess, not a decision (#311) ─
     def test_decision_bare_verb_guarded(self):
         before = self.q("SELECT COUNT(*) FROM shell_decisions")[0]

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -63,6 +63,18 @@ INSERT INTO lock_probe (probe_id, value) VALUES (1, 0);
 """
 
 
+class RenderOnlyAuthenticationTest(unittest.TestCase):
+    def test_render_only_is_noninteractive_even_with_a_tty(self) -> None:
+        self.assertFalse(
+            run.interactive_authentication(headless=False, render_only=True)
+        )
+
+    def test_normal_terminal_boot_remains_interactive(self) -> None:
+        self.assertTrue(
+            run.interactive_authentication(headless=False, render_only=False)
+        )
+
+
 class FlavorRouteDefaultsTest(unittest.TestCase):
     def test_loader_projects_nullable_per_harness_effort(self) -> None:
         con = sqlite3.connect(":memory:")

--- a/tests/test_snapshot_live_runtime.py
+++ b/tests/test_snapshot_live_runtime.py
@@ -1,0 +1,82 @@
+"""Healthy-runtime and offline-maintenance snapshot routing."""
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+
+import snapshot  # noqa: E402
+import server  # noqa: E402
+
+
+class SnapshotLiveRuntimeTest(unittest.TestCase):
+    def test_healthy_runtime_routes_before_requesting_maintenance(self) -> None:
+        with mock.patch.dict(os.environ, {"SC_ADMIN": "1"}, clear=False), \
+             mock.patch.object(snapshot.instance_state, "active_database_path"), \
+             mock.patch.object(
+                 snapshot, "_snapshot_via_runtime_api", return_value="snapshot: wrote live"
+             ), mock.patch.object(
+                 snapshot.state_relocation,
+                 "exclusive_maintenance",
+                 side_effect=AssertionError("healthy runtime must not be stopped"),
+             ), contextlib.redirect_stdout(io.StringIO()) as output:
+            self.assertEqual(snapshot.main(), 0)
+
+        self.assertIn("snapshot: wrote live", output.getvalue())
+
+    def test_api_absence_retains_offline_exclusive_maintenance(self) -> None:
+        state = mock.Mock()
+        with mock.patch.dict(os.environ, {"SC_ADMIN": "1"}, clear=False), \
+             mock.patch.object(snapshot.instance_state, "active_database_path"), \
+             mock.patch.object(snapshot, "_snapshot_via_runtime_api", return_value=None), \
+             mock.patch.object(
+                 snapshot.instance_state, "maintenance_state", return_value=state
+             ), mock.patch.object(
+                 snapshot.state_relocation,
+                 "exclusive_maintenance",
+                 return_value=contextlib.nullcontext(),
+             ) as lease, mock.patch.object(
+                 snapshot.state_relocation, "refuse_live_database_owners"
+             ), mock.patch.object(snapshot, "_main_under_lease", return_value=0):
+            self.assertEqual(snapshot.main(), 0)
+
+        lease.assert_called_once_with(state, command="snapshot")
+
+    def test_runtime_owned_mode_is_read_only_and_never_requests_a_lease(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            database = Path(raw) / "engine.db"
+            database.touch()
+            connection = mock.Mock()
+            with mock.patch.dict(os.environ, {"SC_ADMIN": "1"}, clear=False), \
+                 mock.patch.object(snapshot, "DB_PATH", database), \
+                 mock.patch.object(snapshot.instance_state, "active_database_path"), \
+                 mock.patch.object(snapshot.artifact_policy, "prepare_local_state", return_value=[]), \
+                 mock.patch.object(snapshot.db_driver, "connect", return_value=connection), \
+                 mock.patch.object(snapshot, "persist_instance") as persist, \
+                 mock.patch.object(snapshot, "snapshot_map"), \
+                 mock.patch.object(
+                     snapshot.state_relocation,
+                     "exclusive_maintenance",
+                     side_effect=AssertionError("runtime-owned snapshot requested a lease"),
+                 ), contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(snapshot.main(runtime_owned=True), 0)
+
+        persist.assert_called_once_with(connection)
+        connection.close.assert_called_once_with()
+
+    def test_api_snapshot_subprocess_uses_runtime_owned_mode(self) -> None:
+        self.assertEqual(server._SCRIPTS["snapshot"][2][-1], "--runtime-owned")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_state_relocation.py
+++ b/tests/test_state_relocation.py
@@ -133,6 +133,28 @@ class StateRelocationTests(RelocationFixture):
         )
         self.assertEqual(len(list(self.state.backups.glob("shell_db.preupdate.*.db"))), 1)
 
+    def test_private_receipt_allows_normal_database_writes_before_next_update(self):
+        self.create_database()
+        self.relocate()
+        connection = sqlite3.connect(self.state.database)
+        try:
+            connection.execute("UPDATE payload SET value='advanced'")
+            connection.commit()
+        finally:
+            connection.close()
+
+        result = self.relocate()
+
+        self.assertTrue(result.relocated)
+        connection = sqlite3.connect(self.state.database)
+        try:
+            self.assertEqual(
+                connection.execute("SELECT value FROM payload").fetchone()[0],
+                "advanced",
+            )
+        finally:
+            connection.close()
+
     def test_pre_publication_failure_leaves_legacy_authoritative(self):
         self.create_database()
         with self.assertRaisesRegex(

--- a/tests/test_update_service_cutover.py
+++ b/tests/test_update_service_cutover.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import os
 import sqlite3
 import sys
@@ -22,6 +23,16 @@ class Stop(Exception):
 
 
 class UpdateServiceCutoverTest(unittest.TestCase):
+    def setUp(self):
+        self.intent_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.intent_temp.cleanup)
+        self.intent_path = Path(self.intent_temp.name) / "update-runtime-intent.json"
+        patcher = mock.patch.object(
+            update, "_runtime_intent_path", return_value=self.intent_path
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_in_process_snapshot_uses_scoped_update_admin_authority(self):
         observed_admin = []
 
@@ -136,6 +147,98 @@ class UpdateServiceCutoverTest(unittest.TestCase):
 
     def test_docker_only_runtime_stops_when_final_health_fails(self):
         self.assert_restart_failure_stops_all(pm2=False, docker=True)
+
+    def test_failed_update_retains_docker_relaunch_intent(self):
+        state = mock.Mock()
+        with mock.patch.object(
+            update.instance_state, "resolve", return_value=state
+        ), mock.patch.object(
+            update, "stop_docker_review_server", return_value=("docker", "sc-example")
+        ), mock.patch.object(
+            update, "stop_pm2_review_server", return_value=None
+        ), mock.patch.object(
+            update.state_relocation,
+            "exclusive_maintenance",
+            side_effect=update.state_relocation.MaintenanceBusy("busy"),
+        ), self.assertRaisesRegex(SystemExit, "runtime remains stopped"):
+            update.migrate_with_service_cutover()
+
+        self.assertEqual(
+            json.loads(self.intent_path.read_text()),
+            {"runtimes": ["docker"], "version": 1},
+        )
+
+    def test_invalid_runtime_intent_refuses_before_shutdown(self):
+        self.intent_path.write_text("not json\n")
+        state = mock.Mock()
+        with mock.patch.object(
+            update.instance_state, "resolve", return_value=state
+        ), mock.patch.object(
+            update, "stop_docker_review_server"
+        ) as docker_stop, mock.patch.object(
+            update, "stop_pm2_review_server"
+        ) as pm2_stop, self.assertRaisesRegex(
+            SystemExit, "runtime relaunch intent refused before shutdown"
+        ):
+            update.migrate_with_service_cutover()
+
+        docker_stop.assert_not_called()
+        pm2_stop.assert_not_called()
+
+    def test_retry_rehydrates_absent_docker_and_clears_intent_after_health(self):
+        self.intent_path.write_text(
+            json.dumps({"version": 1, "runtimes": ["docker"]})
+        )
+        state = mock.Mock()
+        with mock.patch.object(
+            update.instance_state, "resolve", return_value=state
+        ), mock.patch.object(
+            update, "stop_docker_review_server", return_value=None
+        ), mock.patch.object(
+            update, "stop_pm2_review_server", return_value=None
+        ), mock.patch.object(
+            update.shutil, "which", side_effect=lambda name: f"/bin/{name}"
+        ), mock.patch.object(
+            update.state_relocation,
+            "exclusive_maintenance",
+            return_value=contextlib.nullcontext(),
+        ), mock.patch.object(
+            update.state_relocation,
+            "relocate_legacy_state",
+            return_value=mock.Mock(database=update.DB_PATH),
+        ), mock.patch.object(
+            update.instance_state, "active_database_path", return_value=update.DB_PATH
+        ), mock.patch.object(update, "bind_cutover_state"), mock.patch.object(
+            update, "migrate_or_rebuild"
+        ), mock.patch.object(update, "start_pm2_review_server") as pm2_start, \
+             mock.patch.object(update, "start_docker_review_server") as docker_start, \
+             mock.patch.object(update, "require_restarted_runtime_health") as health:
+            update.migrate_with_service_cutover()
+
+        pm2_start.assert_called_once_with(None)
+        docker_start.assert_called_once_with(("/bin/docker", f"sc-{update.REPO_ROOT.name}"))
+        health.assert_called_once_with()
+        self.assertFalse(self.intent_path.exists())
+
+    def test_absent_docker_container_is_recreated_through_normal_launch(self):
+        completed = [
+            mock.Mock(returncode=1, stdout="", stderr="No such container"),
+            mock.Mock(returncode=0, stdout="launched", stderr=""),
+            mock.Mock(returncode=0, stdout="true\n", stderr=""),
+        ]
+        with mock.patch.object(
+            update.subprocess, "run", side_effect=completed
+        ) as run, contextlib.redirect_stdout(io.StringIO()):
+            update.start_docker_review_server(("/bin/docker", "sc-example"))
+
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [
+                ["/bin/docker", "start", "sc-example"],
+                [str(update.REPO_ROOT / "sc"), "launch", "--no-build"],
+                ["/bin/docker", "inspect", "-f", "{{.State.Running}}", "sc-example"],
+            ],
+        )
 
     def test_shutdown_failure_is_named_instead_of_claiming_stopped(self):
         service = ("/usr/bin/pm2", "sc-example")

--- a/tests/test_verify_clean_clone.py
+++ b/tests/test_verify_clean_clone.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import pty
 import shutil
 import subprocess
 import tempfile
@@ -57,14 +58,34 @@ class VerifyCleanCloneTest(unittest.TestCase):
             )
             env = os.environ.copy()
             env.pop("SC_ARTIFACT_MODE", None)
-            result = subprocess.run(
-                ["./sc", "verify"], cwd=checkout, env=env,
-                capture_output=True, text=True,
-            )
+            master, slave = pty.openpty()
+            try:
+                process = subprocess.Popen(
+                    ["./sc", "verify"],
+                    cwd=checkout,
+                    env=env,
+                    stdin=slave,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                os.close(slave)
+                slave = -1
+                try:
+                    stdout, stderr = process.communicate(timeout=120)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.communicate()
+                    raise
+            finally:
+                if slave >= 0:
+                    os.close(slave)
+                os.close(master)
             self.assertEqual(
-                result.returncode, 0,
-                f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}",
+                process.returncode, 0,
+                f"stdout:\n{stdout}\n\nstderr:\n{stderr}",
             )
+            self.assertNotIn("Username:", stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- retain managed runtime relaunch intent across failed update retries and recreate an absent Docker runtime through the normal launch path
- treat a private relocation receipt as one-time publication proof while preserving conflict checks for legacy copies
- restore API-down host Admin SQL through the owner-only runtime credential artifact
- extract Codex apply_patch targets so scratch recovery artifacts are allowed without weakening repository branch guards
- make RENDER_ONLY authentication noninteractive on a TTY
- reject normalized duplicate document render targets before writes and at concurrent add/edit authoring boundaries
- serialize snapshots through a healthy API-owned coherent read transaction while retaining offline exclusive maintenance

## Verification

- 163 affected tests green, including pseudo-TTY verify and concurrent document ownership
- targeted Ruff undefined-name checks green
- Python compilation green
- `git diff --check` green
- repository-wide `sc lint` and `sc typecheck` are pre-existing red/untrustworthy gates tracked in #1466 and #1467

Closes #1457
Closes #1458
Closes #1459
Closes #1460
Closes #1462
Closes #1463
Closes #1464