### PR TITLE
feat(ui): start-chat model picker becomes a dropdown with the search on top

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3293,6 +3293,143 @@ function chatModelOptions(select, catalog, harness, defaultModel, query = "") {
   return true;
 }
 
+// Start-chat model dropdown. Closed, it is one control showing the current
+// route; open, the search box sits at the top of the list with the family
+// groups beneath it. The hidden native <select> stays the value carrier so
+// submit + thinking-level logic read one place; the dropdown mirrors its
+// options and dispatches `change` on a pick.
+function chatModelDropdown(select, describe = () => "") {
+  const trigger = el("button", {
+    type: "button",
+    className: "chat-model-trigger",
+    ariaHasPopup: "listbox",
+    ariaExpanded: "false",
+  });
+  const search = el("input", {
+    type: "text",
+    className: "dm-search chat-model-search",
+    placeholder: "Search models — id, name, family, or provider",
+    ariaLabel: "Search models",
+    autocomplete: "off",
+  });
+  const list = el("div", {
+    className: "dm-cardlist chat-model-list",
+    role: "listbox",
+  });
+  const panel = el("div", { className: "chat-model-panel", hidden: true },
+    search, list);
+  const root = el("div", { className: "chat-model-dropdown" },
+    trigger, panel, select);
+  select.hidden = true;
+  let open = false;
+  let highlighted = 0;
+  let choices = [];
+  const label = () => {
+    const option = select.options[select.selectedIndex];
+    trigger.textContent = option ? option.textContent : "Select a model";
+    trigger.title = option?.value || "";
+  };
+  const groups = () => {
+    const out = [];
+    for (const node of select.children) {
+      if (node.tagName === "OPTGROUP")
+        out.push({ label: node.label, options: [...node.children] });
+      else out.push({ label: null, options: [node] });
+    }
+    return out;
+  };
+  const applyHighlight = () => {
+    choices.forEach((choice, j) => {
+      choice.node.classList.toggle("dm-highlight", j === highlighted);
+      choice.node.ariaSelected = String(j === highlighted);
+    });
+    choices[highlighted]?.node.scrollIntoView?.({ block: "nearest" });
+  };
+  const setHighlight = (i) => { highlighted = i; applyHighlight(); };
+  const paint = () => {
+    list.replaceChildren();
+    choices = [];
+    if (!open) return;
+    const q = search.value.trim().toLowerCase();
+    const hit = (option, group) => !q
+      || [option.value, option.textContent, group, describe(option.value)]
+        .some((field) => String(field || "").toLowerCase().includes(q));
+    for (const group of groups()) {
+      const options = group.options.filter(
+        (option) => !option.disabled && hit(option, group.label));
+      if (!options.length) continue;
+      if (group.label) list.append(el("div", { className: "dm-sect" }, group.label));
+      for (const option of options) {
+        const index = choices.length;
+        const card = el("button", {
+          type: "button",
+          role: "option",
+          className: "dm-mcard",
+          title: option.value || option.textContent,
+        });
+        card.append(el("b", {}, option.textContent));
+        card.onmouseenter = () => setHighlight(index);
+        card.onclick = () => pick(option.value);
+        choices.push({ value: option.value, node: card });
+        list.append(card);
+      }
+    }
+    if (!choices.length) list.append(el("div", { className: "dm-note" },
+      q ? `No models match "${search.value.trim()}"`
+        : "No connected provider models available"));
+    highlighted = Math.max(0, Math.min(highlighted, choices.length - 1));
+    applyHighlight();
+  };
+  const close = () => {
+    open = false;
+    highlighted = 0;
+    search.value = "";
+    panel.hidden = true;
+    trigger.ariaExpanded = "false";
+    paint();
+  };
+  const show = () => {
+    open = true;
+    panel.hidden = false;
+    trigger.ariaExpanded = "true";
+    paint();
+    const current = choices.findIndex((choice) => choice.value === select.value);
+    setHighlight(Math.max(0, current));
+    search.focus();
+  };
+  const pick = (value) => {
+    select.value = value;
+    label();
+    close();
+    select.dispatchEvent(new Event("change"));
+    trigger.focus();
+  };
+  trigger.onclick = () => (open ? close() : show());
+  search.oninput = () => { highlighted = 0; paint(); };
+  search.onkeydown = (event) => {
+    if (event.key === "Escape") { close(); trigger.focus(); return; }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const delta = event.key === "ArrowDown" ? 1 : -1;
+      setHighlight(Math.max(0, Math.min(highlighted + delta, choices.length - 1)));
+      return;
+    }
+    if (event.key === "Enter" && choices[highlighted]) {
+      event.preventDefault();
+      pick(choices[highlighted].value);
+    }
+  };
+  // Outside click collapses; picks land first because the cards live inside
+  // `panel`. Self-unregisters once this render generation is detached.
+  const outside = (event) => {
+    if (!root.isConnected) { document.removeEventListener("mousedown", outside); return; }
+    if (open && !root.contains(event.target)) close();
+  };
+  document.addEventListener("mousedown", outside);
+  label();
+  return { root, refresh: () => { label(); if (open) paint(); } };
+}
+
 function chatCreateConversation(shell, fields = {}) {
   return chatApi(
     "/conversations",
@@ -3963,12 +4100,14 @@ async function chatRenderNew(host, shell, defaults, catalog) {
     }));
   }
   const modelSelect = el("select");
