### PR TITLE
fix(relocation): discard a blank legacy DB file instead of refusing as a conflict

### DIFF
--- a/.super-coder/scripts/state_relocation.py
+++ b/.super-coder/scripts/state_relocation.py
@@ -381,6 +381,43 @@ def _relocate_auxiliary_state(repo_root: Path, state: instance_state.InstanceSta
     shutil.rmtree(legacy_backups)
 
 
+def is_blank_database(path: Path) -> bool:
+    """A SQLite file with no schema objects at all — never a real engine DB.
+
+    `sqlite3.connect()` on a missing path creates exactly this: a header-only
+    file with an empty `sqlite_master`. Anything that opened the legacy path
+    without meaning to (a test driving the live root, a probe, an aborted
+    tool) leaves one behind, and the relocation guard would otherwise read
+    it as a second complete database and refuse forever. A DB that carries
+    even one table is NOT blank and keeps the fail-closed treatment.
+    """
+    if not path.is_file() or path.is_symlink():
+        return False
+    try:
+        connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return False
+    try:
+        count = connection.execute("SELECT count(*) FROM sqlite_master").fetchone()[0]
+    except sqlite3.Error:
+        return False
+    finally:
+        connection.close()
+    return count == 0
+
+
+def _discard_blank_legacy(legacy: Path, *, proc_root: Path) -> bool:
+    """Drop a blank legacy file when the private DB is the only real one."""
+    refuse_live_database_owners(legacy, proc_root=proc_root)
+    _remove_legacy_database(legacy)
+    print(
+        f"→ relocation: discarded blank legacy database file {legacy} "
+        "(no schema objects; private state is authoritative)",
+        file=sys.stderr,
+    )
+    return True
+
+
 def _remove_legacy_database(database: Path) -> None:
     for suffix in ("-wal", "-shm", ""):
         Path(str(database) + suffix).unlink(missing_ok=True)
@@ -449,6 +486,16 @@ def relocate_legacy_state(
     with lease:
         receipt = _read_receipt(resolved)
         recovered = False
+        # A blank legacy file next to a real private DB is a stray, not a
+        # conflict: discard it before any branch below can read it as a
+        # second complete database. Only when the private DB exists — a lone
+        # legacy file, blank or not, still follows the ordinary path.
+        if (
+            legacy.exists()
+            and resolved.database.exists()
+            and is_blank_database(legacy)
+        ):
+            _discard_blank_legacy(legacy, proc_root=proc_root)
         if receipt is not None and receipt["status"] == "legacy":
             if not legacy.exists():
                 raise RelocationError(

--- a/tests/test_state_relocation.py
+++ b/tests/test_state_relocation.py
@@ -1,6 +1,8 @@
 """Relocation lifecycle, recovery, exclusion, and selector coverage."""
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import multiprocessing
 import os
@@ -291,6 +293,71 @@ class StateRelocationTests(RelocationFixture):
         self.assertTrue(self.legacy.exists())
         self.assertTrue(self.state.database.exists())
         self.assertFalse(self.state.relocation_receipt.exists())
+
+    def create_blank_database(self, path: Path | None = None) -> Path:
+        # What `sqlite3.connect()` leaves behind when nothing was ever created:
+        # a header-only file with an empty sqlite_master.
+        target = path or self.legacy
+        target.parent.mkdir(parents=True, exist_ok=True)
+        sqlite3.connect(target).close()
+        Path(str(target) + "-wal").write_bytes(b"")
+        return target
+
+    def test_blank_legacy_file_is_discarded_when_private_state_is_live(self):
+        self.create_database(self.state.database, value="private")
+        self.create_blank_database()
+        self.assertTrue(state_relocation.is_blank_database(self.legacy))
+
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            result = self.relocate()
+
+        self.assertFalse(result.relocated)
+        self.assertEqual(result.database, self.state.database)
+        self.assertFalse(self.legacy.exists())
+        self.assertFalse(Path(str(self.legacy) + "-wal").exists())
+        self.assertIn("discarded blank legacy database file", err.getvalue())
+        connection = sqlite3.connect(self.state.database)
+        try:
+            self.assertEqual(
+                "private",
+                connection.execute("SELECT value FROM payload").fetchone()[0],
+            )
+        finally:
+            connection.close()
+
+    def test_blank_legacy_file_is_discarded_after_private_publication(self):
+        self.create_database(value="legacy")
+        first = self.relocate()
+        self.assertTrue(first.relocated)
+        self.assertTrue(self.state.relocation_receipt.exists())
+        self.create_blank_database()
+
+        with contextlib.redirect_stderr(io.StringIO()):
+            again = self.relocate()
+
+        self.assertEqual(again.database, self.state.database)
+        self.assertFalse(self.legacy.exists())
+        self.assertTrue(self.state.relocation_receipt.exists())
+
+    def test_populated_legacy_is_never_treated_as_blank(self):
+        self.create_database(value="legacy")
+        self.assertFalse(state_relocation.is_blank_database(self.legacy))
+        self.create_database(self.state.database, value="private")
+        with self.assertRaisesRegex(
+            state_relocation.RelocationError, "conflicting complete"
+        ):
+            self.relocate()
+        self.assertTrue(self.legacy.exists())
+
+    def test_blank_legacy_without_private_state_follows_the_ordinary_path(self):
+        self.create_blank_database()
+        self.assertFalse(self.state.database.exists())
+        # No private DB means nothing is authoritative yet; the guard stays out
+        # of the way and the ordinary relocation decides, as before.
+        result = self.relocate()
+        self.assertTrue(result.relocated)
+        self.assertFalse(self.legacy.exists())
+        self.assertTrue(self.state.database.exists())
 
     def test_fresh_install_uses_private_state_without_a_relocation_receipt(self):
         self.assertEqual(


### PR DESCRIPTION
## What

The private-state relocation guard refused `./sc update` on sc-cachy today with `conflicting complete legacy and private databases`. The "legacy database" was a 4 KB header-only SQLite file with an empty `sqlite_master`, created when the test suite drove the live root under a scratch HOME. The real private DB was intact; the refusal blocked migration 0247 and the restart.

Relocation now recognises that case: when the private DB exists and the legacy file has **no schema objects at all**, it refuses live owners, removes the stray (plus `-wal`/`-shm`), prints a one-line note on stderr, and continues on the private state. A legacy DB with even one table still fails closed exactly as before. A lone blank file with no private DB is untouched by the new check and follows the ordinary relocation path.

## Tests

`tests/test_state_relocation.py`: blank stray discarded with no receipt; blank stray discarded after a completed relocation (receipt present); populated legacy never treated as blank (existing conflict still refused); blank legacy without private state follows the ordinary path. Relocation, cutover, instance-state, rollback, and materialize suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuJrcYJXBSxjEmRLwFKQCw
