### PR TITLE
fix(skills): restore Planner fork-local skill lane via API fallback

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -78,6 +78,7 @@ import sprint_review_loop  # noqa: E402  (Sprints v2 Dev/Review command surface)
 import sprint_runtime  # noqa: E402  (Sprint dispatch + engine wake delivery)
 import sprint_board  # noqa: E402  (read-only Sprints v2 FnB board projections)
 import skill_projection  # noqa: E402  (exact bounded grant mirrors)
+import skill as skill_mod  # noqa: E402  (planner-owned fork-local catalogue)
 sys.path.insert(0, str(ENGINE / "api"))
 import conversation_routes  # noqa: E402  (Feature #24 browser conversations)
 import review_routes  # noqa: E402  (Feature #26 browser Diff review)
@@ -511,6 +512,141 @@ def get_cli_skills(con) -> dict:
     for skill in skills:
         skill["grant_scopes"] = scopes.get(skill["skill_id"], [])
     return {"skills": skills}
+
+
+# ===========================================================================
+# Authenticated Planner-owned fork-local skill mutations (`sc skill` API lane)
+# ===========================================================================
+#
+# Launched shells (Planner included) run under the restricted execution view
+# (spec execution_view), which masks the engine private-state root, the legacy
+# engine DB, and the snapshot/render files. `sc skill put|grant|revoke|rm`
+# therefore cannot open the DB from the shell seat; only the API (running
+# unrestrained on the host) can. These routes mirror the local CLI mutations:
+# they reuse skill.py's validation + persistence ladder and are planner-only —
+# the same check the CLI enforces via ``require_planner`` for local writes.
+# Retire/unretire stay Admin-only: they edit the fork-tracked retire manifest
+# and deliberately require a tracked file write on the host.
+
+
+class SkillApiError(ValueError):
+    """Client-visible skill mutation failure with a stable HTTP status."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def _resolve_planner_shell(con, shell_id: int) -> dict:
+    """Reject non-planner shell tokens before any mutation.
+
+    Mirrors ``skill.require_planner`` for the API lane: the authenticated
+    bearer must resolve to an active shell whose flavor is exactly ``planner``.
+    Returns the shell row for downstream messaging; raises SkillApiError on miss.
+    """
+    row = con.execute(
+        "SELECT shell_id, shortname, display_name, flavor FROM shells "
+        "WHERE shell_id=? AND COALESCE(is_deleted,0)=0",
+        (shell_id,),
+    ).fetchone()
+    if row is None:
+        raise SkillApiError(401, "invalid or unknown token")
+    if dict(row).get("flavor") != "planner":
+        label = row["shortname"] or row["display_name"] or row["shell_id"]
+        raise SkillApiError(
+            403,
+            f"skill mutations are Planner-owned; shell {label} has "
+            f"flavor {row['flavor'] or 'bespoke'}",
+        )
+    return dict(row)
+
+
+def _skills_mutation_report(fn, *args, **kwargs):
+    """Unwrap skill.py's CLI-exit failures into structured HTTP errors.
+
+    The local CLI exits via ``sys.exit`` on every validation/conflict failure;
+    on the API lane we convert SystemExit strings, DraftValidationError, and
+    SkillConflictError into 400/404/409 responses so the shell's ``mem._api``
+    surfaces them as actionable CLI messages instead of a bare HTTP 500.
+    """
+    try:
+        return 200, fn(*args, **kwargs)
+    except skill_mod.DraftValidationError as exc:
+        return 400, {"error": str(exc)}
+    except skill_mod.SkillConflictError as exc:
+        return 409, {"error": str(exc)}
+    except SystemExit as exc:
+        message = str(exc.code) if exc.code is not None else "skill mutation refused"
+        # Strip the CLI's `sc skill: ` envelope so the client prints its own.
+        prefix = "sc skill: "
+        if message.startswith(prefix):
+            message = message[len(prefix):]
+        return 400, {"error": message}
+
+
+def api_skill_put(con, content: object) -> tuple[int, dict]:
+    """Create/update one fork-local skill from a JSON ``content`` payload."""
+    if not isinstance(content, str) or not content.strip():
+        raise SkillApiError(400, "content must be the skill's SKILL.md body text")
+    if len(content.encode("utf-8")) > skill_mod.MAX_SKILL_FILE_BYTES:
+        raise SkillApiError(
+            400,
+            f"content is {len(content.encode('utf-8'))} bytes; "
+            f"maximum is {skill_mod.MAX_SKILL_FILE_BYTES} bytes",
+        )
+    spec = skill_mod.parse_local_skill_spec(content)
+    verb = skill_mod._put_spec(con, spec)
+    return {"ok": True, "action": "put", "name": spec["name"], "verb": verb}
+
+
+def api_skill_grant(con, name: object, shells: object) -> tuple[int, dict]:
+    """Grant one skill to every named shell ref via its pack/owner row."""
+    if not isinstance(name, str) or not name.strip():
+        raise SkillApiError(400, "name must be a skill name")
+    if not isinstance(shells, list) or not all(isinstance(s, str) for s in shells):
+        raise SkillApiError(400, "shells must be a list of shell names/ids")
+    rows = skill_mod._grant_spec(con, name.strip(), [s.strip() for s in shells if s.strip()])
+    return {
+        "ok": True,
+        "action": "grant",
+        "name": name.strip(),
+        "results": [
+            {"scope": scope, "changed": changed, "shell": ref}
+            for scope, changed, ref in rows
+        ],
+    }
+
+
+def api_skill_revoke(con, name: object, shells: object) -> tuple[int, dict]:
+    """Revoke one skill from every named shell ref."""
+    if not isinstance(name, str) or not name.strip():
+        raise SkillApiError(400, "name must be a skill name")
+    if not isinstance(shells, list) or not all(isinstance(s, str) for s in shells):
+        raise SkillApiError(400, "shells must be a list of shell names/ids")
+    rows = skill_mod._revoke_spec(con, name.strip(), [s.strip() for s in shells if s.strip()])
+    return {
+        "ok": True,
+        "action": "revoke",
+        "name": name.strip(),
+        "results": [
+            {"scope": scope, "changed": changed, "shell": ref}
+            for scope, changed, ref in rows
+        ],
+    }
+
+
+def api_skill_rm(con, name: object) -> tuple[int, dict]:
+    """Soft-delete one fork-local skill and revoke all grants."""
+    if not isinstance(name, str) or not name.strip():
+        raise SkillApiError(400, "name must be a skill name")
+    n, already = skill_mod._rm_spec(con, name.strip())
+    return {
+        "ok": True,
+        "action": "rm",
+        "name": name.strip(),
+        "revoked_grants": n,
+        "already_removed": already,
+    }
 
 
 def get_model_routes(con, *, harness: str | None = None,
@@ -4010,6 +4146,74 @@ class Handler(BaseHTTPRequestHandler):
         finally:
             con.close()
 
+    # -- authenticated Planner skill catalogue mutations (`sc skill` API lane) --
+
+    def _skills_mutation_post(self, path: str, body: dict):
+        """Route POST /_sc/skills/<action> for a launched Planner shell.
+
+        Planner-only; every local CLI rule is enforced server-side via the
+        shared skill module so the restricted shell seat reaches the same
+        catalogue state that a host Admin sees.
+        """
+        sid = self._require_shell_auth()
+        if sid is None:
+            return
+        con = db()
+        try:
+            try:
+                _resolve_planner_shell(con, sid)
+            except SkillApiError as exc:
+                return self._send(exc.status, {"error": str(exc)})
+            if path == "/_sc/skills/put":
+                status, result = _skills_mutation_report(
+                    api_skill_put, con, body.get("content"))
+                return self._send(status, result)
+            if path == "/_sc/skills/grant":
+                status, result = _skills_mutation_report(
+                    api_skill_grant, con, body.get("name"), body.get("shells"))
+                return self._send(status, result)
+            if path == "/_sc/skills/revoke":
+                status, result = _skills_mutation_report(
+                    api_skill_revoke, con, body.get("name"), body.get("shells"))
+                return self._send(status, result)
+            if path == "/_sc/skills/rm":
+                status, result = _skills_mutation_report(
+                    api_skill_rm, con, body.get("name"))
+                return self._send(status, result)
+            return self._send(404, {"error": "not found"})
+        except Exception as e:
+            return self._fail(e)
+        finally:
+            con.close()
+
+    def _skills_mutation_assign(self, body: dict):
+        """PUT /_sc/skills/assign — grant {name, shell} or revoke {name, shell, granted:false}."""
+        sid = self._require_shell_auth()
+        if sid is None:
+            return
+        con = db()
+        try:
+            try:
+                _resolve_planner_shell(con, sid)
+            except SkillApiError as exc:
+                return self._send(exc.status, {"error": str(exc)})
+            name = body.get("name")
+            shell = body.get("shell") if body.get("shell") is not None else body.get("shells")
+            granted = bool(body.get("granted", True))
+            if shell is None:
+                return self._send(400, {"error": "shell (or shells) is required"})
+            if isinstance(shell, list):
+                fn = api_skill_grant if granted else api_skill_revoke
+                status, result = _skills_mutation_report(fn, con, name, shell)
+                return self._send(status, result)
+            fn = api_skill_grant if granted else api_skill_revoke
+            status, result = _skills_mutation_report(fn, con, name, [shell])
+            return self._send(status, result)
+        except Exception as e:
+            return self._fail(e)
+        finally:
+            con.close()
+
     def _mem_post(self, path: str, body: dict):
         sid = self._require_shell_auth()
         if sid is None:
@@ -4903,6 +5107,13 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         path = urlparse(self.path).path
+        if path.startswith("/_sc/skills/"):
+            # Planner-owned fork-local skill catalogue. Retire/unretire remain
+            # Admin-only (fork-tracked retire manifest on the host).
+            try:
+                return self._skills_mutation_post(path, self._body())
+            except Exception as exc:  # noqa: BLE001 — _fail handles reporting
+                return self._fail(exc)
         if path.startswith("/_sc/mem/"):
             return self._mem_post(path, self._body())
         if path.startswith("/_sc/pr/"):
@@ -5187,6 +5398,15 @@ class Handler(BaseHTTPRequestHandler):
         # pm2 block:    PUT /api/pm2  {pm2: {...}}  (persists to instance.json)
         path = urlparse(self.path).path
         parts = path.strip("/").split("/")
+        if len(parts) == 4 and parts[:3] == ["_sc", "skills", "retire"]:
+            return self._send(403, {"error":
+                "skill retire/unretire are Admin-only: they write the tracked "
+                "fork retire manifest on the host"})
+        if len(parts) == 4 and parts[:3] == ["_sc", "skills", "assign"]:
+            try:
+                return self._skills_mutation_assign(self._body())
+            except Exception as exc:  # noqa: BLE001
+                return self._fail(exc)
         con = db()
         try:
             if len(parts) == 3 and parts[:2] == ["_sc", "runtime-flags"]:

--- a/.super-coder/assets/skills/fork_skill_design/SKILL.md
+++ b/.super-coder/assets/skills/fork_skill_design/SKILL.md
@@ -68,6 +68,12 @@ sc skill list
 projections reconcile. Naming a standard shell changes its shared flavor pack;
 naming a Bespoke shell changes only that shell. Creation grants nothing.
 
+A launched Planner seat runs under the restricted execution view and cannot
+open the engine DB directly; `sc skill put` then falls back to the engine API's
+Planner-owned skill lane, which runs the identical validation and persistence
+server-side. `retire`/`unretire` remain Admin-local: they write the fork's
+tracked retire manifest on the host.
+
 ## Update, retire, and recover
 
 ```bash
@@ -78,9 +84,12 @@ sc skill rm <skill_name>
 
 Retry the exact command after fixing a reported snapshot, render, or projection
 path. Pass = the full persistence receipt returns and the projected body
-matches `sc skill list` plus the intended grant. `rm` is only for fork-local
-names; retire an upstream skill with `sc skill retire <name>` and restore it
-with `sc skill unretire <name>`.
+matches `sc skill list` plus the intended grant. On a launched seat the same
+receipt rides the API fallback, so a failure names which of the four layers
+(DB, snapshot, flat render, projection) is still outstanding. `rm` is only for
+fork-local names; retire an upstream skill with `sc skill retire <name>` and
+restore it with `sc skill unretire <name>` — both from an Admin host seat,
+which owns the fork's tracked retire list.
 
 Keep fork-local skill bodies on the supported `sc skill` surface; do not place
 them under engine assets, regenerate the engine seed for them, or set them

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -610,6 +610,7 @@ sc mem roadmap depends <feature_id> [--on <feature_id>]…
 
 sc mem doc add "…" --kind <spec|doc> --feature <id> --body-file <path> --render-path <path>
 sc mem doc freeze <document_id>
+sc mem doc move <document_id> --feature <target_feature_id>
 sc mem task add "…" --feature <id> --doc <id> --seq <n> [--desc "…"]
 sc mem task start <task_id>
 sc mem task done <task_id>
@@ -629,7 +630,10 @@ Load the owning skill before a governed write: `memory` for state/identity,
 `spec` for roadmap tasks, `docs` for documents, `flags` for blockers, and
 `messaging` for shell coordination. Frozen documents require a new document
 revision; decisions are superseded with `--parent`; seed entries are retired
-rather than rewritten.
+rather than rewritten. `doc move` preserves one unfrozen spec''s identity,
+tasks, and document-linked decisions while reassigning them atomically to an
+active feature; it refuses frozen, ordinary-doc, terminal-target, and
+Sprint-bound moves.
 
 ## Failure behavior
 
@@ -669,9 +673,11 @@ copy to `specs_sc/` / `docs_sc/`; the GUI opens it rendered in md-converter.
 Feature = the `roadmap` row; exists from `brainstorm` onward, before any spec.
 Specs hang off the feature, not off each other: several unfrozen specs per
 feature, each a `documents (kind=''spec'')` row, ordered by `seq`. No
-feature-to-feature links; no second roadmap row for related work — related
-work = another spec under the same feature. Freeze = the ship-time record of
-what was built to; it never gates the feature''s other specs.
+feature-to-feature links; related work within one mental model is another spec
+under the same feature. A genuinely new era may split into a fresh feature by
+moving its unfrozen active spec through the guarded workflow below. Freeze =
+the ship-time record of what was built to; it never gates the feature''s other
+specs.
 
 | state | test | meaning |
 |---|---|---|
@@ -682,6 +688,25 @@ what was built to; it never gates the feature''s other specs.
 The **doc** (`kind=''doc''`) = the feature''s readable face — write it when the
 first spec ships, under the same `feature_id`. Sibling of the specs, not a
 parent.
+
+## Split an active era from feature history
+
+When accumulated history makes a feature''s active context misleading or a new
+era has become a separate mental model, preserve the old feature as history and
+move the existing unfrozen active spec intact:
+
+1. Create the fresh feature with its correct work-stream, status, and summary.
+2. Run `sc mem doc move <document_id> --feature <target_feature_id>`.
+3. Re-read the document and task ledger under the target feature; the same ids,
+   task states, and document-linked decisions must now project there.
+4. Edit the historical feature''s title/summary to name the split, then set its
+   truthful terminal status (`shipped` for delivered history, `retired` for
+   abandoned history).
+
+The move assigns the spec''s next target-feature sequence and is atomic across
+the document, its tasks, and document-linked decisions. It refuses frozen
+specs, ordinary docs, terminal targets, and any spec already bound to a Sprint.
+Do not duplicate the spec or cancel/recreate its tasks when this move applies.
 
 ## Assess the work-stream on every feature
 
@@ -1578,6 +1603,12 @@ sc skill list
 projections reconcile. Naming a standard shell changes its shared flavor pack;
 naming a Bespoke shell changes only that shell. Creation grants nothing.
 
+A launched Planner seat runs under the restricted execution view and cannot
+open the engine DB directly; `sc skill put` then falls back to the engine API''s
+Planner-owned skill lane, which runs the identical validation and persistence
+server-side. `retire`/`unretire` remain Admin-local: they write the fork''s
+tracked retire manifest on the host.
+
 ## Update, retire, and recover
 
 ```bash
@@ -1588,9 +1619,12 @@ sc skill rm <skill_name>
 
 Retry the exact command after fixing a reported snapshot, render, or projection
 path. Pass = the full persistence receipt returns and the projected body
-matches `sc skill list` plus the intended grant. `rm` is only for fork-local
-names; retire an upstream skill with `sc skill retire <name>` and restore it
-with `sc skill unretire <name>`.
+matches `sc skill list` plus the intended grant. On a launched seat the same
+receipt rides the API fallback, so a failure names which of the four layers
+(DB, snapshot, flat render, projection) is still outstanding. `rm` is only for
+fork-local names; retire an upstream skill with `sc skill retire <name>` and
+restore it with `sc skill unretire <name>` — both from an Admin host seat,
+which owns the fork''s tracked retire list.
 
 Keep fork-local skill bodies on the supported `sc skill` surface; do not place
 them under engine assets, regenerate the engine seed for them, or set them
@@ -2760,6 +2794,9 @@ never marked done or left pending under a shipped feature:
 sc mem task cancel <task_id> --notes "moved to F<id> as task #<n>"
 sc mem state "[<feature>] — last: <last_done>. next: <next_up>."
 ```
+
+Intact spec move: `sc mem doc move <document_id> --feature <target_feature_id>`
+(see `docs`).
 
 Final Verification follows the boot `TESTING POSTURE`. Complete code; run every
 available focused proof; use observed registered-PR checks only for an

--- a/.super-coder/migrations/0241_global_skill_simplification.sql
+++ b/.super-coder/migrations/0241_global_skill_simplification.sql
@@ -491,6 +491,12 @@ sc skill list
 projections reconcile. Naming a standard shell changes its shared flavor pack;
 naming a Bespoke shell changes only that shell. Creation grants nothing.
 
+A launched Planner seat runs under the restricted execution view and cannot
+open the engine DB directly; `sc skill put` then falls back to the engine API''s
+Planner-owned skill lane, which runs the identical validation and persistence
+server-side. `retire`/`unretire` remain Admin-local: they write the fork''s
+tracked retire manifest on the host.
+
 ## Update, retire, and recover
 
 ```bash
@@ -501,12 +507,16 @@ sc skill rm <skill_name>
 
 Retry the exact command after fixing a reported snapshot, render, or projection
 path. Pass = the full persistence receipt returns and the projected body
-matches `sc skill list` plus the intended grant. `rm` is only for fork-local
-names; retire an upstream skill with `sc skill retire <name>` and restore it
-with `sc skill unretire <name>`.
+matches `sc skill list` plus the intended grant. On a launched seat the same
+receipt rides the API fallback, so a failure names which of the four layers
+(DB, snapshot, flat render, projection) is still outstanding. `rm` is only for
+fork-local names; retire an upstream skill with `sc skill retire <name>` and
+restore it with `sc skill unretire <name>` — both from an Admin host seat,
+which owns the fork''s tracked retire list.
 
-Never place a fork-local body under `.super-coder/assets/skills/`, regenerate
-the engine seed for it, set it common, or write the engine DB directly.',
+Keep fork-local skill bodies on the supported `sc skill` surface; do not place
+them under engine assets, regenerate the engine seed for them, or set them
+common.',
   0
 )
 ON CONFLICT(name) DO UPDATE SET

--- a/.super-coder/migrations/0243_role_aware_boot_contract.sql
+++ b/.super-coder/migrations/0243_role_aware_boot_contract.sql
@@ -995,6 +995,12 @@ sc skill list
 projections reconcile. Naming a standard shell changes its shared flavor pack;
 naming a Bespoke shell changes only that shell. Creation grants nothing.
 
+A launched Planner seat runs under the restricted execution view and cannot
+open the engine DB directly; `sc skill put` then falls back to the engine API''s
+Planner-owned skill lane, which runs the identical validation and persistence
+server-side. `retire`/`unretire` remain Admin-local: they write the fork''s
+tracked retire manifest on the host.
+
 ## Update, retire, and recover
 
 ```bash
@@ -1005,15 +1011,19 @@ sc skill rm <skill_name>
 
 Retry the exact command after fixing a reported snapshot, render, or projection
 path. Pass = the full persistence receipt returns and the projected body
-matches `sc skill list` plus the intended grant. `rm` is only for fork-local
-names; retire an upstream skill with `sc skill retire <name>` and restore it
-with `sc skill unretire <name>`.
+matches `sc skill list` plus the intended grant. On a launched seat the same
+receipt rides the API fallback, so a failure names which of the four layers
+(DB, snapshot, flat render, projection) is still outstanding. `rm` is only for
+fork-local names; retire an upstream skill with `sc skill retire <name>` and
+restore it with `sc skill unretire <name>` — both from an Admin host seat,
+which owns the fork''s tracked retire list.
 
 Keep fork-local skill bodies on the supported `sc skill` surface; do not place
 them under engine assets, regenerate the engine seed for them, or set them
 common.',
   0
-) ON CONFLICT(name) DO UPDATE SET
+)
+ON CONFLICT(name) DO UPDATE SET
   description=excluded.description, category=excluded.category,
   command=excluded.command, common=excluded.common,
   content=excluded.content, is_deleted=0;

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -10,6 +10,16 @@ and every supported mutation persists the local snapshot and projections.
 Naming a standard shell targets its shared flavor pack; naming a Bespoke shell
 targets only that shell.
 
+Launched shells reach this module through two lanes. A local Admin seat opens
+the DB directly and enforces `require_planner` before `put`. A launched shell
+(including the Planner, whose restricted execution view masks the private
+engine-state root) is detected by a failed direct-DB open and rerouted
+through authenticated `/_sc/skills/*` routes on the review API, which runs
+the same validation and persistence ladder server-side. Both lanes share
+`cmd_*_api`/`_put_spec`/`_grant_spec`/`_revoke_spec`/`_rm_spec`. Retire and
+unretire stay Admin-only in both lanes because they write the fork-tracked
+retire manifest on the host.
+
 Engine catalogue rows are authored as assets + `./sc seed-skills`. Fork-local
 rows are DB-canonical and enter through `put --file`; the input file remains a
 draft and is never copied into managed engine assets.
@@ -60,6 +70,95 @@ def connect():
 
 
 def _shell_api_enabled() -> bool:
+    """True when the caller is a launched shell and must go through the API.
+
+    `sc skill list` already used this lane for reads. It's keyed off the API
+    token alone — a host Admin running `sc` in the repo root has no token, so
+    it always takes the direct-DB path.
+    """
+    if not mem.SC_API_TOKEN:
+        return False
+    mem._PROG = "skill"
+    mem._require_api()
+    return True
+
+
+def _put_with_api_fallback(path: Path) -> int:
+    """Run `put` locally; fall back to the API lane when the DB is unreachable.
+
+    The restricted execution view (launched non-Admin shells) masks the
+    private engine-state root, so a Planner calling `sc skill put` from its
+    seat hits a filesystem permission error before the flavor check. Retry
+    through the engine API, which runs unrestricted and reuses the same
+    validation + persistence ladder. Any other failure surfaces unchanged.
+    """
+    try:
+        con = connect()
+    except SystemExit as exc:
+        if not mem.SC_API_TOKEN:
+            raise
+        if "no live DB" in str(exc):
+            raise
+        return cmd_put_api(path)
+    except (OSError, PermissionError):
+        if not mem.SC_API_TOKEN:
+            raise
+        return cmd_put_api(path)
+    try:
+        return cmd_put(con, path)
+    finally:
+        con.close()
+
+
+def _grant_with_api_fallback(name: str, shell_refs: list[str]) -> int:
+    try:
+        con = connect()
+    except SystemExit as exc:
+        if not mem.SC_API_TOKEN or "no live DB" in str(exc):
+            raise
+        return cmd_grant_api(name, shell_refs)
+    except (OSError, PermissionError):
+        if not mem.SC_API_TOKEN:
+            raise
+        return cmd_grant_api(name, shell_refs)
+    try:
+        return cmd_grant(con, name, shell_refs)
+    finally:
+        con.close()
+
+
+def _revoke_with_api_fallback(name: str, shell_refs: list[str]) -> int:
+    try:
+        con = connect()
+    except SystemExit as exc:
+        if not mem.SC_API_TOKEN or "no live DB" in str(exc):
+            raise
+        return cmd_revoke_api(name, shell_refs)
+    except (OSError, PermissionError):
+        if not mem.SC_API_TOKEN:
+            raise
+        return cmd_revoke_api(name, shell_refs)
+    try:
+        return cmd_revoke(con, name, shell_refs)
+    finally:
+        con.close()
+
+
+def _rm_with_api_fallback(name: str) -> int:
+    try:
+        con = connect()
+    except SystemExit as exc:
+        if not mem.SC_API_TOKEN or "no live DB" in str(exc):
+            raise
+        return cmd_rm_api(name)
+    except (OSError, PermissionError):
+        if not mem.SC_API_TOKEN:
+            raise
+        return cmd_rm_api(name)
+    try:
+        return cmd_rm(con, name)
+    finally:
+        con.close()
     if not mem.SC_API_TOKEN:
         return False
     mem._PROG = "skill"
@@ -229,8 +328,82 @@ def _persist_mutation(con, action: str, reconcile) -> None:
     print("persist: DB + snapshot + flat render + skill projections reconciled")
 
 
+class DraftValidationError(ValueError):
+    """One frontmatter/body rule failed — message is client-displayable."""
+
+
+class SkillConflictError(ValueError):
+    """The requested skill mutation violates an engine/fork boundary rule."""
+
+
+def parse_local_skill_spec(text: str) -> dict:
+    """Validate frontmatter + body text and return the skill row spec.
+
+    Raises DraftValidationError with a client-readable message on any rule
+    failure. Shared by the CLI file path and the API JSON-content path so both
+    lanes enforce the identical contract.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise DraftValidationError("draft must start with YAML frontmatter")
+    try:
+        boundary = next(
+            index
+            for index, line in enumerate(lines[1:], start=1)
+            if line.strip() == "---"
+        )
+    except StopIteration:
+        raise DraftValidationError("draft has no closing frontmatter delimiter")
+
+    meta: dict[str, str] = {}
+    for line in lines[1:boundary]:
+        if not line.strip():
+            continue
+        if ":" not in line:
+            raise DraftValidationError(f"invalid frontmatter line: {line!r}")
+        key, value = (part.strip() for part in line.split(":", 1))
+        if key not in LOCAL_FRONTMATTER_FIELDS:
+            raise DraftValidationError(f"unsupported frontmatter field {key!r}")
+        if key in meta:
+            raise DraftValidationError(f"duplicate frontmatter field {key!r}")
+        meta[key] = value
+
+    name = meta.get("name", "")
+    description = meta.get("description", "")
+    if not name or not seed_skills.SKILL_NAME_RE.fullmatch(name) or len(name) > 64:
+        raise DraftValidationError(
+            "frontmatter `name` must be 1-64 lowercase letters, "
+            "digits, or underscores and start with a letter"
+        )
+    if not description:
+        raise DraftValidationError(
+            "frontmatter `description` must be a non-empty line"
+        )
+
+    common_value = meta.get("common", "false").lower()
+    if common_value not in {"false", "0", "no"}:
+        if common_value in {"true", "1", "yes"}:
+            raise DraftValidationError(
+                "fork-local skills must use `common: false`; assign "
+                "them explicitly with `sc skill grant`"
+            )
+        raise DraftValidationError("frontmatter `common` must be true or false")
+
+    body = "\n".join(lines[boundary + 1:]).strip()
+    if not body:
+        raise DraftValidationError("draft must include a non-empty procedure body")
+    return {
+        "name": name,
+        "description": description,
+        "category": meta.get("category") or None,
+        "command": meta.get("command") or None,
+        "common": 0,
+        "content": body,
+    }
+
+
 def parse_local_skill_file(path: Path) -> dict:
-    """Validate the bounded flat frontmatter accepted by `skill put`."""
+    """Read a draft from disk and hand its body to the shared validator."""
     try:
         raw = path.read_bytes()
     except OSError as exc:
@@ -244,62 +417,10 @@ def parse_local_skill_file(path: Path) -> dict:
         text = raw.decode("utf-8")
     except UnicodeDecodeError as exc:
         sys.exit(f"sc skill: draft {path} must be UTF-8: {exc}")
-
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        sys.exit(f"sc skill: draft {path} must start with YAML frontmatter")
     try:
-        boundary = next(
-            index
-            for index, line in enumerate(lines[1:], start=1)
-            if line.strip() == "---"
-        )
-    except StopIteration:
-        sys.exit(f"sc skill: draft {path} has no closing frontmatter delimiter")
-
-    meta: dict[str, str] = {}
-    for line in lines[1:boundary]:
-        if not line.strip():
-            continue
-        if ":" not in line:
-            sys.exit(f"sc skill: invalid frontmatter line in {path}: {line!r}")
-        key, value = (part.strip() for part in line.split(":", 1))
-        if key not in LOCAL_FRONTMATTER_FIELDS:
-            sys.exit(f"sc skill: unsupported frontmatter field {key!r} in {path}")
-        if key in meta:
-            sys.exit(f"sc skill: duplicate frontmatter field {key!r} in {path}")
-        meta[key] = value
-
-    name = meta.get("name", "")
-    description = meta.get("description", "")
-    if not name or not seed_skills.SKILL_NAME_RE.fullmatch(name) or len(name) > 64:
-        sys.exit(
-            "sc skill: frontmatter `name` must be 1-64 lowercase letters, "
-            "digits, or underscores and start with a letter"
-        )
-    if not description:
-        sys.exit("sc skill: frontmatter `description` must be a non-empty line")
-
-    common_value = meta.get("common", "false").lower()
-    if common_value not in {"false", "0", "no"}:
-        if common_value in {"true", "1", "yes"}:
-            sys.exit(
-                "sc skill: fork-local skills must use `common: false`; assign "
-                "them explicitly with `sc skill grant`"
-            )
-        sys.exit("sc skill: frontmatter `common` must be true or false")
-
-    body = "\n".join(lines[boundary + 1:]).strip()
-    if not body:
-        sys.exit(f"sc skill: draft {path} must include a non-empty procedure body")
-    return {
-        "name": name,
-        "description": description,
-        "category": meta.get("category") or None,
-        "command": meta.get("command") or None,
-        "common": 0,
-        "content": body,
-    }
+        return parse_local_skill_spec(text)
+    except DraftValidationError as exc:
+        sys.exit(f"sc skill: draft {path}: {exc}")
 
 
 def print_catalogue(rows: list[dict]) -> int:
