### PR TITLE
fix(opencode): serve identity check crashed on /proc cmdline bytes, emptying the GUI model picker

### DIFF
--- a/.super-coder/scripts/conversation_adapters/opencode.py
+++ b/.super-coder/scripts/conversation_adapters/opencode.py
@@ -418,7 +418,7 @@ def _pid_is_opencode_serve(pid: int) -> bool:
     """Best-effort identity check so only an opencode serve is ever reaped."""
     try:
         raw = Path(f"/proc/{pid}/cmdline").read_bytes()
-        cmdline = raw.replace(b"\x00", " ").decode("utf-8", errors="replace")
+        cmdline = raw.replace(b"\x00", b" ").decode("utf-8", errors="replace")
     except OSError:
         try:
             result = subprocess.run(

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -389,3 +389,34 @@ class OpenCodeServerTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class OpenCodeServeIdentityTest(unittest.TestCase):
+    """`_pid_is_opencode_serve` reads /proc cmdline as bytes; it must not crash.
+
+    The catalogue swallows any exception from the provider probe as "no
+    routes", so a TypeError here silently emptied the GUI's OpenCode model
+    picker on every host where an orphan serve reached the identity check.
+    """
+
+    def _with_cmdline(self, raw: bytes) -> bool:
+        with mock.patch.object(opencode.Path, "read_bytes", return_value=raw):
+            return opencode._pid_is_opencode_serve(17195)
+
+    def test_recognizes_an_opencode_serve_from_proc_cmdline(self) -> None:
+        raw = (
+            b"/home/op/.opencode/bin/opencode\x00serve\x00--hostname\x00"
+            b"127.0.0.1\x00--port\x0055353\x00"
+        )
+        self.assertTrue(self._with_cmdline(raw))
+
+    def test_rejects_a_process_that_is_not_an_opencode_serve(self) -> None:
+        self.assertFalse(self._with_cmdline(b"python3\x00server.py\x00--port\x008837\x00"))
+        self.assertFalse(self._with_cmdline(b"/usr/bin/opencode\x00models\x00"))
+
+    def test_falls_back_to_ps_when_proc_is_unreadable(self) -> None:
+        completed = mock.Mock(returncode=0, stdout="/usr/bin/opencode serve --port 1\n")
+        with mock.patch.object(
+            opencode.Path, "read_bytes", side_effect=OSError("no /proc")
+        ), mock.patch.object(opencode.subprocess, "run", return_value=completed):
+            self.assertTrue(opencode._pid_is_opencode_serve(17195))


### PR DESCRIPTION
## Summary

- `_pid_is_opencode_serve` did `raw.replace(b"\x00", " ")` on the bytes from `/proc/<pid>/cmdline`, which raises `TypeError` on every Linux host that reaches it.
- The check runs when a recorded `opencode serve` outlives a CLI upgrade (version rotation at first adoption) or answers none of our passwords. `model_catalog` swallows the exception as "no routes", so `sc models refresh` reported only claude/codex/kimi sources and the GUI's OpenCode model picker was empty, while the TUI listed models fine. Seen on sc-cachy with an orphan serve (pid from `opencode-server.json`) started before the CLI moved to 1.18.27.
- Fix the separator to bytes and add tests that exercise the identity check with real cmdline bytes plus the `ps` fallback; the existing tests always mocked it.

## Test plan

- [x] `python3 -m unittest tests.test_opencode_server` (14 tests, 3 new) passes.
- [x] Reproduced live: calling `connected_models()` on the affected install raised the TypeError at `_pid_is_opencode_serve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHwFxnmsuTatNfAWBx1vCP