### PR TITLE
fix(conversation): ignore Claude's zero-turn resume preamble result

### DIFF
--- a/.super-coder/scripts/conversation_adapters/claude.py
+++ b/.super-coder/scripts/conversation_adapters/claude.py
@@ -185,6 +185,24 @@ class ClaudeAdapter(ConversationAdapter):
         return None
 
     @staticmethod
+    def _is_resume_preamble(raw: Mapping[str, Any]) -> bool:
+        """A ``result`` that closes no turn (#1497).
+
+        On ``--resume``, Claude Code (observed on 2.1.260) first flushes a
+        background-task notification left by the previous turn as its own
+        queued turn and emits a ``result`` for it — ``num_turns`` 0, no
+        ``stop_reason``, zero usage — before the prompt's turn begins. Treating
+        it as terminal completed the run with an empty reply and left the
+        child running the real turn unobserved. The prompt's own ``result``
+        follows in the same process and remains the terminal.
+        """
+        if raw.get("is_error"):
+            return False
+        if str(raw.get("subtype") or "").startswith("error"):
+            return False
+        return raw.get("num_turns") == 0 and raw.get("stop_reason") is None
+
+    @staticmethod
     def _usage(raw: Mapping[str, Any]) -> dict[str, int | float]:
         usage = raw.get("usage")
         if not isinstance(usage, dict):
@@ -277,6 +295,8 @@ class ClaudeAdapter(ConversationAdapter):
                     )
             return events
         if native_type == "result":
+            if self._is_resume_preamble(raw):
+                return []
             subtype = str(raw.get("subtype") or "")
             detail = str(raw.get("result") or raw.get("error") or "")
             interrupted = any(

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -1185,6 +1185,91 @@ class ConversationAdapterTest(unittest.TestCase):
         self.assertEqual(events[-1].type, "run.completed")
         self.assertEqual(events[-1].payload["status"], "completed")
 
+    def test_claude_resume_preamble_result_is_not_terminal(self) -> None:
+        """#1497: on ``--resume`` Claude first flushes a pending background-task
+        notification as its own turn and emits a zero-turn ``result`` for it
+        before the prompt's turn. Only the prompt's ``result`` ends the run."""
+        adapter, _runner = self.build("claude")
+        preamble = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "num_turns": 0,
+            "stop_reason": None,
+            "duration_api_ms": 0,
+            "result": None,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        }
+        self.assertEqual(adapter._normalize(preamble), [])
+        failed = adapter._normalize(
+            {**preamble, "is_error": True, "subtype": "error_during_execution"}
+        )
+        self.assertEqual(failed[-1].type, "run.failed")
+
+        session_ref = "11111111-2222-4333-8444-555555555555"
+        rows = [
+            {
+                "type": "system",
+                "subtype": "task_notification",
+                "session_id": session_ref,
+                "status": "stopped",
+            },
+            {"type": "system", "subtype": "init", "session_id": session_ref},
+            {**preamble, "session_id": session_ref},
+            {"type": "system", "subtype": "init", "session_id": session_ref},
+            {
+                "type": "stream_event",
+                "session_id": session_ref,
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "hello"},
+                },
+            },
+            {
+                "type": "result",
+                "subtype": "success",
+                "session_id": session_ref,
+                "result": "hello",
+                "num_turns": 1,
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 10, "output_tokens": 2},
+            },
+        ]
+        process = FakeClaudeProcess(session_ref)
+        process.stdout = io.StringIO(
+            "".join(json.dumps(row) + "\n" for row in rows)
+        )
+        turn = NativeTurn(
+            harness="claude",
+            session_ref=session_ref,
+            run_ref="claude-test",
+            worktree=self.root,
+            process_ref=str(process.pid),
+            metadata={"resumed": True},
+            opaque=process,
+        )
+
+        events = list(adapter.stream(turn))
+
+        terminals = [
+            event for event in events if event.type in base_adapter.TERMINAL_EVENTS
+        ]
+        self.assertEqual(len(terminals), 1)
+        self.assertIs(terminals[0], events[-1])
+        self.assertEqual(events[-1].type, "run.completed")
+        self.assertEqual(events[-1].payload["result"], "hello")
+        usage = [event for event in events if event.type == "usage"]
+        self.assertEqual(len(usage), 1)
+        self.assertEqual(usage[0].payload["tokens"]["input_tokens"], 10)
+        self.assertIn(
+            "hello",
+            [
+                event.payload.get("text")
+                for event in events
+                if event.type == "assistant.delta"
+            ],
+        )
+
     def test_interrupted_events_require_structured_evidence(self) -> None:
         with self.assertRaisesRegex(ValueError, "structured native or operator"):
             NormalizedEvent("run.interrupted", {"status": "interrupted"})


### PR DESCRIPTION
Fixes #1497.

## What broke

On `--resume`, Claude Code (observed on 2.1.260) first flushes a background-task notification left by the previous turn as its own queued turn and emits a `result` for it before the prompt's turn begins:

```
system task_notification
system init
result   {"is_error": false, "num_turns": 0, "stop_reason": null, "duration_api_ms": 0, "usage": {all zeros}}
system init
system status
...real turn...
result   {"stop_reason": "end_turn", "num_turns": 1, ...}
```

`ClaudeAdapter._normalize` mapped every native `result` to a terminal event. The broker completed the run with an empty reply in the same second it spawned, the chat closed, and the child kept running the real turn unobserved. Any session that ends a turn with a background task still registered (Fable's watcher habit) hits this on the very next follow-up.

## Fix

`_normalize` drops a success `result` with `num_turns` 0 and no `stop_reason`. Error results with no turns stay terminal. The prompt's own `result` follows in the same process and remains the terminal, so the run streams and completes exactly as before.

## Trade-off

The child is still not waited on after a genuine terminal, as before this change. Print mode lingers after its final `result` only to record background-task completion, and the active-chat reaper already owns lingering processes after a chat closes; blocking the turn on process exit would delay every GUI reply by the length of any pending background task. Left as is deliberately.

## Verification

- New `test_claude_resume_preamble_result_is_not_terminal`: normalizer drops the preamble, keeps zero-turn errors terminal, and a stream carrying the exact resume sequence yields one terminal, last, with the real result and usage.
- `tests.test_conversation_adapters` (62) and `tests.test_conversation_broker` (50) pass locally.
- ruff on the two changed files: same 7 pre-existing findings before and after; none on changed lines.
- Reproduced the CLI behavior with a throwaway Haiku session (repro commands in #1497).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwN8zYGA4pin6fz4RDHHQN