@@ -332,6 +453,70 @@ def cmd_list(con) -> int:
 
 def cmd_list_api() -> int:
     return print_catalogue(mem._api("GET", "/_sc/skills").get("skills") or [])
+
+
+def cmd_put_api(path: Path) -> int:
+    """`sc skill put` over the API lane; parses the draft locally first."""
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        sys.exit(f"sc skill: cannot read draft {path}: {exc}")
+    if len(raw) > MAX_SKILL_FILE_BYTES:
+        sys.exit(
+            f"sc skill: draft {path} is {len(raw)} bytes; maximum is "
+            f"{MAX_SKILL_FILE_BYTES} bytes"
+        )
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        sys.exit(f"sc skill: draft {path} must be UTF-8: {exc}")
+    try:
+        spec = parse_local_skill_spec(text)
+    except DraftValidationError as exc:
+        sys.exit(f"sc skill: draft {path}: {exc}")
+    result = mem._api(
+        "POST", "/_sc/skills/put", {"content": text}, idempotent=False
+    )
+    print(f"put: {result['name']} {result['verb']} (via engine API); "
+          "grants unchanged")
+    return 0
+
+
+def cmd_grant_api(name: str, shell_refs: list[str]) -> int:
+    result = mem._api(
+        "POST", "/_sc/skills/grant",
+        {"name": name, "shells": shell_refs}, idempotent=False,
+    )
+    for row in result.get("results") or []:
+        suffix = "" if row["changed"] else "  (already granted)"
+        print(f"grant: {result['name']} → {row['scope']}{suffix}")
+    print(f"(via engine API — {len(result.get('results') or [])} target(s))")
+    return 0
+
+
+def cmd_revoke_api(name: str, shell_refs: list[str]) -> int:
+    result = mem._api(
+        "POST", "/_sc/skills/revoke",
+        {"name": name, "shells": shell_refs}, idempotent=False,
+    )
+    for row in result.get("results") or []:
+        suffix = "" if row["changed"] else "  (was not granted)"
+        print(f"revoke: {result['name']} ⇸ {row['scope']}{suffix}")
+    print(f"(via engine API — {len(result.get('results') or [])} target(s))")
+    return 0
+
+
+def cmd_rm_api(name: str) -> int:
+    result = mem._api(
+        "POST", "/_sc/skills/rm", {"name": name}, idempotent=False
+    )
+    suffix = " (already removed; persistence reconciled)" if result.get(
+        "already_removed") else ""
+    print(
+        f"rm: {result['name']} soft-deleted, {result['revoked_grants']} "
+        f"grant(s) revoked.{suffix} (via engine API)"
+    )
+    return 0
 
 
 def cmd_grant(con, name: str, shell_refs: list[str]) -> int:
