### PR TITLE
feat(ui): model filter + family grouping in the start-chat picker; lift the models.dev cap

### DIFF
--- a/.super-coder/api/model_catalog.py
+++ b/.super-coder/api/model_catalog.py
@@ -55,7 +55,10 @@ CACHE = ENGINE / "logs" / "model_catalog.json"
 ADAPTERS = ENGINE / "adapters"
 TTL_HOURS = 24
 TIMEOUT = 8
-MAX_HTTP_JSON_BYTES = 4 * 1024 * 1024
+# models.dev/api.json passed 4 MiB in 2026-09 (212 providers, ~7.5k models);
+# the cap guards memory against a hostile endpoint, not against growth,
+# so keep generous headroom over the real catalogue.
+MAX_HTTP_JSON_BYTES = 16 * 1024 * 1024
 MODELS_DEV_URL = "https://models.dev/api.json"
 
 # harness -> models.dev provider key. kimi maps to "kimi-for-coding" (the

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3242,10 +3242,14 @@ function chatOpenStream(
   return source;
 }
 
-function chatModelOptions(select, catalog, harness, defaultModel) {
+function chatModelOptions(select, catalog, harness, defaultModel, query = "") {
   select.replaceChildren();
   const models = catalog.harnesses?.[harness]?.models || [];
-  const available = models.filter((model) => model.availability === "available");
+  const q = String(query || "").trim().toLowerCase();
+  const matches = (model) => !q || [model.id, model.name, model.family, model.provider]
+    .some((field) => String(field || "").toLowerCase().includes(q));
+  const available = models.filter((model) =>
+    model.availability === "available" && matches(model));
   if (defaultModel) select.append(el("option", {
     value: "",
     textContent: `Use shell default — ${defaultModel}`,
@@ -3258,15 +3262,32 @@ function chatModelOptions(select, catalog, harness, defaultModel) {
     value: CHAT_HARNESS_DEFAULT_VALUE,
     textContent: "Use harness default",
   }));
+  // Group by family so a long provider list reads as a few labelled blocks;
+  // models without family data stay flat after the groups, in catalogue order.
+  const families = new Map();
+  const ungrouped = [];
   for (const model of available) {
+    if (!model.family) { ungrouped.push(model); continue; }
+    if (!families.has(model.family)) families.set(model.family, []);
+    families.get(model.family).push(model);
+  }
+  for (const [family, members] of families) {
+    const group = el("optgroup", { label: family });
+    for (const model of members) {
+      group.append(el("option", { value: model.id, textContent: model.id }));
+    }
+    select.append(group);
+  }
+  for (const model of ungrouped) {
     select.append(el("option", { value: model.id, textContent: model.id }));
   }
-  if (!select.options.length) {
+  if (!available.length) {
     select.append(el("option", {
       value: "",
-      textContent: "No connected provider models available",
+      textContent: q
+        ? `No models match "${query.trim()}"`
+        : "No connected provider models available",
       disabled: true,
-      selected: true,
     }));
   }
   return true;
@@ -3942,6 +3963,12 @@ async function chatRenderNew(host, shell, defaults, catalog) {
     }));
   }
   const modelSelect = el("select");
+  const modelSearch = el("input", {
+    type: "text",
+    className: "search chat-model-search",
+    placeholder: "Filter models — id, name, family, or provider",
+    ariaLabel: "Filter models",
+  });
   const effortSelect = el("select", { ariaLabel: "Thinking level" });
   const title = el("input", {
     type: "text",
@@ -3978,10 +4005,16 @@ async function chatRenderNew(host, shell, defaults, catalog) {
   };
   const paintModels = () => {
     harness = harnessSelect.value;
-    chatModelOptions(modelSelect, catalog, harness, byHarness[harness]?.model);
+    const keep = modelSelect.value;
+    chatModelOptions(
+      modelSelect, catalog, harness, byHarness[harness]?.model, modelSearch.value);
+    // A narrowed list keeps the operator's pick while it still matches.
+    if (keep && [...modelSelect.options].some((option) => option.value === keep))
+      modelSelect.value = keep;
     paintEfforts();
   };
   harnessSelect.onchange = paintModels;
+  modelSearch.oninput = paintModels;
   modelSelect.onchange = paintEfforts;
   effortSelect.onchange = paintEfforts;
   paintModels();
@@ -3991,7 +4024,7 @@ async function chatRenderNew(host, shell, defaults, catalog) {
       el("p", { className: "muted" },
         "This prepares the shell through its normal CLI path, then runs each turn headlessly.")),
     el("label", { className: "k" }, "Harness"), harnessSelect,
-    el("label", { className: "k" }, "Model"), modelSelect,
+    el("label", { className: "k" }, "Model"), modelSearch, modelSelect,
     el("label", { className: "k" }, "Thinking level"), effortSelect,
     routeNote,
     el("label", { className: "k" }, "Title"), title,

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -552,6 +552,7 @@ body.interface-view main {
 .chat-new-copy h2 { margin: 0 0 .25rem; font-size: 1.05rem; }
 .chat-new-copy p { margin: 0 0 1rem; }
 .chat-route-note { color: var(--dim); font-size: .72rem; margin-top: .3rem; }
+.chat-new-form .chat-model-search { width: 100%; box-sizing: border-box; margin: 0 0 .35rem; }
 .chat-new-form .act { margin-top: 1rem; }
 
 /* ── Conversation Diff review workspace ─────────────────────────────────── */

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -327,6 +327,71 @@ console.log(JSON.stringify(select.options));
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_model_picker_groups_by_family_and_filters_on_the_search_query():
+    options = APP[
+        APP.index("function chatModelOptions"):
+        APP.index("function chatCreateConversation")
+    ]
+    script = r"""
+const CHAT_HARNESS_DEFAULT_VALUE = "__sc_harness_default__";
+const el = (tag, props) => ({tag, ...props, kids: [],
+  append(node) { this.kids.push(node); }});
+const select = {options: [], replaceChildren() { this.options = []; },
+  append(node) { this.options.push(node); }};
+""" + options + r"""
+const catalog = {harnesses: {opencode: {models: [
+  {id: "ollama-cloud/glm-5.3", availability: "available", family: "glm", provider: "ollama-cloud"},
+  {id: "ollama-cloud/glm-5.1", availability: "available", family: "glm", provider: "ollama-cloud"},
+  {id: "ollama-cloud/deepseek-v4-pro", availability: "available", family: "deepseek", provider: "ollama-cloud"},
+  {id: "halo/ornith1.5-35b", availability: "available", provider: "halo"},
+  {id: "halo/hidden", availability: "unavailable", provider: "halo"},
+]}}};
+const shape = () => select.options.map((node) => node.tag === "optgroup"
+  ? [node.label, node.kids.map((kid) => kid.value)]
+  : [node.value, node.textContent, Boolean(node.disabled)]);
+chatModelOptions(select, catalog, "opencode", null);
+const grouped = shape();
+chatModelOptions(select, catalog, "opencode", null, "GLM");
+const filtered = shape();
+chatModelOptions(select, catalog, "opencode", null, "halo");
+const byProvider = shape();
+chatModelOptions(select, catalog, "opencode", null, "nothing-here");
+const empty = shape();
+console.log(JSON.stringify({grouped, filtered, byProvider, empty}));
+"""
+    assert run_js(script) == {
+        "grouped": [
+            ["", "Use harness default", False],
+            ["glm", ["ollama-cloud/glm-5.3", "ollama-cloud/glm-5.1"]],
+            ["deepseek", ["ollama-cloud/deepseek-v4-pro"]],
+            ["halo/ornith1.5-35b", "halo/ornith1.5-35b", False],
+        ],
+        "filtered": [
+            ["", "Use harness default", False],
+            ["glm", ["ollama-cloud/glm-5.3", "ollama-cloud/glm-5.1"]],
+        ],
+        "byProvider": [
+            ["", "Use harness default", False],
+            ["halo/ornith1.5-35b", "halo/ornith1.5-35b", False],
+        ],
+        "empty": [
+            ["", "Use harness default", False],
+            ["", 'No models match "nothing-here"', True],
+        ],
+    }
+
+
+def test_start_chat_offers_a_model_filter_above_the_picker():
+    new_chat = APP[APP.index("async function chatRenderNew"):
+                   APP.index("function chatTranscriptPageItems")]
+    assert 'className: "search chat-model-search"' in new_chat
+    assert 'ariaLabel: "Filter models"' in new_chat
+    assert "modelSearch.oninput = paintModels;" in new_chat
+    assert "byHarness[harness]?.model, modelSearch.value);" in new_chat
+    assert '"Model"), modelSearch, modelSelect,' in new_chat
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
 def test_missing_retained_harness_status_disables_composer():
     availability = APP[
         APP.index("function chatHarnessUnavailableReason"):

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -468,7 +468,7 @@ class BuildTest(NoCLI):
 
             def read(self, amount):
                 reads.append(amount)
-                return b"x" * (4 * 1024 * 1024 + 1)
+                return b"x" * (mc.MAX_HTTP_JSON_BYTES + 1)
 
         with mock.patch.object(
             mc.urllib.request, "urlopen", return_value=Response()
@@ -478,7 +478,7 @@ class BuildTest(NoCLI):
             ):
                 mc._http_json("https://provider.example/models")
 
-        self.assertEqual(reads, [4 * 1024 * 1024 + 1])
+        self.assertEqual(reads, [mc.MAX_HTTP_JSON_BYTES + 1])
 
 
     def test_bad_provider_key_never_fails_the_sweep(self):


### PR DESCRIPTION
## Summary

- **Configure form (Chats page):** a filter box above the Model picker narrows the list by id, name, family, or provider as you type, keeping the current pick while it still matches. Routes with family data render as `<optgroup>` blocks; ungrouped routes follow in catalogue order. An empty match says `No models match "…"` rather than "No connected provider models available".
- **models.dev cap:** `api.json` is now 4.4 MiB (212 providers, ~7.5k models), over the 4 MiB `MAX_HTTP_JSON_BYTES` guard, so every refresh recorded `models.dev: model catalogue response exceeds safety limits` and the advisory source supplied no family metadata. Raised to 16 MiB; the limit test reads the constant instead of hard-coding 4 MiB.
- `chatModelOptions(select, catalog, harness, defaultModel, query = "")` keeps its existing contract: default options, availability filter, `select.value` semantics on submit.

## Test plan

- [x] `tests/test_conversation_ui.py`: new node test for grouping, query filtering by family/provider, and the empty-match option; new contract test for the filter box wiring; existing picker-label test unchanged (46 pass).
- [x] `tests/test_model_catalog.py` (49 pass) and `tests/test_modal_ui_contract.py`, `tests/test_ui_freshness.py`.
- [x] Live: `_from_models_dev` against the real feed succeeds under the new cap and yields family groups for each harness.
- [x] `node --check .super-coder/ui/app.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHwFxnmsuTatNfAWBx1vCP