### PR TITLE
feat(sprint): sc sprint show + sprint_pln orientation and read surfaces

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2847,6 +2847,25 @@ class Handler(BaseHTTPRequestHandler):
         return self._fail(exc)
 
     @staticmethod
+    def _require_sprint_participant_or_admin(
+        con, sprint_id: int, shell_id: int
+    ) -> None:
+        if con.execute(
+            "SELECT 1 FROM sprints WHERE sprint_id=?", (sprint_id,)
+        ).fetchone() is None:
+            raise KeyError(f"unknown Sprint: {sprint_id}")
+        row = con.execute(
+            "SELECT s.flavor,EXISTS(SELECT 1 FROM sprint_participants p "
+            "WHERE p.sprint_id=? AND p.shell_id=?) AS participates "
+            "FROM shells s WHERE s.shell_id=?",
+            (sprint_id, shell_id, shell_id),
+        ).fetchone()
+        if row is None or (not row["participates"] and row["flavor"] != "admin"):
+            raise sprint_domain.SprintAuthorityError(
+                "only a Sprint participant or FnB may read the Sprint board"
+            )
+
+    @staticmethod
     def _require_sprint_planner(con, sprint_id: int, shell_id: int) -> None:
         sprint = con.execute(
             "SELECT originating_planner_shell_id FROM sprints WHERE sprint_id=?",
@@ -3215,6 +3234,15 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(
                     200,
                     {"sprint_id": sprint_id, "messages": [dict(row) for row in messages]},
+                )
+            if parts[3] == "board":
+                # Read-only projection of the whole Sprint (lifecycle,
+                # participants + current routes, work units, dependencies,
+                # PRs) for its own participants; the FnB browser board reads
+                # the same projection over /api/sprints/<id>.
+                self._require_sprint_participant_or_admin(con, sprint_id, shell_id)
+                return self._send(
+                    200, sprint_board.SprintBoardProjection(con).board(sprint_id)
                 )
             store = sprint_close.SprintCloseStore(con)
             if parts[3] == "report":

--- a/.super-coder/migrations/0248_reseed_sprint_pln_orientation.sql
+++ b/.super-coder/migrations/0248_reseed_sprint_pln_orientation.sql
@@ -1,11 +1,18 @@
----
-name: sprint_pln
-description: Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.
-category: workflow
-common: false
----
+-- 0248 — reseed sprint_pln with Planner orientation and read surfaces.
+-- The Planner skill now explains how a Sprint runs and names every read a
+-- shell has (including the new `sc sprint show` board read) before the
+-- control procedures. No schema change: a full-body UPSERT converges upgraded
+-- installations on the same text a fresh seed produces.
 
-# sprint_pln — govern the armed Sprint
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
 
 Use after `sprint_prep` arms Sprint. System records; Reviewer judges/reports;
 Planner structures/controls; FnB board override = decision #46.
@@ -27,7 +34,7 @@ dispatches every dependency-ready lane as a Force-new Developer wake) ⇄
 `completed` or `aborted` (terminal; nothing is deleted). One Sprint is armed at
 a time.
 
-A lane's life: dispatched → Developer builds on a branch, registers the PR,
+A lane''s life: dispatched → Developer builds on a branch, registers the PR,
 requests review → Reviewer records a verdict → Developer authorizes the merge
 on live green → the merged-work handoff wakes you → you dispatch whatever
 became ready. After the last lane the conformance Reviewer records the
@@ -296,12 +303,12 @@ sc sprint resolve-unit --sprint <id> --work-unit <id> \
   --to completed|cancelled --reason <reason>
 ```
 
-Paused-only; retires the lane's open expectations, supersedes its PR links
+Paused-only; retires the lane''s open expectations, supersedes its PR links
 (registration kept for reconcile-pr), and wakes both seats. Recall+replan
 ships revised work; resolve only closes the lane.
 
 To change future assignment/review model, pause armed Sprint, take each
-participant's `shell_id` and current route from `sc sprint show`, preview the
+participant''s `shell_id` and current route from `sc sprint show`, preview the
 replacement with `sc models resolve`, then replace the route and resume:
 
 ```text
@@ -311,8 +318,8 @@ sc sprint reroute-participant --sprint <id> --participant-shell <id> \
 ```
 
 Prepared Sprints may reroute directly. Paused reroute retires the
-participant's own released expectations and queues fresh ones on the
-replacement route at resume; another seat's open turn still blocks. Existing
+participant''s own released expectations and queues fresh ones on the
+replacement route at resume; another seat''s open turn still blocks. Existing
 chats/runs remain history; next Force-new delivery uses replacement. Reroute
 declared participants only. On decline, preserve reason and choose
 replacement from current capacity; ask Reviewer only if review/conformance
@@ -399,4 +406,11 @@ On an initial clean completion receipt, verify the named Sprint is terminal and
 record `cleanup_state=pending`; run no close command. Stop until the
 engine-authored cleanup success or failure receipt arrives. The Planner does
 not author a second report, accept an actionable handoff, poll cleanup, or ask
-another role to reset a worktree.
+another role to reset a worktree.',
+  0
+) ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -499,6 +499,12 @@ def cmd_disposition_followup(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_show(args: argparse.Namespace) -> int:
+    result = mem._api("GET", f"/_sc/sprint/{args.sprint}/board")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
 def cmd_compile_report(args: argparse.Namespace) -> int:
     result = mem._api("GET", f"/_sc/sprint/{args.sprint}/report?limit={args.limit}")
     print(json.dumps(result["evidence_packet"], indent=2, sort_keys=True))
@@ -853,6 +859,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     followup.add_argument("--resolution-file", help=PAYLOAD_FILE_HELP)
     followup.set_defaults(fn=cmd_disposition_followup)
+
+    show = sub.add_parser(
+        "show",
+        help=(
+            "Read one Sprint: lifecycle, participants with current routes, "
+            "work units, dependencies, and PRs"
+        ),
+    )
+    show.add_argument("--sprint", type=int, required=True)
+    show.set_defaults(fn=cmd_show)
 
     report = sub.add_parser(
         "compile-report", help="Planner prints the bounded evidence packet"

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -88,6 +88,7 @@
     ".super-coder/migrations/0245_reseed_spec_feature_reassignment.sql",
     ".super-coder/migrations/0246_adaptive_shell_posture.sql",
     ".super-coder/migrations/0247_reseed_subfloor_command.sql",
+    ".super-coder/migrations/0248_reseed_sprint_pln_orientation.sql",
     ".super-coder/scripts/activity_monitor.py",
     ".super-coder/scripts/harness_surfaces.py",
     ".super-coder/scripts/instance_state.py",

--- a/tests/test_focused_dev_verification.py
+++ b/tests/test_focused_dev_verification.py
@@ -17,6 +17,7 @@ MIGRATIONS = (
     ENGINE / "migrations" / "0233_reseed_sprint_aware_pr_notifications.sql",
     ENGINE / "migrations" / "0234_reseed_ci_fallback_authority.sql",
     ENGINE / "migrations" / "0240_reseed_sprint_spec_rebinding.sql",
+    ENGINE / "migrations" / "0248_reseed_sprint_pln_orientation.sql",
 )
 sys.path.insert(0, str(ENGINE / "scripts"))
 

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -2729,6 +2729,89 @@ class SprintCliApiTest(unittest.TestCase):
         finally:
             con.close()
 
+    def test_show_reads_the_board_for_participants_and_fnb_only(self):
+        self.use_isolated_db()
+        feature_id, approval_id, task_id = self.seed_declaration("show-reader")
+        participants = self.write(
+            json.dumps(
+                [
+                    {"shell_id": 3, "role": "planner", "harness": "codex"},
+                    {"shell_id": 1, "role": "developer", "harness": "codex"},
+                    {
+                        "shell_id": 2,
+                        "role": "reviewer",
+                        "harness": "kimi",
+                        "model": "kimi-k2",
+                        "effort": "high",
+                    },
+                ]
+            )
+        )
+        sprint_id = self.run_cli(
+            TOKENS["planner"],
+            "declare",
+            "--feature",
+            str(feature_id),
+            "--spec-approval",
+            str(approval_id),
+            "--participants-file",
+            participants,
+            "--merge-grant",
+        )["sprint_id"]
+        unit_id = self.run_cli(
+            TOKENS["planner"],
+            "plan-unit",
+            "--sprint",
+            str(sprint_id),
+            "--developer-shell",
+            "1",
+            "--reviewer-shell",
+            "2",
+            "--title",
+            "Board read",
+            "--expected-output-file",
+            self.write("Participants can read their own Sprint."),
+            "--task",
+            str(task_id),
+        )["work_unit_id"]
+
+        prepared = self.run_cli(
+            TOKENS["planner"], "show", "--sprint", str(sprint_id)
+        )
+        self.assertEqual("prepared", prepared["sprint"]["lifecycle"])
+        by_shell = {row["shell_id"]: row for row in prepared["participants"]}
+        self.assertEqual({1, 2, 3}, set(by_shell))
+        self.assertEqual("unbound-intent", by_shell[2]["binding_status"])
+        self.assertEqual(("kimi", "kimi-k2", "high"), (
+            by_shell[2]["harness"], by_shell[2]["model"], by_shell[2]["effort"]
+        ))
+
+        self.run_cli(
+            TOKENS["planner"],
+            "arm",
+            "--sprint",
+            str(sprint_id),
+            "--conformance-reviewer-shell",
+            "2",
+        )
+
+        for token in (TOKENS["planner"], TOKENS["developer"], TOKENS["admin"]):
+            board = self.run_cli(token, "show", "--sprint", str(sprint_id))
+            self.assertEqual("armed", board["sprint"]["lifecycle"])
+            by_shell = {row["shell_id"]: row for row in board["participants"]}
+            self.assertEqual("bound", by_shell[2]["binding_status"])
+            self.assertEqual(1, by_shell[2]["route_revision"])
+            self.assertEqual("developer", by_shell[1]["role"])
+            self.assertEqual(
+                [unit_id], [unit["work_unit_id"] for unit in board["work_units"]]
+            )
+            self.assertEqual(1, board["work_units"][0]["developer"]["shell_id"])
+
+        with self.assertRaisesRegex(SystemExit, "HTTP 403"):
+            self.run_cli("dev2-token", "show", "--sprint", str(sprint_id))
+        with self.assertRaisesRegex(SystemExit, "HTTP 404"):
+            self.run_cli(TOKENS["planner"], "show", "--sprint", "999")
+
     def test_real_review_merge_dispatch_monitor_and_close_surfaces(self):
         request = self.run_cli(
             TOKENS["developer"],

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -55,7 +55,7 @@ CONFORMANCE_OWNER_SKILLS = {
 
 SPEC_SKILL = ENGINE / "assets" / "skills" / "spec" / "SKILL.md"
 CONTEXT_EFFICIENT_SKILLS = ("sprint_dev", "sprint_rev", "sprint_pln", "spec")
-CONTEXT_EFFICIENT_SKILL_BYTE_CEILING = 44_361
+CONTEXT_EFFICIENT_SKILL_BYTE_CEILING = 47_212
 CONTEXT_EFFICIENT_RESEED = (
     ENGINE / "migrations" / "0202_reseed_context_efficient_skills.sql"
 )
@@ -1471,6 +1471,7 @@ class SprintSkillTest(unittest.TestCase):
             "compile-report",
             "cleanup-status",
             "cleanup",
+            "show",
         }
         combined = "\n".join(
             (ASSETS / name / "SKILL.md").read_text() for name in SKILLS


### PR DESCRIPTION
## Why

A Planner on dos-arch spent ~13 minutes probing for where to read Sprint participants and routes before it could reroute a paused Sprint. Two causes:

1. `sprint_pln` lists mutation commands but never names the read surfaces a Planner has, nor gives the two-minute model of how a Sprint runs.
2. No shell-authenticated read of participants + current routes existed at all. Only the FnB browser board (`/api/sprints/<id>`) carried that projection.

## What

- **`sc sprint show --sprint <id>`** — new GET `/_sc/sprint/<id>/board` for the Sprint's participants and FnB, reusing the existing `sprint_board` projection (lifecycle, participants with routes/binding status/route revision, work units, dependencies, PRs, health). 403 for non-participants, 404 for unknown Sprint. Test covers prepared and armed reads, three roles, and both refusals.
- **`sprint_pln`** — new "How a Sprint runs" and "What you can read" sections before the control procedures; the reroute procedure now says where the inputs come from (`show` + `sc models resolve`). Migration `0248` reseeds the body.

## Trade-offs stated

- **One PR, not two.** `test_skills_use_only_the_shipped_shell_command_surface` requires every shipped `sc sprint` subcommand to appear in a skill, so the engine read and the skill text cannot be green independently without a throwaway reseed. Two commits keep them reviewable separately.
- **Byte ceiling raised** `44_361 → 47_212` (the new exact sum, matching the prior practice of pinning to the sum). The growth is all Planner orientation, in line with decision #286 and the intent that Planners are the most informed role while Devs/Reviewers stay focused.
- Skill text informs; it does not add enforcement.

## Verification

Focused: `test_sprint_cli`, `test_sprint_skills`, `test_focused_dev_verification`, `test_flavor_skill_packs`, `test_sprint_removal_manifest`, `test_sprint_close`, `test_migration_management`, `test_sprint_board_api`, `test_skills_freshness` — all green. `ruff` on touched files: zero delta vs `origin/main` (repo-wide lint/typecheck hooks are noisy at baseline). Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