@@ -370,16 +555,21 @@ def cmd_revoke(con, name: str, shell_refs: list[str]) -> int:
     return 0
 
 
-def cmd_put(con, path: Path) -> int:
-    require_planner(con)
-    spec = parse_local_skill_file(path)
+def _put_spec(con, spec: dict) -> str:
+    """Create-or-replace one fork-local skill row and persist every layer.
+
+    Caller must enforce planner ownership before invoking. Returns the action
+    verb (created|restored|updated) on success; on failure raises
+    SystemExit|SkillConflictError so the caller can report or re-raise with a
+    boundary prefix.
+    """
     name = spec["name"]
     reserved = set(seed_skills.seeded_skill_names()) | set(
         seed_skills.tombstoned_skill_names()
     )
     if name in reserved:
-        sys.exit(
-            f"sc skill: '{name}' is ENGINE-owned and cannot be overwritten by "
+        raise SkillConflictError(
+            f"'{name}' is ENGINE-owned and cannot be overwritten by "
             "the fork-local lane; change it in the upstream engine skill workflow"
         )
 
@@ -418,7 +608,103 @@ def cmd_put(con, path: Path) -> int:
         f"put {name}",
         lambda: skill_projection.reconcile_existing_checkouts(con),
     )
-    print(f"put: {name} {verb} in the DB; grants unchanged")
+    return verb
+
+
+def _grant_spec(con, name: str, shell_refs: list[str]) -> list[tuple[str, bool, str]]:
+    """Grant one skill to every shell ref (flavor pack or Bespoke shell)."""
+    skill_id = resolve_skill_id(con, name)
+    rows: list[tuple[str, bool, str]] = []
+    targets: list[int] = []
+    for ref in shell_refs:
+        shell_id, label = resolve_shell(con, ref)
+        targets.append(shell_id)
+        changed, scope = set_target_grant(con, shell_id, label, skill_id, True)
+        rows.append((scope, bool(changed), ref))
+    con.commit()
+    _persist_mutation(
+        con,
+        f"grant {name}",
+        lambda: skill_projection.reconcile_assignment_targets(con, targets),
+    )
+    return rows
+
+
+def _revoke_spec(con, name: str, shell_refs: list[str]) -> list[tuple[str, bool, str]]:
+    """Revoke one skill from every shell ref (flavor pack or Bespoke shell)."""
+    skill_id = resolve_skill_id(con, name)
+    rows: list[tuple[str, bool, str]] = []
+    targets: list[int] = []
+    for ref in shell_refs:
+        shell_id, label = resolve_shell(con, ref)
+        targets.append(shell_id)
+        changed, scope = set_target_grant(con, shell_id, label, skill_id, False)
+        rows.append((scope, bool(changed), ref))
+    con.commit()
+    _persist_mutation(
+        con,
+        f"revoke {name}",
+        lambda: skill_projection.reconcile_assignment_targets(con, targets),
+    )
+    return rows
+
+
+def _rm_spec(con, name: str) -> tuple[int, bool]:
+    """Soft-delete one fork-local skill + revoke all grants. Returns count."""
+    engine_owned = set(seed_skills.seeded_skill_names()) | set(
+        seed_skills.tombstoned_skill_names()
+    )
+    if name in engine_owned:
+        raise SkillConflictError(
+            f"'{name}' is an ENGINE skill — the seed re-inserts it on every "
+            "update/rebuild, so a local rm cannot stick. `./sc skill retire "
+            f"{name}` retires it fork-wide (durable), or `./sc skill revoke` "
+            "removes it from a flavor or Bespoke shell."
+        )
+    row = con.execute(
+        "SELECT skill_id, is_deleted FROM skills WHERE name=?", (name,)
+    ).fetchone()
+    if row is None:
+        raise SkillConflictError(f"no local skill '{name}' in the live DB")
+    skill_id, already_deleted = row
+    n = con.execute("DELETE FROM flavor_skills WHERE skill_id=?", (skill_id,)).rowcount
+    n += con.execute("DELETE FROM shell_skills WHERE skill_id=?", (skill_id,)).rowcount
+    con.execute("UPDATE skills SET is_deleted=1 WHERE skill_id=?", (skill_id,))
+    con.commit()
+    _persist_mutation(
+        con,
+        f"rm {name}",
+        lambda: skill_projection.reconcile_existing_checkouts(con),
+    )
+    return int(n), bool(already_deleted)
+
+
+def resolve_skill_id(con, name: str) -> int:
+    """Resolve a skill name to its id, raising SkillConflictError on a miss."""
+    try:
+        return resolve_skill(con, name)
+    except SystemExit as exc:
+        raise SkillConflictError(str(exc) or f"no skill '{name}'") from exc
+
+
+def cmd_put(con, path: Path) -> int:
+    require_planner(con)
+    spec = parse_local_skill_file(path)
+    try:
+        verb = _put_spec(con, spec)
+    except SkillConflictError as exc:
+        sys.exit(f"sc skill: {exc}")
+    print(f"put: {spec['name']} {verb} in the DB; grants unchanged")
+    return 0
+
+
+def cmd_rm(con, name: str) -> int:
+    try:
+        n, already = _rm_spec(con, name)
+    except SkillConflictError as exc:
+        sys.exit(f"sc skill: {exc}")
+    suffix = " (already removed; persistence reconciled)" if already else ""
+    print(f"rm: {name} soft-deleted, {n} grant(s) revoked.{suffix}")
     return 0
 
 
@@ -486,35 +772,6 @@ def cmd_unretire(con, name: str) -> int:
     return 0
 
 
-def cmd_rm(con, name: str) -> int:
-    engine_owned = set(seed_skills.seeded_skill_names()) | set(
-        seed_skills.tombstoned_skill_names()
-    )
-    if name in engine_owned:
-        sys.exit(f"sc skill: '{name}' is an ENGINE skill — the seed re-inserts it "
-                 "on every update/rebuild, so a local rm cannot stick. "
-                 f"`./sc skill retire {name}` retires it fork-wide (durable), or "
-                 "`./sc skill revoke` removes it from a flavor or Bespoke shell.")
-    row = con.execute(
-        "SELECT skill_id, is_deleted FROM skills WHERE name=?", (name,)
-    ).fetchone()
-    if row is None:
-        sys.exit(f"sc skill: no local skill '{name}' in the live DB")
-    skill_id, already_deleted = row
-    n = con.execute("DELETE FROM flavor_skills WHERE skill_id=?", (skill_id,)).rowcount
-    n += con.execute("DELETE FROM shell_skills WHERE skill_id=?", (skill_id,)).rowcount
-    con.execute("UPDATE skills SET is_deleted=1 WHERE skill_id=?", (skill_id,))
-    con.commit()
-    _persist_mutation(
-        con,
-        f"rm {name}",
-        lambda: skill_projection.reconcile_existing_checkouts(con),
-    )
-    suffix = " (already removed; persistence reconciled)" if already_deleted else ""
-    print(f"rm: {name} soft-deleted, {n} grant(s) revoked.{suffix}")
-    return 0
-
-
 def main(argv: list[str]) -> int:
     usage = ("usage: ./sc skill list | put --file <SKILL.md> | "
              "grant <name> <shell>... | "
@@ -526,6 +783,28 @@ def main(argv: list[str]) -> int:
     cmd, args = argv[0], argv[1:]
     if cmd == "list" and not args and _shell_api_enabled():
         return cmd_list_api()
+    if cmd == "put" and len(args) == 2 and args[0] == "--file":
+        # The restricted execution view masks the engine's private state root,
+        # so a launched Planner cannot open the DB directly; when that happens
+        # the API lane runs the same validation + persistence ladder remotely.
+        return _put_with_api_fallback(Path(args[1]))
+    if cmd == "grant" and len(args) >= 2:
+        return _grant_with_api_fallback(args[0], args[1:])
+    if cmd == "revoke" and len(args) >= 2:
+        return _revoke_with_api_fallback(args[0], args[1:])
+    if cmd == "rm" and len(args) == 1:
+        return _rm_with_api_fallback(args[0])
+    con = connect()
+    try:
+        if cmd == "list" and not args:
+            return cmd_list(con)
+        if cmd == "retire" and len(args) == 1:
+            return cmd_retire(con, args[0])
+        if cmd == "unretire" and len(args) == 1:
+            return cmd_unretire(con, args[0])
+        sys.exit(usage)
+    finally:
+        con.close()
     con = connect()
     try:
         if cmd == "list" and not args:

--- a/tests/test_local_skill_persistence.py
+++ b/tests/test_local_skill_persistence.py
@@ -593,5 +593,120 @@ class ManifestScopeTest(unittest.TestCase):
         self.assertEqual(n, 2)
 
 
+class SkillApiLaneTest(unittest.TestCase):
+    """`sc skill put` falls back to the engine API when the restricted view
+    masks the engine DB (a launched Planner's seat)."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.db = self.tmp / "shell_db.db"
+        con = sqlite3.connect(self.db)
+        con.executescript(SKILLS_DDL + ";" + SHELLS_DDL + ";" + GRANTS_DDL + ";")
+        con.execute(
+            "INSERT INTO shells (shell_id, shortname, api_key) VALUES (1, 'dev1', 'dev-token')"
+        )
+        con.execute(
+            "INSERT INTO shells (shell_id, shortname, flavor, api_key) "
+            "VALUES (2, 'PLN1', 'planner', 'planner-token')"
+        )
+        con.execute("INSERT INTO skills (name, common) VALUES ('eng_a', 1)")
+        con.commit()
+        con.close()
+        self._saved_db = skill_mod.DB_PATH
+        skill_mod.DB_PATH = self.db
+        self._saved_names = seed_skills.seeded_skill_names
+        seed_skills.seeded_skill_names = lambda: ["eng_a"]
+        self._saved_token = skill_mod.mem.SC_API_TOKEN
+        self._saved_base = skill_mod.mem.SC_API_BASE
+        # The API-lane fallback fires only when the token is present; simulate
+        # the launched shell exactly.
+        skill_mod.mem.SC_API_TOKEN = "planner-token"
+        skill_mod.mem.SC_API_BASE = "http://127.0.0.1:9"  # unreachable by design
+
+    def tearDown(self):
+        mock.patch.stopall()
+        skill_mod.DB_PATH = self._saved_db
+        seed_skills.seeded_skill_names = self._saved_names
+        skill_mod.mem.SC_API_TOKEN = self._saved_token
+        skill_mod.mem.SC_API_BASE = self._saved_base
+
+    def write_draft(self, name: str, body: str = "procedure") -> Path:
+        path = self.tmp / f"{name}.md"
+        path.write_text(
+            "---\n"
+            f"name: {name}\n"
+            "description: local workflow\n"
+            "category: substrate\n"
+            "common: false\n"
+            "---\n\n"
+            f"{body}\n"
+        )
+        return path
+
+    def test_local_put_works_when_db_is_reachable(self):
+        """A planner token + reachable DB keeps the canonical local put lane."""
+        with mock.patch.object(skill_mod, "_persist_snapshot"), \
+             mock.patch.object(skill_mod, "_persist_render"), \
+             mock.patch.object(
+                 skill_mod.skill_projection, "reconcile_existing_checkouts"):
+            skill_mod.main(["put", "--file", str(self.write_draft("loc_local"))])
+        con = sqlite3.connect(self.db)
+        try:
+            self.assertEqual(
+                con.execute(
+                    "SELECT content, is_deleted FROM skills WHERE name='loc_local'"
+                ).fetchone(),
+                ("procedure", 0),
+            )
+        finally:
+            con.close()
+
+    def test_api_fallback_fires_on_permission_error(self):
+        """A masked DB path raises OSError/PermissionError — the call reroutes."""
+        draft = self.write_draft("loc_api")
+        api_calls: list[tuple[str, str, dict]] = []
+
+        def fake_api(method, path, payload, *, idempotent=None, **kwargs):
+            api_calls.append((method, path, payload))
+            if path == "/_sc/skills/put":
+                return {
+                    "ok": True,
+                    "action": "put",
+                    "name": "loc_api",
+                    "verb": "created",
+                }
+            raise AssertionError(f"unexpected API call {path}")
+
+        with mock.patch.object(
+            skill_mod, "connect", side_effect=PermissionError("masked root")
+        ), mock.patch.object(skill_mod.mem, "_api", side_effect=fake_api):
+            skill_mod.main(["put", "--file", str(draft)])
+
+        self.assertEqual(len(api_calls), 1)
+        self.assertEqual(api_calls[0][0], "POST")
+        self.assertEqual(api_calls[0][1], "/_sc/skills/put")
+        self.assertIn("loc_api", api_calls[0][2].get("content", ""))
+
+    def test_api_fallback_does_not_swallow_no_db(self):
+        """`no live DB` (a missing/empty engine DB on a host seat) still dies."""
+        draft = self.write_draft("loc_nodb")
+        with mock.patch.object(
+            skill_mod, "connect",
+            side_effect=SystemExit("sc skill: no live DB — run `./sc rebuild` first.")
+        ), self.assertRaises(SystemExit) as cm:
+            skill_mod.main(["put", "--file", str(draft)])
+        self.assertIn("no live DB", str(cm.exception))
+
+    def test_no_token_does_not_fall_back(self):
+        """A restricted-view failure WITHOUT a token cannot reach the API and
+        surfaces the underlying filesystem error unchanged."""
+        skill_mod.mem.SC_API_TOKEN = ""
+        draft = self.write_draft("loc_noretry")
+        with mock.patch.object(
+            skill_mod, "connect", side_effect=PermissionError("masked root")
+        ), self.assertRaises(PermissionError):
+            skill_mod.main(["put", "--file", str(draft)])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Restores Planner-owned fork-local skill curation on launched seats.

## Root cause

PR #1426 restricted non-Admin shells' execution views so the engine's private-state root, legacy DB, snapshot, and render files are masked. `sc skill put` opens the live DB directly, so a Planner calling it from its launched seat hits a filesystem permission error before the token-based `require_planner` flavor check can even run. This broke the Planner's fork-local skill lifecycle end-to-end.

## What changed

### `scripts/skill.py`
- Split the draft validator into `parse_local_skill_spec` (pure text, raises `DraftValidationError`) and `parse_local_skill_file` (disk + delegation to the spec validator). Both the CLI and the API now enforce the identical frontmatter contract.
- Extracted the mutation bodies into `_put_spec`, `_grant_spec`, `_revoke_spec`, `_rm_spec`, all of which raise `SkillConflictError` on boundary violations (engine-owned name, missing local skill) rather than `sys.exit`. The CLI-level `cmd_*` functions wrap them with `sys.exit` to keep the existing interface.
- Added `cmd_*_api` wrappers that call `mem._api("POST", "/_sc/skills/<action>", ...)` and print the same receipts the local lane does.
- `main` routes every mutation through a `*_with_api_fallback` helper: the direct-DB local path runs first; if `connect()` fails with `PermissionError`/`OSError` (the restricted view masking the engine DB) and the caller has `SC_API_TOKEN`, the same command retries through the API. A "no live DB" failure — meaning the engine genuinely isn't installed — still dies loud; no token means no fallback.

### `api/server.py`
- POST `/_sc/skills/put`, `/_sc/skills/grant`, `/_sc/skills/revoke`, `/_sc/skills/rm` and PUT `/_sc/skills/assign`.
- Every route calls `_require_shell_auth`, then `_resolve_planner_shell` (the API-side mirror of `require_planner`) to verify the bearer is a launched planner-flavored shell; a 403 reports the mismatch with the shell's label.
- `_skills_mutation_report` catches `DraftValidationError` and `SkillConflictError` plus the `SystemExit` bodies that `resolve_shell`/`resolve_skill` raise inside the shared helpers, and converts them into structured 4xx responses so `mem._api` surfaces the actionable message. The persistence ladder (snapshot → flat render → skill projection) is unchanged — it runs through the same `_persist_mutation` on the server's host seat.
- `retire`/`unretire` remain Admin-only: they write the fork's tracked retire manifest on the host and are deliberately outside the API lane.

### Documentation + seed alignment
- `assets/skills/fork_skill_design/SKILL.md` now documents the fallback: a launched Planner seat uses the same `sc skill` commands, and the receipt names which of the four persistence layers remain outstanding on failure. It also clarifies that `retire`/`unretire` are Admin-local (tracked retire manifest).
- Regenerated `migrations/0001_seed_skills.sql` and updated the seed blocks in `0241_global_skill_simplification.sql` and `0243_role_aware_boot_contract.sql` so a fresh DB built from any of them matches the updated asset.

### Tests
- `SkillApiLaneTest` in `tests/test_local_skill_persistence.py` covers the API fallback contract:
  - local `put` on a reachable DB stays canonical (no API call made);
  - `PermissionError` from `connect` with a token triggers exactly one POST to `/_sc/skills/put` carrying the draft body;
  - "no live DB" is NOT swallowed into a retry;
  - no token means no fallback even when connect fails.

### Verification
- `pytest -q -k 'skill or api'` — 505 passed, 1 skipped.
- `tests/test_local_skill_persistence.py` — 23 tests, OK.

Co-Authored-By: Code-01 (super-coder) <noreply@super-coder.local>