### PR TITLE
fix(skill): every sc skill verb survives the restricted seat; Planner lane owns retire/unretire

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -495,8 +495,8 @@ def get_delivery_audit(con) -> dict:
 def get_cli_skills(con) -> dict:
     """Exact read projection used by authenticated ``sc skill list`` calls."""
     skills = rows(con.execute(
-        "SELECT skill_id, name, common, is_deleted FROM skills "
-        "ORDER BY is_deleted, name"
+        "SELECT skill_id, name, description, category, common, is_deleted "
+        "FROM skills ORDER BY is_deleted, name"
     ))
     scopes: dict[int, list[str]] = {}
     for row in rows(con.execute(
@@ -511,7 +511,7 @@ def get_cli_skills(con) -> dict:
         scopes.setdefault(row["skill_id"], []).append(row["scope"])
     for skill in skills:
         skill["grant_scopes"] = scopes.get(skill["skill_id"], [])
-    return {"skills": skills}
+    return {"skills": skill_mod.annotate_catalogue(skills)}
 
 
 # ===========================================================================
@@ -525,8 +525,9 @@ def get_cli_skills(con) -> dict:
 # unrestrained on the host) can. These routes mirror the local CLI mutations:
 # they reuse skill.py's validation + persistence ladder and are planner-only —
 # the same check the CLI enforces via ``require_planner`` for local writes.
-# Retire/unretire stay Admin-only: they edit the fork-tracked retire manifest
-# and deliberately require a tracked file write on the host.
+# Retire/unretire ride the same lane: the retire list is instance-local
+# (never Git-tracked), and the API runs on the host with the same authority the
+# local CLI has, so a launched Planner owns every `sc skill` verb.
 
 
 class SkillApiError(ValueError):
@@ -647,6 +648,28 @@ def api_skill_rm(con, name: object) -> tuple[int, dict]:
         "revoked_grants": n,
         "already_removed": already,
     }
+
+
+def api_skill_retire(con, name: object) -> tuple[int, dict]:
+    """Retire one engine skill fork-wide via the instance retire list."""
+    if not isinstance(name, str) or not name.strip():
+        raise SkillApiError(400, "name must be a skill name")
+    already, dormant = skill_mod._retire_spec(con, name.strip())
+    return {
+        "ok": True,
+        "action": "retire",
+        "name": name.strip(),
+        "already_listed": already,
+        "dormant_grants": dormant,
+    }
+
+
+def api_skill_unretire(con, name: object) -> tuple[int, dict]:
+    """Restore one retired engine skill and its dormant grants."""
+    if not isinstance(name, str) or not name.strip():
+        raise SkillApiError(400, "name must be a skill name")
+    grants = skill_mod._unretire_spec(con, name.strip())
+    return {"ok": True, "action": "unretire", "name": name.strip(), "grants": grants}
 
 
 def get_model_routes(con, *, harness: str | None = None,
@@ -4214,6 +4237,14 @@ class Handler(BaseHTTPRequestHandler):
             if path == "/_sc/skills/rm":
                 status, result = _skills_mutation_report(
                     api_skill_rm, con, body.get("name"))
+                return self._send(status, result)
+            if path == "/_sc/skills/retire":
+                status, result = _skills_mutation_report(
+                    api_skill_retire, con, body.get("name"))
+                return self._send(status, result)
+            if path == "/_sc/skills/unretire":
+                status, result = _skills_mutation_report(
+                    api_skill_unretire, con, body.get("name"))
                 return self._send(status, result)
             return self._send(404, {"error": "not found"})
         except Exception as e:

--- a/.super-coder/assets/skills/fork_skill_design/SKILL.md
+++ b/.super-coder/assets/skills/fork_skill_design/SKILL.md
@@ -69,10 +69,10 @@ projections reconcile. Naming a standard shell changes its shared flavor pack;
 naming a Bespoke shell changes only that shell. Creation grants nothing.
 
 A launched Planner seat runs under the restricted execution view and cannot
-open the engine DB directly; `sc skill put` then falls back to the engine API's
-Planner-owned skill lane, which runs the identical validation and persistence
-server-side. `retire`/`unretire` remain Admin-local: they write the fork's
-tracked retire manifest on the host.
+open the engine DB directly; every `sc skill` verb then falls back to the
+engine API's Planner-owned skill lane, which runs the identical validation and
+persistence server-side. `sc skill list` shows each row's category so a
+redraft can carry the existing metadata forward.
 
 ## Update, retire, and recover
 
@@ -88,8 +88,8 @@ matches `sc skill list` plus the intended grant. On a launched seat the same
 receipt rides the API fallback, so a failure names which of the four layers
 (DB, snapshot, flat render, projection) is still outstanding. `rm` is only for
 fork-local names; retire an upstream skill with `sc skill retire <name>` and
-restore it with `sc skill unretire <name>` — both from an Admin host seat,
-which owns the fork's tracked retire list.
+restore it with `sc skill unretire <name>`. The retire list is instance-local
+state and rides `sc update`; it is never committed.
 
 Keep fork-local skill bodies on the supported `sc skill` surface; do not place
 them under engine assets, regenerate the engine seed for them, or set them

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1608,10 +1608,10 @@ projections reconcile. Naming a standard shell changes its shared flavor pack;
 naming a Bespoke shell changes only that shell. Creation grants nothing.
 
 A launched Planner seat runs under the restricted execution view and cannot
-open the engine DB directly; `sc skill put` then falls back to the engine API''s
-Planner-owned skill lane, which runs the identical validation and persistence
-server-side. `retire`/`unretire` remain Admin-local: they write the fork''s
-tracked retire manifest on the host.
+open the engine DB directly; every `sc skill` verb then falls back to the
+engine API''s Planner-owned skill lane, which runs the identical validation and
+persistence server-side. `sc skill list` shows each row''s category so a
+redraft can carry the existing metadata forward.
 
 ## Update, retire, and recover
 
@@ -1627,8 +1627,8 @@ matches `sc skill list` plus the intended grant. On a launched seat the same
 receipt rides the API fallback, so a failure names which of the four layers
 (DB, snapshot, flat render, projection) is still outstanding. `rm` is only for
 fork-local names; retire an upstream skill with `sc skill retire <name>` and
-restore it with `sc skill unretire <name>` — both from an Admin host seat,
-which owns the fork''s tracked retire list.
+restore it with `sc skill unretire <name>`. The retire list is instance-local
+state and rides `sc update`; it is never committed.
 
 Keep fork-local skill bodies on the supported `sc skill` surface; do not place
 them under engine assets, regenerate the engine seed for them, or set them

--- a/.super-coder/migrations/0250_reseed_fork_skill_design_planner_lane.sql
+++ b/.super-coder/migrations/0250_reseed_fork_skill_design_planner_lane.sql
@@ -1,0 +1,111 @@
+-- 0250 — reseed fork_skill_design for the complete Planner skill lane.
+-- Every `sc skill` verb, retire/unretire included, now rides the engine API
+-- from a launched Planner seat; the retire list is instance-local state
+-- (subfloor#1493). No schema change: a full-body UPSERT converges upgraded
+-- installations on the same text a fresh seed produces.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'fork_skill_design',
+  'Design and maintain DB-canonical fork-local skills that describe the fork''s real systems, tools, testing seats, and core processes. Planner-only; use when a capability needs durable shell guidance without becoming global doctrine.',
+  'substrate',
+  NULL,
+  0,
+  '# fork_skill_design — describe fork capabilities
+
+Use a fork-local skill when shells need durable knowledge specific to this
+repository, stack, host, VM, deployment surface, database, or core fork
+process. Keep global skills limited to Subfloor itself, supplied tools and
+testing environments, and core Subfloor processes.
+
+## Discover the real capability
+
+Read the repo map, tracked configuration, declared dev-kit hooks, and current
+readiness evidence before drafting. Identify:
+
+- the capability and the shells that need it;
+- its tracked declaration or owning source;
+- the seat, host, VM, service, or database it reaches;
+- readiness states and evidence locations;
+- authority, recovery, and data-tenancy boundaries; and
+- one observable success receipt.
+
+Pass = every operational claim names evidence available in this fork. Do not
+infer package managers, test policy, credentials, hosts, or deployment steps.
+
+## Apply the purpose test
+
+Keep a line only when it explains this fork, a supplied tool or testing
+environment, or a core fork process. Use an imperative only when variation
+would break shared state, authority, compatibility, or recovery. Remove generic
+planning, coding, API, test, database, deployment, VM, and troubleshooting
+method.
+
+## Draft and persist
+
+Write a Planner-owned draft with a lowercase underscore name and
+`common: false`:
+
+```yaml
+---
+name: repo_capability
+description: State the capability and when it fires.
+category: substrate
+common: false
+---
+```
+
+Describe locations, commands, states, boundaries, and receipts. A testing-seat
+skill identifies the runner, fixtures, reach, readiness, and evidence; it does
+not choose assertions. A VM or host skill identifies the supplied control
+surface and reset boundary; it does not invent a lifecycle. A deployment or
+database skill records the fork''s tracked procedure and authority; it does not
+teach generic deployment or SQL technique.
+
+Persist and grant through the supported DB-canonical surface:
+
+```bash
+sc skill put --file <path/to/SKILL.md>
+sc skill grant <skill_name> <shell>...
+sc skill list
+```
+
+`put` succeeds only after DB, local snapshot, flat catalogue, and managed skill
+projections reconcile. Naming a standard shell changes its shared flavor pack;
+naming a Bespoke shell changes only that shell. Creation grants nothing.
+
+A launched Planner seat runs under the restricted execution view and cannot
+open the engine DB directly; every `sc skill` verb then falls back to the
+engine API''s Planner-owned skill lane, which runs the identical validation and
+persistence server-side. `sc skill list` shows each row''s category so a
+redraft can carry the existing metadata forward.
+
+## Update, retire, and recover
+
+```bash
+sc skill put --file <path/to/SKILL.md>
+sc skill revoke <skill_name> <shell>...
+sc skill rm <skill_name>
+```
+
+Retry the exact command after fixing a reported snapshot, render, or projection
+path. Pass = the full persistence receipt returns and the projected body
+matches `sc skill list` plus the intended grant. On a launched seat the same
+receipt rides the API fallback, so a failure names which of the four layers
+(DB, snapshot, flat render, projection) is still outstanding. `rm` is only for
+fork-local names; retire an upstream skill with `sc skill retire <name>` and
+restore it with `sc skill unretire <name>`. The retire list is instance-local
+state and rides `sc update`; it is never committed.
+
+Keep fork-local skill bodies on the supported `sc skill` surface; do not place
+them under engine assets, regenerate the engine seed for them, or set them
+common.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/render.py
+++ b/.super-coder/scripts/render.py
@@ -26,13 +26,23 @@ import skill_projection
 from _serialize_guard import require_admin
 from seed_skills import sync_engine_skills
 
-DB_PATH = instance_state.active_database_path(ENGINE)
+# Resolved when a render opens the DB, never at import: `sc skill` imports
+# this module from launched seats that cannot read the private state root
+# (#1493). Tests may pin it.
+DB_PATH: Path | None = None
+
+
+def _db_path() -> Path:
+    if DB_PATH is not None:
+        return DB_PATH
+    return instance_state.active_database_path(ENGINE)
 
 
 def _open():
-    if not DB_PATH.exists() or DB_PATH.stat().st_size == 0:
-        sys.exit(f"render: no usable DB at {DB_PATH} — run `./sc rebuild` first.")
-    return db_driver.connect(DB_PATH)
+    db_path = _db_path()
+    if not db_path.exists() or db_path.stat().st_size == 0:
+        sys.exit(f"render: no usable DB at {db_path} — run `./sc rebuild` first.")
+    return db_driver.connect(db_path)
 
 
 def _resolve_shell(con, shortname: str):

--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -50,9 +50,12 @@ ENGINE = Path(__file__).resolve().parents[1]
 SKILLS_DIR = ENGINE / "assets" / "skills"
 SHELL_TEMPLATES = ENGINE / "templates" / "shells"
 OUT = ENGINE / "migrations" / "0001_seed_skills.sql"
+# Resolved on first use, never at import: a launched non-Admin seat cannot
+# read the private state root, and every `sc skill` verb imports this module
+# before its API fallback can run (#1493). Tests and relocation code pin it.
 # Update imports the seed helpers while recovering relocation publication.
 # The standalone command validates active_database_path in ``main``.
-DB_PATH = instance_state.maintenance_database_path(ENGINE)
+DB_PATH: Path | None = None
 RETIRED_FILE = artifact_policy.retired_skills_path()
 TOMBSTONES_FILE = ENGINE / "assets" / "skill_tombstones.json"
 SKILL_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
@@ -507,16 +510,24 @@ def _fork_mode() -> bool:
     return not update.is_source_repo() and not update.EJECTED_MARKER.exists()
 
 
+def live_db_path() -> Path:
+    """The maintenance DB target, pinned or resolved at call time."""
+    if DB_PATH is not None:
+        return DB_PATH
+    return instance_state.maintenance_database_path(ENGINE)
+
+
 def _upsert_live(skills: list[dict]) -> None:
     """The documented half of seeding: put the parsed asset skills IN THE LIVE
     DB, so a grant right after (`./sc skill grant`) resolves instead of being a
     silent no-op (#253). Passing ALL asset specs (not just seed names) is what
     lets a freshly-authored fork-local skill land."""
-    if not DB_PATH.exists() or not DB_PATH.stat().st_size:
+    db_path = live_db_path()
+    if not db_path.exists() or not db_path.stat().st_size:
         print("seed_skills: no live DB yet — skills land on first rebuild/launch.")
         return
     import db_driver  # lazy — sibling module; keeps import surface unchanged
-    con = db_driver.connect(DB_PATH)
+    con = db_driver.connect(db_path)
     try:
         initialized = con.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='skills'"

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -16,9 +16,11 @@ the DB directly and enforces `require_planner` before `put`. A launched shell
 engine-state root) is detected by a failed direct-DB open and rerouted
 through authenticated `/_sc/skills/*` routes on the review API, which runs
 the same validation and persistence ladder server-side. Both lanes share
-`cmd_*_api`/`_put_spec`/`_grant_spec`/`_revoke_spec`/`_rm_spec`. Retire and
-unretire stay Admin-only in both lanes because they write the fork-tracked
-retire manifest on the host.
+`cmd_*_api` and the `_*_spec` helpers, and every verb rides the fallback —
+including retire/unretire, whose retire list is instance-local state the API
+host writes exactly as the local CLI would. Nothing here resolves the private
+DB path at import time: that resolution is what fails on a restricted seat,
+so it happens inside `connect()` where the fallback can catch it (#1493).
 
 Engine catalogue rows are authored as assets + `./sc seed-skills`. Fork-local
 rows are DB-canonical and enter through `put --file`; the input file remains a
@@ -58,15 +60,17 @@ import skill_projection
 import snapshot
 
 ENGINE = Path(__file__).resolve().parents[1]
-DB_PATH = instance_state.active_database_path(ENGINE)
+DB_PATH: Path | None = None  # resolved in connect(); tests pin it
 MAX_SKILL_FILE_BYTES = 128 * 1024
 LOCAL_FRONTMATTER_FIELDS = {"name", "description", "category", "command", "common"}
 
 
 def connect():
-    if not DB_PATH.exists() or not DB_PATH.stat().st_size:
+    """Open the live DB; raises InstanceStateError/OSError on a restricted seat."""
+    db_path = DB_PATH if DB_PATH is not None else instance_state.active_database_path(ENGINE)
+    if not db_path.exists() or not db_path.stat().st_size:
         sys.exit("sc skill: no live DB — run `./sc rebuild` (or `./sc launch`) first.")
-    return db_driver.connect(DB_PATH)
+    return db_driver.connect(db_path)
 
 
 def _shell_api_enabled() -> bool:
@@ -83,87 +87,30 @@ def _shell_api_enabled() -> bool:
     return True
 
 
-def _put_with_api_fallback(path: Path) -> int:
-    """Run `put` locally; fall back to the API lane when the DB is unreachable.
+def _with_api_fallback(local, remote):
+    """Run a verb on the local DB; reroute to the API lane when the seat cannot open it.
 
     The restricted execution view (launched non-Admin shells) masks the
-    private engine-state root, so a Planner calling `sc skill put` from its
-    seat hits a filesystem permission error before the flavor check. Retry
-    through the engine API, which runs unrestricted and reuses the same
-    validation + persistence ladder. Any other failure surfaces unchanged.
+    private engine-state root, so `connect()` raises an InstanceStateError or a
+    filesystem permission error before any verb runs. With a shell token
+    present, retry through the engine API, which runs unrestricted and reuses
+    the same validation + persistence ladder. A missing/empty DB on a host
+    seat ("no live DB") and any failure without a token surface unchanged.
     """
     try:
         con = connect()
     except SystemExit as exc:
-        if not mem.SC_API_TOKEN:
-            raise
-        if "no live DB" in str(exc):
-            raise
-        return cmd_put_api(path)
-    except (OSError, PermissionError):
-        if not mem.SC_API_TOKEN:
-            raise
-        return cmd_put_api(path)
-    try:
-        return cmd_put(con, path)
-    finally:
-        con.close()
-
-
-def _grant_with_api_fallback(name: str, shell_refs: list[str]) -> int:
-    try:
-        con = connect()
-    except SystemExit as exc:
         if not mem.SC_API_TOKEN or "no live DB" in str(exc):
             raise
-        return cmd_grant_api(name, shell_refs)
-    except (OSError, PermissionError):
+        return remote()
+    except (OSError, instance_state.InstanceStateError):
         if not mem.SC_API_TOKEN:
             raise
-        return cmd_grant_api(name, shell_refs)
+        return remote()
     try:
-        return cmd_grant(con, name, shell_refs)
+        return local(con)
     finally:
         con.close()
-
-
-def _revoke_with_api_fallback(name: str, shell_refs: list[str]) -> int:
-    try:
-        con = connect()
-    except SystemExit as exc:
-        if not mem.SC_API_TOKEN or "no live DB" in str(exc):
-            raise
-        return cmd_revoke_api(name, shell_refs)
-    except (OSError, PermissionError):
-        if not mem.SC_API_TOKEN:
-            raise
-        return cmd_revoke_api(name, shell_refs)
-    try:
-        return cmd_revoke(con, name, shell_refs)
-    finally:
-        con.close()
-
-
-def _rm_with_api_fallback(name: str) -> int:
-    try:
-        con = connect()
-    except SystemExit as exc:
-        if not mem.SC_API_TOKEN or "no live DB" in str(exc):
-            raise
-        return cmd_rm_api(name)
-    except (OSError, PermissionError):
-        if not mem.SC_API_TOKEN:
-            raise
-        return cmd_rm_api(name)
-    try:
-        return cmd_rm(con, name)
-    finally:
-        con.close()
-    if not mem.SC_API_TOKEN:
-        return False
-    mem._PROG = "skill"
-    mem._require_api()
-    return True
 
 
 def require_planner(con) -> int:
@@ -423,32 +370,47 @@ def parse_local_skill_file(path: Path) -> dict:
         sys.exit(f"sc skill: draft {path}: {exc}")
 
 
-def print_catalogue(rows: list[dict]) -> int:
+def annotate_catalogue(rows: list[dict]) -> list[dict]:
+    """Stamp each row with its engine/local origin and fork retire state.
+
+    Runs where the seed and the instance retire list are readable — the local
+    lane and the API host — so a launched seat's `list` never touches private
+    state itself (#1493).
+    """
     engine = set(seed_skills.seeded_skill_names())
     retired = set(seed_skills.retired_skill_names())
+    for row in rows:
+        row["origin"] = "engine" if row["name"] in engine else "local"
+        row["retired"] = bool(row["is_deleted"]) and row["name"] in retired
+    return rows
+
+
+def print_catalogue(rows: list[dict]) -> int:
     if not rows:
         print("(no skills)")
         return 0
     w = max(len(row["name"]) for row in rows)
+    cw = max(len(row.get("category") or "-") for row in rows)
     for row in rows:
         name = row["name"]
         common = row["common"]
         deleted = row["is_deleted"]
-        origin = "engine" if name in engine else "local "
+        origin = "engine" if row.get("origin") == "engine" else "local "
         tag = "common" if common else "opt-in"
-        dead = ("  [retired]" if name in retired else "  [deleted]") if deleted else ""
+        category = row.get("category") or "-"
+        dead = ("  [retired]" if row.get("retired") else "  [deleted]") if deleted else ""
         scopes = ", ".join(row.get("grant_scopes") or []) or "(ungranted)"
-        print(f"{name:<{w}}  {origin}  {tag}  → {scopes}{dead}")
+        print(f"{name:<{w}}  {origin}  {tag}  {category:<{cw}}  → {scopes}{dead}")
     return 0
 
 
 def cmd_list(con) -> int:
     rows = [dict(row) for row in con.execute(
-        "SELECT s.skill_id, s.name, s.common, s.is_deleted "
-        "FROM skills s ORDER BY s.is_deleted, s.name").fetchall()]
+        "SELECT s.skill_id, s.name, s.description, s.category, s.common, "
+        "s.is_deleted FROM skills s ORDER BY s.is_deleted, s.name").fetchall()]
     for row in rows:
         row["grant_scopes"] = grant_scopes(con, row["skill_id"])
-    return print_catalogue(rows)
+    return print_catalogue(annotate_catalogue(rows))
 
 
 def cmd_list_api() -> int:
@@ -516,6 +478,26 @@ def cmd_rm_api(name: str) -> int:
         f"rm: {result['name']} soft-deleted, {result['revoked_grants']} "
         f"grant(s) revoked.{suffix} (via engine API)"
     )
+    return 0
+
+
+def cmd_retire_api(name: str) -> int:
+    result = mem._api(
+        "POST", "/_sc/skills/retire", {"name": name}, idempotent=False
+    )
+    listed = "  (already listed)" if result.get("already_listed") else ""
+    print(f"retire: {result['name']}{listed} — retired fork-wide; "
+          f"{result['dormant_grants']} grant(s) kept dormant (restored on "
+          "unretire). (via engine API)")
+    return 0
+
+
+def cmd_unretire_api(name: str) -> int:
+    result = mem._api(
+        "POST", "/_sc/skills/unretire", {"name": name}, idempotent=False
+    )
+    print(f"unretire: {result['name']} — restored with {result['grants']} "
+          "grant(s) live again. (via engine API)")
     return 0
 
 
@@ -722,14 +704,17 @@ def _display_retire_file() -> Path:
         return seed_skills.RETIRED_FILE
 
 
-def cmd_retire(con, name: str) -> int:
+def _retire_spec(con, name: str) -> tuple[bool, int]:
+    """Retire one engine skill fork-wide. Returns (already_listed, dormant grants)."""
     if name not in set(seed_skills.seeded_skill_names()):
         if con.execute("SELECT 1 FROM skills WHERE name=?", (name,)).fetchone():
-            sys.exit(f"sc skill: '{name}' is a LOCAL skill — `./sc skill rm {name}` "
-                     "retires it (the retire list is for engine skills the seed "
-                     "would resurrect).")
-        sys.exit(f"sc skill: no engine skill '{name}' — `./sc skill list` shows the "
-                 "catalogue.")
+            raise SkillConflictError(
+                f"'{name}' is a LOCAL skill — `./sc skill rm {name}` retires it "
+                "(the retire list is for engine skills the seed would resurrect)."
+            )
+        raise SkillConflictError(
+            f"no engine skill '{name}' — `./sc skill list` shows the catalogue."
+        )
     names = seed_skills.retired_skill_names()
     already = name in names
     if not already:
@@ -742,33 +727,51 @@ def cmd_retire(con, name: str) -> int:
     dormant = grant_count(
         con, con.execute(
             "SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0])
-    rel = _display_retire_file()
-    print(f"retire: {name}" + ("  (already listed)" if already else "")
-          + f" — retired fork-wide; {dormant} grant(s) kept dormant "
-          "(restored on unretire).")
-    action = "commit" if artifact_policy.tracks_local_artifacts() else "kept local at"
-    print(f"→ {action} {rel} — the list rides `./sc update`.")
-    return 0
+    return already, dormant
 
 
-def cmd_unretire(con, name: str) -> int:
+def _unretire_spec(con, name: str) -> int:
+    """Restore one retired engine skill. Returns the grants live again."""
     names = seed_skills.retired_skill_names()
     if name not in names:
-        sys.exit(f"sc skill: '{name}' is not on the retire list "
-                 f"({seed_skills.RETIRED_FILE}).")
+        raise SkillConflictError(
+            f"'{name}' is not on the retire list ({seed_skills.RETIRED_FILE})."
+        )
     _write_retire_list([n for n in names if n != name])
     seed_skills.apply_retired(con)
     try:
         skill_projection.reconcile_existing_checkouts(con)
     except skill_projection.ProjectionError as exc:
         sys.exit(skill_projection.partial_failure_message(f"unretire {name}", exc))
-    grants = grant_count(
+    return grant_count(
         con, con.execute(
             "SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0])
-    rel = _display_retire_file()
-    print(f"unretire: {name} — restored with {grants} grant(s) live again.")
+
+
+def _retire_list_note() -> str:
     action = "commit" if artifact_policy.tracks_local_artifacts() else "kept local at"
-    print(f"→ {action} {rel}.")
+    return f"→ {action} {_display_retire_file()} — the list rides `./sc update`."
+
+
+def cmd_retire(con, name: str) -> int:
+    try:
+        already, dormant = _retire_spec(con, name)
+    except SkillConflictError as exc:
+        sys.exit(f"sc skill: {exc}")
+    print(f"retire: {name}" + ("  (already listed)" if already else "")
+          + f" — retired fork-wide; {dormant} grant(s) kept dormant "
+          "(restored on unretire).")
+    print(_retire_list_note())
+    return 0
+
+
+def cmd_unretire(con, name: str) -> int:
+    try:
+        grants = _unretire_spec(con, name)
+    except SkillConflictError as exc:
+        sys.exit(f"sc skill: {exc}")
+    print(f"unretire: {name} — restored with {grants} grant(s) live again.")
+    print(_retire_list_note())
     return 0
 
 
@@ -781,49 +784,33 @@ def main(argv: list[str]) -> int:
         print(usage)
         return 0
     cmd, args = argv[0], argv[1:]
-    if cmd == "list" and not args and _shell_api_enabled():
-        return cmd_list_api()
+    if cmd == "list" and not args:
+        if _shell_api_enabled():
+            return cmd_list_api()
+        return _with_api_fallback(cmd_list, cmd_list_api)
     if cmd == "put" and len(args) == 2 and args[0] == "--file":
-        # The restricted execution view masks the engine's private state root,
-        # so a launched Planner cannot open the DB directly; when that happens
-        # the API lane runs the same validation + persistence ladder remotely.
-        return _put_with_api_fallback(Path(args[1]))
+        path = Path(args[1])
+        return _with_api_fallback(
+            lambda con: cmd_put(con, path), lambda: cmd_put_api(path))
     if cmd == "grant" and len(args) >= 2:
-        return _grant_with_api_fallback(args[0], args[1:])
+        return _with_api_fallback(
+            lambda con: cmd_grant(con, args[0], args[1:]),
+            lambda: cmd_grant_api(args[0], args[1:]))
     if cmd == "revoke" and len(args) >= 2:
-        return _revoke_with_api_fallback(args[0], args[1:])
+        return _with_api_fallback(
+            lambda con: cmd_revoke(con, args[0], args[1:]),
+            lambda: cmd_revoke_api(args[0], args[1:]))
     if cmd == "rm" and len(args) == 1:
-        return _rm_with_api_fallback(args[0])
-    con = connect()
-    try:
-        if cmd == "list" and not args:
-            return cmd_list(con)
-        if cmd == "retire" and len(args) == 1:
-            return cmd_retire(con, args[0])
-        if cmd == "unretire" and len(args) == 1:
-            return cmd_unretire(con, args[0])
-        sys.exit(usage)
-    finally:
-        con.close()
-    con = connect()
-    try:
-        if cmd == "list" and not args:
-            return cmd_list(con)
-        if cmd == "put" and len(args) == 2 and args[0] == "--file":
-            return cmd_put(con, Path(args[1]))
-        if cmd == "grant" and len(args) >= 2:
-            return cmd_grant(con, args[0], args[1:])
-        if cmd == "revoke" and len(args) >= 2:
-            return cmd_revoke(con, args[0], args[1:])
-        if cmd == "rm" and len(args) == 1:
-            return cmd_rm(con, args[0])
-        if cmd == "retire" and len(args) == 1:
-            return cmd_retire(con, args[0])
-        if cmd == "unretire" and len(args) == 1:
-            return cmd_unretire(con, args[0])
-        sys.exit(usage)
-    finally:
-        con.close()
+        return _with_api_fallback(
+            lambda con: cmd_rm(con, args[0]), lambda: cmd_rm_api(args[0]))
+    if cmd == "retire" and len(args) == 1:
+        return _with_api_fallback(
+            lambda con: cmd_retire(con, args[0]), lambda: cmd_retire_api(args[0]))
+    if cmd == "unretire" and len(args) == 1:
+        return _with_api_fallback(
+            lambda con: cmd_unretire(con, args[0]),
+            lambda: cmd_unretire_api(args[0]))
+    sys.exit(usage)
 
 
 if __name__ == "__main__":

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -41,11 +41,14 @@ from _serialize_guard import require_admin
 
 ENGINE = Path(__file__).resolve().parents[1]
 REPO_ROOT = ENGINE.parent
-DB_PATH = instance_state.maintenance_database_path(ENGINE)
+# Both targets resolve when a snapshot opens them, never at import: `sc skill`
+# imports this module from launched seats that cannot read the private state
+# root (#1493). ``bind_state_targets`` and tests pin them.
+DB_PATH: Path | None = None
 # Generated instance state is always local and gitignored.
 # Recovery-safe equivalent of ``artifact_policy.content_path()``; ``main``
 # applies the ordinary selector before either target is opened.
-OUT_PATH = instance_state.maintenance_snapshot_path(REPO_ROOT)
+OUT_PATH: Path | None = None
 # One-release cleanup: if a not-yet-migrated fork still carries the old in-engine
 # copy, remove it once we write the new one so it can't shadow or drift.
 LEGACY_PATH = ENGINE / "snapshot" / "content.sql"
@@ -56,6 +59,18 @@ def bind_state_targets(*, database: Path, snapshot: Path) -> None:
     global DB_PATH, OUT_PATH
     DB_PATH = Path(database)
     OUT_PATH = Path(snapshot)
+
+
+def _db_path() -> Path:
+    if DB_PATH is not None:
+        return DB_PATH
+    return instance_state.maintenance_database_path(ENGINE)
+
+
+def _out_path() -> Path:
+    if OUT_PATH is not None:
+        return OUT_PATH
+    return instance_state.maintenance_snapshot_path(REPO_ROOT)
 
 
 # Every durable Sprints v2 table.  Keep this as the one snapshot authority for
@@ -548,8 +563,8 @@ def persist_instance(con) -> Path:
     """
     artifact_policy.prepare_local_state()
     content = serialize_instance(con)
-    artifact_policy.atomic_write_text(OUT_PATH, content)
-    return OUT_PATH
+    artifact_policy.atomic_write_text(_out_path(), content)
+    return _out_path()
 
 
 def _main_under_lease() -> int:
@@ -557,9 +572,10 @@ def _main_under_lease() -> int:
     copied = artifact_policy.prepare_local_state()
     if copied:
         print(f"snapshot: localized {len(copied)} existing artifact(s)")
-    if not DB_PATH.exists():
-        raise SystemExit(f"snapshot: no live DB at {DB_PATH} — run `./sc rebuild` first.")
-    con = db_driver.connect(DB_PATH)
+    db_path = _db_path()
+    if not db_path.exists():
+        raise SystemExit(f"snapshot: no live DB at {db_path} — run `./sc rebuild` first.")
+    con = db_driver.connect(db_path)
     try:
         reconciled = seed_skills.reconcile_tombstoned_skills(con)
         pack_changes = seed_skills.reconcile_standard_flavor_packs(con)
@@ -584,9 +600,9 @@ def _main_under_lease() -> int:
             pass
         print(f"snapshot: removed legacy {LEGACY_PATH.relative_to(REPO_ROOT)}")
     try:
-        displayed = OUT_PATH.relative_to(REPO_ROOT)
+        displayed = _out_path().relative_to(REPO_ROOT)
     except ValueError:
-        displayed = OUT_PATH
+        displayed = _out_path()
     print(f"snapshot: wrote {displayed}")
     snapshot_map()
     return 0
@@ -597,17 +613,18 @@ def _main_runtime_owned() -> int:
     copied = artifact_policy.prepare_local_state()
     if copied:
         print(f"snapshot: localized {len(copied)} existing artifact(s)")
-    if not DB_PATH.exists():
-        raise SystemExit(f"snapshot: no live DB at {DB_PATH} — run `./sc rebuild` first.")
-    con = db_driver.connect(DB_PATH)
+    db_path = _db_path()
+    if not db_path.exists():
+        raise SystemExit(f"snapshot: no live DB at {db_path} — run `./sc rebuild` first.")
+    con = db_driver.connect(db_path)
     try:
         persist_instance(con)
     finally:
         con.close()
     try:
-        displayed = OUT_PATH.relative_to(REPO_ROOT)
+        displayed = _out_path().relative_to(REPO_ROOT)
     except ValueError:
-        displayed = OUT_PATH
+        displayed = _out_path()
     print(f"snapshot: wrote {displayed}")
     snapshot_map()
     return 0
@@ -668,10 +685,10 @@ def main(*, lease_held: bool = False, runtime_owned: bool = False) -> int:
             return 0
     state = instance_state.maintenance_state(ENGINE)
     if lease_held:
-        state_relocation.refuse_live_database_owners(DB_PATH)
+        state_relocation.refuse_live_database_owners(_db_path())
         return _main_under_lease()
     with state_relocation.exclusive_maintenance(state, command="snapshot"):
-        state_relocation.refuse_live_database_owners(DB_PATH)
+        state_relocation.refuse_live_database_owners(_db_path())
         return _main_under_lease()
 
 

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -148,7 +148,8 @@
     "tests/test_sprint_v2_domain.py",
     "tests/test_sprint_work_dispatch.py",
     "tests/test_update_materialize.py",
-    ".super-coder/migrations/0249_reseed_docs_frozen_render_path.sql"
+    ".super-coder/migrations/0249_reseed_docs_frozen_render_path.sql",
+    ".super-coder/migrations/0250_reseed_fork_skill_design_planner_lane.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1569,6 +1569,14 @@ class AuthenticatedCliCatalogueRouteTest(unittest.TestCase):
         self.assertEqual(
             skill["grant_scopes"], ["flavor:dev", "shell:custom"]
         )
+        # A Planner redrafting a skill over the API lane needs the row's
+        # existing metadata, not just its name.
+        self.assertIn("category", skill)
+        self.assertIn("description", skill)
+        # Origin and retire state are stamped host-side so a launched seat's
+        # `sc skill list` never reads the instance retire list itself.
+        self.assertEqual(skill["origin"], "local")
+        self.assertFalse(skill["retired"])
 
     def test_exact_route_read_is_a_durable_projection_not_a_host_probe(self) -> None:
         with (

--- a/tests/test_local_skill_persistence.py
+++ b/tests/test_local_skill_persistence.py
@@ -20,6 +20,7 @@ Run:
 """
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 import sys
 import tempfile
@@ -706,6 +707,117 @@ class SkillApiLaneTest(unittest.TestCase):
             skill_mod, "connect", side_effect=PermissionError("masked root")
         ), self.assertRaises(PermissionError):
             skill_mod.main(["put", "--file", str(draft)])
+
+    # ── subfloor#1493: the restricted seat fails BEFORE connect() ────────────
+    RESTRICTED = "cannot read private state owner metadata: [Errno 13] Permission denied"
+
+    def _restricted_resolvers(self):
+        """Patch every resolver on every `instance_state` object in play.
+
+        test_instance_state.py swaps sys.modules["instance_state"] at
+        collection, so the module skill.py holds can differ from the one a
+        fresh `import instance_state` returns; patch both, and refuse any
+        local DB open outright so a missed patch can never reach a real DB.
+        """
+        modules = {id(m): m for m in (
+            skill_mod.instance_state, sys.modules.get("instance_state"),
+        ) if m is not None}
+
+        def refuse(engine, **_kwargs):
+            raise skill_mod.instance_state.InstanceStateError(self.RESTRICTED)
+
+        patches = [
+            mock.patch.object(module, name, refuse)
+            for module in modules.values()
+            for name in ("active_database_path", "maintenance_database_path",
+                         "maintenance_snapshot_path")
+        ]
+        patches.append(mock.patch.object(
+            skill_mod.db_driver, "connect",
+            side_effect=AssertionError("local lane opened a DB on a restricted seat"),
+        ))
+        return patches
+
+    def test_import_chain_never_resolves_private_state(self):
+        """Importing `skill` (→ render → flat → skill_projection → seed_skills,
+        and snapshot) on a seat that cannot read the private state root must
+        succeed; the resolution belongs inside connect(), where the API
+        fallback can catch it."""
+        import importlib
+        chain = ("skill", "render", "flat", "skill_projection", "seed_skills",
+                 "snapshot")
+        with contextlib.ExitStack() as stack:
+            for patch in self._restricted_resolvers():
+                stack.enter_context(patch)
+            stack.enter_context(mock.patch.dict(sys.modules))
+            for name in chain:
+                sys.modules.pop(name, None)
+            fresh = importlib.import_module("skill")
+            self.assertIsNone(fresh.DB_PATH)
+            self.assertIsNone(sys.modules["seed_skills"].DB_PATH)
+            self.assertIsNone(sys.modules["render"].DB_PATH)
+            self.assertIsNone(sys.modules["snapshot"].DB_PATH)
+            self.assertIsNone(sys.modules["snapshot"].OUT_PATH)
+            # `refuse` raises the class from the module skill.py holds; a
+            # fresh import may bind a different `instance_state` object.
+            with self.assertRaisesRegex(
+                skill_mod.instance_state.InstanceStateError, "owner metadata"
+            ):
+                fresh.connect()
+
+    def test_every_verb_reroutes_when_private_state_is_unreadable(self):
+        """With a token, every `sc skill` verb reaches its API route when the
+        seat cannot even resolve the DB path — retire/unretire included."""
+        draft = self.write_draft("loc_all")
+        calls: list[tuple[str, dict]] = []
+
+        def fake_api(method, path, payload=None, *, idempotent=None, **kwargs):
+            calls.append((path, payload))
+            return {
+                "/_sc/skills/put": {"name": "loc_all", "verb": "created"},
+                "/_sc/skills/grant": {"name": "loc_all", "results": []},
+                "/_sc/skills/revoke": {"name": "loc_all", "results": []},
+                "/_sc/skills/rm": {"name": "loc_all", "revoked_grants": 0},
+                "/_sc/skills/retire": {"name": "eng_a", "already_listed": False,
+                                       "dormant_grants": 2},
+                "/_sc/skills/unretire": {"name": "eng_a", "grants": 2},
+                "/_sc/skills": {"skills": []},
+            }[path]
+
+        skill_mod.DB_PATH = None
+        with contextlib.ExitStack() as stack:
+            for patch in self._restricted_resolvers():
+                stack.enter_context(patch)
+            stack.enter_context(
+                mock.patch.object(skill_mod.mem, "_api", side_effect=fake_api))
+            for argv in (
+                ["put", "--file", str(draft)],
+                ["grant", "loc_all", "PLN1"],
+                ["revoke", "loc_all", "PLN1"],
+                ["rm", "loc_all"],
+                ["retire", "eng_a"],
+                ["unretire", "eng_a"],
+                ["list"],
+            ):
+                self.assertEqual(skill_mod.main(argv), 0, argv)
+
+        self.assertEqual(
+            [path for path, _ in calls],
+            ["/_sc/skills/put", "/_sc/skills/grant", "/_sc/skills/revoke",
+             "/_sc/skills/rm", "/_sc/skills/retire", "/_sc/skills/unretire",
+             "/_sc/skills"],
+        )
+        self.assertEqual(calls[4][1], {"name": "eng_a"})
+        self.assertEqual(calls[5][1], {"name": "eng_a"})
+
+    def test_unreadable_private_state_without_token_stays_loud(self):
+        skill_mod.mem.SC_API_TOKEN = ""
+        skill_mod.DB_PATH = None
+        with contextlib.ExitStack() as stack:
+            for patch in self._restricted_resolvers():
+                stack.enter_context(patch)
+            with self.assertRaises(skill_mod.instance_state.InstanceStateError):
+                skill_mod.main(["retire", "eng_a"])
 
 
 if __name__ == "__main__":

--- a/tests/test_skill_retire.py
+++ b/tests/test_skill_retire.py
@@ -27,9 +27,11 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+sys.path.insert(0, str(ROOT / ".super-coder" / "api"))
 import seed_skills
 import skill as skill_cli
 import render_check
+import server
 
 ENGINE_SKILLS = ("redline_review", "review", "git")
 
@@ -258,6 +260,54 @@ class RetireTest(unittest.TestCase):
     def test_cmd_unretire_unlisted_is_loud(self):
         with self.assertRaises(SystemExit):
             skill_cli.cmd_unretire(self.con, "review")
+
+    # ── the Planner API lane shares the spec helpers ─────────────────────────
+    def test_spec_helpers_raise_conflicts_instead_of_exiting(self):
+        with self.assertRaisesRegex(skill_cli.SkillConflictError, "LOCAL skill"):
+            skill_cli._retire_spec(self.con, "test_authoring_dosarch")
+        with self.assertRaisesRegex(skill_cli.SkillConflictError, "no engine skill"):
+            skill_cli._retire_spec(self.con, "no_such_skill")
+        with self.assertRaisesRegex(skill_cli.SkillConflictError, "not on the retire list"):
+            skill_cli._unretire_spec(self.con, "review")
+
+    def test_api_retire_and_unretire_round_trip(self):
+        status, body = server._skills_mutation_report(
+            server.api_skill_retire, self.con, "redline_review")
+        self.assertEqual((status, body), (200, {
+            "ok": True, "action": "retire", "name": "redline_review",
+            "already_listed": False, "dormant_grants": 1,
+        }))
+        self.assertEqual(json.loads(seed_skills.RETIRED_FILE.read_text()),
+                         ["redline_review"])
+        self.assertEqual(self._deleted("redline_review"), 1)
+        self.reconcile_existing.assert_called_once_with(self.con)
+
+        status, body = server._skills_mutation_report(
+            server.api_skill_retire, self.con, "redline_review")
+        self.assertEqual(status, 200)
+        self.assertTrue(body["already_listed"])
+
+        self.reconcile_existing.reset_mock()
+        status, body = server._skills_mutation_report(
+            server.api_skill_unretire, self.con, "redline_review")
+        self.assertEqual((status, body), (200, {
+            "ok": True, "action": "unretire", "name": "redline_review", "grants": 1,
+        }))
+        self.assertEqual(json.loads(seed_skills.RETIRED_FILE.read_text()), [])
+        self.assertEqual(self._deleted("redline_review"), 0)
+        self.reconcile_existing.assert_called_once_with(self.con)
+
+    def test_api_retire_refusals_are_structured(self):
+        status, body = server._skills_mutation_report(
+            server.api_skill_retire, self.con, "test_authoring_dosarch")
+        self.assertEqual(status, 409)
+        self.assertIn("LOCAL skill", body["error"])
+        status, body = server._skills_mutation_report(
+            server.api_skill_unretire, self.con, "review")
+        self.assertEqual(status, 409)
+        self.assertIn("not on the retire list", body["error"])
+        with self.assertRaises(server.SkillApiError):
+            server.api_skill_retire(self.con, "")
 
     def test_grant_of_retired_skill_is_loud(self):
         skill_cli.cmd_retire(self.con, "redline_review")


### PR DESCRIPTION
Fixes #1493 and completes the Planner skill lane: a launched Planner can run every `sc skill` verb from its seat.

**Stacked on #1495** (both allocate migrations; retarget to `main` after #1495 merges, per the git skill's stack procedure).

## What was wrong

- `sc skill` died at import on a launched seat. `seed_skills`, `render`, `snapshot`, and `skill.py` each resolved the private DB path at module import; the restricted execution view cannot read the private state root, so the documented API fallback never ran.
- `sc skill list` on the API lane read the fork retire list on the client, which needs the same private state.
- Retire/unretire were Admin-only because they "write the fork-tracked retire manifest". That list has been instance-local since artifact_policy stopped tracking generated state; the rationale was stale.
- The catalogue projection had no description/category, so the dos-arch Planner had to guess a category when redrafting a skill.

## Change

- The four modules resolve the DB path on first use. `DB_PATH` stays a pinnable module attribute for tests and `bind_state_targets`.
- One `_with_api_fallback` helper replaces four near-identical copies and an unreachable second dispatch block in `main`; it reroutes on `InstanceStateError` as well as `OSError`.
- `/_sc/skills/retire` and `/_sc/skills/unretire` join the Planner lane. Retire logic moves into `_retire_spec`/`_unretire_spec` (SkillConflictError → 409) shared by the CLI and the API.
- `annotate_catalogue` stamps `origin` and `retired` where the seed and retire list are readable (local lane or API host); the projection also carries `description` and `category`, and `sc skill list` shows the category.
- `fork_skill_design` says every verb rides the lane; migration 0250 reseeds it and 0001 is regenerated.

Alternative rejected: lazy-importing render/snapshot inside `skill.py` only. That would leave `sc render` and `sc snapshot` crashing at import on the same seats instead of failing at the Admin gate.

## Tests

- Fresh import of the whole chain under refusing resolvers succeeds and `connect()` raises where the fallback catches it.
- Every verb (put/grant/revoke/rm/retire/unretire/list) reaches its API route with a token; without a token the error stays loud.
- Server-lane retire/unretire round trip, idempotent retry, structured refusals.
- Catalogue projection carries category/description/origin/retired.
- Affected suites (skill persistence, retire, freshness, snapshot, update cutover, flat render, render-check, worktree targets, tombstones, sigpipe, boot contract, sprint skills, migration management, removal manifest, instance state, legacy compat, convergence gate, backup dir, rollback, API endpoints) green in both collection orders. Ruff: no new findings.

Note for reviewers: the restricted-seat tests refuse any local DB open outright. `test_instance_state.py` swaps `sys.modules["instance_state"]` at collection, and a first version of these tests patched the wrong module object, letting the local lane reach this worktree's own gitignored DB. Worth a follow-up flag on that collection-time swap.

## Operator effect on the dos-arch fork

After `sc update`, the Planner runs `sc skill put --file <draft>` directly; no API workaround needed. With #1495 merged as well, the frozen-path collision clears with one `sc mem doc edit 192 --render-path …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
