### PR TITLE
fix(update): report noncritical inconsistencies

### DIFF
--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -100,6 +100,33 @@ def document_rel_path(row) -> str:
     return f"{base}/{slug}.md"
 
 
+def document_render_issues(con: sqlite3.Connection) -> list[str]:
+    """Return document projection inconsistencies without writing anything."""
+    rows = con.execute(
+        "SELECT document_id,feature_id,kind,seq,title,body,render_path "
+        "FROM documents WHERE body IS NOT NULL AND body != '' "
+        "ORDER BY feature_id,kind,seq,document_id"
+    ).fetchall()
+    owners: dict[Path, int] = {}
+    issues: list[str] = []
+    for row in rows:
+        rel = document_rel_path(row)
+        try:
+            target = _document_target(Path(), rel, row["kind"])
+        except ValueError as exc:
+            issues.append(f"document ID {row['document_id']}: {exc}")
+            continue
+        previous = owners.get(target)
+        if previous is not None:
+            issues.append(
+                f"duplicate document render path {rel!r}: "
+                f"document IDs {previous} and {row['document_id']}"
+            )
+            continue
+        owners[target] = row["document_id"]
+    return issues
+
+
 # ── Flat visibility render ────────────────────────────────────────────────────
 
 def _render_documents(con, written, skipped, root: Path) -> None:
@@ -115,19 +142,9 @@ def _render_documents(con, written, skipped, root: Path) -> None:
         "LEFT JOIN roadmap r ON r.feature_id = d.feature_id "
         "ORDER BY d.feature_id, d.kind, d.seq"
     ).fetchall()
-    owners: dict[Path, tuple[int, str]] = {}
-    for row in rows:
-        if not row["body"]:
-            continue
-        rel = document_rel_path(row)
-        target = _document_target(root, rel, row["kind"])
-        previous = owners.get(target)
-        if previous is not None:
-            raise ValueError(
-                f"duplicate document render path {rel!r}: "
-                f"document IDs {previous[0]} and {row['document_id']}"
-            )
-        owners[target] = (row["document_id"], rel)
+    issues = document_render_issues(con)
+    if issues:
+        raise ValueError(issues[0])
 
     expected: set[Path] = set()
     for r in rows:

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -101,6 +101,38 @@ EJECTED_MARKER = STATE_DIR / "ejected"
 # this export remains the warned fallback and the stable name callers know.
 ENGINE_PATHS = engine_manifest.ENGINE_PATHS
 
+_UPDATE_ADVISORIES: list[tuple[str, str, str]] = []
+
+
+def reset_update_report() -> None:
+    _UPDATE_ADVISORIES.clear()
+
+
+def record_update_advisory(area: str, detail: str, action: str) -> None:
+    entry = (
+        area,
+        " ".join(str(detail).split()),
+        " ".join(str(action).split()),
+    )
+    if entry in _UPDATE_ADVISORIES:
+        return
+    _UPDATE_ADVISORIES.append(entry)
+    print(f"! update advisory [{entry[0]}]: {entry[1]}")
+    print(f"  follow-up: {entry[2]}")
+
+
+def render_update_report(*, only_if_any: bool = False) -> int:
+    if only_if_any and not _UPDATE_ADVISORIES:
+        return 0
+    print("\nupdate report:")
+    if not _UPDATE_ADVISORIES:
+        print("  no follow-ups detected")
+        return 0
+    for index, (area, detail, action) in enumerate(_UPDATE_ADVISORIES, 1):
+        print(f"  {index}. [{area}] {detail}")
+        print(f"     follow-up: {action}")
+    return len(_UPDATE_ADVISORIES)
+
 _VISUAL_QA_MARKER_RE = re.compile(
     r"^# managed-by: subfloor — visual-qa shim v(?P<version>\d+)$"
 )