-  const modelSearch = el("input", {
-    type: "text",
-    className: "search chat-model-search",
-    placeholder: "Filter models — id, name, family, or provider",
-    ariaLabel: "Filter models",
-  });
+  const describeModel = (id) => {
+    const model = (catalog.harnesses?.[harness]?.models || [])
+      .find((entry) => entry.id === id);
+    return model
+      ? [model.name, model.family, model.provider].filter(Boolean).join(" ")
+      : "";
+  };
+  const modelDropdown = chatModelDropdown(modelSelect, describeModel);
   const effortSelect = el("select", { ariaLabel: "Thinking level" });
   const title = el("input", {
     type: "text",
@@ -4005,16 +4144,11 @@ async function chatRenderNew(host, shell, defaults, catalog) {
   };
   const paintModels = () => {
     harness = harnessSelect.value;
-    const keep = modelSelect.value;
-    chatModelOptions(
-      modelSelect, catalog, harness, byHarness[harness]?.model, modelSearch.value);
-    // A narrowed list keeps the operator's pick while it still matches.
-    if (keep && [...modelSelect.options].some((option) => option.value === keep))
-      modelSelect.value = keep;
+    chatModelOptions(modelSelect, catalog, harness, byHarness[harness]?.model);
+    modelDropdown.refresh();
     paintEfforts();
   };
   harnessSelect.onchange = paintModels;
-  modelSearch.oninput = paintModels;
   modelSelect.onchange = paintEfforts;
   effortSelect.onchange = paintEfforts;
   paintModels();
@@ -4024,7 +4158,7 @@ async function chatRenderNew(host, shell, defaults, catalog) {
       el("p", { className: "muted" },
         "This prepares the shell through its normal CLI path, then runs each turn headlessly.")),
     el("label", { className: "k" }, "Harness"), harnessSelect,
-    el("label", { className: "k" }, "Model"), modelSearch, modelSelect,
+    el("label", { className: "k" }, "Model"), modelDropdown.root,
     el("label", { className: "k" }, "Thinking level"), effortSelect,
     routeNote,
     el("label", { className: "k" }, "Title"), title,

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -552,7 +552,25 @@ body.interface-view main {
 .chat-new-copy h2 { margin: 0 0 .25rem; font-size: 1.05rem; }
 .chat-new-copy p { margin: 0 0 1rem; }
 .chat-route-note { color: var(--dim); font-size: .72rem; margin-top: .3rem; }
-.chat-new-form .chat-model-search { width: 100%; box-sizing: border-box; margin: 0 0 .35rem; }
+.chat-model-dropdown { position: relative; }
+.chat-model-trigger {
+  width: 100%; display: flex; justify-content: space-between; align-items: center; gap: .6rem;
+  text-align: left; cursor: pointer; background: var(--panel2); color: var(--ink);
+  border: 1px solid var(--line); border-radius: 8px; padding: .5rem .6rem; font: inherit;
+}
+.chat-model-trigger::after { content: "▾"; color: var(--dim); flex: none; }
+.chat-model-trigger[aria-expanded="true"], .chat-model-trigger:focus-visible {
+  outline: none; border-color: rgba(255,255,255,.25);
+}
+.chat-model-panel {
+  position: absolute; left: 0; right: 0; top: calc(100% + 4px); z-index: 20;
+  display: flex; flex-direction: column; gap: .4rem; padding: .5rem;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(0,0,0,.4);
+}
+.chat-model-panel[hidden] { display: none; }
+.chat-model-panel .dm-sect { padding-top: .35rem; }
+.chat-model-list { max-height: 18rem; }
 .chat-new-form .act { margin-top: 1rem; }
 
 /* ── Conversation Diff review workspace ─────────────────────────────────── */

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -381,14 +381,100 @@ console.log(JSON.stringify({grouped, filtered, byProvider, empty}));
     }
 
 
-def test_start_chat_offers_a_model_filter_above_the_picker():
+def test_start_chat_uses_the_searchable_dropdown_over_the_hidden_select():
     new_chat = APP[APP.index("async function chatRenderNew"):
                    APP.index("function chatTranscriptPageItems")]
-    assert 'className: "search chat-model-search"' in new_chat
-    assert 'ariaLabel: "Filter models"' in new_chat
-    assert "modelSearch.oninput = paintModels;" in new_chat
-    assert "byHarness[harness]?.model, modelSearch.value);" in new_chat
-    assert '"Model"), modelSearch, modelSelect,' in new_chat
+    assert "const modelDropdown = chatModelDropdown(modelSelect, describeModel);" in new_chat
+    assert "modelDropdown.refresh();" in new_chat
+    assert '"Model"), modelDropdown.root,' in new_chat
+    assert "modelSelect.onchange = paintEfforts;" in new_chat
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_model_dropdown_opens_with_search_on_top_and_picks_through_the_select():
+    source = APP[
+        APP.index("function chatModelDropdown"):
+        APP.index("function chatCreateConversation")
+    ]
+    script = r"""
+class Node {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase(); this.children = []; this.isConnected = true;
+    this.classes = new Set();
+    this.classList = {
+      toggle: (name, on) => { on ? this.classes.add(name) : this.classes.delete(name); },
+    };
+  }
+  append(...kids) { for (const kid of kids) this.children.push(kid); }
+  replaceChildren(...kids) { this.children = [...kids]; }
+  focus() { focused.push(this.className); }
+  contains(node) { return node === this || this.children.some((kid) => kid.contains?.(node)); }
+  dispatchEvent(event) { changes.push(event.type + ":" + this.value); }
+  get options() {
+    return this.children.flatMap((kid) => kid.tagName === "OPTGROUP" ? kid.children : [kid]);
+  }
+  get selectedIndex() { return this.options.findIndex((o) => o.value === this.value); }
+}
+const focused = []; const changes = [];
+const document = { addEventListener() {}, removeEventListener() {} };
+const el = (tag, props = {}, ...kids) => {
+  const node = Object.assign(new Node(tag), tag === "input" ? {value: ""} : {}, props);
+  node.append(...kids.map((kid) => kid instanceof Node ? kid : {text: kid}));
+  return node;
+};
+""" + source + r"""
+const select = el("select");
+const group = el("optgroup", {label: "glm"});
+group.append(el("option", {value: "ollama-cloud/glm-5.3", textContent: "ollama-cloud/glm-5.3"}),
+             el("option", {value: "ollama-cloud/glm-5.1", textContent: "ollama-cloud/glm-5.1"}));
+select.append(el("option", {value: "", textContent: "Use harness default"}), group,
+              el("option", {value: "halo/ornith", textContent: "halo/ornith"}));
+select.value = "";
+const meta = {"halo/ornith": "ornith halo"};
+const dd = chatModelDropdown(select, (id) => meta[id] || "");
+const [trigger, panel, hiddenSelect] = dd.root.children;
+const [search, list] = panel.children;
+const rows = () => list.children.map((n) =>
+  n.className === "dm-sect" ? "#" + n.children[0].text
+  : n.className === "dm-note" ? "!" + n.children[0].text
+  : (n.classes.has("dm-highlight") ? "*" : "") + n.children[0].children[0].text);
+const out = {order: [trigger.className, search.className.split(" ")[0], list.className.split(" ")[0]],
+  hiddenSelect: hiddenSelect.hidden, closedLabel: trigger.textContent, panelHidden: panel.hidden};
+trigger.onclick();
+out.opened = {panelHidden: panel.hidden, expanded: trigger.ariaExpanded, rows: rows(), focused: focused.slice()};
+search.value = "halo"; search.oninput();
+out.byProvider = rows();
+search.value = "zzz"; search.oninput();
+out.empty = rows();
+search.value = "glm"; search.oninput();
+search.onkeydown({key: "ArrowDown", preventDefault() {}});
+search.onkeydown({key: "Enter", preventDefault() {}});
+out.picked = {value: select.value, label: trigger.textContent, panelHidden: panel.hidden,
+  changes, searchCleared: search.value};
+console.log(JSON.stringify(out));
+"""
+    assert run_js(script) == {
+        "order": ["chat-model-trigger", "dm-search", "dm-cardlist"],
+        "hiddenSelect": True,
+        "closedLabel": "Use harness default",
+        "panelHidden": True,
+        "opened": {
+            "panelHidden": False,
+            "expanded": "true",
+            "rows": ["*Use harness default", "#glm", "ollama-cloud/glm-5.3",
+                     "ollama-cloud/glm-5.1", "halo/ornith"],
+            "focused": ["dm-search chat-model-search"],
+        },
+        "byProvider": ["*halo/ornith"],
+        "empty": ['!No models match "zzz"'],
+        "picked": {
+            "value": "ollama-cloud/glm-5.1",
+            "label": "ollama-cloud/glm-5.1",
+            "panelHidden": True,
+            "changes": ["change:ollama-cloud/glm-5.1"],
+            "searchCleared": "",
+        },
+    }
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node is required")


### PR DESCRIPTION
## Summary

- The Configure form's model search moves **inside** the dropdown. Closed, the picker is one control showing the current route. Open, the search box is the first row of the panel with the family-grouped list beneath it.
- Typing narrows by id, name, family, or provider; arrow keys move the highlight, Enter picks, Escape or an outside click closes. Opening highlights the current pick.
- The native `<select>` stays in the form, hidden, as the value carrier: submit and the thinking-level logic read it unchanged, and the dropdown dispatches `change` on a pick. `chatModelOptions` is untouched.
- Panel styling reuses the Shells-page picker classes (`dm-search`, `dm-sect`, `dm-mcard`) so both pickers read the same.

## Test plan

- [x] `tests/test_conversation_ui.py`: new node test drives the dropdown over a fake DOM — search first in the panel, hidden select, grouped rows, provider filter, empty match, keyboard pick updating the select and dispatching change; contract test for the form wiring. 47 pass.
- [x] `tests/test_modal_ui_contract.py` passes; `node --check .super-coder/ui/app.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHwFxnmsuTatNfAWBx1vCP