### PR TITLE
feat(ui): forgiving model search — fold case and punctuation, match every term

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -9,6 +9,19 @@ const el = (t, props = {}, ...kids) => {
 };
 const esc = (s) => (s ?? "").replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
 
+// Forgiving model search. Both sides fold to lowercase letters + digits only,
+// then every whitespace-separated term of the query must appear in one of the
+// folded fields: "glm 5-3 flash", "GLM5.3", and "flash glm" all reach
+// ollama-cloud/glm-5.3-flash. Fields fold separately so a term never spans two.
+const modelSearchFold = (value) =>
+  String(value ?? "").toLowerCase().replace(/[^\p{L}\p{N}]+/gu, "");
+function modelSearchHit(query, fields) {
+  const terms = String(query ?? "").split(/\s+/).map(modelSearchFold).filter(Boolean);
+  if (!terms.length) return true;
+  const haystack = fields.map(modelSearchFold).join("|");
+  return terms.every((term) => haystack.includes(term));
+}
+
 // Unified list search box — identical look + placement (first element under the
 // header) on every page that filters a list (Roadmap board, Docs, Flags).
 // `onq(value)` fires on each keystroke; the caller owns the persisted query
@@ -624,13 +637,12 @@ function dmModelPicker(harness, cat, row, save, onRouteChanged = () => {}) {
     results.textContent = "";
     applyHighlight = () => {};   // the list this closed over is detached now
     if (!open) { results.hidden = true; return; }
-    const q = input.value.trim().toLowerCase();
-    const hit = (m) => !q || [m.id, m.name, m.family]
-      .some((s) => (s || "").toLowerCase().includes(q));
+    const q = input.value.trim();
+    const hit = (m) => modelSearchHit(q, [m.id, m.name, m.family]);
     const models = cat.stale && !liveBlock ? [] : (data.models || []).filter(
       (m) => m.availability === "available" && hit(m));
     choices = [
-      ...(!q || "harness default".includes(q)
+      ...(modelSearchHit(q, ["harness default"])
         ? [{ value: null, label: "Harness default", sub: "clear the model override" }]
         : []),
       ...models.map((m) => ({ value: m.id, label: m.id, sub: routeSub(m) })),
@@ -3245,9 +3257,9 @@ function chatOpenStream(
 function chatModelOptions(select, catalog, harness, defaultModel, query = "") {
   select.replaceChildren();
   const models = catalog.harnesses?.[harness]?.models || [];
-  const q = String(query || "").trim().toLowerCase();
-  const matches = (model) => !q || [model.id, model.name, model.family, model.provider]
-    .some((field) => String(field || "").toLowerCase().includes(q));
+  const q = String(query || "").trim();
+  const matches = (model) =>
+    modelSearchHit(q, [model.id, model.name, model.family, model.provider]);
   const available = models.filter((model) =>
     model.availability === "available" && matches(model));
   if (defaultModel) select.append(el("option", {
@@ -3350,10 +3362,9 @@ function chatModelDropdown(select, describe = () => "") {
     list.replaceChildren();
     choices = [];
     if (!open) return;
-    const q = search.value.trim().toLowerCase();
-    const hit = (option, group) => !q
-      || [option.value, option.textContent, group, describe(option.value)]
-        .some((field) => String(field || "").toLowerCase().includes(q));
+    const q = search.value.trim();
+    const hit = (option, group) => modelSearchHit(
+      q, [option.value, option.textContent, group, describe(option.value)]);
     for (const group of groups()) {
       const options = group.options.filter(
         (option) => !option.disabled && hit(option, group.label));

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -11,6 +11,10 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 APP = (ROOT / ".super-coder" / "ui" / "app.js").read_text()
+MODEL_SEARCH = APP[
+    APP.index("const modelSearchFold"):
+    APP.index("// Unified list search box")
+]
 INDEX = (ROOT / ".super-coder" / "ui" / "index.html").read_text()
 STYLE = (ROOT / ".super-coder" / "ui" / "style.css").read_text()
 POLL_BLOCK = APP[
@@ -303,7 +307,7 @@ def test_start_chat_has_default_and_configured_paths_without_terminal_controls()
 
 
 def test_model_picker_labels_do_not_expose_harness_support_confidence():
-    options = APP[
+    options = MODEL_SEARCH + APP[
         APP.index("function chatModelOptions"):
         APP.index("function chatCreateConversation")
     ]
@@ -327,8 +331,39 @@ console.log(JSON.stringify(select.options));
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_model_search_folds_punctuation_and_case_and_matches_every_term():
+    script = MODEL_SEARCH + r"""
+const fields = ["ollama-cloud/glm-5.3-flash", "GLM 5.3 Flash", "glm", "ollama-cloud"];
+console.log(JSON.stringify({
+  spaced: modelSearchHit("glm 5-3 flash", fields),
+  squashed: modelSearchHit("GLM5.3", fields),
+  reordered: modelSearchHit("flash glm", fields),
+  provider: modelSearchHit("ollama cloud", fields),
+  dotted: modelSearchHit("5.3", fields),
+  typo: modelSearchHit("glmm", fields),
+  otherModel: modelSearchHit("glm 5.1", fields),
+  spanning: modelSearchHit("flashglm", fields),
+  empty: modelSearchHit("   ", fields),
+  missing: modelSearchHit("", [null, undefined]),
+}));
+"""
+    assert run_js(script) == {
+        "spaced": True,
+        "squashed": True,
+        "reordered": True,
+        "provider": True,
+        "dotted": True,
+        "typo": False,
+        "otherModel": False,
+        "spanning": False,
+        "empty": True,
+        "missing": True,
+    }
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
 def test_model_picker_groups_by_family_and_filters_on_the_search_query():
-    options = APP[
+    options = MODEL_SEARCH + APP[
         APP.index("function chatModelOptions"):
         APP.index("function chatCreateConversation")
     ]
@@ -392,7 +427,7 @@ def test_start_chat_uses_the_searchable_dropdown_over_the_hidden_select():
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
 def test_model_dropdown_opens_with_search_on_top_and_picks_through_the_select():
-    source = APP[
+    source = MODEL_SEARCH + APP[
         APP.index("function chatModelDropdown"):
         APP.index("function chatCreateConversation")
     ]

--- a/tests/test_shells_ui_contract.py
+++ b/tests/test_shells_ui_contract.py
@@ -244,6 +244,9 @@ console.log(JSON.stringify({
 
 def test_live_native_model_picker_ignores_global_stale_catalogue():
     helper = APP[
+        APP.index("const modelSearchFold"):
+        APP.index("// Unified list search box")
+    ] + APP[
         APP.index("function nativeOptionLabel"):
         APP.index("async function renderDefaultModels")
     ]


### PR DESCRIPTION
## Summary

- Model ids are punctuation-heavy (`ollama-cloud/glm-5.3-flash`), so the plain lowercase substring test failed the natural way people type them: `glm 5-3 flash` found nothing.
- New `modelSearchHit(query, fields)`: both sides fold to lowercase letters + digits only, and every whitespace-separated term of the query must appear in one of the folded fields. `glm 5-3 flash`, `GLM5.3`, and `flash glm` all reach the same route; `glm 5.1` does not match `glm-5.3`. Fields fold separately so a term never spans two of them.
- Used by the Chats Configure dropdown, `chatModelOptions`, and the Shells-page default-model picker, so all three searches behave the same.

## Test plan

- [x] New node test for the matcher (spaced, squashed, reordered, provider, dotted, typo, wrong version, field-spanning, empty).
- [x] `tests/test_conversation_ui.py`, `tests/test_shells_ui_contract.py`, `tests/test_modal_ui_contract.py`: 61 pass; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHwFxnmsuTatNfAWBx1vCP