### PR TITLE
fix(docs): allow render_path edits on a frozen document

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1744,10 +1744,17 @@ def patch_document(
             ).fetchone()
             if document is None:
                 return False, "no such document"
-            if document["frozen"]:
+            # A frozen row's content is immutable; its render_path is a
+            # location, not content. It stays editable so a frozen doc that
+            # collides with or violates the managed render layout can be
+            # moved without unfreezing (#629).
+            if document["frozen"] and cols != ["render_path"]:
                 return (
                     False,
-                    "document is frozen — open the next spec, don't edit this one",
+                    (
+                        "document is frozen — open the next spec, don't edit this "
+                        "one (only render_path may change on a frozen document)"
+                    ),
                 )
 
             candidate = dict(document)

--- a/.super-coder/assets/skills/docs/SKILL.md
+++ b/.super-coder/assets/skills/docs/SKILL.md
@@ -225,10 +225,14 @@ it.
 
 Unfrozen -> edit in place: no new row, no seq bump. Pass any of `--title` /
 `--body-file` / `--render-path`; renders + snapshots like `add`. Frozen ->
-refused; open a new spec under the same feature instead:
+title + body refused; open a new spec under the same feature instead. A
+frozen doc's `--render-path` alone stays editable: it is a location, not
+content, so a retired or mis-pathed frozen row that collides in the render
+layer can be moved off the path without unfreezing it:
 ```
 sc mem doc edit <document_id> --body-file ./draft.md
 sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
+sc mem doc edit <frozen_id> --render-path specs_sc/<slug>-retired.md   # frozen: path only
 ```
 
 ## Freeze + document on ship — the planner's handoff
@@ -242,9 +246,9 @@ Shipping is a two-shell act (keeps `shipped` honest):
   the paperwork:
 
 1. **Freeze the shipped spec** — immutable thereafter; the feature's other
-   specs stay unfrozen and unaffected. NEVER edit a frozen spec (open a new
-   spec under the same feature); the GUI and render layer both refuse edits
-   to frozen docs:
+   specs stay unfrozen and unaffected. NEVER edit a frozen spec's content
+   (open a new spec under the same feature); the GUI and render layer both
+   refuse title/body edits to frozen docs — only its render path may move:
    ```
    sc mem doc freeze <document_id>
    ```

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -56,7 +56,7 @@ gitignored. After `self_update` succeeds, stage only the durable public update:
 ```bash
 git add .sc-state/engine.ref
 git status --short
-SC_SHELL_FLAVOR=admin git commit -m "chore: update super-coder engine pin"
+SC_SHELL_FLAVOR=admin git commit -m "chore: update subfloor engine pin"
 ```
 
 Set the marker on this commit command even inside an Admin shell. The update
@@ -94,7 +94,7 @@ deleted.
 git ls-files --error-unmatch .super-coder/schema.sql
 ```
 
-Exit 0 means this repository authors super-coder itself: `.super-coder/` is
+Exit 0 means this repository authors Subfloor itself: `.super-coder/` is
 tracked source, not a dependency, and `.sc-state/engine.ref` is not the delivery
 unit. Engine implementation still arrives through a Developer branch and PR;
 Admin fast-forwards main and merges only the exact approved PR. Apply live
@@ -651,7 +651,7 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'docs',
-  'Author or review docs & specs in super-coder. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.',
+  'Author or review docs & specs in Subfloor. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.',
   'substrate',
   NULL,
   0,
@@ -875,10 +875,14 @@ it.
 
 Unfrozen -> edit in place: no new row, no seq bump. Pass any of `--title` /
 `--body-file` / `--render-path`; renders + snapshots like `add`. Frozen ->
-refused; open a new spec under the same feature instead:
+title + body refused; open a new spec under the same feature instead. A
+frozen doc''s `--render-path` alone stays editable: it is a location, not
+content, so a retired or mis-pathed frozen row that collides in the render
+layer can be moved off the path without unfreezing it:
 ```
 sc mem doc edit <document_id> --body-file ./draft.md
 sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
+sc mem doc edit <frozen_id> --render-path specs_sc/<slug>-retired.md   # frozen: path only
 ```
 
 ## Freeze + document on ship — the planner''s handoff
@@ -892,9 +896,9 @@ Shipping is a two-shell act (keeps `shipped` honest):
   the paperwork:
 
 1. **Freeze the shipped spec** — immutable thereafter; the feature''s other
-   specs stay unfrozen and unaffected. NEVER edit a frozen spec (open a new
-   spec under the same feature); the GUI and render layer both refuse edits
-   to frozen docs:
+   specs stay unfrozen and unaffected. NEVER edit a frozen spec''s content
+   (open a new spec under the same feature); the GUI and render layer both
+   refuse title/body edits to frozen docs — only its render path may move:
    ```
    sc mem doc freeze <document_id>
    ```
@@ -1173,7 +1177,7 @@ operation with the runtime down.
 
 - API down, database healthy: use host Admin `sc health`, `sc logs`, and
   read-only `sc sql`, then restore the managed service with `sc restart` /
-  `make dos-r`.
+  `subfloor restart`.
 - Migration or rebuild work: load `engine_migrations` and require its backup,
   candidate, ledger, and restart receipts.
 - Snapshot or render repair: load `snapshot`; do not hand-edit serialized or
@@ -1638,15 +1642,15 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'git',
-  'Git conventions for a super-coder shell — one repo, one cwd. Sync the base before work, branch before committing, open PRs (never merge without the FnB''s OK), attribute commits per-shell. Use before any git work.',
+  'Git conventions for a Subfloor shell — one repo, one cwd. Sync the base before work, branch before committing, open PRs (never merge without the FnB''s OK), attribute commits per-shell. Use before any git work.',
   'substrate',
   NULL,
   0,
-  '# git — version control, the super-coder way
+  '# git — version control, the Subfloor way
 
 One repo at its root -> plain `git` (cwd = repo root) is safe.
 
-Project = this repo minus `.super-coder/`. Engine = `.super-coder/` — gitignored, materialized by `sc update`, authored upstream in super-coder. NEVER commit or edit anything under `.super-coder/`.
+Project = this repo minus `.super-coder/`. Engine = `.super-coder/` — gitignored, materialized by `sc update`, authored upstream in Subfloor. NEVER commit or edit anything under `.super-coder/`.
 
 ## GitHub capability boundary
 
@@ -1923,7 +1927,7 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'issue_reporting',
-  'Report engine defects upstream — the moment a sc command fails or lies, a skill contradicts your reality, the API blocks a documented workflow, or you work around the engine to proceed. File a GitHub issue on super-coder; your repo''s app bugs stay in the fork.',
+  'Report engine defects upstream — the moment a sc command fails or lies, a skill contradicts your reality, the API blocks a documented workflow, or you work around the engine to proceed. File a GitHub issue on Subfloor; your repo''s app bugs stay in the fork.',
   'substrate',
   NULL,
   1,
@@ -2516,7 +2520,7 @@ ON CONFLICT(name) DO UPDATE SET
 
 INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
   'self_update',
-  'Update this fork''s super-coder engine in place — fetch + materialize new code + migrations, all memory intact; sound rollback. The shell hands off to its own next boot. Use when a super-coder update is available.',
+  'Update this fork''s Subfloor engine in place — fetch + materialize new code + migrations, all memory intact; sound rollback. The shell hands off to its own next boot. Use when a Subfloor update is available.',
   'substrate',
   'sc update',
   0,
@@ -3232,6 +3236,52 @@ Use the simplest path supported by current durable state. Treat authority,
 lifecycle, writes, and handoffs as hard boundaries. Repeat a read only when
 later activity could have changed it or a command requires revalidation.
 
+## How a Sprint runs
+
+One Sprint binds one roadmap feature, exact governing spec revisions, a
+participant set (you, Developers, Reviewers) each on one harness/model/Thinking
+level (`effort`) route, and work units: editing lanes made of spec tasks, each
+with one Developer and one Reviewer, ordered by dependencies and planned waves.
+
+Lifecycle: `prepared` (editable, `sprint_prep`) → `armed` (the runtime
+dispatches every dependency-ready lane as a Force-new Developer wake) ⇄
+`paused` (relay is off; restructuring and rerouting happen here) →
+`completed` or `aborted` (terminal; nothing is deleted). One Sprint is armed at
+a time.
+
+A lane''s life: dispatched → Developer builds on a branch, registers the PR,
+requests review → Reviewer records a verdict → Developer authorizes the merge
+on live green → the merged-work handoff wakes you → you dispatch whatever
+became ready. After the last lane the conformance Reviewer records the
+whole-Sprint report; the engine closes the Sprint and cleans worktrees. The
+engine delivers every wake and watches every registered PR; you never poll or
+boot participants.
+
+Authority: Reviewers own verdicts, conformance, and re-enter/abort judgment.
+You own plan structure: lanes, dependencies, waves, assignment, routes, pause,
+resume, dispatch. The FnB can override any of it from the GUI Sprints tab,
+which renders the same projection `sc sprint show` returns.
+
+## What you can read
+
+| Need | Read |
+|---|---|
+| Whole Sprint: lifecycle, participants with current routes, units, dependencies, PRs, health | `sc sprint show --sprint <id>` |
+| Messages addressed to you | `sc sprint inbox --sprint <id>` |
+| Exact bound spec body | `sc sprint spec-revision --sprint <id> --document <id> [--body-only]` |
+| PR-watcher evidence behind a stalled gate | `sc sprint watcher-state --sprint <id>` |
+| Post-Sprint cleanup evidence | `sc sprint cleanup-status --sprint <id>` |
+| Bounded history packet: judgments, pauses, anomalies, follow-ups | `sc sprint compile-report --sprint <id> --limit 50` |
+| Candidate routes and what each supports | `sc models list [<harness>]`; preview one with `sc models resolve <harness> [<model>] [--effort <level>]` |
+| Shell roster, feature, spec tasks, settled decisions | `sc mem get shells`, `sc mem get roadmap`, `sc mem get tasks --feature <id>`, `sc mem get decisions` |
+
+`show` participants carry `shell_id`, `role`, `harness`, `model`, `effort`,
+`binding_status`, and `route_revision`; units carry `developer`, `reviewer`,
+`disposition`, `prerequisite_ids`, and `pull_requests`. A Thinking level
+applies only to controlled routes: `null` model + `null` effort is Harness
+default, and Vibe takes no effort. Nothing else is readable from a shell; the
+engine database is not a surface.
+
 ## Route the entry
 
 Load `sprint_pln` on every entry, then classify:
@@ -3472,8 +3522,9 @@ Paused-only; retires the lane''s open expectations, supersedes its PR links
 (registration kept for reconcile-pr), and wakes both seats. Recall+replan
 ships revised work; resolve only closes the lane.
 
-To change future assignment/review model, pause armed Sprint, clear released
-expectation, then validate + replace route:
+To change future assignment/review model, pause armed Sprint, take each
+participant''s `shell_id` and current route from `sc sprint show`, preview the
+replacement with `sc models resolve`, then replace the route and resume:
 
 ```text
 sc sprint reroute-participant --sprint <id> --participant-shell <id> \

