### PR TITLE
fix(update): isolate managed skill rendering

### DIFF
--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -270,6 +270,21 @@ def _render_skills_catalogue(con, written, skipped, root: Path) -> None:
                       with_banner("\n".join(index).rstrip()), written, skipped)
 
 
+def render_skills_catalogue(
+    con: sqlite3.Connection, root: Path | None = None
+) -> dict:
+    """Render only the managed ``skills_sc`` catalogue.
+
+    Update reconciliation uses this narrow surface so an unrelated document or
+    roadmap render error cannot prevent native skill projections from converging.
+    """
+    root = root or artifact_policy.render_root()
+    written: list[Path] = []
+    skipped: list[Path] = []
+    _render_skills_catalogue(con, written, skipped, root)
+    return {"written": written, "skipped": skipped}
+
+
 def render_visibility(con: sqlite3.Connection, root: "Path | None" = None) -> dict:
     """Render flat `_sc` visibility files under the active artifact root.
 

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -1486,7 +1486,7 @@ def regrant() -> int:
 
 
 def reconcile_skill_projections() -> dict:
-    """Sweep existing checkouts and the active catalogue render after DB sync."""
+    """Sweep existing checkouts and the managed skill catalogue after DB sync."""
     con = db_driver.connect(DB_PATH)
     try:
         try:
@@ -1495,7 +1495,7 @@ def reconcile_skill_projections() -> dict:
             sys.exit(skill_projection.partial_failure_message(
                 "update catalogue reconciliation", exc
             ))
-        catalogue = flat.render_visibility(con)
+        catalogue = flat.render_skills_catalogue(con)
     finally:
         con.close()
     summary["written"].extend(catalogue["written"])

--- a/tests/test_skill_convergence_release_gate.py
+++ b/tests/test_skill_convergence_release_gate.py
@@ -153,7 +153,7 @@ class SkillConvergenceReleaseGateTest(unittest.TestCase):
     @contextmanager
     def patched_update(self, fixture, projection_runs, catalogue_runs):
         real_projection = skill_projection.reconcile_existing_checkouts
-        real_catalogue = update.flat.render_visibility
+        real_catalogue = update.flat.render_skills_catalogue
 
         def reconcile(con):
             summary = real_projection(con, repo_root=fixture.root)
@@ -216,7 +216,7 @@ class SkillConvergenceReleaseGateTest(unittest.TestCase):
             )
             stack.enter_context(
                 mock.patch.object(
-                    update.flat, "render_visibility", side_effect=render_catalogue
+                    update.flat, "render_skills_catalogue", side_effect=render_catalogue
                 )
             )
             yield

--- a/tests/test_update_legacy_compat.py
+++ b/tests/test_update_legacy_compat.py
@@ -317,6 +317,15 @@ class LegacyUpdateCompatTest(unittest.TestCase):
             fixture = build_dirty_skill_fork(Path(td) / "downstream")
             with closing(sqlite3.connect(fixture.database)) as con:
                 update.seed_skills.reconcile_tombstoned_skills(con)
+                con.executemany(
+                    "INSERT INTO documents "
+                    "(feature_id,kind,seq,title,body,render_path) "
+                    "VALUES (NULL,'doc',?,?,?,?)",
+                    (
+                        (9001, "Legacy owner", "owner", "docs_sc/shared.md"),
+                        (9002, "Legacy duplicate", "duplicate", "docs_sc//shared.md"),
+                    ),
+                )
                 con.commit()
 
             shell_authored = (
@@ -326,7 +335,7 @@ class LegacyUpdateCompatTest(unittest.TestCase):
             shell_authored.parent.mkdir()
             shell_authored.write_text("shell-owned\n")
             real_projection = update.skill_projection.reconcile_existing_checkouts
-            real_catalogue = update.flat.render_visibility
+            real_catalogue = update.flat.render_skills_catalogue
 
             def reconcile(con):
                 return real_projection(con, repo_root=fixture.root)
@@ -348,7 +357,7 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 "reconcile_existing_checkouts",
                 side_effect=reconcile,
             ) as projection, mock.patch.object(
-                update.flat, "render_visibility", side_effect=render_catalogue
+                update.flat, "render_skills_catalogue", side_effect=render_catalogue
             ), mock.patch.object(
                 update, "repair_callable_dispatcher"
             ), mock.patch.object(
@@ -371,6 +380,9 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 (fixture.root / ".sc-state/engine.ref").read_text(),
             )
             self.assertEqual(shell_authored.read_text(), "shell-owned\n")
+            self.assertFalse(
+                fixture.catalogue_root.parent.joinpath("docs_sc/shared.md").exists()
+            )
             self.assertEqual(
                 {
                     str(path.relative_to(fixture.root)): path.read_bytes()


### PR DESCRIPTION
## Outcome

Unblocks downstream updates whose legacy document rows share a canonical render path. The update compatibility sweep now renders only native skill projections and the managed `skills_sc` catalogue; it no longer invokes unrelated document or roadmap rendering.

Strict duplicate-path validation remains unchanged for full flat renders and new/edit document writes. No legacy document data is mutated or silently selected.

Closes #1469.

## Verification

- `./sc test tests/test_update_legacy_compat.py tests/test_skill_convergence_release_gate.py tests/test_flat_render.py tests/test_update_materialize.py tests/test_update_service_cutover.py` — 71 passed
- `git diff --check` — passed
- `./sc lint ...` — unavailable as a clean gate due unchanged baseline failures; tracked in #1470
- `./sc typecheck ...` — unavailable as a clean gate due 88 unchanged dependency errors; tracked in #1471