### PR TITLE
docs: recovery for an update that aborts after materialize

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -646,6 +646,32 @@ remain ignored. Then restart the session to boot onto the new floor.
 > default), `--force` to knowingly discard it, or `./sc eject` to own the
 > engine outright (see *Customize a fork vs diverge from it*, next).
 
+### An update that aborts partway — re-run it
+
+An update that fails **after** the materialize step leaves a consistent,
+resumable state: `engine.ref` is not advanced, the new engine is fully on disk,
+and whatever migrations ran are already recorded in the ledger. **Re-run `./sc
+update`.** The second run is dispatched from the on-disk (new) engine, the
+materialize is a byte-identical no-op, `migrate` reports nothing pending, and
+the run continues from where the first one stopped and advances the pin.
+
+Don't reach for `./sc rollback` here — that is the remedy for a *completed*
+update that turned out bad, not for one that stopped halfway.
+
+> [!class4]
+> **Why a fix that is already upstream can still bite a fork once.** The
+> crossing is driven by the updater you *already have*: `update.py` is loaded
+> into memory before the new engine is written over it, so for the rest of that
+> run old updater code is reading new engine data. A defect fixed in the updater
+> therefore takes effect from the **next** crossing — a fork pinned before the
+> fix hits it exactly once, and the re-run is the crossing that clears it. This
+> is the same constraint that makes a breaking engine change ship as a two-hop
+> floor (a compatibility release first, the real change second). Worked example:
+> [#1430](https://github.com/jedbjorn/subfloor/issues/1430), where a pre-fix
+> updater validated the new engine's skill-tombstone registry with its own
+> older, hyphen-rejecting name pattern and aborted catalogue sync on
+> `api-design`.
+
 ### Roll back a bad update
 
 ```bash


### PR DESCRIPTION
Closes #1430.

### What

Adds `docs/README.md` § *An update that aborts partway — re-run it*, under **Update a fork**.

### Why

#1430's named defect — a pre-fix updater validating the new engine's skill-tombstone registry with its own older, hyphen-rejecting `SKILL_NAME_RE` and aborting catalogue sync on `api-design` — is already fixed forward. Current `main` calls `reload_materialized_seed_skills()` immediately after `materialize_fetched_engine()` (`.super-coder/scripts/update.py:1788`), and `tests/test_update_materialize.py:1372` pins the exact case.

What was missing was the recovery. The crossing is driven by the updater already loaded in memory, so that fix takes effect only from the *next* crossing; every fork pinned before it hits the defect once, and nothing upstream can prevent that retroactively. Meanwhile the failure surfaced as a bare traceback with no guidance, so the reporter sat at "Workaround: blocked; none applied" while a one-command recovery existed — and `./sc rollback`, the nearest documented remedy, is the wrong reach for a half-finished update.

The doc states the resumable-state invariant (pin not advanced, engine fully on disk, applied migrations in the ledger), the recovery (`./sc update` again — the second run dispatches the new on-disk updater, materialize is a byte-identical no-op, `migrate` reports nothing pending), the anti-instruction about rollback, and the underlying constraint — the same one that makes a breaking engine change ship as a two-hop floor (Decision #556).

Recovery verified in the field by @J3deye on the `kcsos` fork crossing `8f99b801` → `d079ec68`.

### Scope

Docs only, per FnB direction. Two things deliberately **not** done here:

- **The `self_update` skill** carries the shell-facing mirror of this section and does not yet have the recovery. A skill body edit needs a reseed migration, which this scope excludes.
- **The generalized defect class is still live.** `update.py:84-99` imports 14 engine modules before materialization; only `seed_skills` is reloaded afterward, so the other 13 (`rebuild`, `migrate`, `install`, `instance_state`, `skill_projection`, `flat`, …) stay stale across the crossing with import-time constants like `DB_PATH` frozen from the old engine. The structural fix — hand off to the newly materialized `update.py` in a child process after materialize, which would also let the parent print the recovery line on any post-materialize failure — was considered and deferred.

### Testing

`python3 -m unittest tests.test_fresh_install_shell_contract` — 3 tests, green (the only test asserting against `docs/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143tTyaGLPWQ8J658dCSq9J