--- a/.super-coder/migrations/0249_reseed_docs_frozen_render_path.sql
+++ b/.super-coder/migrations/0249_reseed_docs_frozen_render_path.sql
@@ -1,0 +1,466 @@
+-- 0249 — reseed docs with the frozen render_path allowance.
+-- A frozen document's render_path is a location, not content: `sc mem doc
+-- edit <id> --render-path` now moves a frozen row off a colliding path
+-- (subfloor#629). The docs skill says so. No schema change: a full-body
+-- UPSERT converges upgraded installations on the same text a fresh seed
+-- produces.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'docs',
+  'Author or review docs & specs in Subfloor. The DB owns the body (documents table); roadmap tracks specs (the dev cycle), the Docs tab holds docs. Use whenever asked for a doc, spec, report, design, RFC, ADR, runbook, or to edit existing ones.',
+  'substrate',
+  NULL,
+  0,
+  '# docs — author & review documents
+
+The DB owns document bodies: a `documents` row is the source — NEVER author a
+loose `.md` file as the canonical body. `sc render` writes the read-only flat
+copy to `specs_sc/` / `docs_sc/`; the GUI opens it rendered in md-converter.
+
+| kind | lives on | meaning |
+|---|---|---|
+| `spec` | the **Roadmap** (the dev cycle) | working spec for a feature; a feature can hold several at once; **freezes on ship** |
+| `doc` | the **Docs** tab | documentation; not part of the spec lifecycle |
+
+`<self>` = your shell_id.
+
+## One feature, many specs
+
+Feature = the `roadmap` row; exists from `brainstorm` onward, before any spec.
+Specs hang off the feature, not off each other: several unfrozen specs per
+feature, each a `documents (kind=''spec'')` row, ordered by `seq`. No
+feature-to-feature links; related work within one mental model is another spec
+under the same feature. A genuinely new era may split into a fresh feature by
+moving its unfrozen active spec through the guarded workflow below. Freeze =
+the ship-time record of what was built to; it never gates the feature''s other
+specs.
+
+| state | test | meaning |
+|---|---|---|
+| **shipped** | `frozen = 1` | delivered; immutable record |
+| **active** | unfrozen + has rows in `spec_tasks` | the spec being built now |
+| **backlog** | unfrozen, no task plan | the pile, ordered by `seq` |
+
+The **doc** (`kind=''doc''`) = the feature''s readable face — write it when the
+first spec ships, under the same `feature_id`. Sibling of the specs, not a
+parent.
+
+## Split an active era from feature history
+
+When accumulated history makes a feature''s active context misleading or a new
+era has become a separate mental model, preserve the old feature as history and
+move the existing unfrozen active spec intact:
+
+1. Create the fresh feature with its correct work-stream, status, and summary.
+2. Run `sc mem doc move <document_id> --feature <target_feature_id>`.
+3. Re-read the document and task ledger under the target feature; the same ids,
+   task states, and document-linked decisions must now project there.
+4. Edit the historical feature''s title/summary to name the split, then set its
+   truthful terminal status (`shipped` for delivered history, `retired` for
+   abandoned history).
+
+The move assigns the spec''s next target-feature sequence and is atomic across
+the document, its tasks, and document-linked decisions. It refuses frozen
+specs, ordinary docs, terminal targets, and any spec already bound to a Sprint.
+Do not duplicate the spec or cancel/recreate its tasks when this move applies.
+
+## Assess the work-stream on every feature
+
+A feature attaches to a work-stream (`projects` row) via `roadmap.project_id`.
+The GUI Flow view groups on it; `NULL` shows as Ungrouped = invisible to the
+grouping. On every feature create / spec author / spec update, assess the
+work-stream in the same act:
+
+```
+sc mem get projects   # existing work-streams — pick the fit
+sc mem get roadmap    # this feature''s current project_id
+```
+
+| case | action |
+|---|---|
+| new feature | create pre-assigned: `sc mem roadmap add "<title>" --project <shortname>` |
+| existing + Ungrouped | `sc mem roadmap project <feature_id> <shortname>` |
+| no fitting stream | `sc mem project add <shortname> "<title>" --purpose "…"` -> then assign |
+| already correctly assigned | no-op — don''t churn |
+
+Auto-assign when only one plausible fit / it clearly belongs to an existing
+stream. Surface to the FnB only when ambiguous — several streams fit, or a
+new stream you''re unsure how to name. Exempt (as with stages): work that
+isn''t a feature/spec (a quick fix) needs no work-stream.
+
+## Establish posture, then challenge
+
+Before writing — don''t duplicate, don''t re-litigate, and don''t transcribe the
+request uncritically:
+```
+sc mem get documents      # every control-plane spec/doc (kind, seq, frozen, task_count)
+sc mem get decisions      # active-decision index (<id> = full row + rationale; --all incl. superseded)
+sc map-sql "SELECT path FROM dr_filepath WHERE role=''doc'';"   # repo''s own docs (map db)
+```
+
+Spec touches a recorded decision -> honor it, or supersede explicitly: say so
+in the spec + record `sc mem decision "…" --parent <old_id>`. NEVER silently
+re-decide a settled choice.
+
+Read the documentation for every related system the change relies on or alters.
+Documentation is the preferred account of intended posture. If it is absent,
+ambiguous, or plausibly stale, use the repo map to locate and verify the narrow
+code path; name that fallback in the spec. Documentation and code disagree ->
+surface both as an inconsistency to the FnB. Do not silently choose one as truth.
+
+Walk the proposed workflow end to end. Challenge contradictions, missing
+boundaries, hidden assumptions, audience mismatches, partial failure, concurrent
+use, permissions, and the unhappy path. Ask the FnB to resolve anything that
+could change implementation or acceptance. Finalize only after each material
+question is either resolved or explicitly deferred; a deferral belongs in
+**Out of Scope**, with the boundary it leaves behind. Editorial uncertainty that
+cannot change the build does not block authoring.
+
+The conversation is input; the spec is the resolved contract. Paraphrase or
+synthesize settled FnB decisions beside the design clause they govern. Preserve
+the requirement and consequential rationale, not the dialogue. Never promote an
+unconfirmed suggestion to a requirement or hide an unresolved choice in fluent
+prose.
+
+## Required spec contract
+
+Every newly authored spec, and every substantive revision to an unfrozen spec,
+must make these boundaries explicit:
+
+| section | holds |
+|---|---|
+| `## Current Posture` | related systems and intended behavior before this change; name the documents and decisions consulted, plus any code paths used because documentation was missing, ambiguous, or stale |
+| `## Scope` / `### In Scope` | behavior this delivery promises to add, change, or remove |
+| `## Scope` / `### Out of Scope` | adjacent behavior deliberately excluded from this delivery, including explicit deferrals and the boundary retained |
+| relevant design sections | synthesized FnB decisions and rationale placed beside the requirement they constrain |
+| `## Anticipated User Activity` | actors, per-surface audience posture, reach, process curation, safety hardening, tenancy, and behavior beyond intention |
+
+Out of scope means "not in this delivery," never "will never be built." Do not
+use it to park an unresolved requirement that changes the in-scope design. Mixed
+surfaces may have different audiences and controls; specify them separately.
+Frozen historical specs are immutable and need no backfill.
+
+## Author
+
+Write through `sc mem doc add` (routes through the engine API): `--body-file`
+reads the markdown from a file (no shell-escaping a long body); `--seq`
+auto-increments within `(feature, kind)`; it renders + snapshots for you
+(pipeline = the `snapshot` skill). The render+snapshot is serialized by one
+in-process API lock — sufficient because these artifacts only ever come from
+manual admin-shell or GUI actions (single writer by design; cross-process
+concurrency is out of scope for v1, decision #20 / roadmap #21).
+```
+# a doc against a feature (kind=''doc''); DB owns the body:
+sc mem doc add "…" --kind doc --feature <id> --body-file ./draft.md --render-path docs_sc/….md
+
+# a feature''s next spec stage (kind=''spec''); seq auto-advances:
+sc mem doc add "…" --kind spec --feature <id> --body-file ./draft.md --render-path specs_sc/….md
+```
+
+## Specs carry "Anticipated User Activity"
+
+Every spec (`kind=''spec''`) ships an `## Anticipated User Activity` section —
+the feature''s posture statement: who is expected to touch it, where it can be
+reached, how much process guidance each surface needs, which safety controls its
+exposure and impact require, whose data it holds, and what it does not intend to
+allow. Soft vocabulary, hard invariants — the nouns stay gentle, every statement
+stays checkable from code ("a Valid User only ever sees rows tied to their own
+account"), because review + Verification test the build against this section.
+
+Shape (H3s under the section H2):
+
+| H3 | holds |
+|---|---|
+| `### Vocabulary` | the cast — roles from the shared roster below + any feature-specific ones, each defined in one line |
+| `### Expected Activity` | per role: what they do, what they see, what they can change |
+| `### Reach` | where the feature meets the world — pages, endpoints, jobs, files it adds or alters, and which roles can arrive at each |
+| `### Audience and Assurance` | for each reachable surface: intended audience posture(s), process curation, and concrete safety hardening derived from exposure, authority, data sensitivity, reversibility, and blast radius |
+| `### Data Tenancy` | whose data the feature touches; what stays within one account; what, if anything, is deliberately shared |
+| `### Beyond Intention` | activity the feature does not intend to accommodate — anything observed here in review is a finding, not a nuance |
+
+Shared roster (always available; same meaning in every spec):
+
+| role | means |
+|---|---|
+| **Valid Privileged User** | signed-in user with an operator/admin role, acting within what that role allows |
+| **Valid User** | signed-in user acting inside their own account and their own data |
+| **Visitor** | expected traffic that has not signed in (public/shared surfaces) |
+| **Future Potential User** | a role anticipated later, not built now — the design must not wall it out |
+| **System** | the product acting on a schedule or trigger — daemons, jobs, watchers |
+| **Shell** | an AI agent shell acting through its granted tools — its activity is messages, memory writes, file edits |
+| **Unexpected Participant** | anyone acting outside the roles above — where the spec says what must never be reachable |
+
+Audience postures describe the expected user of a surface; they do not replace
+the activity roles above and are not mutually exclusive:
+
+| posture | design consequence |
+|---|---|
+| **Unknown User** | identity and competence are not established at entry; public/anonymous reach needs the most tolerance of unanticipated input, guidance, safe defaults, and bounded disclosure |
+| **Authenticated User** | identity is established, but trust is not assumed; keep account boundaries, validation, recovery, and clear feedback explicit |
+| **Operational User** | a trained user performs a recurring workflow; optimize safe repetition, observable state, partial-failure recovery, and low ambiguity |
+| **Technical User** | a user understands technical concepts or automation; instructional curation may be lighter, while contracts, validation, precise errors, and compatibility stay rigorous |
+| **Administrator** | a user holds broad authority; instructional curation may be light, while authorization, consequential-action confirmation, auditability, reversibility, and recovery reflect the larger blast radius |
+
+Separate **process curation** from **safety hardening**. Expertise can reduce
+explanation and hand-holding; it never waives correctness, input validation,
+authorization, tenancy, or safe failure. Derive hardening from the surface''s
+reach and consequence, not from a single audience ranking. An Unknown User
+demands the strongest unanticipated-input posture; an Administrator may demand
+the strongest authority and recovery controls. State concrete obligations, not
+only a posture label.
+
+An Unknown User is expected anonymous/public traffic. An Unexpected Participant
+is activity outside the stated contract, whether or not identity is known. For
+machine-only behavior, name `System` or `Shell`, say that there is no human
+audience, and still specify reach and assurance.
+
+Language — soft by design. Specs never use: threat model, attack or attack
+surface, adversary, exploit, abuse case, vulnerability, breach, privilege
+escalation, exfiltration, malicious. Say it in roster words instead: threat
+model -> anticipated activity · attacker -> Unexpected Participant · abuse
+case -> Beyond Intention · access matrix -> Expected Activity · attack
+surface -> Reach · isolation -> tenancy. Describe behavior and boundaries,
+never hostility.
+
+Internal-only feature -> the section still ships; identify its operational,
+technical, or administrator surface, reach, authority controls, and tenancy
+posture. Whole section ≤ ~60 lines — it frames the build, it does not enumerate
+it.
+
+## Revise before freeze
+
+Unfrozen -> edit in place: no new row, no seq bump. Pass any of `--title` /
+`--body-file` / `--render-path`; renders + snapshots like `add`. Frozen ->
+title + body refused; open a new spec under the same feature instead. A
+frozen doc''s `--render-path` alone stays editable: it is a location, not
+content, so a retired or mis-pathed frozen row that collides in the render
+layer can be moved off the path without unfreezing it:
+```
+sc mem doc edit <document_id> --body-file ./draft.md
+sc mem doc edit <document_id> --title "New title" --render-path specs_sc/….md
+sc mem doc edit <frozen_id> --render-path specs_sc/<slug>-retired.md   # frozen: path only
+```
+
+## Freeze + document on ship — the planner''s handoff
+
+Shipping is a two-shell act (keeps `shipped` honest):
+
+- **dev**: flips `roadmap_status = shipped` + opens a **docs-pending** flag
+  (`spec` skill, Step 5) — `shipped` never silently claims a doc that doesn''t
+  exist yet.
+- **planner**: on that flag (arrives in your inbox per the `flags` skill), do
+  the paperwork:
+
+1. **Freeze the shipped spec** — immutable thereafter; the feature''s other
+   specs stay unfrozen and unaffected. NEVER edit a frozen spec''s content
+   (open a new spec under the same feature); the GUI and render layer both
+   refuse title/body edits to frozen docs — only its render path may move:
+   ```
+   sc mem doc freeze <document_id>
+   ```
+2. **Read the shipped code, then write the doc** — from the code as it
+   actually shipped, NOT from the spec body. The spec is intent; the code is
+   truth (drift lands during production). Read the implementation first,
+   write what it does:
+   ```
+   sc mem doc add "<feature> — how it works" --kind doc --feature <id> --body-file ./draft.md --render-path docs_sc/<slug>.md
+   ```
+3. **Close the docs-pending flag** pointing at the doc:
+   ```
+   sc mem flag close <flag_id> --notes "Spec frozen; doc <document_id> written → docs_sc/<slug>.md"
+   ```
+
+Until step 3, `shipped` + open flag = the truthful interim state: delivered,
+doc pending.
+
+## View
+
+GUI "open in md-converter ↗" (Roadmap card / Docs tab) opens any doc rendered
+— the body rides in the URL, no upload. Long-form authoring: write the
+markdown to `body`; render + md-converter own presentation.
+
+---
+
+# Authoring format (themed-markdown)
+
+The `body` you write IS themed-markdown — the format md-converter renders.
+Your job = structure; styling = the renderer''s job. NEVER write visual
+instructions (colors, fonts, sizes, themes) — apply the four semantic
+classes; the theme picks colors.
+
+Use ONLY the constructs below — anything else drops silently or breaks the
+render.
+
+`req` = required · `opt` = optional · `≤N` = soft character cap (over-cap
+wraps awkwardly / overflows a fixed UI slot).
+
+## Frontmatter
+
+```
+---
+title: Document Title
+tags: [tag1, tag2]
+date: YYYY-MM-DD
+project: Project Name
+purpose: Brief description
+---
+```
+
+| Field | Status | Cap |
+|---|---|---|
+| `title` | req | ≤40 |
+| `tags` | req (YAML list; `[]` ok) | — |
+| `date` | opt | `YYYY-MM-DD` |
+| `project` | opt | ≤40 |
+| `purpose` | opt | ≤40 |
+
+`date`/`project`/`purpose` -> footer meta cards. `sc render` injects
+`feature`, `roadmap_status`, `frozen`, `rendered_by`, `source` on top —
+NEVER write those yourself. Tags = YAML list only; comma-separated
+(`tags: a, b`) breaks.
+
+## Structure
+
+| Syntax | Role | Cap |
+|---|---|---|
+| `# Title` | doc title (opt; falls back to `frontmatter.title`) | — |
+| `## Section` | sidebar tab | ≤28 |
+| `### Heading` | subsection -> `<h3>` | ≤80 |
+
+H4–H6 ⛔.
+
+**Tab rule:** every H2 = one tab; content between two H2s belongs to the
+first. Content between H1 and the first H2 is silently dropped — put intro
+under an H2 (e.g. "Overview"). Single-section docs may omit H2s (whole doc =
+one tab).
+
+**Doc scale:** ≤25 sections + ≤15 Mermaid diagrams (every section renders
+up-front; every Mermaid re-renders per tab switch) — split larger material.
+
+## Inline · lists · tables · images · code
+
+- Inline: `**bold**` · `*italic*` · `~~strike~~` · `` `code` `` · `[text](url)`
+- Lists: `-` unordered · `1.` ordered · `- [ ]` / `- [x]` tasks
+- Tables: standard GFM pipe tables
+- Images: `![alt](https://url/img.png)` — absolute URLs only, descriptive alt
+- Video: a bare video URL alone on its own line renders as a player — a
+  `github.com/user-attachments/assets/<id>` URL (paste a video into a GitHub
+  issue/PR to mint one) or any absolute URL ending `.mp4`/`.webm`/`.mov`/`.ogg`.
+  NEVER wrap it in `![]()` / `[]()` — bare triggers the player.
+- Code: fenced with a language hint (```` ```python ````)
+
+## Color classes
+
+`class1`–`class4` — on callouts, stat cards, mermaid nodes, linear steps.
+Choose the class by meaning; the theme decides the color. Keep one class per
+semantic role across the doc (e.g. `class1` = primary, `class2` = supporting,
+`class3` = positive/done, `class4` = caution/warning). Consistency >
+specific choice.
+
+## Callouts
+
+```
+> [!class1]
+> Callout content.
+```
+Cap ≤280 (one short paragraph). class1–class4.
+
+## Stat cards
+
+````
+```stats
+:::class1
+value: 87%
+label: User satisfaction
+description: Up 12% from last quarter
+:::class2
+value: 1.2M
+label: Active users
+```
+````
+
+| Field | Status | Cap | Notes |
+|---|---|---|---|
+| `value` | req | ≤12 | short token (`87%`, `1.2M`) — not sentences |
+| `label` | req | ≤28 | one short noun phrase |
+| `description` | opt | one short line | omit if no signal |
+
+Layout: 2 per row; trailing odd card spans the row.
+
+## Mermaid
+
+````
+```mermaid
+graph LR
+  A[Start]:::class1 --> B[Middle]:::class2 --> C[End]:::class3
+```
+````
+
+Class via `:::classN` on nodes. The app injects `classDef` — NEVER write
+`classDef`, `fill:`, or any style directive. Node label cap ≤24 (long labels
+balloon auto-sized nodes).
+
+**Quote labels with special characters** — unquoted node text is parsed as
+Mermaid grammar. Any label containing `/`, `(`, `)`, `*`, `[`, `]`, `{`, `}`,
+`<`, `>`, `#`, `:`, `;`, or a quote MUST be double-quoted inside the brackets
+-> else *"Syntax error in text"* and nothing renders. Notably `A[/text/]` =
+the parallelogram shape, so a literal path like `/lease/mail/*` breaks unless
+quoted.
+
+```
+GOOD:  AD["/admin/user-credentials/"]:::class3
+       N["count > 0"]:::class2
+BAD:   AD[/admin/user-credentials/]      (parsed as a parallelogram shape → error)
+       N[count > 0]                      (> is a grammar token → error)
+```
+
+Cylinder/stadium shapes are fine as-is — `DB[(secrets.db)]`, `X([ready])` —
+quote only the inner text, not the shape brackets.
+
+## Linear
+
+````
+```linear
+Step 1 :::class1 -> Step 2 :::class2 -> Step 3 :::class3
+```
+````
+Steps separated by `->`, optional `:::classN`. Renders vertically — one step
+per row, top→bottom (never horizontal). Step text cap ≤48.
+
+## Never
+
+- H4–H6 · blockquotes (except callouts) · footnotes · raw HTML
+- Color / font / size / theme / visual mentions (the theme owns styling)
+- Content between H1 and the first H2 (silently dropped — use an H2)
+- Comma-separated `tags` (must be a YAML list)
+- `classDef` / `fill:` / style directives inside Mermaid
+- Unquoted Mermaid labels containing special characters
+
+## Open in md-converter
+
+A doc whose `body` lives in the DB already opens in the app from the GUI
+("open in md-converter ↗" on the Roadmap/Docs card) — author nothing there.
+
+When committing a **standalone** themed-markdown file to the repo (a README,
+or a rendered `docs_sc/` page meant to be read on GitHub), drop a one-click
+badge in its preamble — between `# Title` and the first `##` (shows on
+GitHub, dropped from the render by the preamble rule):
+
+```markdown
+[![Open in md-converter](https://img.shields.io/badge/Open%20in-md--converter-6b46c1?style=flat-square)](https://md-converter.designs-os.com/?url=https://github.com/<owner>/<repo>/blob/<branch>/<path>)
+```
+
+Fill `<owner>/<repo>/<branch>/<path>` with the file''s GitHub location (any
+subdirectory depth). Public repos only — the badge fetches the raw file in
+the reader''s browser (no server/auth). Destination unknown -> keep the
+placeholders and tell the user to fill them.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -62,7 +62,7 @@ Run from the repo root, like every engine command:
     ./sc mem task edit <task_id>     [--title "…"] [--desc "…"]   # revise title/description
     ./sc mem oriented                # mark first-run complete (bootstrapped=1)
     ./sc mem doc add "<title>" --body-file PATH [--feature ID] [--kind spec|doc] [--seq N]
-    ./sc mem doc edit <document_id>  [--title "…"] [--body-file PATH] [--render-path …]   # unfrozen only
+    ./sc mem doc edit <document_id>  [--title "…"] [--body-file PATH] [--render-path …]   # frozen: --render-path only
     ./sc mem doc move <document_id>  --feature <target_feature_id>   # unfrozen spec + plan, atomic
     ./sc mem doc freeze <document_id>
     ./sc mem doc qaqc <spec_document_id> --verdict approved|changes_requested [--findings-doc ID]
@@ -1142,7 +1142,7 @@ def build_parser() -> argparse.ArgumentParser:
     da.add_argument("--kind", default="spec", choices=["spec", "doc"])
     da.add_argument("--seq", type=int)
     da.add_argument("--render-path", dest="render_path")
-    de = dsub.add_parser("edit", help="revise an unfrozen doc's title/body/render-path")
+    de = dsub.add_parser("edit", help="revise a doc's title/body/render-path (frozen: render-path only)")
     de.add_argument("document_id", type=int)
     de.add_argument("--title")
     de.add_argument("--body-file", dest="body_file")

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -147,7 +147,8 @@
     "tests/test_sprint_spec_revisions.py",
     "tests/test_sprint_v2_domain.py",
     "tests/test_sprint_work_dispatch.py",
-    "tests/test_update_materialize.py"
+    "tests/test_update_materialize.py",
+    ".super-coder/migrations/0249_reseed_docs_frozen_render_path.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -1312,6 +1312,61 @@ class ApiMemTest(unittest.TestCase):
             "derived candidate",
         )
 
+    def test_frozen_doc_render_path_moves_off_a_collision(self):
+        # subfloor#629: a retired frozen duplicate sharing a render_path with
+        # its live successor stalls every flat render on the fork. The frozen
+        # row's path is the only thing that may change, and changing it must
+        # clear the collision.
+        body = self.tmp / "frozen-collision.md"
+        body.write_text("# sales site\n")
+        self.run_mem("roadmap", "add", "frozen collision feature")
+        feature_id = self.q(
+            "SELECT feature_id FROM roadmap WHERE title='frozen collision feature'"
+        )[0]
+        self.run_mem(
+            "doc", "add", "SC-099 Sales Site", "--kind", "spec",
+            "--body-file", str(body), "--render-path", "specs_sc/sc-099-sales-site.md",
+            "--feature", str(feature_id),
+        )
+        live = self.q(
+            "SELECT document_id FROM documents WHERE title='SC-099 Sales Site'"
+        )[0]
+        # Legacy rows predate the write-side duplicate check: seed the
+        # collision directly, the way such a row exists on a real fork.
+        retired = self.write(
+            "INSERT INTO documents (feature_id,kind,seq,title,body,render_path,frozen) "
+            "VALUES (?,'spec',2,'RETIRED (dupe)','# sales site\n',"
+            "'specs_sc/sc-099-sales-site.md',1)",
+            feature_id,
+        )
+        self.assertEqual(
+            self.q("SELECT COUNT(*) FROM documents WHERE render_path=?",
+                   "specs_sc/sc-099-sales-site.md")[0],
+            2,
+        )
+
+        with self.assertRaises(SystemExit) as caught:
+            self.run_mem("doc", "edit", str(retired), "--title", "RETIRED")
+        self.assertIn("frozen", str(caught.exception))
+        with self.assertRaises(SystemExit) as caught:
+            self.run_mem("doc", "edit", str(retired),
+                         "--render-path", "specs_sc/sc-099-sales-site.md")
+        self.assertIn("document IDs", str(caught.exception))
+
+        self.assertEqual(
+            self.run_mem("doc", "edit", str(retired),
+                         "--render-path", "specs_sc/sc-099-sales-site-retired.md"),
+            0,
+        )
+        row = self.q("SELECT title,render_path,frozen FROM documents WHERE document_id=?",
+                     retired)
+        self.assertEqual(tuple(row),
+                         ("RETIRED (dupe)", "specs_sc/sc-099-sales-site-retired.md", 1))
+        self.assertEqual(
+            self.q("SELECT render_path FROM documents WHERE document_id=?", live)[0],
+            "specs_sc/sc-099-sales-site.md",
+        )
+
     def test_concurrent_doc_adds_cannot_claim_one_render_path(self):
         self.run_mem("roadmap", "add", "concurrent render owners")
         feature_id = self.q(

--- a/tests/test_sprint_spec_revisions.py
+++ b/tests/test_sprint_spec_revisions.py
@@ -495,6 +495,49 @@ class GoverningRevisionCase(unittest.TestCase):
         self.assertEqual(0, self.con.execute("SELECT COUNT(*) FROM sprint_events").fetchone()[0])
         self.assertEqual(0, self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0])
 
+    def test_frozen_document_accepts_only_render_path(self) -> None:
+        # A frozen row's content is immutable, but its render_path is a
+        # location: it must stay movable so a frozen doc that collides in the
+        # render layer can be cleared without unfreezing (#629).
+        self.con.execute(
+            "UPDATE documents SET frozen=1 WHERE document_id=?", (self.document_id,)
+        )
+        self.con.commit()
+        for payload in (
+            {"body": "# rewritten\n"},
+            {"title": "Renamed"},
+            {"title": "Renamed", "render_path": "specs_sc/moved.md"},
+        ):
+            ok, err = server.patch_document(
+                self.con,
+                self.document_id,
+                payload,
+                editor_surface="shell_api",
+                editor_shell_id=2,
+            )
+            self.assertFalse(ok, payload)
+            self.assertIn("document is frozen", err)
+            self.assertIn("only render_path", err)
+        self.assertEqual(
+            (True, None),
+            server.patch_document(
+                self.con,
+                self.document_id,
+                {"render_path": "specs_sc/moved.md"},
+                editor_surface="shell_api",
+                editor_shell_id=2,
+            ),
+        )
+        row = self.con.execute(
+            "SELECT title,body,render_path,frozen FROM documents WHERE document_id=?",
+            (self.document_id,),
+        ).fetchone()
+        self.assertEqual(
+            ("Governing spec", self.original, "specs_sc/moved.md", 1), tuple(row)
+        )
+        self.assertEqual(0, self.con.execute("SELECT COUNT(*) FROM sprint_events").fetchone()[0])
+        self.assertEqual(0, self.con.execute("SELECT COUNT(*) FROM wake_message").fetchone()[0])
+
     def test_relay_failure_rolls_back_document_event_and_wake(self) -> None:
         with mock.patch.object(
             sprint_message_delivery.SprintMessageStore,


### PR DESCRIPTION
Fixes the blocker in #629 (defect 4), reproduced again on the dos-arch fork: frozen specs 192 and 193 both carry `render_path = specs_sc/sc-099-sales-site.md`. Since the duplicate-path check became strict, every flat render on the fork stops there, which blocks skill projection (`/_sc/skills/put`) and every `sc mem doc` write. Neither row could be edited because `patch_document` refused any frozen document before reaching the `render_path` allowance directly beneath the guard.

## Change

- `patch_document` accepts a `render_path`-only payload on a frozen document. Title and body stay refused; the error now states the allowance. The duplicate-path check still runs, so the new path must be free.
- No Sprint spec-edit evidence changes: body cannot change on this path, so `body_changed` is false and no `spec.body_edited` event is written.
- CLI help and the `docs` skill say a frozen doc's render path may move; content may not.
- Migration `0249_reseed_docs_frozen_render_path.sql` (allocated via `migration.new_migration`, allowlisted in the Sprint-removal manifest) reseeds the docs skill body so upgraded installations converge. `0001_seed_skills.sql` is regenerated from assets per the `engine_migrations` skill; beyond the docs block it also converges the rebrand and sprint_pln text that #1486 and #1490 shipped only as reseed migrations 0247/0248.

## Why this and not the other options from #629

A render path is where a doc lands, not what it says. The freeze protects content. Allowing the path to move is a one-line rule change that clears the fork in one `sc mem doc edit <id> --render-path` command. Skip-and-report rendering (#629 option c) would silently ship partial renders, which #1468 deliberately made fail-before-write. A data migration cannot pick a new path for an arbitrary fork's duplicate rows.

## Operator steps on the fork after `sc update`

```
sc mem doc edit 192 --render-path specs_sc/sc-099-sales-site-retired.md
```

Then re-run the skill put. Pass = Dev-06's projected `test_authoring_dosarch` skill mentions `substrate_peer_con`.

## Tests

- `tests/test_sprint_spec_revisions.py::test_frozen_document_accepts_only_render_path`
- `tests/test_mem.py::test_frozen_doc_render_path_moves_off_a_collision` (the exact fork scenario over the live API + CLI)
- `tests/test_skills_freshness.py` green with 0249 (this is what render-check runs); 0249 proven idempotent and convergent on the asset body. Migration-management, manifest, skill-persistence, tombstone, and flat-render suites green. Ruff: no new findings in changed files.

The GUI still renders frozen docs read-only; the path move is a CLI/API operation.

Not addressed here: #1493 (`sc skill` crashes at import on a launched seat). That is a separate import-chain change across `seed_skills`, `render`, and `skill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