@@ -725,22 +757,55 @@ def sync_repo_checkout() -> None:
     an operator updating one commit behind, and the warning is what the silent
     version lacked. `--no-fetch` skips this step outright.
     """
+    status = git("status", "--short", check=False)
+    if status.returncode != 0:
+        record_update_advisory(
+            "checkout",
+            "Git could not inspect the working tree before update",
+            "run `git status` and reconcile the checkout after update",
+        )
+    elif status.stdout.strip():
+        count = len(status.stdout.splitlines())
+        record_update_advisory(
+            "checkout",
+            f"working tree contains {count} local change(s); update preserved them",
+            "review `git status --short` and commit, stash, or discard each change",
+        )
+
     branch = git("rev-parse", "--abbrev-ref", "HEAD", check=False).stdout.strip()
     if not branch or branch == "HEAD":
+        record_update_advisory(
+            "checkout",
+            "detached HEAD prevented checkout fast-forward",
+            "attach the checkout to its intended branch and reconcile its upstream",
+        )
         print("→ engine sync: detached HEAD — skipped (no branch to fast-forward)")
         return
     upstream = git("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}",
                    check=False)
     tracking = upstream.stdout.strip()
     if upstream.returncode != 0 or not tracking:
+        record_update_advisory(
+            "checkout",
+            f"branch {branch!r} has no upstream and was not fast-forwarded",
+            "set or inspect the branch upstream after update",
+        )
         print(f"→ engine sync: '{branch}' tracks no upstream — skipped")
         return
     before = git("rev-parse", "HEAD", check=False).stdout.strip()
     pull = git("pull", "--ff-only", check=False)
     if pull.returncode != 0:
+        detail = pull.stderr.strip().splitlines()[-1] if pull.stderr.strip() else ""
+        record_update_advisory(
+            "checkout",
+            f"fast-forward failed for {branch} -> {tracking}: "
+            f"{detail or 'Git refused the pull'}",
+            "reconcile the checkout by hand; the engine update continued "
+            "from the current tree",
+        )
         print(f"! engine sync: `git pull --ff-only` failed for "
               f"{branch} → {tracking}.")
-        print(f"  {pull.stderr.strip().splitlines()[-1] if pull.stderr.strip() else ''}")
+        print(f"  {detail}")
         print(f"  Updating anyway from the CURRENT tree — update never merges, "
               f"rebases or resets. Reconcile {REPO_ROOT} by hand for the newer floor.")
         return
@@ -1487,19 +1552,61 @@ def regrant() -> int:
 
 def reconcile_skill_projections() -> dict:
     """Sweep existing checkouts and the managed skill catalogue after DB sync."""
+    summary: dict = {
+        "written": [],
+        "skipped": [],
+        "deleted": [],
+        "checkouts": [],
+        "complete": True,
+        "render_issues": [],
+    }
     con = db_driver.connect(DB_PATH)
     try:
         try:
             summary = skill_projection.reconcile_existing_checkouts(con)
         except skill_projection.ProjectionError as exc:
-            sys.exit(skill_projection.partial_failure_message(
-                "update catalogue reconciliation", exc
-            ))
-        catalogue = flat.render_skills_catalogue(con)
+            summary["complete"] = False
+            record_update_advisory(
+                "skill projection",
+                skill_projection.partial_failure_message(
+                    "update catalogue reconciliation", exc
+                ),
+                "fix the named path, then run `./sc update --no-fetch`",
+            )
+        else:
+            summary["complete"] = True
+        try:
+            catalogue = flat.render_skills_catalogue(con)
+        except Exception as exc:  # noqa: BLE001 - projection is advisory
+            summary["complete"] = False
+            record_update_advisory(
+                "skill catalogue",
+                f"{type(exc).__name__}: {exc}",
+                "resolve the named projection issue, then run `./sc update --no-fetch`",
+            )
+        else:
+            summary["written"].extend(catalogue["written"])
+            summary["skipped"].extend(catalogue["skipped"])
+        try:
+            render_issues = flat.document_render_issues(con)
+        except Exception as exc:  # noqa: BLE001 - diagnostic is advisory
+            record_update_advisory(
+                "document render check",
+                "could not inspect document render consistency: "
+                f"{type(exc).__name__}: {exc}",
+                "inspect the document catalogue and run `./sc render flat` as FnB",
+            )
+        else:
+            summary["render_issues"] = render_issues
+            for issue in render_issues:
+                record_update_advisory(
+                    "document render",
+                    issue,
+                    "resolve document path ownership, then run `./sc render flat` "
+                    "as FnB",
+                )
     finally:
         con.close()
-    summary["written"].extend(catalogue["written"])
-    summary["skipped"].extend(catalogue["skipped"])
     return summary
 
 
@@ -1557,10 +1664,17 @@ def reconcile_under_cutover(
         f"{len(projections['skipped'])} unchanged across "
         f"{len(projections['checkouts'])} existing checkout(s)"
     )
-    print(
-        "  note: DB and disk are current; already-running harness sessions may "
-        "retain previously loaded skill text until reboot"
-    )
+    if not projections.get("complete", True):
+        print("  continued with projection follow-up(s); see update report")
+        print(
+            "  note: DB changes are current; incomplete disk projections remain "
+            "visible in the report"
+        )
+    else:
+        print(
+            "  note: DB and disk are current; already-running harness sessions may "
+            "retain previously loaded skill text until reboot"
+        )
     print("→ wire map automation + map the repo")
     run_script("map_setup.py", update_target_ref=target_sha)
     print("→ snapshot the live state")
@@ -1590,6 +1704,7 @@ def reconcile_under_cutover(
 
 
 def main(argv: list[str]) -> int:
+    reset_update_report()
     run_update_compat()
     no_fetch = "--no-fetch" in argv
     force = "--force" in argv
@@ -1708,6 +1823,7 @@ def main(argv: list[str]) -> int:
     )
 
     print("\nupdate: done — new floor laid in place; your rows are intact.")
+    render_update_report()
     if source:
         # Source repo tracks the engine itself — no fork repin PR; just commit
         # the reconciled tree on a branch as usual.

--- a/.super-coder/scripts/update_compat.py
+++ b/.super-coder/scripts/update_compat.py
@@ -106,6 +106,10 @@ def main() -> int:
         # while their tracked bootstrap still routes to a retired script.
         import update
 
+        reset_report = getattr(update, "reset_update_report", None)
+        if reset_report is not None:
+            reset_report()
+
         update.repair_callable_dispatcher(current)
         # A current updater publishes only after migrate + snapshot. Defer its
         # linked-worktree overlays until then so a crash cannot leave bytes that
@@ -118,9 +122,18 @@ def main() -> int:
                 "→ update compatibility: reconcile managed skill projections "
                 f"at {current[:12]}"
             )
-            update.reconcile_skill_projections()
-            SKILL_SWEEP_MARKER.parent.mkdir(parents=True, exist_ok=True)
-            SKILL_SWEEP_MARKER.write_text(f"{current}\n")
+            summary = update.reconcile_skill_projections() or {}
+            if summary.get("complete", True):
+                SKILL_SWEEP_MARKER.parent.mkdir(parents=True, exist_ok=True)
+                SKILL_SWEEP_MARKER.write_text(f"{current}\n")
+            else:
+                print(
+                    "  compatibility skill sweep incomplete; marker retained "
+                    "for retry"
+                )
+        render_report = getattr(update, "render_update_report", None)
+        if render_report is not None:
+            render_report(only_if_any=True)
 
     needed, current = needs_legacy_bridge()
     if not needed:

--- a/tests/test_flat_render.py
+++ b/tests/test_flat_render.py
@@ -139,6 +139,15 @@ class FlatDocumentReconciliationTest(unittest.TestCase):
             ):
                 flat._render_documents(con, written, skipped, root)
 
+            self.assertEqual(
+                flat.document_render_issues(con),
+                [
+                    (
+                        "duplicate document render path 'specs_sc//shared.md': "
+                        "document IDs 11 and 12"
+                    )
+                ],
+            )
             self.assertEqual(target.read_text(), "preserved\n")
             self.assertEqual(written, [])
             self.assertEqual(skipped, [])

--- a/tests/test_skill_convergence_release_gate.py
+++ b/tests/test_skill_convergence_release_gate.py
@@ -267,19 +267,13 @@ class SkillConvergenceReleaseGateTest(unittest.TestCase):
             )
         return projected, catalogued
 
-    def test_update_failure_is_loud_then_two_retries_converge_to_noop(self) -> None:
+    def test_update_advises_then_two_retries_converge_to_noop(self) -> None:
         fixture = self.build_fixture("update-fork")
         projection_runs = []
         catalogue_runs = []
         with self.patched_update(fixture, projection_runs, catalogue_runs):
             with self.blocked_projection_root(fixture) as (parked, sentinel):
-                with self.assertRaisesRegex(
-                    SystemExit,
-                    "update catalogue reconciliation committed in the DB, but "
-                    "skill projection failed: managed skill root is a symlink.*"
-                    "run `./sc update --no-fetch`.*retry exact cleanup",
-                ):
-                    update.main(["--no-fetch"])
+                self.assertEqual(update.main(["--no-fetch"]), 0)
                 self.assertEqual(sentinel.read_bytes(), b"outside projection control\n")
                 self.assertTrue(parked.joinpath(TOMBSTONE_SKILLS[0]).is_dir())
                 self.assertEqual(

--- a/tests/test_update_legacy_compat.py
+++ b/tests/test_update_legacy_compat.py
@@ -58,6 +58,39 @@ def commit(root: Path, message: str) -> str:
 
 
 class LegacyUpdateCompatTest(unittest.TestCase):
+    def test_projection_and_render_inconsistencies_are_advisory(self) -> None:
+        connection = sqlite3.connect(":memory:")
+        output = io.StringIO()
+        with mock.patch.object(
+            update.db_driver, "connect", return_value=connection
+        ), mock.patch.object(
+            update.skill_projection,
+            "reconcile_existing_checkouts",
+            side_effect=update.skill_projection.ProjectionError("unsafe skill root"),
+        ), mock.patch.object(
+            update.flat,
+            "render_skills_catalogue",
+            side_effect=ValueError("catalogue collision"),
+        ), mock.patch.object(
+            update.flat,
+            "document_render_issues",
+            return_value=["duplicate document path: IDs 1 and 2"],
+        ), contextlib.redirect_stdout(output):
+            update.reset_update_report()
+            summary = update.reconcile_skill_projections()
+            update.render_update_report()
+
+        self.assertFalse(summary["complete"])
+        self.assertEqual(
+            summary["render_issues"],
+            ["duplicate document path: IDs 1 and 2"],
+        )
+        rendered = output.getvalue()
+        self.assertIn("[skill projection]", rendered)
+        self.assertIn("[skill catalogue]", rendered)
+        self.assertIn("[document render]", rendered)
+        self.assertIn("update report:", rendered)
+
     def test_installed_repo_reconciles_managed_host_wrapper(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td) / "fork"
@@ -364,7 +397,7 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 update, "reconcile_linked_dispatchers"
             ), mock.patch.object(
                 update_compat, "needs_legacy_bridge", return_value=(False, None)
-            ):
+            ), contextlib.redirect_stdout(io.StringIO()) as output:
                 self.assertEqual(0, update_compat.main())
                 first_projection = {
                     str(path.relative_to(fixture.root)): path.read_bytes()
@@ -380,6 +413,8 @@ class LegacyUpdateCompatTest(unittest.TestCase):
                 (fixture.root / ".sc-state/engine.ref").read_text(),
             )
             self.assertEqual(shell_authored.read_text(), "shell-owned\n")
+            self.assertIn("[document render]", output.getvalue())
+            self.assertIn("duplicate document render path", output.getvalue())
             self.assertFalse(
                 fixture.catalogue_root.parent.joinpath("docs_sc/shared.md").exists()
             )

--- a/tests/test_update_source_sync.py
+++ b/tests/test_update_source_sync.py
@@ -50,9 +50,11 @@ class SourceSyncCase(unittest.TestCase):
     def sync(self) -> str:
         """Run the sync against the fixture checkout, returning its output."""
         buf = io.StringIO()
+        update.reset_update_report()
         with mock.patch.object(update, "REPO_ROOT", self.work), \
                 contextlib.redirect_stdout(buf):
             update.sync_repo_checkout()
+            update.render_update_report()
         return buf.getvalue()
 
     def fall_behind(self, n: int = 1) -> str:
@@ -124,6 +126,8 @@ class SourceSyncCase(unittest.TestCase):
         self.assertTrue((self.work / "scratch.txt").exists(),
                         "the operator's file was discarded")
         self.assertIn("fast-forwarded", out)
+        self.assertIn("working tree contains 1 local change(s)", out)
+        self.assertIn("review `git status --short`", out)
 
     def test_overlapping_uncommitted_work_warns_without_blocking(self):
         """Git refuses an unsafe pull; update keeps its recovery path open."""
@@ -136,6 +140,7 @@ class SourceSyncCase(unittest.TestCase):
         self.assertEqual((self.work / "a.txt").read_text(), "operator edit\n")
         self.assertIn("git pull --ff-only", out)
         self.assertIn("Updating anyway", out)
+        self.assertIn("update report:", out)
 
     def test_diverged_warns_without_merging_resetting_or_blocking(self):
         tip = self.fall_behind()


### PR DESCRIPTION
## Outcome

Makes update completion resilient to non-critical checkout and projection inconsistencies while preserving hard integrity gates.

- dirty, detached, untracked, or non-fast-forwardable checkouts remain untouched and become actionable update-report entries
- skill projection/catalogue failures warn, retain their compatibility retry marker, and no longer abort safe migration/publication
- document render paths are checked read-only during update; collisions are reported for FnB follow-up without rendering or mutating documents
- a final update report summarizes every follow-up, or explicitly reports a clean run
- unsafe engine overwrite, migration/state integrity, publication, and runtime-health failures remain fatal
- the compatibility bridge capability-detects the reporting surface so legacy updater fixtures remain supported

This addresses the repeated stale-floor adoption failure reported in #1469. Updating from #1472 to this commit uses #1472’s narrow skill renderer in the already-running parent, then the freshly materialized compatibility process reports the legacy document collision without aborting.

Closes #1469.

## Verification

- 91 update/render/skill-convergence tests passed
- `./sc render-check` passed
- `git diff --check` passed
- added-line length/style subset passed
- `./sc lint ...` remains unavailable on unchanged baseline findings (#1470)
- `./sc typecheck ...` remains unavailable on 88 unchanged dependency errors (#1471); no findings point to added lines
- `./sc verify` blocked before candidate construction by private owner-metadata permissions (#1473)