### PR TITLE
feat(conversation): orphan turn recovery and lockout removal

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -15,7 +15,9 @@ import http.client
 import io
 import json
 import math
+import os
 import re
+import signal
 import sys
 import time
 import uuid
@@ -41,6 +43,10 @@ from conversation_adapters import ADAPTER_TYPES
 
 # Server startup owns the ordinary active_database_path gate before routing.
 DB_PATH = instance_state.maintenance_database_path(ENGINE)
+
+# Injection seam for the one signal this module sends: SIGINT to a lingering
+# turn's process group.  Mirrors the reaper's ``signal_group`` constructor arg.
+_SIGNAL_GROUP = os.killpg
 
 _ALLOWED_HOST_SET = frozenset(("127.0.0.1", "localhost", "::1"))
 _BROWSER_HARNESSES = tuple(sorted(ADAPTER_TYPES))
@@ -398,6 +404,20 @@ _SPRINT_MANAGED_COLUMN = (
     " AND sp.lifecycle IN ('armed','paused')) AS sprint_managed"
 )
 
+# The registry row is the authority for "a native process still holds this
+# chat".  Joining it into the conversation read keeps the process projection at
+# zero extra queries; only the /proc identity check costs anything.
+_REGISTRY_PROCESS_COLUMNS = (
+    "reg.process_pid AS registry_pid,"
+    "reg.process_start_ticks AS registry_start_ticks,"
+    "reg.updated_at AS registry_updated_at,"
+)
+
+_REGISTRY_PROCESS_JOIN = (
+    " LEFT JOIN active_shell_chats reg"
+    " ON reg.shell_id=c.shell_id AND reg.chat_id=c.conversation_id"
+)
+
 _CLOSE_REQUESTED_AFTER_REOPEN = (
     "requested.event_type='conversation.close.requested' "
     "AND requested.sequence>COALESCE("
@@ -429,12 +449,42 @@ def _conversation_row(con, conversation_id: str, owner_user_id: int):
         " WHERE active.conversation_id=c.conversation_id "
         " AND active.state IN ('leased','starting','running') "
         " ORDER BY active.run_id DESC LIMIT 1) AS active_run_id,"
+        + _REGISTRY_PROCESS_COLUMNS
         + _SPRINT_MANAGED_COLUMN
         + " FROM conversations c JOIN shells s ON s.shell_id=c.shell_id "
-        "WHERE c.conversation_id=? AND c.owner_user_id=? "
+        + _REGISTRY_PROCESS_JOIN
+        + " WHERE c.conversation_id=? AND c.owner_user_id=? "
         f"AND c.harness IN ({_BROWSER_HARNESS_SQL})",
         (conversation_id, owner_user_id, *_BROWSER_HARNESSES),
     ).fetchone()
+
+
+def _process_projection(row) -> dict:
+    """Name the native process the registry still links to this chat.
+
+    ``lingering`` is the incident this exists for: a process that outlived the
+    turn the GUI already shows as finished.  Nothing alive stays nameless.
+    """
+    pid = row["registry_pid"]
+    start_ticks = row["registry_start_ticks"]
+    alive = pid is not None and start_ticks is not None and (
+        active_chat_registry.has_live_process(
+            active_chat_registry.ActiveChat(
+                int(row["shell_id"]),
+                row["conversation_id"],
+                row["state"],
+                int(pid),
+                int(start_ticks),
+            )
+        )
+    )
+    return {
+        "pid": int(pid) if pid is not None else None,
+        "start_ticks": int(start_ticks) if start_ticks is not None else None,
+        "alive": alive,
+        "lingering": alive and row["state"] not in ("queued", "running"),
+        "since": row["registry_updated_at"],
+    }
 
 
 def _conversation_projection(row) -> dict:
@@ -491,6 +541,7 @@ def _conversation_projection(row) -> dict:
         "closed_at": row["closed_at"],
         "close_requested_at": row["close_requested_at"],
         "sprint_managed": bool(row["sprint_managed"]),
+        "process": _process_projection(row),
         "version": int(row["version"]),
     }
 
@@ -772,6 +823,37 @@ def _live_shell_session(shell) -> str | None:
     return run_mod.shell_liveness.session_state(
         shell["shortname"] or "",
         snapshot,
+    )
+
+
+def _browser_sessions(shell) -> list[dict]:
+    """The browser-owned processes liveness attributes to one shell."""
+    snapshot = run_mod.shell_liveness.compute()
+    sessions = snapshot.get("browser_sessions") or {}
+    return list(sessions.get(shell["shortname"] or "") or ())
+
+
+def _shell_busy_error(shell, shell_id: int, state: str, action: str) -> ApiError:
+    """Refuse an occupied shell by name: a bare SHELL_BUSY offers no way out."""
+    details = {"shell_id": shell_id, "state": state}
+    session = next(iter(_browser_sessions(shell)), None) if state == "browser" else None
+    if session is None:
+        return ApiError(
+            409,
+            "SHELL_BUSY",
+            f"shell {shell['shortname']!r} has a live CLI session; "
+            f"close it before {action}",
+            details,
+        )
+    details["conversation_id"] = session.get("conversation_id")
+    details["pid"] = session.get("pid")
+    return ApiError(
+        409,
+        "SHELL_BUSY",
+        f"shell {shell['shortname']!r} is held by browser chat "
+        f"{details['conversation_id']} (pid {details['pid']}); interrupt or "
+        f"close that chat before {action}",
+        details,
     )
 
 
@@ -1107,12 +1189,8 @@ def _create_conversation(con, operator: dict, headers, body: dict):
     if active_chat_registry.get(con, shell_id) is None:
         live_state = _wait_for_cli_release(shell)
         if live_state is not None:
-            raise ApiError(
-                409,
-                "SHELL_BUSY",
-                f"shell {shell['shortname']!r} has a live CLI session; "
-                "close it before opening a browser chat",
-                {"shell_id": shell_id, "state": live_state},
+            raise _shell_busy_error(
+                shell, shell_id, live_state, "opening a browser chat"
             )
 
     conversation_id = "cv_" + uuid.uuid4().hex
@@ -1156,12 +1234,8 @@ def _create_conversation(con, operator: dict, headers, body: dict):
         if active_chat_registry.get(con, shell_id) is None:
             live_state = _live_shell_session(current_shell)
             if live_state is not None:
-                raise ApiError(
-                    409,
-                    "SHELL_BUSY",
-                    f"shell {current_shell['shortname']!r} has a live CLI session; "
-                    "close it before opening a browser chat",
-                    {"shell_id": shell_id, "state": live_state},
+                raise _shell_busy_error(
+                    current_shell, shell_id, live_state, "opening a browser chat"
                 )
 
         active = active_chat_registry.get(con, shell_id)
@@ -1329,8 +1403,11 @@ def _list_conversations(con, operator: dict, query):
         " AND " + _CLOSE_REQUESTED_AFTER_REOPEN +
         " ORDER BY requested.sequence DESC LIMIT 1"
         ") END AS close_requested_at,"
+        + _REGISTRY_PROCESS_COLUMNS
         + _SPRINT_MANAGED_COLUMN
-        + " FROM conversations c JOIN shells s ON s.shell_id=c.shell_id WHERE "
+        + " FROM conversations c JOIN shells s ON s.shell_id=c.shell_id"
+        + _REGISTRY_PROCESS_JOIN
+        + " WHERE "
         + " AND ".join(clauses)
         + " ORDER BY c.last_activity_at DESC,c.conversation_id DESC LIMIT ?",
         (*params, limit + 1),
@@ -1672,6 +1749,31 @@ def _request_interrupt(run_id: int, *, replay: bool) -> None:
         raise ApiError(503, exc.code, exc.detail) from exc
 
 
+def _lingering_run(con, conversation, requested_run: int | None):
+    """The finished-looking run whose process the registry still names alive."""
+    process = _process_projection(conversation)
+    if not process["lingering"]:
+        return None
+    clauses = ["conversation_id=?", "process_pid=?", "process_start_ticks=?"]
+    params: list = [
+        conversation["conversation_id"],
+        process["pid"],
+        process["start_ticks"],
+    ]
+    if requested_run is not None:
+        clauses.append("run_id=?")
+        params.append(requested_run)
+    row = con.execute(
+        "SELECT run_id,process_group_id FROM conversation_runs WHERE "
+        + " AND ".join(clauses)
+        + " ORDER BY run_id DESC LIMIT 1",
+        params,
+    ).fetchone()
+    if row is None or row["process_group_id"] is None:
+        return None
+    return int(row["run_id"]), int(row["process_group_id"]), process["pid"]
+
+
 def _interrupt(con, operator: dict, conversation_id: str, headers, body: dict):
     _only_fields(body, {"run_id"})
     key = _idempotency_key(headers)
@@ -1680,8 +1782,11 @@ def _interrupt(con, operator: dict, conversation_id: str, headers, body: dict):
     request_hash = _request_hash(normalized)
 
     replay = False
+    lingering_group = None
     with db_driver.write_transaction(con, "conversation.interrupt.create"):
-        _require_conversation(con, conversation_id, operator["user_id"])
+        conversation = _require_conversation(
+            con, conversation_id, operator["user_id"]
+        )
         existing = con.execute(
             "SELECT message_id,request_hash,body FROM conversation_messages "
             "WHERE conversation_id=? AND idempotency_key=?",
@@ -1714,13 +1819,20 @@ def _interrupt(con, operator: dict, conversation_id: str, headers, body: dict):
                 + " ORDER BY run_id DESC LIMIT 1",
                 params,
             ).fetchone()
-            if active is None:
-                raise ApiError(
-                    409,
-                    "RUN_ALREADY_TERMINAL",
-                    "no matching active run can be interrupted",
-                )
-            run_id = int(active["run_id"])
+            lingering_pid = None
+            if active is not None:
+                run_id = int(active["run_id"])
+            else:
+                # A finished-looking turn whose child still runs is idle, not
+                # terminal: the process is the source of truth for "running".
+                lingering = _lingering_run(con, conversation, requested_run)
+                if lingering is None:
+                    raise ApiError(
+                        409,
+                        "RUN_ALREADY_TERMINAL",
+                        "no matching active run can be interrupted",
+                    )
+                run_id, lingering_group, lingering_pid = lingering
             audit_body = json.dumps(
                 {"kind": "interrupt", "run_id": run_id},
                 separators=(",", ":"),
@@ -1746,8 +1858,24 @@ def _interrupt(con, operator: dict, conversation_id: str, headers, body: dict):
                 "version=version+1 WHERE conversation_id=?",
                 (conversation_id,),
             )
+            if lingering_group is not None:
+                _append_event(
+                    con,
+                    conversation_id,
+                    "run.interrupt.requested",
+                    {"lingering": True, "pid": lingering_pid},
+                    run_id=run_id,
+                )
             audit = _message_projection(_message_row(con, message_id))
-    _request_interrupt(run_id, replay=replay)
+    if lingering_group is not None:
+        try:
+            _SIGNAL_GROUP(lingering_group, signal.SIGINT)
+        except ProcessLookupError:
+            # The group exited between the identity check and the signal —
+            # the requested end state, already reached.
+            pass
+    else:
+        _request_interrupt(run_id, replay=replay)
     return _json(
         202,
         {

--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -621,15 +621,11 @@ def _reopen_conversation(con, operator: dict, conversation) -> list[str]:
     if active is None:
         live_state = _live_shell_session(shell)
         if live_state is not None:
-            raise ApiError(
-                409,
-                "SHELL_BUSY",
-                f"shell {shell['shortname']!r} has a live CLI session; "
-                "close it before reopening a browser chat",
-                {
-                    "shell_id": int(conversation["shell_id"]),
-                    "state": live_state,
-                },
+            raise _shell_busy_error(
+                shell,
+                int(conversation["shell_id"]),
+                live_state,
+                "reopening a browser chat",
             )
     try:
         closed = active_chat_registry.close_active(
@@ -829,8 +825,11 @@ def _live_shell_session(shell) -> str | None:
 def _browser_sessions(shell) -> list[dict]:
     """The browser-owned processes liveness attributes to one shell."""
     snapshot = run_mod.shell_liveness.compute()
-    sessions = snapshot.get("browser_sessions") or {}
-    return list(sessions.get(shell["shortname"] or "") or ())
+    # Liveness keys sessions by worktree directory; the accessor matches the
+    # shortname case-insensitively, the way orphan_split does.
+    return list(
+        run_mod.shell_liveness.browser_sessions(shell["shortname"] or "", snapshot)
+    )
 
 
 def _shell_busy_error(shell, shell_id: int, state: str, action: str) -> ApiError:

--- a/.super-coder/api/log_lines.py
+++ b/.super-coder/api/log_lines.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""UTC line stamps for the server's stdout/stderr, which land in server.log.
+
+The dispatcher redirects both streams to one file, and the server writes with
+bare `print` plus `logging` warnings from the scripts, so nothing in that file
+was attributable to a moment in time. The wrapper stamps each *line* once, at
+the point the line starts, so a partial write keeps a single prefix.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+
+STAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class TimestampedWriter:
+    """Wrap a text stream, prefixing every line with a UTC timestamp."""
+
+    def __init__(self, stream, clock=_utc_now):
+        self._stream = stream
+        self._clock = clock
+        self._at_line_start = True
+
+    def write(self, text: str) -> int:
+        if not text:
+            return 0
+        stamp = self._clock().strftime(STAMP_FORMAT) + " "
+        out = []
+        segments = text.split("\n")
+        for index, segment in enumerate(segments):
+            if segment and self._at_line_start:
+                out.append(stamp)
+                self._at_line_start = False
+            out.append(segment)
+            if index < len(segments) - 1:
+                out.append("\n")
+                self._at_line_start = True
+        self._stream.write("".join(out))
+        return len(text)
+
+    def flush(self) -> None:
+        self._stream.flush()
+
+    def __getattr__(self, name):
+        # fileno / isatty / encoding and friends belong to the real stream.
+        return getattr(self._stream, name)
+
+
+def install(clock=_utc_now) -> None:
+    """Wrap sys.stdout and sys.stderr once; installing twice is a no-op."""
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name)
+        if isinstance(stream, TimestampedWriter):
+            continue
+        setattr(sys, name, TimestampedWriter(stream, clock=clock))

--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -27,6 +27,7 @@ import http.client
 import io
 import ipaddress
 import json
+import logging
 import os
 import sqlite3
 import subprocess
@@ -81,6 +82,7 @@ import skill_projection  # noqa: E402  (exact bounded grant mirrors)
 import skill as skill_mod  # noqa: E402  (planner-owned fork-local catalogue)
 sys.path.insert(0, str(ENGINE / "api"))
 import conversation_routes  # noqa: E402  (Feature #24 browser conversations)
+import log_lines  # noqa: E402  (UTC line stamps for server.log)
 import review_routes  # noqa: E402  (Feature #26 browser Diff review)
 import map_db  # noqa: E402  (read-only handle to the dr_* catalogue in map.db)
 import ports as ports_mod  # noqa: E402
@@ -5867,6 +5869,15 @@ def _run_server(port: int) -> int:
 
 
 def main(argv):
+    # server.log is stdout+stderr as the dispatcher redirected them; stamp both
+    # before the first line is written. basicConfig carries no time of its own
+    # — the writer adds one per line, once.
+    log_lines.install()
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
     port = None
     if "--port" in argv:
         port = int(argv[argv.index("--port") + 1])

--- a/.super-coder/migrations/0249_conversation_run_transcript_offset.sql
+++ b/.super-coder/migrations/0249_conversation_run_transcript_offset.sql
@@ -1,0 +1,29 @@
+-- 0249 — durable native transcript adoption evidence.
+--
+-- The native session file is the channel the CLI writes regardless of the
+-- stdout pipe.  Recording its path and the byte offset at spawn lets a broker
+-- that lost the pipe tail exactly this turn's output instead of reconciling
+-- the whole session as unknown.
+--
+-- The reaper now also sweeps terminal runs that still name a process, so the
+-- one-time backfill drops process identity from runs whose outcome is already
+-- proven.  ``unknown`` rows keep theirs: their process may still be alive and
+-- the reaper is the authority that ends it.
+
+BEGIN;
+
+ALTER TABLE conversation_runs
+ADD COLUMN transcript_path TEXT;
+
+ALTER TABLE conversation_runs
+ADD COLUMN transcript_offset INTEGER
+    CHECK (transcript_offset IS NULL OR transcript_offset >= 0);
+
+UPDATE conversation_runs
+SET process_pid=NULL,
+    process_start_ticks=NULL,
+    process_group_id=NULL
+WHERE state IN ('succeeded','failed','cancelled')
+  AND process_pid IS NOT NULL;
+
+COMMIT;

--- a/.super-coder/migrations/0251_conversation_run_transcript_offset.sql
+++ b/.super-coder/migrations/0251_conversation_run_transcript_offset.sql
@@ -1,4 +1,4 @@
--- 0249 — durable native transcript adoption evidence.
+-- 0251 — durable native transcript adoption evidence.
 --
 -- The native session file is the channel the CLI writes regardless of the
 -- stdout pipe.  Recording its path and the byte offset at spawn lets a broker

--- a/.super-coder/scripts/conversation_adapters/base.py
+++ b/.super-coder/scripts/conversation_adapters/base.py
@@ -328,6 +328,17 @@ class ConversationAdapter(abc.ABC):
     def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
         raise NotImplementedError
 
+    def attach(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        """Re-observe a live native turn that no longer has a pipe.
+
+        A harness that writes a durable native transcript can hand the broker
+        the same normalized stream after a restart; the rest reconcile.
+        """
+        raise AdapterError(
+            "HARNESS_ATTACH_UNSUPPORTED",
+            f"{self.harness} cannot attach to a running native turn",
+        )
+
     @abc.abstractmethod
     def interrupt(self, turn: NativeTurn) -> InterruptResult:
         raise NotImplementedError

--- a/.super-coder/scripts/conversation_adapters/claude.py
+++ b/.super-coder/scripts/conversation_adapters/claude.py
@@ -6,10 +6,13 @@ import json
 import os
 import re
 import signal
+import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Iterator, Mapping
 
+import active_chat_registry
 import route_transport
 
 from .base import (
@@ -45,10 +48,16 @@ class ClaudeAdapter(ConversationAdapter):
         runner: ProcessRunner | None = None,
         manifest: Mapping[str, Any] | None = None,
         config_dir: Path | None = None,
+        attach_poll_seconds: float = 0.5,
+        sleep: Callable[[float], None] = time.sleep,
+        signal_group: Callable[[int, signal.Signals], None] = os.killpg,
     ) -> None:
         super().__init__(manifest or load_manifest(self.harness))
         self.runner = runner or SubprocessRunner()
         self.config_dir = config_dir
+        self.attach_poll_seconds = attach_poll_seconds
+        self.sleep = sleep
+        self.signal_group = signal_group
 
     def probe(self) -> ProbeResult:
         launch = self.manifest["headless"]["launch"][0]
@@ -124,6 +133,12 @@ class ClaudeAdapter(ConversationAdapter):
             session_ref=session_ref,
             resume=resume,
         )
+        # The transcript position is read before the spawn: anything the child
+        # appends belongs to this turn and must survive a lost pipe.
+        transcript = self._session_path(session_ref, worktree)
+        transcript_offset = (
+            transcript.stat().st_size if transcript.is_file() else 0
+        )
         process = self.runner.spawn(
             context.execution_argv(command),
             cwd=worktree,
@@ -136,7 +151,12 @@ class ClaudeAdapter(ConversationAdapter):
             run_ref=f"claude-{uuid.uuid4()}",
             worktree=worktree,
             process_ref=str(pid) if pid is not None else None,
-            metadata={"command": command, "resumed": resume},
+            metadata={
+                "command": command,
+                "resumed": resume,
+                "transcript_path": str(transcript),
+                "transcript_offset": transcript_offset,
+            },
             opaque=process,
         )
 
@@ -390,9 +410,154 @@ class ClaudeAdapter(ConversationAdapter):
             turn.metadata["terminal"] = event.type
             yield event
 
+    @staticmethod
+    def _identity_alive(turn: NativeTurn) -> bool:
+        pid = turn.metadata.get("process_pid")
+        start_ticks = turn.metadata.get("process_start_ticks")
+        if not isinstance(pid, int) or not isinstance(start_ticks, int):
+            return False
+        return active_chat_registry.process_identity(str(pid)) == (
+            pid,
+            start_ticks,
+        )
+
+    def _transcript_events(
+        self,
+        raw: Mapping[str, Any],
+    ) -> tuple[list[NormalizedEvent], str | None]:
+        """Normalize one transcript entry; report its assistant text."""
+        message = raw.get("message")
+        if not isinstance(message, dict):
+            return [], None
+        if raw.get("type") == "user":
+            return self._normalize(raw), None
+        if raw.get("type") != "assistant":
+            return [], None
+        content = message.get("content")
+        if not isinstance(content, list):
+            return [], None
+        events: list[NormalizedEvent] = []
+        text: str | None = None
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text" and isinstance(
+                block.get("text"), str
+            ):
+                text = block["text"]
+                events.append(
+                    NormalizedEvent(
+                        "assistant.delta",
+                        {"text": text},
+                        "assistant.text",
+                    )
+                )
+            elif block.get("type") == "tool_use":
+                events.append(
+                    NormalizedEvent(
+                        "tool.started",
+                        {"tool_ref": block.get("id"), "name": block.get("name")},
+                        "assistant.tool_use",
+                    )
+                )
+        return events, text
+
+    def _drain_transcript(
+        self,
+        path: Path,
+        offset: int,
+    ) -> tuple[int, list[NormalizedEvent], str | None]:
+        """Consume only whole lines, so a half-written entry is read next."""
+        try:
+            with path.open("rb") as stream:
+                stream.seek(offset)
+                data = stream.read()
+        except FileNotFoundError:
+            return offset, [], None
+        except OSError as exc:
+            raise AdapterError(
+                "HARNESS_SESSION_INSPECTION_FAILED",
+                f"cannot tail Claude session: {exc}",
+                retryable=True,
+            ) from exc
+        end = data.rfind(b"\n")
+        if end < 0:
+            return offset, [], None
+        events: list[NormalizedEvent] = []
+        text: str | None = None
+        for line in data[: end + 1].decode("utf-8", "replace").splitlines():
+            if not line.strip():
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(raw, dict):
+                continue
+            entry_events, entry_text = self._transcript_events(raw)
+            events.extend(entry_events)
+            if entry_text is not None:
+                text = entry_text
+        return offset + end + 1, events, text
+
+    def attach(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        """Re-observe a live turn through the session file it keeps writing."""
+        transcript = turn.metadata.get("transcript_path")
+        if not transcript or not self._identity_alive(turn):
+            raise AdapterError(
+                "HARNESS_ATTACH_UNSUPPORTED",
+                "Claude attach needs a transcript path and a live process",
+            )
+        path = Path(str(transcript))
+        offset = int(turn.metadata.get("transcript_offset") or 0)
+        yield NormalizedEvent(
+            "session.started",
+            {
+                "session_ref": turn.session_ref,
+                "resumed": True,
+                "attached": True,
+            },
+            "transcript-attach",
+        )
+        yield NormalizedEvent("run.started", {"status": "running"}, "transcript-attach")
+        last_text: str | None = None
+        while True:
+            # Liveness is read first so the final drain always follows exit.
+            alive = self._identity_alive(turn)
+            offset, events, text = self._drain_transcript(path, offset)
+            yield from events
+            if text is not None:
+                last_text = text
+            if not alive:
+                break
+            self.sleep(self.attach_poll_seconds)
+        turn.metadata["transcript_offset"] = offset
+        if last_text is None:
+            yield NormalizedEvent(
+                "run.failed",
+                {
+                    "error": "HARNESS_EXITED_WITHOUT_REPLY",
+                    "detail": "Claude exited without writing a reply",
+                },
+                "process.exit",
+            )
+            return
+        yield NormalizedEvent(
+            "run.completed",
+            {"status": "completed", "result": last_text},
+            "process.exit",
+        )
+
     def interrupt(self, turn: NativeTurn) -> InterruptResult:
         process = turn.opaque
-        if process is None or process.poll() is not None:
+        if process is None:
+            # An attached turn has no pipe; its recorded group is the handle.
+            group = turn.metadata.get("process_group_id")
+            if not isinstance(group, int) or not self._identity_alive(turn):
+                return InterruptResult(False, "Claude process is not running")
+            self.signal_group(group, signal.SIGINT)
+            return InterruptResult(True)
+        if process.poll() is not None:
             return InterruptResult(False, "Claude process is not running")
         signal_owned_process(process, signal.SIGINT)
         return InterruptResult(True)
@@ -449,14 +614,16 @@ class ClaudeAdapter(ConversationAdapter):
                 f"cannot inspect Claude session: {exc}",
                 retryable=True,
             ) from exc
+        # A Claude session file never contains a ``result`` entry; the reply
+        # that ends a turn is the last assistant text block with no tool call
+        # after it.
         terminal: str | None = None
-        if last and last.get("type") == "result":
-            events = self._normalize(last)
-            terminal_event = next(
-                (event.type for event in events if event.type in TERMINAL_EVENTS),
-                None,
-            )
-            terminal = terminal_event
+        if last is not None:
+            events, text = self._transcript_events(last)
+            if text is not None and not any(
+                event.type == "tool.started" for event in events
+            ):
+                terminal = "run.completed"
         return SessionInspection(
             session_ref,
             seen_session or path.is_file(),

--- a/.super-coder/scripts/conversation_adapters/claude.py
+++ b/.super-coder/scripts/conversation_adapters/claude.py
@@ -532,6 +532,10 @@ class ClaudeAdapter(ConversationAdapter):
                 break
             self.sleep(self.attach_poll_seconds)
         turn.metadata["transcript_offset"] = offset
+        # The identity check is the attach lane's process.wait(): the broker
+        # clears the run's process identity on this evidence exactly as it
+        # does on a returncode, so the reaper never has to record the exit.
+        turn.metadata["process_exited"] = True
         if last_text is None:
             yield NormalizedEvent(
                 "run.failed",

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -1786,7 +1786,10 @@ class ConversationBroker(threading.Thread):
                 return self._finish_adapter_event(
                     active,
                     _with_exit_code(pending_terminal, returncode),
-                    process_exited=isinstance(returncode, int),
+                    process_exited=(
+                        isinstance(returncode, int)
+                        or bool(turn.metadata.get("process_exited"))
+                    ),
                 )
             if (
                 isinstance(stream_error, AdapterError)

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -59,6 +59,7 @@ DEFAULT_EVENT_BACKLOG_SIZE = 1024
 DEFAULT_EVENT_FLUSH_SECONDS = 0.1
 DEFAULT_BUSY_RETRY_ATTEMPTS = 6
 DEFAULT_LINGER_GRACE_SECONDS = 3.0
+DEFAULT_MAX_DEFERRALS = 120
 _STREAM_END = object()
 
 
@@ -102,6 +103,11 @@ class BrokerRun:
     route_binding: Mapping[str, Any] | None = None
     binding_digest: str | None = None
     lifecycle_epoch: int = 1
+    process_pid: int | None = None
+    process_start_ticks: int | None = None
+    process_group_id: int | None = None
+    transcript_path: str | None = None
+    transcript_offset: int | None = None
 
     def context(self) -> ConversationContext:
         # Browser conversations run with worktree command access.
@@ -295,6 +301,11 @@ class BrokerStore:
             route_binding=binding,
             binding_digest=binding_digest,
             lifecycle_epoch=int(row["lifecycle_epoch"]),
+            process_pid=row["process_pid"],
+            process_start_ticks=row["process_start_ticks"],
+            process_group_id=row["process_group_id"],
+            transcript_path=row["transcript_path"],
+            transcript_offset=row["transcript_offset"],
         )
 
     @staticmethod
@@ -302,6 +313,8 @@ class BrokerStore:
         return (
             "SELECT r.run_id,r.conversation_id,r.trigger_message_id,r.shell_id,"
             "r.harness_session_before,r.harness_session_after,r.runner_ref,"
+            "r.process_pid,r.process_start_ticks,r.process_group_id,"
+            "r.transcript_path,r.transcript_offset,"
             "r.state AS run_state,c.harness,c.provider,c.model,c.effort,"
             "c.route_contract_version,c.route_binding,"
             "c.worktree,c.title,m.body,"
@@ -637,11 +650,13 @@ class BrokerStore:
                         f"adapter returned {turn.session_ref}",
                     )
                 require_transition("run", row["state"], "running")
+                transcript_offset = turn.metadata.get("transcript_offset")
                 changed = con.execute(
                     "UPDATE conversation_runs SET state='running',"
                     "harness_session_after=?,runner_ref=?,heartbeat_at=?,"
                     "lease_expires_at=?,process_pid=?,process_start_ticks=?,"
-                    "process_group_id=? WHERE run_id=? AND lease_owner=? "
+                    "process_group_id=?,transcript_path=?,transcript_offset=? "
+                    "WHERE run_id=? AND lease_owner=? "
                     "AND state='starting'",
                     (
                         turn.session_ref,
@@ -651,6 +666,12 @@ class BrokerStore:
                         process_pid,
                         process_start_ticks,
                         process_group_id,
+                        turn.metadata.get("transcript_path"),
+                        (
+                            transcript_offset
+                            if isinstance(transcript_offset, int)
+                            else None
+                        ),
                         run_id,
                         owner,
                     ),
@@ -758,12 +779,16 @@ class BrokerStore:
         error_detail: str | None = None,
         exit_code: int | None = None,
         keep_process_link: bool = False,
+        process_exited: bool = False,
     ) -> bool:
         """Commit terminal event and release every durable lock atomically.
 
         ``keep_process_link`` finishes a run whose native process is still
         alive (a lingering turn): the reply becomes visible, but the registry
         keeps naming the process so nothing alive is invisible.
+        ``process_exited`` is the opposite evidence: the caller watched the
+        native process exit, so the run row stops naming a pid nothing can
+        find.  A finish without either claim leaves identity to the reaper.
         """
         if outcome not in TERMINAL_RUN_STATES:
             raise BrokerError(
@@ -869,7 +894,14 @@ class BrokerStore:
                     )
                 con.execute(
                     "UPDATE conversation_runs SET state=?,ended_at=?,"
-                    "exit_code=?,error_code=?,error_detail=? WHERE run_id=?",
+                    "exit_code=?,error_code=?,error_detail=?"
+                    + (
+                        ",process_pid=NULL,process_start_ticks=NULL,"
+                        "process_group_id=NULL"
+                        if process_exited
+                        else ""
+                    )
+                    + " WHERE run_id=?",
                     (
                         outcome,
                         now,
@@ -1039,7 +1071,11 @@ class BrokerStore:
         return continuation_id
 
     def release_process_link(self, run_id: int) -> bool:
-        """Clear the registry link a lingering finish deliberately kept."""
+        """Clear the registry link a lingering finish deliberately kept.
+
+        The process is verifiably gone, so the whole turn — the lingering run
+        and every continuation of its trigger message — stops naming it.
+        """
         con = self.connect()
         try:
             with db_driver.write_transaction(
@@ -1047,12 +1083,18 @@ class BrokerStore:
                 "conversation.broker.release_process_link",
             ):
                 row = con.execute(
-                    "SELECT shell_id,conversation_id FROM conversation_runs "
-                    "WHERE run_id=?",
+                    "SELECT shell_id,conversation_id,trigger_message_id "
+                    "FROM conversation_runs WHERE run_id=?",
                     (run_id,),
                 ).fetchone()
                 if row is None:
                     raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+                con.execute(
+                    "UPDATE conversation_runs SET process_pid=NULL,"
+                    "process_start_ticks=NULL,process_group_id=NULL "
+                    "WHERE trigger_message_id=? AND process_pid IS NOT NULL",
+                    (row["trigger_message_id"],),
+                )
                 return active_chat_registry.clear_process(
                     con,
                     shell_id=int(row["shell_id"]),
@@ -1060,6 +1102,78 @@ class BrokerStore:
                 )
         finally:
             con.close()
+
+    def defer_run(
+        self,
+        run_id: int,
+        owner: str,
+        seconds: float,
+        *,
+        reason: str,
+        detail: str,
+    ) -> bool:
+        """Hold a leased run back without spending its outbox intent.
+
+        The shell's previous native process is still alive, which is not this
+        turn's failure: the run keeps its lease row and its queued message,
+        and the ordinary expiry/adoption path re-dispatches it once the lease
+        it is given here runs out.
+        """
+        con = self.connect()
+        now = self.clock()
+        try:
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.defer_run",
+            ):
+                row = con.execute(
+                    "SELECT conversation_id,trigger_message_id,state "
+                    "FROM conversation_runs WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if row is None:
+                    raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+                if row["state"] != "leased":
+                    raise BrokerError(
+                        "CONVERSATION_RUN_NOT_LEASED",
+                        f"run {run_id} is {row['state']}",
+                    )
+                changed = con.execute(
+                    "UPDATE conversation_runs SET lease_owner=?,"
+                    "lease_expires_at=?,heartbeat_at=? "
+                    "WHERE run_id=? AND state='leased'",
+                    (
+                        owner,
+                        _stamp(now + timedelta(seconds=seconds)),
+                        _stamp(now),
+                        run_id,
+                    ),
+                ).rowcount
+                if changed != 1:
+                    return False
+                first = (
+                    con.execute(
+                        "SELECT 1 FROM conversation_events "
+                        "WHERE run_id=? AND event_type='run.deferred'",
+                        (run_id,),
+                    ).fetchone()
+                    is None
+                )
+                if first:
+                    self._append_event(
+                        con,
+                        conversation_id=row["conversation_id"],
+                        event_type="run.deferred",
+                        payload={"reason": reason, "detail": detail[:16384]},
+                        message_id=int(row["trigger_message_id"]),
+                        run_id=run_id,
+                    )
+                conversation_id = str(row["conversation_id"])
+        finally:
+            con.close()
+        if first:
+            conversation_events.notify(conversation_id)
+        return True
 
     def renew_runs(self, owner: str, run_ids: list[int]) -> int:
         if not run_ids:
@@ -1239,6 +1353,7 @@ class ConversationBroker(threading.Thread):
         self._wake = threading.Event()
         self._stop_event = threading.Event()
         self._active: dict[int, _ActiveRun] = {}
+        self._deferrals: dict[int, int] = {}
         self._active_lock = threading.Lock()
         self._started_once = threading.Event()
 
@@ -1419,19 +1534,18 @@ class ConversationBroker(threading.Thread):
 
     @staticmethod
     def _produce_stream(
-        adapter: ConversationAdapter,
-        turn: NativeTurn,
+        source: Callable[[], Any],
         items: queue.Queue[object],
         stopped: threading.Event,
     ) -> None:
-        """Drain one native stream into its bounded per-run queue.
+        """Drain one native event source into its bounded per-run queue.
 
         The iterator runs to exhaustion: a terminal line is the harness
         reporting a result, not proof the process is gone, and abandoning the
         iterator early leaves the child unobserved and unwaited.
         """
         try:
-            for event in adapter.stream(turn):
+            for event in source():
                 while not stopped.is_set():
                     try:
                         items.put(event, timeout=0.1)
@@ -1472,6 +1586,24 @@ class ConversationBroker(threading.Thread):
         process = turn.opaque
         return process is not None and process.poll() is None
 
+    @staticmethod
+    def _attach_metadata(run: BrokerRun) -> dict[str, Any]:
+        """The recovery evidence for a turn whose process is still the same."""
+        if run.process_pid is None or run.process_start_ticks is None:
+            return {}
+        if active_chat_registry.process_identity(str(run.process_pid)) != (
+            run.process_pid,
+            run.process_start_ticks,
+        ):
+            return {}
+        return {
+            "process_pid": run.process_pid,
+            "process_start_ticks": run.process_start_ticks,
+            "process_group_id": run.process_group_id,
+            "transcript_path": run.transcript_path,
+            "transcript_offset": run.transcript_offset or 0,
+        }
+
     def _open_continuation(self, active: _ActiveRun) -> int | None:
         persisted, continuation_id = self._retry_busy(
             partial(self.store.open_continuation, active.run_id, self.owner),
@@ -1481,6 +1613,32 @@ class ConversationBroker(threading.Thread):
             return None
         active.continuation_run_id = continuation_id
         return continuation_id
+
+    def _defer_run(self, run: BrokerRun, exc: Exception) -> bool:
+        """Wait out this chat's own lingering process instead of failing.
+
+        The refusal describes the shell, not the turn, so the message stays
+        queued and its lease is re-armed for the ordinary adoption path.  The
+        bound keeps a permanently occupied shell from deferring forever.
+        """
+        with self._active_lock:
+            deferrals = self._deferrals.get(run.run_id, 0) + 1
+            self._deferrals[run.run_id] = deferrals
+            if deferrals > DEFAULT_MAX_DEFERRALS:
+                del self._deferrals[run.run_id]
+                return False
+        persisted, deferred = self._retry_busy(
+            partial(
+                self.store.defer_run,
+                run.run_id,
+                self.owner,
+                self.recovery_seconds,
+                reason="SHELL_LINGERING",
+                detail=str(getattr(exc, "detail", exc)),
+            ),
+            wait=True,
+        )
+        return bool(persisted and deferred)
 
     def _release_process_link(self, active: _ActiveRun) -> None:
         self._retry_busy(
@@ -1493,6 +1651,8 @@ class ConversationBroker(threading.Thread):
         active: _ActiveRun,
         adapter: ConversationAdapter,
         turn: NativeTurn,
+        *,
+        source: Callable[[], Any] | None = None,
     ) -> bool:
         """Persist one stream with real flush deadlines and bounded batches.
 
@@ -1508,7 +1668,7 @@ class ConversationBroker(threading.Thread):
         stopped = threading.Event()
         threading.Thread(
             target=self._produce_stream,
-            args=(adapter, turn, items, stopped),
+            args=(source or partial(adapter.stream, turn), items, stopped),
             name=f"conversation-stream-{active.run.run_id}",
             daemon=True,
         ).start()
@@ -1622,12 +1782,11 @@ class ConversationBroker(threading.Thread):
             if not self._flush_all(active, pending):
                 return False
             if pending_terminal is not None:
+                returncode = turn.metadata.get("returncode")
                 return self._finish_adapter_event(
                     active,
-                    _with_exit_code(
-                        pending_terminal,
-                        turn.metadata.get("returncode"),
-                    ),
+                    _with_exit_code(pending_terminal, returncode),
+                    process_exited=isinstance(returncode, int),
                 )
             if (
                 isinstance(stream_error, AdapterError)
@@ -1647,6 +1806,7 @@ class ConversationBroker(threading.Thread):
         event: NormalizedEvent,
         *,
         keep_process_link: bool = False,
+        process_exited: bool = False,
     ) -> bool:
         if event.type == "run.failed" and active.interrupt_requested:
             event = NormalizedEvent(
@@ -1690,6 +1850,7 @@ class ConversationBroker(threading.Thread):
                 ),
                 exit_code=exit_code if isinstance(exit_code, int) else None,
                 keep_process_link=keep_process_link,
+                process_exited=process_exited,
             ),
             wait=True,
         )
@@ -1826,8 +1987,16 @@ class ConversationBroker(threading.Thread):
                     adapter = self.adapter_factory(run.harness)
                     active.adapter = adapter
                 except Exception as exc:
+                    # A shell still running this chat's previous process has
+                    # not failed this turn; every other refusal here is proven.
+                    if getattr(
+                        exc, "code", None
+                    ) == "SHELL_LINGERING" and self._defer_run(run, exc):
+                        return
                     self._finish_error(run.run_id, exc, proven=True)
                     return
+                with self._active_lock:
+                    self._deferrals.pop(run.run_id, None)
 
                 self.store.mark_starting(run.run_id, self.owner)
                 try:
@@ -1865,16 +2034,32 @@ class ConversationBroker(threading.Thread):
                     proven=False,
                 )
                 return
+            attach = self._attach_metadata(run)
             active.turn = NativeTurn(
                 harness=run.harness,
                 session_ref=session_ref,
                 run_ref=run.runner_ref,
                 worktree=run.worktree.resolve(),
-                metadata={"recovered": True},
+                process_ref=str(run.process_pid) if attach else None,
+                metadata={"recovered": True, **attach},
             )
             self._deliver_interrupt(active)
             recovery = getattr(self.launch_preparer, "recovery", None)
             context = recovery(run) if callable(recovery) else run.context()
+            # The transcript is the durable channel the harness writes with or
+            # without a pipe. Adapters that cannot tail it raise
+            # HARNESS_ATTACH_UNSUPPORTED and reconcile as before.
+            if (
+                attach
+                and callable(getattr(adapter, "attach", None))
+                and self._consume_stream(
+                    active,
+                    adapter,
+                    active.turn,
+                    source=partial(adapter.attach, active.turn),
+                )
+            ):
+                return
             self._reconcile_loop(active, context)
         except Exception as exc:
             # Store failures are loud in service stderr, but try to close the

--- a/.super-coder/scripts/conversation_broker.py
+++ b/.super-coder/scripts/conversation_broker.py
@@ -46,6 +46,9 @@ from conversation_state import require_transition
 
 LIVE_RUN_STATES = frozenset({"leased", "starting", "running"})
 TERMINAL_RUN_STATES = frozenset({"succeeded", "failed", "cancelled", "unknown"})
+TERMINAL_MESSAGE_STATES = frozenset({"completed", "failed", "cancelled"})
+# A lingering process that only reports usage or its session is not new work.
+QUIET_EVENTS = frozenset({"usage", "session.started"})
 DEFAULT_LEASE_SECONDS = 30
 DEFAULT_HEARTBEAT_SECONDS = 10
 DEFAULT_RECOVERY_SECONDS = 5
@@ -55,6 +58,7 @@ DEFAULT_EVENT_BATCH_SIZE = 64
 DEFAULT_EVENT_BACKLOG_SIZE = 1024
 DEFAULT_EVENT_FLUSH_SECONDS = 0.1
 DEFAULT_BUSY_RETRY_ATTEMPTS = 6
+DEFAULT_LINGER_GRACE_SECONDS = 3.0
 _STREAM_END = object()
 
 
@@ -124,6 +128,24 @@ class _ActiveRun:
     turn: NativeTurn | None = None
     interrupt_requested: bool = False
     interrupt_sent: bool = False
+    continuation_run_id: int | None = None
+
+    @property
+    def run_id(self) -> int:
+        """The run this worker writes to: the continuation once one is open."""
+        return self.continuation_run_id or self.run.run_id
+
+
+def _with_exit_code(event: NormalizedEvent, exit_code: Any) -> NormalizedEvent:
+    """Stamp the verified process exit onto the terminal the stream carried."""
+    if not isinstance(exit_code, int) or "exit_code" in event.payload:
+        return event
+    return NormalizedEvent(
+        event.type,
+        {**dict(event.payload), "exit_code": exit_code},
+        event.native_type,
+        event.interrupt_evidence,
+    )
 
 
 def _utcnow() -> datetime:
@@ -735,8 +757,14 @@ class BrokerStore:
         error_code: str | None = None,
         error_detail: str | None = None,
         exit_code: int | None = None,
+        keep_process_link: bool = False,
     ) -> bool:
-        """Commit terminal event and release every durable lock atomically."""
+        """Commit terminal event and release every durable lock atomically.
+
+        ``keep_process_link`` finishes a run whose native process is still
+        alive (a lingering turn): the reply becomes visible, but the registry
+        keeps naming the process so nothing alive is invisible.
+        """
         if outcome not in TERMINAL_RUN_STATES:
             raise BrokerError(
                 "CONVERSATION_OUTCOME_INVALID",
@@ -782,7 +810,12 @@ class BrokerStore:
                     "SELECT state FROM conversation_messages WHERE message_id=?",
                     (row["trigger_message_id"],),
                 ).fetchone()[0]
-                require_transition("message", message_current, message_state)
+                # A continuation finishes a message its lingering predecessor
+                # already closed. The message machine has no exit from a
+                # terminal state, so that first close stands for the turn.
+                message_closed = message_current in TERMINAL_MESSAGE_STATES
+                if not message_closed:
+                    require_transition("message", message_current, message_state)
                 close_after = bool(row["close_requested"])
                 if close_after:
                     queued_ids = [
@@ -846,16 +879,18 @@ class BrokerStore:
                         run_id,
                     ),
                 )
-                active_chat_registry.clear_process(
-                    con,
-                    shell_id=int(row["shell_id"]),
-                    chat_id=str(row["conversation_id"]),
-                )
-                con.execute(
-                    "UPDATE conversation_messages SET state=?,completed_at=? "
-                    "WHERE message_id=?",
-                    (message_state, now, row["trigger_message_id"]),
-                )
+                if not keep_process_link:
+                    active_chat_registry.clear_process(
+                        con,
+                        shell_id=int(row["shell_id"]),
+                        chat_id=str(row["conversation_id"]),
+                    )
+                if not message_closed:
+                    con.execute(
+                        "UPDATE conversation_messages SET state=?,completed_at=? "
+                        "WHERE message_id=?",
+                        (message_state, now, row["trigger_message_id"]),
+                    )
                 if not already_closed:
                     con.execute(
                         "UPDATE conversations SET state=?,last_activity_at=?,"
@@ -903,6 +938,128 @@ class BrokerStore:
             str(conversation_id),
         )
         return True
+
+    def open_continuation(self, run_id: int, owner: str) -> int | None:
+        """Reopen a lingering turn as the next attempt of the same message.
+
+        A lingering finish closed the run while its native process kept
+        working, so later output still belongs to that trigger message: the
+        continuation copies the finished run's native and process identity
+        under ``attempt+1``.  The conversation walks idle -> queued -> running
+        because neither this module's table nor migration 0132's trigger has a
+        direct idle -> running edge, and both steps are legal.  The trigger
+        message keeps the terminal state its lingering finish committed.
+        Returns None for a closed conversation, which takes no new work.
+        """
+        con = self.connect()
+        now, expires = self._times()
+        try:
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.open_continuation",
+            ):
+                row = con.execute(
+                    "SELECT r.conversation_id,r.shell_id,r.trigger_message_id,"
+                    "r.harness_session_before,r.harness_session_after,"
+                    "r.runner_ref,r.archive_id,r.process_pid,"
+                    "r.process_start_ticks,r.process_group_id,"
+                    "c.state AS conversation_state "
+                    "FROM conversation_runs r JOIN conversations c "
+                    "ON c.conversation_id=r.conversation_id WHERE r.run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if row is None:
+                    raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+                if row["conversation_state"] == "closed":
+                    return None
+                attempt = con.execute(
+                    "SELECT MAX(attempt)+1 FROM conversation_runs "
+                    "WHERE trigger_message_id=?",
+                    (row["trigger_message_id"],),
+                ).fetchone()[0]
+                continuation_id = int(
+                    con.execute(
+                        "INSERT INTO conversation_runs "
+                        "(conversation_id,shell_id,trigger_message_id,attempt,"
+                        "harness_session_before,harness_session_after,"
+                        "runner_ref,archive_id,state,lease_owner,"
+                        "lease_expires_at,started_at,heartbeat_at,process_pid,"
+                        "process_start_ticks,process_group_id) "
+                        "VALUES (?,?,?,?,?,?,?,?,'running',?,?,?,?,?,?,?)",
+                        (
+                            row["conversation_id"],
+                            row["shell_id"],
+                            row["trigger_message_id"],
+                            attempt,
+                            row["harness_session_after"]
+                            or row["harness_session_before"],
+                            row["harness_session_after"],
+                            row["runner_ref"],
+                            row["archive_id"],
+                            owner,
+                            expires,
+                            now,
+                            now,
+                            row["process_pid"],
+                            row["process_start_ticks"],
+                            row["process_group_id"],
+                        ),
+                    ).lastrowid
+                )
+                self._append_event(
+                    con,
+                    conversation_id=row["conversation_id"],
+                    event_type="run.resumed",
+                    payload={"continues_run_id": run_id, "status": "running"},
+                    message_id=int(row["trigger_message_id"]),
+                    run_id=continuation_id,
+                )
+                if row["conversation_state"] != "running":
+                    require_transition(
+                        "conversation",
+                        row["conversation_state"],
+                        "queued",
+                    )
+                    con.execute(
+                        "UPDATE conversations SET state='queued' "
+                        "WHERE conversation_id=?",
+                        (row["conversation_id"],),
+                    )
+                    require_transition("conversation", "queued", "running")
+                    con.execute(
+                        "UPDATE conversations SET state='running',"
+                        "last_activity_at=?,version=version+1 "
+                        "WHERE conversation_id=?",
+                        (now, row["conversation_id"]),
+                    )
+                conversation_id = str(row["conversation_id"])
+        finally:
+            con.close()
+        conversation_events.notify(conversation_id)
+        return continuation_id
+
+    def release_process_link(self, run_id: int) -> bool:
+        """Clear the registry link a lingering finish deliberately kept."""
+        con = self.connect()
+        try:
+            with db_driver.write_transaction(
+                con,
+                "conversation.broker.release_process_link",
+            ):
+                row = con.execute(
+                    "SELECT shell_id,conversation_id FROM conversation_runs "
+                    "WHERE run_id=?",
+                    (run_id,),
+                ).fetchone()
+                if row is None:
+                    raise BrokerError("CONVERSATION_RUN_NOT_FOUND", str(run_id))
+                return active_chat_registry.clear_process(
+                    con,
+                    shell_id=int(row["shell_id"]),
+                    chat_id=str(row["conversation_id"]),
+                )
+        finally:
+            con.close()
 
     def renew_runs(self, owner: str, run_ids: list[int]) -> int:
         if not run_ids:
@@ -1051,6 +1208,7 @@ class ConversationBroker(threading.Thread):
         event_backlog_size: int = DEFAULT_EVENT_BACKLOG_SIZE,
         event_flush_seconds: float = DEFAULT_EVENT_FLUSH_SECONDS,
         busy_retry_attempts: int = DEFAULT_BUSY_RETRY_ATTEMPTS,
+        linger_grace_seconds: float = DEFAULT_LINGER_GRACE_SECONDS,
     ) -> None:
         super().__init__(name="conversation-broker", daemon=True)
         self.store = store or BrokerStore(db_path)
@@ -1071,6 +1229,9 @@ class ConversationBroker(threading.Thread):
             raise ValueError("event_flush_seconds must be positive")
         if busy_retry_attempts <= 0:
             raise ValueError("busy_retry_attempts must be positive")
+        if linger_grace_seconds <= 0:
+            raise ValueError("linger_grace_seconds must be positive")
+        self.linger_grace_seconds = linger_grace_seconds
         self.event_batch_size = event_batch_size
         self.event_backlog_size = event_backlog_size
         self.event_flush_seconds = event_flush_seconds
@@ -1091,7 +1252,7 @@ class ConversationBroker(threading.Thread):
 
     def active_run_ids(self) -> list[int]:
         with self._active_lock:
-            return sorted(self._active)
+            return sorted(active.run_id for active in self._active.values())
 
     def wait_started(self, timeout: float = 5.0) -> bool:
         return self._started_once.wait(timeout)
@@ -1106,11 +1267,26 @@ class ConversationBroker(threading.Thread):
 
     def interrupt(self, run_id: int) -> bool:
         """Persist and, when possible, immediately deliver an interrupt."""
-        self.store.request_interrupt(run_id)
         with self._active_lock:
-            active = self._active.get(run_id)
+            active = next(
+                (
+                    item
+                    for item in self._active.values()
+                    if run_id in {item.run.run_id, item.run_id}
+                ),
+                None,
+            )
             if active is not None:
                 active.interrupt_requested = True
+        try:
+            self.store.request_interrupt(
+                active.run_id if active is not None else run_id
+            )
+        except BrokerError as exc:
+            # A lingering finish closed the run row while its native process
+            # kept working; the live worker still owns that signal.
+            if active is None or exc.code != "CONVERSATION_RUN_NOT_ACTIVE":
+                raise
         if active is not None:
             self._deliver_interrupt(active)
         self.notify()
@@ -1248,7 +1424,12 @@ class ConversationBroker(threading.Thread):
         items: queue.Queue[object],
         stopped: threading.Event,
     ) -> None:
-        """Drain one native stream into its bounded per-run queue."""
+        """Drain one native stream into its bounded per-run queue.
+
+        The iterator runs to exhaustion: a terminal line is the harness
+        reporting a result, not proof the process is gone, and abandoning the
+        iterator early leaves the child unobserved and unwaited.
+        """
         try:
             for event in adapter.stream(turn):
                 while not stopped.is_set():
@@ -1257,7 +1438,7 @@ class ConversationBroker(threading.Thread):
                         break
                     except queue.Full:
                         continue
-                if stopped.is_set() or event.type in TERMINAL_EVENTS:
+                if stopped.is_set():
                     break
         except Exception as exc:
             while not stopped.is_set():
@@ -1274,13 +1455,53 @@ class ConversationBroker(threading.Thread):
                 except queue.Full:
                     continue
 
+    def _flush_all(
+        self,
+        active: _ActiveRun,
+        pending: list[NormalizedEvent],
+    ) -> bool:
+        while pending:
+            if not self._flush_events(active.run_id, pending, wait=True):
+                return False
+        return True
+
+    def _lingers(self, turn: NativeTurn, silent_since: float) -> bool:
+        """True when the harness reported a result but its process runs on."""
+        if time.monotonic() - silent_since < self.linger_grace_seconds:
+            return False
+        process = turn.opaque
+        return process is not None and process.poll() is None
+
+    def _open_continuation(self, active: _ActiveRun) -> int | None:
+        persisted, continuation_id = self._retry_busy(
+            partial(self.store.open_continuation, active.run_id, self.owner),
+            wait=True,
+        )
+        if not persisted or continuation_id is None:
+            return None
+        active.continuation_run_id = continuation_id
+        return continuation_id
+
+    def _release_process_link(self, active: _ActiveRun) -> None:
+        self._retry_busy(
+            partial(self.store.release_process_link, active.run_id),
+            wait=True,
+        )
+
     def _consume_stream(
         self,
         active: _ActiveRun,
         adapter: ConversationAdapter,
         turn: NativeTurn,
     ) -> bool:
-        """Persist one stream with real flush deadlines and bounded batches."""
+        """Persist one stream with real flush deadlines and bounded batches.
+
+        The native process, not the first terminal line, ends a run: a
+        terminal is held pending and superseded by any later one.  The run
+        finishes on stream end, or, once the process lingers silently past
+        the grace window, early while keeping its registry process link.
+        Output after a lingering finish opens a continuation run.
+        """
         items: queue.Queue[object] = queue.Queue(
             maxsize=self.event_backlog_size
         )
@@ -1293,6 +1514,9 @@ class ConversationBroker(threading.Thread):
         ).start()
         pending: list[NormalizedEvent] = []
         pending_since: float | None = None
+        pending_terminal: NormalizedEvent | None = None
+        silent_since = time.monotonic()
+        lingering = False
         retry_after = 0.0
         stream_error: Exception | None = None
         try:
@@ -1318,23 +1542,44 @@ class ConversationBroker(threading.Thread):
                     item = None
 
                 if isinstance(item, NormalizedEvent):
+                    silent_since = time.monotonic()
                     if item.type in TERMINAL_EVENTS:
-                        while pending:
-                            if not self._flush_events(
-                                active.run.run_id,
-                                pending,
-                                wait=True,
-                            ):
-                                return False
-                        return self._finish_adapter_event(active, item)
-                    if not pending:
-                        pending_since = time.monotonic()
-                    pending.append(item)
+                        # The last result wins; the process ends the run.
+                        pending_terminal = item
+                        item = None
+                    else:
+                        if lingering and item.type not in QUIET_EVENTS:
+                            if self._open_continuation(active) is None:
+                                return True
+                            lingering = False
+                        if not pending:
+                            pending_since = time.monotonic()
+                        pending.append(item)
                 elif isinstance(item, Exception):
                     stream_error = item
                     break
                 elif item is _STREAM_END:
                     break
+
+                if lingering:
+                    # Nothing may be written until a continuation run exists.
+                    continue
+                if pending_terminal is not None and self._lingers(
+                    turn,
+                    silent_since,
+                ):
+                    if not self._flush_all(active, pending):
+                        return False
+                    if not self._finish_adapter_event(
+                        active,
+                        pending_terminal,
+                        keep_process_link=True,
+                    ):
+                        return False
+                    pending_since = None
+                    pending_terminal = None
+                    lingering = True
+                    continue
 
                 now = time.monotonic()
                 deadline_reached = (
@@ -1360,7 +1605,7 @@ class ConversationBroker(threading.Thread):
                 if now < retry_after and not force_backpressure:
                     continue
                 if self._flush_events(
-                    active.run.run_id,
+                    active.run_id,
                     pending,
                     wait=force_backpressure,
                 ):
@@ -1369,13 +1614,21 @@ class ConversationBroker(threading.Thread):
                 else:
                     retry_after = now + self.recovery_seconds
 
-            while pending:
-                if not self._flush_events(
-                    active.run.run_id,
-                    pending,
-                    wait=True,
-                ):
-                    return False
+            if lingering:
+                # Verified exit with no continuation: only quiet events can
+                # still be buffered, and the process no longer needs naming.
+                self._release_process_link(active)
+                return True
+            if not self._flush_all(active, pending):
+                return False
+            if pending_terminal is not None:
+                return self._finish_adapter_event(
+                    active,
+                    _with_exit_code(
+                        pending_terminal,
+                        turn.metadata.get("returncode"),
+                    ),
+                )
             if (
                 isinstance(stream_error, AdapterError)
                 and stream_error.code.startswith("HARNESS_SUBMISSION_")
@@ -1392,6 +1645,8 @@ class ConversationBroker(threading.Thread):
         self,
         active: _ActiveRun,
         event: NormalizedEvent,
+        *,
+        keep_process_link: bool = False,
     ) -> bool:
         if event.type == "run.failed" and active.interrupt_requested:
             event = NormalizedEvent(
@@ -1411,7 +1666,7 @@ class ConversationBroker(threading.Thread):
         persisted, _result = self._retry_busy(
             partial(
                 self.store.finish_run,
-                active.run.run_id,
+                active.run_id,
                 outcome,
                 event_type=event.type,
                 payload={
@@ -1434,6 +1689,7 @@ class ConversationBroker(threading.Thread):
                     else str(error) if error else None
                 ),
                 exit_code=exit_code if isinstance(exit_code, int) else None,
+                keep_process_link=keep_process_link,
             ),
             wait=True,
         )
@@ -1471,7 +1727,7 @@ class ConversationBroker(threading.Thread):
         turn = active.turn
         if adapter is None or turn is None:
             self._finish_error(
-                active.run.run_id,
+                active.run_id,
                 BrokerError(
                     "HARNESS_IDENTITY_NOT_CAPTURED",
                     "native dispatch crossed the starting boundary without "
@@ -1492,7 +1748,7 @@ class ConversationBroker(threading.Thread):
                 persisted, _result = self._retry_busy(
                     partial(
                         self.store.note_reconcile_error,
-                        active.run.run_id,
+                        active.run_id,
                         self.owner,
                         reconcile_detail,
                     ),
@@ -1501,7 +1757,7 @@ class ConversationBroker(threading.Thread):
                 if not persisted:
                     return
                 if failures >= self.reconcile_attempts:
-                    self._finish_error(active.run.run_id, exc, proven=False)
+                    self._finish_error(active.run_id, exc, proven=False)
                     return
                 self._stop_event.wait(self.recovery_seconds)
                 continue
@@ -1512,7 +1768,7 @@ class ConversationBroker(threading.Thread):
                     partial(
                         self.store.renew_runs,
                         self.owner,
-                        [active.run.run_id],
+                        [active.run_id],
                     ),
                     wait=True,
                 )
@@ -1540,7 +1796,7 @@ class ConversationBroker(threading.Thread):
             self._retry_busy(
                 partial(
                     self.store.finish_run,
-                    active.run.run_id,
+                    active.run_id,
                     outcome,
                     event_type=self._terminal_event(outcome),
                     payload=terminal_payload,
@@ -1624,7 +1880,7 @@ class ConversationBroker(threading.Thread):
             # Store failures are loud in service stderr, but try to close the
             # durable run if its state still permits a conservative terminal.
             try:
-                self._finish_error(run.run_id, exc, proven=False)
+                self._finish_error(active.run_id, exc, proven=False)
             except Exception as finish_exc:
                 print(
                     f"conversation-broker: run {run.run_id} failed: {exc}; "

--- a/.super-coder/scripts/conversation_launch.py
+++ b/.super-coder/scripts/conversation_launch.py
@@ -208,32 +208,62 @@ class ConversationLaunchPreparer:
                 "unsupported stored conversation route contract",
             )
 
-        def occupying_state() -> str | None:
-            snapshot = self.liveness()
-            return (
-                "busy"
-                if flavor == "admin" and snapshot.get("admin_root_pids")
-                else shell_liveness.session_state(shortname, snapshot)
-            )
+        def occupying_state() -> tuple[str | None, dict | None]:
+            """The slot verdict, plus the foreign browser session that holds it.
 
-        def wait_for_free_slot() -> str | None:
-            state = occupying_state()
+            A browser-owned process of THIS conversation is this chat's own
+            lingering turn: the broker owns continuation and queueing, so it
+            never refuses its own follow-up.  Any other holder is named.
+            """
+            snapshot = self.liveness()
+            if flavor == "admin" and snapshot.get("admin_root_pids"):
+                return "busy", None
+            state = shell_liveness.session_state(shortname, snapshot)
+            if state != "browser":
+                return state, None
+            sessions = (snapshot.get("browser_sessions") or {}).get(shortname) or ()
+            foreign = [
+                session
+                for session in sessions
+                if session.get("conversation_id") != broker_run.conversation_id
+            ]
+            if not foreign:
+                return None, None
+            return state, foreign[0]
+
+        def wait_for_free_slot() -> tuple[str | None, dict | None]:
+            state, session = occupying_state()
             for _ in range(self.liveness_retries):
                 if state is None:
-                    return None
+                    return None, None
                 self.sleep(self.liveness_delay)
-                state = occupying_state()
-            return state
+                state, session = occupying_state()
+            return state, session
+
+        def busy_detail(state: str, session: dict | None, tail: str) -> str:
+            if session is None:
+                return (
+                    f"shell {shortname!r} already has a live CLI session "
+                    f"({state}); {tail}"
+                )
+            return (
+                f"shell {shortname!r} is held by browser chat "
+                f"{session.get('conversation_id')} (pid {session.get('pid')}); "
+                f"{tail}"
+            )
 
         # Native harnesses can emit their terminal result just before their
         # process disappears from /proc. Give that browser-owned teardown a
         # short drain window; a genuinely occupied CLI slot remains a refusal.
-        state = wait_for_free_slot()
+        state, session = wait_for_free_slot()
         if state is not None:
             raise ConversationLaunchError(
                 "SHELL_BUSY",
-                f"shell {shortname!r} already has a live CLI session "
-                f"({state}); close it before starting a browser turn",
+                busy_detail(
+                    state,
+                    session,
+                    "interrupt or close it before starting a browser turn",
+                ),
             )
 
         try:
@@ -276,12 +306,16 @@ class ConversationLaunchPreparer:
         # Preparation renders and may create/sync the worktree. Recheck at the
         # dispatch edge so a CLI launch that raced that work is still refused
         # before the adapter can send the prompt.
-        state = wait_for_free_slot()
+        state, session = wait_for_free_slot()
         if state is not None:
             raise ConversationLaunchError(
                 "SHELL_BUSY",
-                f"shell {shortname!r} acquired a live CLI session during "
-                f"browser preparation ({state}); no prompt was dispatched",
+                busy_detail(
+                    state,
+                    session,
+                    "it was acquired during browser preparation, so no prompt "
+                    "was dispatched",
+                ),
             )
 
         expected = broker_run.worktree.resolve()

--- a/.super-coder/scripts/conversation_launch.py
+++ b/.super-coder/scripts/conversation_launch.py
@@ -221,15 +221,20 @@ class ConversationLaunchPreparer:
             state = shell_liveness.session_state(shortname, snapshot)
             if state != "browser":
                 return state, None
-            sessions = (snapshot.get("browser_sessions") or {}).get(shortname) or ()
+            sessions = shell_liveness.browser_sessions(shortname, snapshot)
             foreign = [
                 session
                 for session in sessions
                 if session.get("conversation_id") != broker_run.conversation_id
             ]
-            if not foreign:
+            if foreign:
+                return state, foreign[0]
+            if not sessions:
                 return None, None
-            return state, foreign[0]
+            # This chat's own previous turn is still running. Two print-mode
+            # processes on one native session file is the hazard, so the
+            # follow-up waits for exit or Stop; it never dispatches over it.
+            return "lingering", sessions[0]
 
         def wait_for_free_slot() -> tuple[str | None, dict | None]:
             state, session = occupying_state()
@@ -240,16 +245,27 @@ class ConversationLaunchPreparer:
                 state, session = occupying_state()
             return state, session
 
-        def busy_detail(state: str, session: dict | None, tail: str) -> str:
+        def refusal(
+            state: str, session: dict | None, tail: str
+        ) -> ConversationLaunchError:
             if session is None:
-                return (
+                return ConversationLaunchError(
+                    "SHELL_BUSY",
                     f"shell {shortname!r} already has a live CLI session "
-                    f"({state}); {tail}"
+                    f"({state}); {tail}",
                 )
-            return (
+            if state == "lingering":
+                return ConversationLaunchError(
+                    "SHELL_LINGERING",
+                    f"this chat's previous turn is still running "
+                    f"(pid {session.get('pid')}); wait for it to finish or "
+                    f"press Stop, then send again",
+                )
+            return ConversationLaunchError(
+                "SHELL_BUSY",
                 f"shell {shortname!r} is held by browser chat "
                 f"{session.get('conversation_id')} (pid {session.get('pid')}); "
-                f"{tail}"
+                f"{tail}",
             )
 
         # Native harnesses can emit their terminal result just before their
@@ -257,13 +273,10 @@ class ConversationLaunchPreparer:
         # short drain window; a genuinely occupied CLI slot remains a refusal.
         state, session = wait_for_free_slot()
         if state is not None:
-            raise ConversationLaunchError(
-                "SHELL_BUSY",
-                busy_detail(
-                    state,
-                    session,
-                    "interrupt or close it before starting a browser turn",
-                ),
+            raise refusal(
+                state,
+                session,
+                "interrupt or close it before starting a browser turn",
             )
 
         try:
@@ -308,14 +321,11 @@ class ConversationLaunchPreparer:
         # before the adapter can send the prompt.
         state, session = wait_for_free_slot()
         if state is not None:
-            raise ConversationLaunchError(
-                "SHELL_BUSY",
-                busy_detail(
-                    state,
-                    session,
-                    "it was acquired during browser preparation, so no prompt "
-                    "was dispatched",
-                ),
+            raise refusal(
+                state,
+                session,
+                "it was acquired during browser preparation, so no prompt "
+                "was dispatched",
             )
 
         expected = broker_run.worktree.resolve()

--- a/.super-coder/scripts/conversation_reaper.py
+++ b/.super-coder/scripts/conversation_reaper.py
@@ -375,7 +375,12 @@ class ReaperStore:
                 if row is None:
                     return False
                 run_state = str(row["state"])
-                if run_state in TERMINAL_RUN_STATES:
+                # `unknown` keeps its pre-lingering record: state untouched,
+                # `run.interrupted` as the reaper's outcome. Only a run the
+                # broker proved finished gets the `run.reaped` record.
+                if run_state == "unknown":
+                    self._append_interrupted_event(con, candidate, reason)
+                elif run_state in TERMINAL_RUN_STATES:
                     self._append_reaped_event(con, candidate, reason, run_state)
                 else:
                     require_transition("run", run_state, "cancelled")

--- a/.super-coder/scripts/conversation_reaper.py
+++ b/.super-coder/scripts/conversation_reaper.py
@@ -18,6 +18,7 @@ import db_driver
 from conversation_state import require_transition
 
 TERMINAL_MESSAGE_STATES = frozenset({"completed", "failed", "cancelled"})
+TERMINAL_RUN_STATES = frozenset({"succeeded", "failed", "cancelled", "unknown"})
 DEFAULT_HEARTBEAT_SECONDS = 60.0
 DEFAULT_TERM_GRACE_SECONDS = 15.0
 DEFAULT_KILL_GRACE_SECONDS = 15.0
@@ -163,11 +164,20 @@ class ReaperStore:
 
     @staticmethod
     def _sweepable_sql() -> str:
+        """A run this reaper may still act on.
+
+        A TERMINAL run with a live pid is the lingering case: the turn finished
+        (the GUI has its reply) while the process kept working, so the registry
+        link is deliberately held. The NOT-protected clause is what gates it —
+        the moment the FnB closes the chat, the link goes and the process
+        becomes reapable. The reaper's own outcome event ends the ladder: a run
+        it has already reaped or interrupted is never swept twice."""
+        terminal = ",".join(f"'{state}'" for state in sorted(TERMINAL_RUN_STATES))
         return (
-            "(r.state IN ('starting','running') OR (r.state='unknown' "
+            f"(r.state IN ('starting','running') OR (r.state IN ({terminal}) "
             "AND NOT EXISTS(SELECT 1 FROM conversation_events reaped "
             "WHERE reaped.run_id=r.run_id "
-            "AND reaped.event_type='run.interrupted')))"
+            "AND reaped.event_type IN ('run.interrupted','run.reaped'))))"
         )
 
     def candidates(self) -> list[ReaperCandidate]:
@@ -266,13 +276,41 @@ class ReaperStore:
             con.close()
 
     @staticmethod
-    def _append_interrupted_event(con, candidate: ReaperCandidate, reason: str) -> None:
+    def _append_event(
+        con,
+        candidate: ReaperCandidate,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> None:
         sequence = con.execute(
             "SELECT COALESCE(MAX(sequence),0)+1 FROM conversation_events "
             "WHERE conversation_id=?",
             (candidate.conversation_id,),
         ).fetchone()[0]
-        payload = json.dumps(
+        con.execute(
+            "INSERT INTO conversation_events "
+            "(conversation_id,sequence,event_type,payload,message_id,run_id) "
+            "VALUES (?,?,?,?,?,?)",
+            (
+                candidate.conversation_id,
+                sequence,
+                event_type,
+                json.dumps(payload, separators=(",", ":"), sort_keys=True),
+                candidate.message_id,
+                candidate.run_id,
+            ),
+        )
+
+    def _append_interrupted_event(
+        self,
+        con,
+        candidate: ReaperCandidate,
+        reason: str,
+    ) -> None:
+        self._append_event(
+            con,
+            candidate,
+            "run.interrupted",
             {
                 "interrupt_evidence": "operator",
                 "outcome": "cancelled",
@@ -281,24 +319,38 @@ class ReaperStore:
                     "reason": reason,
                 },
             },
-            separators=(",", ":"),
-            sort_keys=True,
         )
-        con.execute(
-            "INSERT INTO conversation_events "
-            "(conversation_id,sequence,event_type,payload,message_id,run_id) "
-            "VALUES (?,?,'run.interrupted',?,?,?)",
-            (
-                candidate.conversation_id,
-                sequence,
-                payload,
-                candidate.message_id,
-                candidate.run_id,
-            ),
+
+    def _append_reaped_event(
+        self,
+        con,
+        candidate: ReaperCandidate,
+        reason: str,
+        run_state: str,
+    ) -> None:
+        """The reaper's outcome on a run that is ALREADY finished — a record,
+        never a state change. Its terminal is the broker's; re-finishing it
+        here would overwrite a proven outcome with the reaper's guess."""
+        self._append_event(
+            con,
+            candidate,
+            "run.reaped",
+            {
+                "outcome": "reaped",
+                "run_state": run_state,
+                "reaper": {
+                    "process_group_id": candidate.process_group_id,
+                    "reason": reason,
+                },
+            },
         )
 
     def finish_interrupted(self, candidate: ReaperCandidate, reason: str) -> bool:
-        """Write the reaper-owned terminal state iff identity stays unprotected."""
+        """Write the reaper-owned terminal state iff identity stays unprotected.
+
+        An already-terminal run gets the outcome EVENT and nothing else: its
+        state, ended_at, message and conversation belong to whoever finished
+        it."""
         con = self.connect()
         now = _stamp(self.clock())
         try:
@@ -323,7 +375,9 @@ class ReaperStore:
                 if row is None:
                     return False
                 run_state = str(row["state"])
-                if run_state != "unknown":
+                if run_state in TERMINAL_RUN_STATES:
+                    self._append_reaped_event(con, candidate, reason, run_state)
+                else:
                     require_transition("run", run_state, "cancelled")
                     con.execute(
                         "UPDATE conversation_runs SET state='cancelled',ended_at=?,"
@@ -357,7 +411,7 @@ class ReaperStore:
                             "version=version+1 WHERE conversation_id=?",
                             (target, now, candidate.conversation_id),
                         )
-                self._append_interrupted_event(con, candidate, reason)
+                    self._append_interrupted_event(con, candidate, reason)
         finally:
             con.close()
         conversation_events.notify(candidate.conversation_id)

--- a/.super-coder/scripts/db_driver.py
+++ b/.super-coder/scripts/db_driver.py
@@ -137,6 +137,12 @@ def connect(path):
         con.row_factory = sqlite3.Row
         con.execute("PRAGMA foreign_keys=ON")
         _enable_wal(con)
+        # WAL + NORMAL never fsyncs on commit, so a stalled fsync cannot hold
+        # the write lock (host NVMe timeouts of 30 s were observed holding it
+        # through COMMIT under FULL and starving every daemon). The file stays
+        # intact on power loss; only the last commits before a crash can roll
+        # back (decision #314).
+        con.execute("PRAGMA synchronous=NORMAL")
         con.execute(f"PRAGMA busy_timeout={DEFAULT_BUSY_TIMEOUT_MS}")
         return con
     except BaseException:

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -1238,7 +1238,9 @@ def _shell_status(shell, snap: "dict | None") -> str:
         label, paint = "Unknown", style.dim
     else:
         state = shell_liveness.session_state(shell["shortname"] or "", snap)
-        if state == "busy":
+        if state == "browser":
+            label, paint = "BROWSER", style.red
+        elif state == "busy":
             label, paint = "Busy", style.amber
         elif state == "orphan":
             label, paint = "Orphaned", style.red
@@ -1247,6 +1249,21 @@ def _shell_status(shell, snap: "dict | None") -> str:
         else:
             label, paint = "Available", style.green
     return f"{paint(label)}{' ' * (12 - len(label))}"
+
+
+def browser_refusal(shortname: str, snap: dict) -> str:
+    """The refusal for a slot held by the engine's OWN browser turn.
+
+    It still refuses — one shell, one session — but a browser process is not
+    anonymous: the operator gets the conversation, the pid, and the two ways
+    out, instead of a dead end and a pid to hunt by hand."""
+    named = ", ".join(
+        f"conversation {s['conversation_id']} (pid {s['pid']}"
+        f"{', lingering' if s.get('lingering') else ''})"
+        for s in shell_liveness.browser_sessions(shortname, snap))
+    return (f"sc run: shell '{shortname}' slot is held by a BROWSER turn — "
+            f"{named}. Two ways out: interrupt the turn from that GUI chat, "
+            f"or close that chat. Then re-run.")
 
 
 def confirm_live(shell, snap: "dict | None") -> bool:
@@ -2215,6 +2232,8 @@ def main() -> None:
     if headless and chosen["shortname"] and chosen["flavor"] != "admin":
         snap = shell_liveness.compute()
         if snap.get("supported") and shell_liveness.is_active(chosen["shortname"], snap):
+            if shell_liveness.session_state(chosen["shortname"], snap) == "browser":
+                sys.exit(browser_refusal(chosen["shortname"], snap))
             pids, orphans = shell_liveness.orphan_split(chosen["shortname"], snap)
             if pids and len(orphans) == len(pids):
                 # The slot-holder outlived its terminal/parent — still refuse

--- a/.super-coder/scripts/shell_liveness.py
+++ b/.super-coder/scripts/shell_liveness.py
@@ -62,6 +62,15 @@ claim whose process is gone is `expected_absent`, which is not `available`:
 the difference between "nobody launched anything here" and "a launch claimed
 this shell and its worker is missing".
 
+Browser turns: the engine launches its own harness process for a GUI
+conversation — a child of the API server, cwd in the shell's worktree, i.e.
+indistinguishable from a CLI session by cwd alone. Joined against
+`active_shell_chats` and `conversation_runs` by pid + start ticks it becomes a
+NAMED hold (`browser_conversation`, `browser_sessions`, and `session_state`'s
+'browser'), so a consumer can point at the conversation instead of refusing the
+shell with nothing to show. `lingering` marks the process whose run already
+finished — alive past its own terminal.
+
 Non-Linux: /proc is absent; compute() returns supported=False. Fall back to
 `lsof -a +D <worktree>` / `ps`. The substrate host is Linux.
 
@@ -86,6 +95,10 @@ DB_PATH = instance_state.active_database_path(ENGINE)
 PROC = Path("/proc")
 
 _FALLBACK_BINS = {"claude", "codex", "opencode", "vibe", "kimi"}
+
+# A conversation run in one of these states is finished; a process still holding
+# its identity is LINGERING — alive after its run's terminal.
+_TERMINAL_RUN_STATES = ("succeeded", "failed", "cancelled", "unknown")
 
 
 def harness_binaries() -> set[str]:
@@ -333,6 +346,55 @@ def _launch_claims() -> dict[str, dict]:
     return {r["shortname"].lower(): dict(r) for r in rows}
 
 
+def _browser_processes() -> dict[tuple[int, int], dict]:
+    """(pid, start_ticks) → {conversation_id, lingering} for every process the
+    engine itself launched for a browser conversation.
+
+    A GUI turn is a harness child of the API server whose cwd is the shell's
+    worktree, so the scan above counts it as an anonymous CLI session and every
+    consumer refuses the shell with nothing to name. The registry (the one
+    active chat per shell) and the run rows (any state — a LINGERING process
+    belongs to a run that already finished) both carry the pid + start_ticks
+    identity, which is what makes the answer safe against a recycled pid.
+
+    Best-effort exactly like _launch_claims: no DB, a locked DB, or a fork
+    without these tables all mean "nothing is browser-owned", and the scan
+    reads as it did before."""
+    if not DB_PATH.exists() or DB_PATH.stat().st_size == 0:
+        return {}
+    con = None
+    try:
+        con = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True, timeout=2)
+        con.row_factory = sqlite3.Row
+        rows = con.execute(
+            "SELECT chat_id AS conversation_id, process_pid AS pid, "
+            "process_start_ticks AS start_ticks, NULL AS state "
+            "FROM active_shell_chats WHERE process_pid IS NOT NULL "
+            "UNION ALL "
+            "SELECT conversation_id, process_pid, process_start_ticks, state "
+            "FROM conversation_runs WHERE process_pid IS NOT NULL").fetchall()
+    except sqlite3.Error:
+        return {}
+    finally:
+        if con is not None:
+            con.close()
+    tagged: dict[tuple[int, int], dict] = {}
+    working: set[tuple[int, int]] = set()
+    for r in rows:
+        key = (int(r["pid"]), int(r["start_ticks"]))
+        entry = tagged.setdefault(key, {"conversation_id": str(r["conversation_id"]),
+                                        "lingering": False})
+        if r["state"] is None:
+            continue
+        if r["state"] in _TERMINAL_RUN_STATES:
+            entry["lingering"] = True
+        else:
+            working.add(key)         # a live run on this pid — not lingering
+    for key in working:
+        tagged[key]["lingering"] = False
+    return tagged
+
+
 def claim_live(claim: dict) -> bool:
     """Is the process a launch claim names still the one that was launched, and
     does it still hold that shell's worktree?
@@ -384,6 +446,7 @@ def compute() -> dict:
     labels = _shell_labels()
     claims = _launch_claims()
     live_claims = {name: c for name, c in claims.items() if claim_live(c)}
+    browser = _browser_processes()
 
     # First pass: every harness process and its raw pid/comm (cwd resolved next).
     harness_pids: set[int] = set()
@@ -404,6 +467,7 @@ def compute() -> dict:
 
     processes: list[dict] = []
     worktree_sessions: dict[str, list[int]] = {}
+    browser_sessions_by_shell: dict[str, list[dict]] = {}
     indeterminate_pids: list[int] = []
     admin_root_pids: list[int] = []
 
@@ -419,10 +483,14 @@ def compute() -> dict:
         except ValueError:
             continue                                          # another repo — ignore
         parts = rel.parts
+        tag = browser.get((pid, _start_ticks(pid))) if browser else None
         if len(parts) >= 2 and parts[0] == ".sc-worktrees":
             shortname = parts[1]                              # worktree dir = shortname.lower()
             region = "worktree"
             worktree_sessions.setdefault(shortname, []).append(pid)
+            if tag:
+                browser_sessions_by_shell.setdefault(shortname, []).append(
+                    {"pid": pid, **tag})
         else:
             shortname = None                                  # repo root (or a subdir of it)
             region = "root"
@@ -441,6 +509,9 @@ def compute() -> dict:
             "claimed": live_claims.get(shortname or "", {}).get("pid") == pid,
             "orphaned": (None if pid == self_pid
                          else _orphan_verdict(pid)),
+            # The engine's own browser turn, named rather than anonymous.
+            "browser_conversation": (tag or {}).get("conversation_id"),
+            "lingering": bool((tag or {}).get("lingering")),
         })
 
     active_other = sorted(worktree_sessions)
@@ -457,6 +528,7 @@ def compute() -> dict:
         "admin_presence": admin_presence,
         "processes": processes,
         "worktree_sessions": worktree_sessions,
+        "browser_sessions": browser_sessions_by_shell,
         "active_other_shells": active_other,
         "admin_root_pids": admin_root_pids,
         "indeterminate": indeterminate,
@@ -494,18 +566,38 @@ def orphan_split(shortname: str, snap: dict) -> "tuple[list[int], list[int]]":
              if p.get("orphaned") and not p.get("claimed")])
 
 
+def browser_sessions(shortname: str, snap: dict) -> list[dict]:
+    """This shell's browser-owned worktree processes —
+    [{pid, conversation_id, lingering}] — for a caller that must NAME them.
+    The snapshot keys these by worktree directory; shortnames are compared
+    case-insensitively, exactly as orphan_split does."""
+    for name, sessions in snap.get("browser_sessions", {}).items():
+        if name.lower() == shortname.lower():
+            return sessions
+    return []
+
+
 def session_state(shortname: str, snap: dict) -> "str | None":
     """One shell's slot verdict, the shape the picker annotation needs:
-    'busy' (a working session holds the worktree), 'orphan' (EVERY session pid
-    is an orphan — closed terminal / dead parent still holding the slot), or
-    None (dormant, or liveness unsupported). A single live session among
-    orphans wins: someone is working there → 'busy'."""
+    'busy' (a working CLI session holds the worktree), 'browser' (every live
+    session is a turn the engine itself launched for a GUI conversation),
+    'orphan' (EVERY session pid is an orphan — closed terminal / dead parent
+    still holding the slot), or None (dormant, or liveness unsupported). A
+    single live session among orphans wins: someone is working there.
+
+    'browser' is not an all-clear — the slot is still held — but it is a
+    NAMED hold: the caller can point at the conversation and the pid, and the
+    operator has a way out that does not involve hunting a pid by hand."""
     if not snap.get("supported"):
         return None
     pids, orphans = orphan_split(shortname, snap)
     if not pids:
         return None
-    return "orphan" if len(orphans) == len(pids) else "busy"
+    if len(orphans) == len(pids):
+        return "orphan"
+    live = set(pids) - set(orphans)
+    owned = {s["pid"] for s in browser_sessions(shortname, snap)}
+    return "browser" if live <= owned else "busy"
 
 
 def record_state(shortname: str, snap: dict) -> "str | None":

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2888,6 +2888,27 @@ function chatHash(shortname, conversationId = "") {
     + (conversationId ? `/${encodeURIComponent(conversationId)}` : "");
 }
 
+// A bare SHELL_BUSY leaves the operator hunting for the pid by hand. When the
+// API names the chat holding the shell, the toast links straight to it.
+function chatBusyToast(error, shortname) {
+  const held = error.details || {};
+  if (error.code !== "SHELL_BUSY" || !held.conversation_id) {
+    toast(`${error.code}: ${error.message}`);
+    return;
+  }
+  const open = el("button", {
+    className: "chat-busy-open",
+    type: "button",
+    textContent: "open that chat",
+  });
+  open.onclick = () => {
+    location.hash = chatHash(shortname, held.conversation_id);
+  };
+  toast(el("span", {},
+    `${error.code}: ${held.conversation_id} (pid ${held.pid}) still holds this shell — `,
+    open));
+}
+
 function chatModeHash(shortname, conversationId, mode = "chat") {
   return chatHash(shortname, conversationId)
     + (mode === "diff" ? "/diff" : "");
@@ -3048,13 +3069,19 @@ function chatWorkingDots() {
     el("span", {}, "."));
 }
 
-function chatStatePill(state) {
-  const label = {
-    queued: "queued", running: "working", waiting: "waiting",
-    error: "failed", idle: "idle", closed: "closed",
-  }[state] || state;
+// `process` is the conversation projection's process block. A lingering child
+// outlived the turn the transcript already shows as finished — the pill names
+// its pid so nothing alive stays nameless.
+function chatStatePill(state, process) {
+  const lingering = Boolean(process?.lingering);
+  const label = lingering
+    ? `process still running · pid ${process.pid}`
+    : ({
+      queued: "queued", running: "working", waiting: "waiting",
+      error: "failed", idle: "idle", closed: "closed",
+    }[state] || state);
   const pill = el("span", {
-    className: `chat-state state-${state || "idle"}`,
+    className: `chat-state state-${state || "idle"}${lingering ? " lingering" : ""}`,
   });
   if (state !== "running") {
     pill.textContent = label;
@@ -3098,11 +3125,10 @@ function chatPaintHistoryItem(item, conversation) {
   item.context.textContent =
     `${chatStartedLabel(conversation)} | ${chatModelLabel(conversation)}`;
   item.name.textContent = chatConversationName(conversation);
-  const nextState = conversation.state || "idle";
-  if (!item.state.classList.contains(`state-${nextState}`)) {
-    const state = chatStatePill(nextState);
-    item.state.replaceWith(state);
-    item.state = state;
+  const next = chatStatePill(conversation.state || "idle", conversation.process);
+  if (item.state.className !== next.className) {
+    item.state.replaceWith(next);
+    item.state = next;
   }
   chatPaintStar(item.star, Boolean(conversation.starred));
 }
@@ -3242,7 +3268,7 @@ function chatOpenStream(
     "conversation.reopened",
     "message.accepted", "session.started", "run.started",
     "assistant.delta", "tool.started", "tool.completed", "permission.requested",
-    "input.requested", "usage", "run.completed", "run.failed",
+    "input.requested", "usage", "run.completed", "run.resumed", "run.failed",
     "run.interrupt.requested", "run.interrupted", "run.unknown",
   ];
   for (const type of types) {
@@ -4191,7 +4217,7 @@ async function chatRenderNew(host, shell, defaults, catalog) {
       const conversation = await chatCreateConversation(shell, body);
       location.hash = chatHash(shell.shortname, conversation.conversation_id);
     } catch (error) {
-      toast(`${error.code}: ${error.message}`);
+      chatBusyToast(error, shell.shortname);
       submit.disabled = false;
       submit.textContent = "Start chat";
     }
@@ -4854,7 +4880,11 @@ async function chatRenderOpen(
       || closing || (closed && !reopenable);
     send.disabled = Boolean(unavailableReason)
       || closing || (closed && !reopenable);
-    stop.disabled = conversation.state !== "running" || closing || Boolean(stopRequest);
+    // A lingering child is still working even though the turn reads finished,
+    // so Stop stays the way out of it.
+    const lingering = Boolean(conversation.process?.lingering);
+    stop.disabled = (conversation.state !== "running" && !lingering)
+      || closing || Boolean(stopRequest);
     stop.textContent = stopRequest ? "Stopping…" : "Stop";
     headerStop.disabled = stop.disabled;
     headerStop.textContent = stop.textContent;
@@ -4974,7 +5004,8 @@ async function chatRenderOpen(
   }
   send.onclick = submit;
   stop.onclick = async () => {
-    if (conversation.state !== "running") return;
+    if (conversation.state !== "running" && !conversation.process?.lingering)
+      return;
     if (!stopRequest) stopRequest = { key: requestKey() };
     paint();
     try {
@@ -5150,6 +5181,9 @@ async function chatRenderOpen(
     transcriptState.lastSequence = sequence;
     if (message && type === "run.started") message.state = "running";
     if (message && type === "run.completed") message.state = "completed";
+    // The lingering child kept working past its terminal: the broker opened a
+    // continuation run, so the finished-looking turn goes back to running.
+    if (message && type === "run.resumed") message.state = "running";
     if (message && ["run.failed", "run.unknown"].includes(type))
       message.state = "failed";
     if (message && type === "run.interrupted") message.state = "cancelled";
@@ -5169,6 +5203,10 @@ async function chatRenderOpen(
       if (event.run_id != null)
         transcriptState.assistantSegments.delete(event.run_id);
       if (onWakeDelivered) onWakeDelivered(conversation.shell.shell_id);
+    }
+    if (type === "run.resumed") {
+      conversation.state = "running";
+      conversation.active_run_id = event.run_id;
     }
     if (type === "conversation.updated" || type === "conversation.renamed")
       Object.assign(conversation, event.payload || {});
@@ -5390,7 +5428,7 @@ async function renderInterface(root) {
       const conversation = await chatCreateConversation(shell);
       location.hash = chatHash(shell.shortname, conversation.conversation_id);
     } catch (error) {
-      toast(`${error.code}: ${error.message}`);
+      chatBusyToast(error, shell.shortname);
       newChat.disabled = false;
       configure.disabled = false;
       newChat.textContent = "＋ Chat";
@@ -5473,7 +5511,7 @@ async function renderInterface(root) {
     });
     const context = el("span", { className: "chat-history-context" });
     const name = el("span", { className: "chat-history-name" });
-    const state = chatStatePill(conversation.state);
+    const state = chatStatePill(conversation.state, conversation.process);
     const star = el("button", {
       className: "chat-history-star",
       type: "button",

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -397,6 +397,14 @@ body.interface-view main {
 .chat-state.state-error { color: #ef7d86; border-color: rgba(239,125,134,.45); }
 .chat-state.state-idle { color: var(--ok); border-color: rgba(76,175,125,.4); }
 .chat-state.state-closed { opacity: .6; }
+/* A lingering process outranks the chat's own state: it is the live fact. */
+.chat-state.lingering {
+  color: var(--warn); border-color: rgba(212,145,74,.45); text-transform: none;
+}
+.chat-busy-open {
+  background: none; border: 0; padding: 0; font: inherit; color: var(--accent);
+  text-decoration: underline; cursor: pointer;
+}
 .chat-pane {
   min-width: 0; min-height: 0; display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto; background: var(--panel2);

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -149,7 +149,8 @@
     "tests/test_sprint_work_dispatch.py",
     "tests/test_update_materialize.py",
     ".super-coder/migrations/0249_reseed_docs_frozen_render_path.sql",
-    ".super-coder/migrations/0250_reseed_fork_skill_design_planner_lane.sql"
+    ".super-coder/migrations/0250_reseed_fork_skill_design_planner_lane.sql",
+    ".super-coder/migrations/0249_conversation_run_transcript_offset.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -150,7 +150,7 @@
     "tests/test_update_materialize.py",
     ".super-coder/migrations/0249_reseed_docs_frozen_render_path.sql",
     ".super-coder/migrations/0250_reseed_fork_skill_design_planner_lane.sql",
-    ".super-coder/migrations/0249_conversation_run_transcript_offset.sql"
+    ".super-coder/migrations/0251_conversation_run_transcript_offset.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -1270,6 +1270,80 @@ class ConversationAdapterTest(unittest.TestCase):
             ],
         )
 
+    def test_claude_reads_past_a_result_and_the_last_one_wins(self) -> None:
+        """A result is the harness reporting a turn, not the process exiting.
+
+        The stream keeps reading; a later result supersedes the earlier one,
+        EOF waits for the child, and no 'stream ended' failure follows a
+        terminal that was observed.
+        """
+        adapter, _runner = self.build("claude")
+        session_ref = "22222222-3333-4444-8555-666666666666"
+        rows = [
+            {"type": "system", "subtype": "init", "session_id": session_ref},
+            {
+                "type": "result",
+                "subtype": "success",
+                "session_id": session_ref,
+                "result": "background task",
+                "num_turns": 1,
+                "stop_reason": "end_turn",
+            },
+            {
+                "type": "stream_event",
+                "session_id": session_ref,
+                "event": {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "the real turn"},
+                },
+            },
+            {
+                "type": "result",
+                "subtype": "success",
+                "session_id": session_ref,
+                "result": "the real turn",
+                "num_turns": 3,
+                "stop_reason": "end_turn",
+            },
+        ]
+        process = FakeClaudeProcess(session_ref)
+        process.stdout = io.StringIO(
+            "".join(json.dumps(row) + "\n" for row in rows)
+        )
+        turn = NativeTurn(
+            harness="claude",
+            session_ref=session_ref,
+            run_ref="claude-test",
+            worktree=self.root,
+            process_ref=str(process.pid),
+            metadata={"resumed": True},
+            opaque=process,
+        )
+
+        events = list(adapter.stream(turn))
+
+        terminals = [
+            event for event in events if event.type in base_adapter.TERMINAL_EVENTS
+        ]
+        self.assertEqual([event.type for event in terminals], ["run.completed"] * 2)
+        self.assertIs(terminals[-1], events[-1])
+        self.assertEqual(events[-1].payload["result"], "the real turn")
+        self.assertEqual(turn.metadata["terminal"], "run.completed")
+        self.assertEqual(turn.metadata["returncode"], 0)
+        self.assertEqual(process.returncode, 0)
+        self.assertNotIn(
+            "stream ended without a terminal result",
+            [event.payload.get("error") for event in events],
+        )
+        self.assertIn(
+            "the real turn",
+            [
+                event.payload.get("text")
+                for event in events
+                if event.type == "assistant.delta"
+            ],
+        )
+
     def test_interrupted_events_require_structured_evidence(self) -> None:
         with self.assertRaisesRegex(ValueError, "structured native or operator"):
             NormalizedEvent("run.interrupted", {"status": "interrupted"})

--- a/tests/test_conversation_adapters.py
+++ b/tests/test_conversation_adapters.py
@@ -37,6 +37,7 @@ from conversation_adapters import (  # noqa: E402
     adapter_for,
 )
 from conversation_adapters import base as base_adapter
+from conversation_adapters import claude as claude_adapter
 from conversation_adapters import codex as codex_adapter
 from conversation_adapters import opencode as opencode_adapter
 from conversation_adapters.base import SubprocessRunner
@@ -1095,24 +1096,32 @@ class ConversationAdapterTest(unittest.TestCase):
                 "cwd": str(cwd_rows[0]),
             }
         ]
+        # A Claude session file records assistant/user turns, never a
+        # ``result``: a trailing tool call is a turn still working and a
+        # trailing text block is the reply that ended it.
         middle_cwds = cwd_rows[1:-1] if terminal else cwd_rows[1:]
         rows.extend(
             {
                 "type": "assistant",
                 "session_id": session_ref,
                 "cwd": str(stored_cwd),
-                "message": {"content": "working"},
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "id": "tool-1", "name": "Bash"}
+                    ]
+                },
             }
             for stored_cwd in middle_cwds
         )
         if terminal:
             rows.append(
                 {
-                    "type": "result",
-                    "subtype": "success",
+                    "type": "assistant",
                     "session_id": session_ref,
                     "cwd": str(cwd_rows[-1]),
-                    "result": "done",
+                    "message": {
+                        "content": [{"type": "text", "text": "done"}]
+                    },
                 }
             )
         path.write_text("".join(json.dumps(row) + "\n" for row in rows))
@@ -2455,6 +2464,237 @@ class ConversationAdapterTest(unittest.TestCase):
         self.assertEqual(cwd, self.root)
         self.assertEqual(argv[argv.index("--resume") + 1], session_ref)
         self.assertNotIn("--session-id", argv)
+
+    def claude_entry(self, session_ref: str, *blocks: dict) -> str:
+        kind = (
+            "user"
+            if blocks and blocks[0].get("type") == "tool_result"
+            else "assistant"
+        )
+        return json.dumps(
+            {
+                "type": kind,
+                "session_id": session_ref,
+                "cwd": str(self.root),
+                "message": {"content": list(blocks)},
+            }
+        )
+
+    def test_claude_launch_records_the_transcript_position_at_spawn(self) -> None:
+        adapter, _runner = self.build("claude")
+        started = adapter.start(self.context, "hello")
+        path = adapter._session_path(started.session_ref, self.root)
+
+        self.assertEqual(started.metadata["transcript_path"], str(path))
+        self.assertEqual(started.metadata["transcript_offset"], 0)
+
+        self.write_claude_session(adapter, started.session_ref)
+        resumed = adapter.resume(started.session_ref, self.context, "again")
+
+        self.assertEqual(
+            resumed.metadata["transcript_offset"],
+            path.stat().st_size,
+        )
+
+    def test_claude_attach_tails_a_growing_transcript_to_its_reply(self) -> None:
+        session_ref = "22222222-2222-4222-8222-222222222222"
+        adapter, _runner = self.build("claude")
+        adapter.attach_poll_seconds = 0.25
+        path = adapter._session_path(session_ref, self.root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Everything before the offset belongs to an earlier turn.
+        path.write_text(
+            self.claude_entry(session_ref, {"type": "text", "text": "earlier"})
+            + "\n"
+        )
+        offset = path.stat().st_size
+        tool_use = self.claude_entry(
+            session_ref,
+            {"type": "tool_use", "id": "tool-9", "name": "Bash"},
+        )
+        tool_result = self.claude_entry(
+            session_ref,
+            {"type": "tool_result", "tool_use_id": "tool-9", "is_error": False},
+        )
+        reply = self.claude_entry(
+            session_ref,
+            {"type": "thinking", "thinking": "secret"},
+            {"type": "text", "text": "final answer"},
+        )
+        alive = [True]
+        # Each poll interval writes the next chunk; the last one ends the
+        # process. The middle chunk deliberately stops mid-line.
+        steps = [
+            lambda: path.write_text(
+                path.read_text() + tool_use + "\n" + tool_result[:20]
+            ),
+            lambda: path.write_text(
+                path.read_text() + tool_result[20:] + "\n" + reply + "\n"
+            ),
+            lambda: alive.clear(),
+        ]
+        adapter.sleep = lambda seconds: (
+            self.assertEqual(seconds, 0.25),
+            steps.pop(0)(),
+        )
+        turn = NativeTurn(
+            harness="claude",
+            session_ref=session_ref,
+            run_ref="claude-attach",
+            worktree=self.root,
+            metadata={
+                "transcript_path": str(path),
+                "transcript_offset": offset,
+                "process_pid": 4321,
+                "process_start_ticks": 99,
+                "process_group_id": 4321,
+            },
+        )
+
+        with mock.patch.object(
+            claude_adapter.active_chat_registry,
+            "process_identity",
+            side_effect=lambda ref: (4321, 99) if alive else (None, None),
+        ):
+            events = list(adapter.attach(turn))
+
+        self.assertEqual(
+            [(event.type, event.payload) for event in events],
+            [
+                (
+                    "session.started",
+                    {
+                        "session_ref": session_ref,
+                        "resumed": True,
+                        "attached": True,
+                    },
+                ),
+                ("run.started", {"status": "running"}),
+                ("tool.started", {"tool_ref": "tool-9", "name": "Bash"}),
+                ("tool.completed", {"tool_ref": "tool-9", "status": "completed"}),
+                ("assistant.delta", {"text": "final answer"}),
+                (
+                    "run.completed",
+                    {"status": "completed", "result": "final answer"},
+                ),
+            ],
+        )
+        self.assertEqual(steps, [])
+
+    def test_claude_attach_reports_an_exit_with_no_reply(self) -> None:
+        session_ref = "33333333-3333-4333-8333-333333333333"
+        adapter, _runner = self.build("claude")
+        path = adapter._session_path(session_ref, self.root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("")
+        turn = NativeTurn(
+            harness="claude",
+            session_ref=session_ref,
+            run_ref="claude-attach",
+            worktree=self.root,
+            metadata={
+                "transcript_path": str(path),
+                "transcript_offset": 0,
+                "process_pid": 4321,
+                "process_start_ticks": 99,
+            },
+        )
+
+        with mock.patch.object(
+            claude_adapter.active_chat_registry,
+            "process_identity",
+            return_value=(None, None),
+        ), self.assertRaisesRegex(AdapterError, "HARNESS_ATTACH_UNSUPPORTED"):
+            next(iter(adapter.attach(turn)))
+
+        identities = iter([(4321, 99), (None, None)])
+        with mock.patch.object(
+            claude_adapter.active_chat_registry,
+            "process_identity",
+            side_effect=lambda ref: next(identities),
+        ):
+            events = list(adapter.attach(turn))
+
+        self.assertEqual(events[-1].type, "run.failed")
+        self.assertEqual(
+            events[-1].payload["error"],
+            "HARNESS_EXITED_WITHOUT_REPLY",
+        )
+
+    def test_claude_inspect_reads_the_last_assistant_entry(self) -> None:
+        adapter, _runner = self.build("claude")
+        cases = {
+            "reply": ([{"type": "text", "text": "done"}], "idle"),
+            "tool call": (
+                [{"type": "tool_use", "id": "tool-1", "name": "Bash"}],
+                "unknown",
+            ),
+            "reply then tool call": (
+                [
+                    {"type": "text", "text": "done"},
+                    {"type": "tool_use", "id": "tool-1", "name": "Bash"},
+                ],
+                "unknown",
+            ),
+            "tool result": (
+                [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-1",
+                        "is_error": False,
+                    }
+                ],
+                "unknown",
+            ),
+        }
+        for index, (label, (blocks, state)) in enumerate(cases.items(), 1):
+            with self.subTest(last_entry=label):
+                session_ref = f"44444444-4444-4444-8444-{index:012d}"
+                path = adapter._session_path(session_ref, self.root)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    self.claude_entry(session_ref, *blocks)
+                    + "\n"
+                    # A half-written entry is never the last complete one.
+                    + '{"type":"assis'
+                )
+
+                inspection = adapter.inspect(session_ref, self.context)
+
+                self.assertTrue(inspection.exists)
+                self.assertEqual(inspection.state, state)
+
+    def test_claude_interrupt_falls_back_to_the_recorded_process_group(
+        self,
+    ) -> None:
+        signalled: list[tuple[int, int]] = []
+        adapter, _runner = self.build("claude")
+        adapter.signal_group = lambda group, value: signalled.append(
+            (group, value)
+        )
+        turn = NativeTurn(
+            harness="claude",
+            session_ref="55555555-5555-4555-8555-555555555555",
+            run_ref="claude-attach",
+            worktree=self.root,
+            metadata={"process_pid": 4321, "process_start_ticks": 99,
+                      "process_group_id": 4321},
+        )
+
+        with mock.patch.object(
+            claude_adapter.active_chat_registry,
+            "process_identity",
+            return_value=(4321, 99),
+        ):
+            self.assertTrue(adapter.interrupt(turn).acknowledged)
+        with mock.patch.object(
+            claude_adapter.active_chat_registry,
+            "process_identity",
+            return_value=(None, None),
+        ):
+            self.assertFalse(adapter.interrupt(turn).acknowledged)
+
+        self.assertEqual(signalled, [(4321, signal.SIGINT)])
 
     def test_claude_resume_rejects_resolved_paths_outside_worktree(self) -> None:
         adapter, runner = self.build("claude")

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -2209,6 +2209,175 @@ class ConversationResourceTest(ConversationApiCase):
             con.close()
         self.assertEqual(state, "closed")
 
+    def seed_lingering_process(
+        self,
+        conversation_id: str,
+        *,
+        pid: int = 4242,
+        start_ticks: int = 990,
+        process_group_id: int = 4200,
+    ) -> int:
+        """A finished run whose recorded process the registry still links."""
+        con = self.connect()
+        try:
+            con.execute(
+                "UPDATE active_shell_chats SET process_pid=?,"
+                "process_start_ticks=?,updated_at='2026-09-04 10:00:00' "
+                "WHERE chat_id=?",
+                (pid, start_ticks, conversation_id),
+            )
+            message_id = int(
+                con.execute(
+                    "INSERT INTO conversation_messages "
+                    "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                    "idempotency_key,request_hash,state,completed_at) "
+                    "VALUES (?,'user','1','prompt','done','linger','h',"
+                    "'completed',datetime('now'))",
+                    (conversation_id,),
+                ).lastrowid
+            )
+            run_id = int(
+                con.execute(
+                    "INSERT INTO conversation_runs "
+                    "(conversation_id,shell_id,trigger_message_id,lease_owner,"
+                    "lease_expires_at,state,started_at,ended_at,process_pid,"
+                    "process_start_ticks,process_group_id) "
+                    "VALUES (?,1,?,'fixture','2026-09-04 11:00:00','succeeded',"
+                    "'2026-09-04 10:00:00','2026-09-04 10:01:00',?,?,?)",
+                    (
+                        conversation_id,
+                        message_id,
+                        pid,
+                        start_ticks,
+                        process_group_id,
+                    ),
+                ).lastrowid
+            )
+            con.commit()
+        finally:
+            con.close()
+        return run_id
+
+    def test_projection_names_a_lingering_process_from_the_registry(self) -> None:
+        conversation_id = self.create(key="linger-projection")["conversation_id"]
+        self.seed_lingering_process(conversation_id)
+        with mock.patch.object(
+            conversation_routes.active_chat_registry,
+            "process_details",
+            return_value=conversation_routes.active_chat_registry.ProcessIdentity(
+                4242, 990, 4200
+            ),
+        ):
+            status, _, projection = self.request(
+                "GET", f"/api/conversations/{conversation_id}"
+            )
+        self.assertEqual(status, 200, projection)
+        self.assertEqual(
+            projection["process"],
+            {
+                "pid": 4242,
+                "start_ticks": 990,
+                "alive": True,
+                "lingering": True,
+                "since": "2026-09-04 10:00:00",
+            },
+        )
+
+    def test_projection_process_is_null_without_a_registry_row(self) -> None:
+        with closing(self.connect()) as con:
+            conversation_id = self.seed_conversation(con, number=61)
+            con.commit()
+        status, _, projection = self.request(
+            "GET", f"/api/conversations/{conversation_id}"
+        )
+        self.assertEqual(status, 200, projection)
+        self.assertEqual(
+            projection["process"],
+            {
+                "pid": None,
+                "start_ticks": None,
+                "alive": False,
+                "lingering": False,
+                "since": None,
+            },
+        )
+
+    def test_interrupting_a_lingering_turn_signals_its_process_group(self) -> None:
+        conversation_id = self.create(key="linger-stop")["conversation_id"]
+        run_id = self.seed_lingering_process(conversation_id)
+        with (
+            mock.patch.object(
+                conversation_routes.active_chat_registry,
+                "has_live_process",
+                return_value=True,
+            ),
+            mock.patch.object(
+                conversation_routes, "_SIGNAL_GROUP"
+            ) as signal_group,
+        ):
+            status, _, receipt = self.request(
+                "POST",
+                f"/api/conversations/{conversation_id}/interruptions",
+                body={},
+                key="linger-interrupt",
+            )
+        self.assertEqual(status, 202, receipt)
+        self.assertEqual(receipt["run_id"], run_id)
+        signal_group.assert_called_once_with(4200, conversation_routes.signal.SIGINT)
+        with closing(self.connect()) as con:
+            events = con.execute(
+                "SELECT payload FROM conversation_events "
+                "WHERE run_id=? AND event_type='run.interrupt.requested'",
+                (run_id,),
+            ).fetchall()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(
+            json.loads(events[0]["payload"]), {"lingering": True, "pid": 4242}
+        )
+
+    def test_interrupting_an_idle_chat_without_a_process_stays_terminal(self) -> None:
+        conversation_id = self.create(key="linger-dead")["conversation_id"]
+        self.seed_lingering_process(conversation_id)
+        with mock.patch.object(
+            conversation_routes.active_chat_registry,
+            "has_live_process",
+            return_value=False,
+        ):
+            status, _, error = self.request(
+                "POST",
+                f"/api/conversations/{conversation_id}/interruptions",
+                body={},
+                key="linger-dead-interrupt",
+            )
+        self.assertEqual(status, 409, error)
+        self.assertEqual(error["error"]["code"], "RUN_ALREADY_TERMINAL")
+
+    def test_creating_a_chat_names_the_browser_session_holding_the_shell(self) -> None:
+        holder = "cv_" + "b" * 32
+        with (
+            mock.patch.object(
+                conversation_routes, "_wait_for_cli_release", return_value="browser"
+            ),
+            mock.patch.object(
+                conversation_routes,
+                "_browser_sessions",
+                return_value=[
+                    {"pid": 4242, "conversation_id": holder, "lingering": True}
+                ],
+            ),
+        ):
+            status, _, error = self.request(
+                "POST",
+                "/api/conversations",
+                body={"shell_id": 1, "harness": "codex"},
+                key="browser-owned-shell",
+            )
+        self.assertEqual(status, 409, error)
+        self.assertEqual(error["error"]["code"], "SHELL_BUSY")
+        self.assertEqual(error["error"]["details"]["conversation_id"], holder)
+        self.assertEqual(error["error"]["details"]["pid"], 4242)
+        self.assertIn(holder, error["error"]["message"])
+
     def test_closed_sprint_conversation_never_reopens(self) -> None:
         conversation_id = self.seed_sprint_conversation()
         con = self.connect()

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -235,6 +235,67 @@ class SparseDeltaAdapter(FakeAdapter):
         yield NormalizedEvent("run.completed", {"status": "completed"})
 
 
+class LingeringProcess:
+    """A native child that outlives the result line it printed."""
+
+    def __init__(self, *, alive: bool = True) -> None:
+        self.returncode: int | None = None if alive else 0
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def exit(self) -> None:
+        self.returncode = 0
+
+
+class LingeringAdapter(FakeAdapter):
+    """Report a result, then keep the same process and stream working.
+
+    ``tail`` chooses what follows the first result: ``second`` another reply,
+    ``none`` an immediate exit, ``interrupt`` a wait for the operator signal.
+    """
+
+    def __init__(self, *, alive: bool = True, tail: str = "second") -> None:
+        super().__init__()
+        self.process = LingeringProcess(alive=alive)
+        self.tail = tail
+        self.first_terminal = threading.Event()
+        self.release = threading.Event()
+
+    def start(
+        self,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        turn = super().start(context, message)
+        turn.process_ref = str(os.getpid())
+        turn.opaque = self.process
+        return turn
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        yield NormalizedEvent("session.started", {"session_ref": turn.session_ref})
+        yield NormalizedEvent("assistant.delta", {"text": "first"})
+        yield NormalizedEvent(
+            "run.completed",
+            {"status": "completed", "result": "first"},
+        )
+        self.first_terminal.set()
+        if self.tail == "none":
+            self.process.exit()
+            return
+        self.release.wait(5)
+        if self.tail == "interrupt":
+            self.interrupted.wait(5)
+            self.process.exit()
+            return
+        yield NormalizedEvent("assistant.delta", {"text": "second"})
+        yield NormalizedEvent(
+            "run.completed",
+            {"status": "completed", "result": "second"},
+        )
+        self.process.exit()
+
+
 class ReconcileSequenceAdapter(FakeAdapter):
     """End the stream uncertain, then prove running and terminal states."""
 
@@ -805,6 +866,45 @@ class ConversationBrokerCase(unittest.TestCase):
         broker.start()
         self.assertTrue(broker.wait_started())
         return broker
+
+    def wait_run_attempt(
+        self,
+        message_id: int,
+        attempt: int,
+        timeout: float = 3,
+    ) -> int:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            con = self.connect()
+            row = con.execute(
+                "SELECT run_id FROM conversation_runs "
+                "WHERE trigger_message_id=? AND attempt=?",
+                (message_id, attempt),
+            ).fetchone()
+            con.close()
+            if row is not None:
+                return int(row[0])
+            time.sleep(0.01)
+        self.fail(f"message {message_id} never reached attempt {attempt}")
+
+    def registry_pid(self, shell_id: int = 1) -> int | None:
+        con = self.connect()
+        row = con.execute(
+            "SELECT process_pid FROM active_shell_chats WHERE shell_id=?",
+            (shell_id,),
+        ).fetchone()
+        con.close()
+        return None if row is None else row["process_pid"]
+
+    def conversation_events(self, conversation_id: str) -> list[sqlite3.Row]:
+        con = self.connect()
+        rows = con.execute(
+            "SELECT event_type,payload,run_id FROM conversation_events "
+            "WHERE conversation_id=? ORDER BY sequence",
+            (conversation_id,),
+        ).fetchall()
+        con.close()
+        return rows
 
     def wait_run_state(self, run_id: int, state: str, timeout: float = 3) -> None:
         deadline = time.monotonic() + timeout
@@ -2158,6 +2258,167 @@ class ServiceContractTest(ConversationBrokerCase):
         payload = json.loads(terminal["payload"])
         self.assertEqual(payload["adapter_terminal"], "run.failed")
         self.assertEqual(payload["interrupt_evidence"], "operator")
+
+    def test_late_result_supersedes_an_early_one_in_a_single_run(self) -> None:
+        adapter = LingeringAdapter(alive=False)
+        adapter.release.set()
+        broker = self.start_broker(lambda _harness: adapter)
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        run_id = self.wait_run_attempt(message_id, 1)
+        self.wait_run_state(run_id, "succeeded")
+        self.assertTrue(broker.wait_idle(3))
+
+        con = self.connect()
+        attempts = [
+            row["attempt"]
+            for row in con.execute(
+                "SELECT attempt FROM conversation_runs "
+                "WHERE trigger_message_id=?",
+                (message_id,),
+            )
+        ]
+        con.close()
+        self.assertEqual(attempts, [1])
+        events = self.conversation_events(conversation_id)
+        terminals = [
+            json.loads(row["payload"])
+            for row in events
+            if row["event_type"] == "run.completed"
+        ]
+        self.assertEqual(len(terminals), 1)
+        self.assertEqual(terminals[0]["result"], "second")
+        deltas = [
+            (json.loads(row["payload"])["text"], row["run_id"])
+            for row in events
+            if row["event_type"] == "assistant.delta"
+        ]
+        self.assertEqual(deltas, [("first", run_id), ("second", run_id)])
+
+    def test_lingering_process_keeps_its_link_and_continues_the_turn(
+        self,
+    ) -> None:
+        adapter = LingeringAdapter()
+        broker = self.start_broker(
+            lambda _harness: adapter,
+            linger_grace_seconds=0.05,
+        )
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        first_run = self.wait_run_attempt(message_id, 1)
+        self.assertTrue(adapter.first_terminal.wait(3))
+        self.wait_run_state(first_run, "succeeded")
+        # The reply is visible, but the live process is still named.
+        self.assertEqual(self.registry_pid(), os.getpid())
+
+        adapter.release.set()
+        continuation = self.wait_run_attempt(message_id, 2)
+        self.wait_run_state(continuation, "succeeded")
+        self.assertTrue(broker.wait_idle(3))
+
+        events = self.conversation_events(conversation_id)
+        resumed = [row for row in events if row["event_type"] == "run.resumed"]
+        self.assertEqual(len(resumed), 1)
+        self.assertEqual(resumed[0]["run_id"], continuation)
+        self.assertEqual(
+            json.loads(resumed[0]["payload"])["continues_run_id"],
+            first_run,
+        )
+        deltas = [
+            (json.loads(row["payload"])["text"], row["run_id"])
+            for row in events
+            if row["event_type"] == "assistant.delta"
+        ]
+        self.assertEqual(
+            deltas,
+            [("first", first_run), ("second", continuation)],
+        )
+        self.assertIsNone(self.registry_pid())
+        con = self.connect()
+        message_state = con.execute(
+            "SELECT state FROM conversation_messages WHERE message_id=?",
+            (message_id,),
+        ).fetchone()[0]
+        conversation_state = con.execute(
+            "SELECT state FROM conversations WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()[0]
+        con.close()
+        # The message machine has no exit from a terminal state, so the
+        # lingering finish's close stands for the whole turn.
+        self.assertEqual(message_state, "completed")
+        self.assertEqual(conversation_state, "idle")
+
+    def test_exit_inside_the_grace_window_finishes_and_clears_the_link(
+        self,
+    ) -> None:
+        adapter = LingeringAdapter(tail="none")
+        broker = self.start_broker(
+            lambda _harness: adapter,
+            linger_grace_seconds=1.0,
+        )
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        run_id = self.wait_run_attempt(message_id, 1)
+        self.wait_run_state(run_id, "succeeded")
+        self.assertTrue(broker.wait_idle(3))
+
+        con = self.connect()
+        attempts = [
+            row["attempt"]
+            for row in con.execute(
+                "SELECT attempt FROM conversation_runs "
+                "WHERE trigger_message_id=?",
+                (message_id,),
+            )
+        ]
+        con.close()
+        self.assertEqual(attempts, [1])
+        self.assertIsNone(self.registry_pid())
+        terminals = [
+            json.loads(row["payload"])
+            for row in self.conversation_events(conversation_id)
+            if row["event_type"] == "run.completed"
+        ]
+        self.assertEqual(len(terminals), 1)
+        self.assertEqual(terminals[0]["result"], "first")
+
+    def test_interrupt_while_lingering_reaches_the_adapter(self) -> None:
+        adapter = LingeringAdapter(tail="interrupt")
+        broker = self.start_broker(
+            lambda _harness: adapter,
+            linger_grace_seconds=0.05,
+        )
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        run_id = self.wait_run_attempt(message_id, 1)
+        self.wait_run_state(run_id, "succeeded")
+
+        self.assertTrue(broker.interrupt(run_id))
+        self.assertTrue(adapter.interrupted.wait(3))
+
+        adapter.release.set()
+        self.assertTrue(broker.wait_idle(3))
+        con = self.connect()
+        attempts = [
+            row["attempt"]
+            for row in con.execute(
+                "SELECT attempt FROM conversation_runs "
+                "WHERE trigger_message_id=?",
+                (message_id,),
+            )
+        ]
+        con.close()
+        self.assertEqual(attempts, [1])
+        self.assertIsNone(self.registry_pid())
 
     def test_opencode_blocking_message_is_interruptible_after_identity(
         self,

--- a/tests/test_conversation_broker.py
+++ b/tests/test_conversation_broker.py
@@ -24,6 +24,7 @@ ENGINE = ROOT / ".super-coder"
 SCRIPTS = ENGINE / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
+import active_chat_registry  # noqa: E402
 import conversation_boot  # noqa: E402
 from conversation_adapters import (  # noqa: E402
     AdapterError,
@@ -294,6 +295,97 @@ class LingeringAdapter(FakeAdapter):
             {"status": "completed", "result": "second"},
         )
         self.process.exit()
+
+
+class ExitingProcessAdapter(FakeAdapter):
+    """Name a live process, then verify its exit like the Claude stream."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.process = LingeringProcess()
+
+    def start(
+        self,
+        context: ConversationContext,
+        message: str,
+    ) -> NativeTurn:
+        turn = super().start(context, message)
+        turn.process_ref = str(os.getpid())
+        turn.opaque = self.process
+        return turn
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        yield NormalizedEvent("session.started", {"session_ref": turn.session_ref})
+        yield NormalizedEvent(
+            "run.completed",
+            {"status": "completed", "result": "done"},
+        )
+        self.process.exit()
+        turn.metadata["returncode"] = 0
+
+
+class TwiceLingeringAdapter(LingeringAdapter):
+    """Linger after both replies, so the exit finds the link still held."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.exit_release = threading.Event()
+
+    def stream(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        yield NormalizedEvent("session.started", {"session_ref": turn.session_ref})
+        yield NormalizedEvent(
+            "run.completed",
+            {"status": "completed", "result": "first"},
+        )
+        self.first_terminal.set()
+        self.release.wait(5)
+        yield NormalizedEvent("assistant.delta", {"text": "second"})
+        yield NormalizedEvent(
+            "run.completed",
+            {"status": "completed", "result": "second"},
+        )
+        self.exit_release.wait(5)
+        self.process.exit()
+
+
+class TranscriptAttachAdapter(FakeAdapter):
+    """Adopt a live turn through the transcript position the run recorded."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.attached: list[dict] = []
+
+    def attach(self, turn: NativeTurn) -> Iterator[NormalizedEvent]:
+        self.attached.append(dict(turn.metadata))
+        with Path(turn.metadata["transcript_path"]).open("rb") as stream:
+            stream.seek(turn.metadata["transcript_offset"])
+            tail = stream.read().decode().strip()
+        yield NormalizedEvent(
+            "session.started",
+            {"session_ref": turn.session_ref, "attached": True},
+        )
+        yield NormalizedEvent("assistant.delta", {"text": tail})
+        yield NormalizedEvent(
+            "run.completed",
+            {"status": "completed", "result": tail},
+        )
+
+
+class LingeringOncePreparer:
+    """Refuse the first dispatch the way conversation_launch does."""
+
+    def __init__(self, archive_id: int) -> None:
+        self.archive_id = archive_id
+        self.calls = 0
+
+    def __call__(self, run: BrokerRun) -> tuple[ConversationContext, int]:
+        self.calls += 1
+        if self.calls == 1:
+            raise AdapterError(
+                "SHELL_LINGERING",
+                "this chat's previous turn is still running (pid 4321)",
+            )
+        return run.context(), self.archive_id
 
 
 class ReconcileSequenceAdapter(FakeAdapter):
@@ -896,6 +988,40 @@ class ConversationBrokerCase(unittest.TestCase):
         con.close()
         return None if row is None else row["process_pid"]
 
+    def run_identity(self, run_id: int) -> tuple:
+        con = self.connect()
+        row = con.execute(
+            "SELECT process_pid,process_start_ticks,process_group_id "
+            "FROM conversation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        con.close()
+        return tuple(row)
+
+    def name_live_process(self, conversation_id: str, run_id: int, **columns):
+        """Give a recovered run the identity and transcript a live turn has."""
+        con = self.connect()
+        con.execute(
+            "UPDATE conversation_runs SET process_pid=?,process_start_ticks=?,"
+            "process_group_id=?,transcript_path=?,transcript_offset=? "
+            "WHERE run_id=?",
+            (
+                columns["pid"],
+                columns["start_ticks"],
+                columns["pid"],
+                columns.get("transcript_path"),
+                columns.get("transcript_offset"),
+                run_id,
+            ),
+        )
+        con.execute(
+            "UPDATE active_shell_chats SET process_pid=?,process_start_ticks=? "
+            "WHERE chat_id=?",
+            (columns["pid"], columns["start_ticks"], conversation_id),
+        )
+        con.commit()
+        con.close()
+
     def conversation_events(self, conversation_id: str) -> list[sqlite3.Row]:
         con = self.connect()
         rows = con.execute(
@@ -1043,6 +1169,46 @@ class StoreContractTest(ConversationBrokerCase):
         ).fetchone()
         con.close()
         self.assertEqual(tuple(finalized), ("succeeded", None, None))
+
+    def test_unproven_finish_keeps_the_transcript_and_identity(self) -> None:
+        conversation_id = self.add_conversation()
+        self.add_message(conversation_id)
+        transcript = self.root / "session.jsonl"
+        store = BrokerStore(self.db_path)
+        run = store.claim_next("broker")
+        store.mark_starting(run.run_id, "broker")
+        store.mark_native_started(
+            run.run_id,
+            "broker",
+            NativeTurn(
+                "codex",
+                "native-session",
+                "native-run",
+                self.worktree,
+                process_ref=str(os.getpid()),
+                metadata={
+                    "transcript_path": str(transcript),
+                    "transcript_offset": 12,
+                },
+            ),
+        )
+
+        # An unproven outcome says nothing about the process; the reaper owns it.
+        store.finish_run(run.run_id, "unknown", event_type="run.unknown")
+
+        con = self.connect()
+        row = con.execute(
+            "SELECT process_pid,process_start_ticks,process_group_id,"
+            "transcript_path,transcript_offset FROM conversation_runs "
+            "WHERE run_id=?",
+            (run.run_id,),
+        ).fetchone()
+        con.close()
+        self.assertEqual(row["process_pid"], os.getpid())
+        self.assertGreater(row["process_start_ticks"], 0)
+        self.assertEqual(row["process_group_id"], os.getpgid(os.getpid()))
+        self.assertEqual(row["transcript_path"], str(transcript))
+        self.assertEqual(row["transcript_offset"], 12)
 
     def test_recovery_leaves_unprotected_process_identity_for_reaper(self) -> None:
         conversation_id, _message_id, run_id = self.add_live_run(
@@ -2419,6 +2585,170 @@ class ServiceContractTest(ConversationBrokerCase):
         con.close()
         self.assertEqual(attempts, [1])
         self.assertIsNone(self.registry_pid())
+
+    def test_verified_exit_stops_naming_the_process_on_the_run(self) -> None:
+        adapter = ExitingProcessAdapter()
+        broker = self.start_broker(lambda _harness: adapter)
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        run_id = self.wait_run_attempt(message_id, 1)
+        self.wait_run_state(run_id, "succeeded")
+        self.assertTrue(broker.wait_idle(3))
+
+        self.assertEqual(self.run_identity(run_id), (None, None, None))
+        self.assertIsNone(self.registry_pid())
+
+    def test_release_after_lingering_clears_every_attempt(self) -> None:
+        adapter = TwiceLingeringAdapter()
+        broker = self.start_broker(
+            lambda _harness: adapter,
+            linger_grace_seconds=0.05,
+        )
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        first_run = self.wait_run_attempt(message_id, 1)
+        self.wait_run_state(first_run, "succeeded")
+        # The reply is committed while the process is still named.
+        self.assertEqual(self.run_identity(first_run)[0], os.getpid())
+        adapter.release.set()
+        continuation = self.wait_run_attempt(message_id, 2)
+        self.wait_run_state(continuation, "succeeded")
+        self.assertEqual(self.run_identity(continuation)[0], os.getpid())
+
+        adapter.exit_release.set()
+        self.assertTrue(broker.wait_idle(3))
+
+        for run_id in (first_run, continuation):
+            self.assertEqual(self.run_identity(run_id), (None, None, None))
+        self.assertIsNone(self.registry_pid())
+
+    def test_a_lingering_shell_defers_the_turn_instead_of_failing_it(
+        self,
+    ) -> None:
+        con = self.connect()
+        archive_id = int(
+            con.execute(
+                "INSERT INTO shell_memory_archives "
+                "(shell_id,session_id,date,full_narrative) "
+                "VALUES (1,'9002','2026-09-04','defer tests')"
+            ).lastrowid
+        )
+        con.commit()
+        con.close()
+        preparer = LingeringOncePreparer(archive_id)
+        adapter = FakeAdapter()
+        broker = self.start_broker(
+            lambda _harness: adapter,
+            launch_preparer=preparer,
+            recovery_seconds=0.05,
+        )
+        conversation_id = self.add_conversation()
+        message_id = self.add_message(conversation_id)
+        broker.notify()
+
+        run_id = self.wait_run_attempt(message_id, 1)
+        self.wait_run_state(run_id, "succeeded")
+        self.assertTrue(broker.wait_idle(3))
+
+        self.assertEqual(preparer.calls, 2)
+        self.assertEqual(adapter.started, 1)
+        events = self.conversation_events(conversation_id)
+        deferred = [
+            json.loads(row["payload"])
+            for row in events
+            if row["event_type"] == "run.deferred"
+        ]
+        self.assertEqual(len(deferred), 1)
+        self.assertEqual(deferred[0]["reason"], "SHELL_LINGERING")
+        con = self.connect()
+        attempts = [
+            row["attempt"]
+            for row in con.execute(
+                "SELECT attempt FROM conversation_runs "
+                "WHERE trigger_message_id=?",
+                (message_id,),
+            )
+        ]
+        outbox_state = con.execute(
+            "SELECT state FROM conversation_outbox WHERE message_id=?",
+            (message_id,),
+        ).fetchone()[0]
+        message_state = con.execute(
+            "SELECT state FROM conversation_messages WHERE message_id=?",
+            (message_id,),
+        ).fetchone()[0]
+        con.close()
+        # One run, one dispatch intent: the deferral spent neither.
+        self.assertEqual(attempts, [1])
+        self.assertEqual(outbox_state, "dispatched")
+        self.assertEqual(message_state, "completed")
+
+    def test_recovery_adopts_a_live_turn_through_its_transcript(self) -> None:
+        conversation_id, _message_id, run_id = self.add_live_run(
+            state="running",
+            session_after="native-session",
+            runner_ref="native-run",
+        )
+        transcript = self.root / "transcript.jsonl"
+        transcript.write_text("earlier turn\n")
+        offset = transcript.stat().st_size
+        transcript.write_text("earlier turn\nlive reply\n")
+        identity = active_chat_registry.process_details(str(os.getpid()))
+        self.name_live_process(
+            conversation_id,
+            run_id,
+            pid=identity.pid,
+            start_ticks=identity.start_ticks,
+            transcript_path=str(transcript),
+            transcript_offset=offset,
+        )
+        adapter = TranscriptAttachAdapter()
+
+        broker = self.start_broker(lambda _harness: adapter)
+
+        self.wait_run_state(run_id, "succeeded")
+        self.assertTrue(broker.wait_idle())
+        self.assertEqual(adapter.reconciled, 0)
+        self.assertEqual(len(adapter.attached), 1)
+        self.assertEqual(adapter.attached[0]["transcript_offset"], offset)
+        self.assertEqual(adapter.attached[0]["process_pid"], identity.pid)
+        self.assertEqual(
+            adapter.attached[0]["process_start_ticks"],
+            identity.start_ticks,
+        )
+        terminals = [
+            json.loads(row["payload"])
+            for row in self.conversation_events(conversation_id)
+            if row["event_type"] == "run.completed"
+        ]
+        self.assertEqual(terminals[-1]["result"], "live reply")
+
+    def test_recovery_reconciles_when_the_named_process_is_gone(self) -> None:
+        conversation_id, _message_id, run_id = self.add_live_run(
+            state="running",
+            session_after="native-session",
+            runner_ref="native-run",
+        )
+        self.name_live_process(
+            conversation_id,
+            run_id,
+            pid=4194305,
+            start_ticks=9001,
+            transcript_path=str(self.root / "transcript.jsonl"),
+            transcript_offset=0,
+        )
+        adapter = TranscriptAttachAdapter()
+
+        broker = self.start_broker(lambda _harness: adapter)
+
+        self.wait_run_state(run_id, "succeeded")
+        self.assertTrue(broker.wait_idle())
+        self.assertEqual(adapter.attached, [])
+        self.assertEqual(adapter.reconciled, 1)
 
     def test_opencode_blocking_message_is_interruptible_after_identity(
         self,

--- a/tests/test_conversation_launch.py
+++ b/tests/test_conversation_launch.py
@@ -511,31 +511,37 @@ def browser_snapshot(*sessions: dict) -> dict:
     }
 
 
-def test_preparer_dispatches_over_its_own_lingering_browser_process(
+def test_preparer_waits_on_its_own_lingering_browser_process(
     launch_case, monkeypatch
 ):
+    """Two print-mode processes on one native session file is the hazard:
+    the chat's own lingering turn refuses with SHELL_LINGERING, never
+    SHELL_BUSY, and never dispatches over it."""
     db_path, worktree = launch_case
+    called = False
+
+    def prepare(**_kwargs):
+        nonlocal called
+        called = True
+
     monkeypatch.setattr(
         shell_liveness, "session_state", lambda shortname, snap: "browser"
     )
     preparer = ConversationLaunchPreparer(
         db_path,
-        prepare_launch=lambda **_: SimpleNamespace(
-            cwd=str(worktree),
-            archive_id=42,
-            harness="codex",
-            model="gpt-test",
-            effort="high",
-            env={},
-        ),
+        prepare_launch=prepare,
         liveness=lambda: browser_snapshot(
             {"pid": 4242, "conversation_id": "cv_" + "a" * 32, "lingering": True}
         ),
         liveness_retries=0,
     )
-    _context, archive_id = preparer(make_run(worktree))
+    with pytest.raises(ConversationLaunchError) as caught:
+        preparer(make_run(worktree))
 
-    assert archive_id == 42
+    assert caught.value.code == "SHELL_LINGERING"
+    assert "pid 4242" in caught.value.detail
+    assert "Stop" in caught.value.detail
+    assert not called
 
 
 def test_preparer_names_a_foreign_browser_chat_holding_the_shell(

--- a/tests/test_conversation_launch.py
+++ b/tests/test_conversation_launch.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(ENGINE / "api"))
 import instance_state  # noqa: E402
 import route_bindings  # noqa: E402
 import run as run_mod  # noqa: E402
+import shell_liveness
 from conversation_boot import BootDirective  # noqa: E402
 from conversation_broker import BrokerRun  # noqa: E402
 from conversation_launch import (  # noqa: E402
@@ -488,6 +489,83 @@ def test_preparer_refuses_a_cli_process_holding_the_shell(launch_case):
         preparer(make_run(worktree))
 
     assert caught.value.code == "SHELL_BUSY"
+    assert not called
+
+
+def browser_snapshot(*sessions: dict) -> dict:
+    # Unit B's shape, built by hand: one browser-owned pid per entry.
+    return {
+        "supported": True,
+        "processes": [
+            {
+                "pid": session["pid"],
+                "shortname": "dev",
+                "orphaned": False,
+                "claimed": True,
+                "browser_conversation": session["conversation_id"],
+                "lingering": session.get("lingering", True),
+            }
+            for session in sessions
+        ],
+        "browser_sessions": {"dev": list(sessions)},
+    }
+
+
+def test_preparer_dispatches_over_its_own_lingering_browser_process(
+    launch_case, monkeypatch
+):
+    db_path, worktree = launch_case
+    monkeypatch.setattr(
+        shell_liveness, "session_state", lambda shortname, snap: "browser"
+    )
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=lambda **_: SimpleNamespace(
+            cwd=str(worktree),
+            archive_id=42,
+            harness="codex",
+            model="gpt-test",
+            effort="high",
+            env={},
+        ),
+        liveness=lambda: browser_snapshot(
+            {"pid": 4242, "conversation_id": "cv_" + "a" * 32, "lingering": True}
+        ),
+        liveness_retries=0,
+    )
+    _context, archive_id = preparer(make_run(worktree))
+
+    assert archive_id == 42
+
+
+def test_preparer_names_a_foreign_browser_chat_holding_the_shell(
+    launch_case, monkeypatch
+):
+    db_path, worktree = launch_case
+    called = False
+
+    def prepare(**_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        shell_liveness, "session_state", lambda shortname, snap: "browser"
+    )
+    holder = "cv_" + "b" * 32
+    preparer = ConversationLaunchPreparer(
+        db_path,
+        prepare_launch=prepare,
+        liveness=lambda: browser_snapshot(
+            {"pid": 4242, "conversation_id": holder, "lingering": True}
+        ),
+        liveness_retries=0,
+    )
+    with pytest.raises(ConversationLaunchError) as caught:
+        preparer(make_run(worktree))
+
+    assert caught.value.code == "SHELL_BUSY"
+    assert holder in caught.value.detail
+    assert "pid 4242" in caught.value.detail
     assert not called
 
 

--- a/tests/test_conversation_reaper.py
+++ b/tests/test_conversation_reaper.py
@@ -416,7 +416,7 @@ class ConversationReaperTest(unittest.TestCase):
         self.assertEqual(conversation_state, "error")
         self.assertEqual(
             [row["event_type"] for row in events],
-            ["run.unknown", "run.reaped"],
+            ["run.unknown", "run.interrupted"],
         )
 
     def test_unknown_run_without_process_identity_is_untouched(self) -> None:

--- a/tests/test_conversation_reaper.py
+++ b/tests/test_conversation_reaper.py
@@ -174,6 +174,116 @@ class ConversationReaperTest(unittest.TestCase):
             )
         )
 
+    def finish_succeeded(self, run_id: int, ended_at: str) -> None:
+        """The lingering shape: the broker proved a terminal for the run while
+        its process kept working, so the run is finished and the pid identity
+        stays on the row."""
+        con = self.connect()
+        con.execute(
+            "UPDATE conversation_runs SET state='succeeded',ended_at=? "
+            "WHERE run_id=?",
+            (ended_at, run_id),
+        )
+        con.commit()
+        con.close()
+
+    def unlink_registry(self) -> None:
+        con = self.connect()
+        con.execute(
+            "UPDATE active_shell_chats SET process_pid=NULL,process_start_ticks=NULL"
+        )
+        con.commit()
+        con.close()
+
+    def test_lingering_run_is_reapable_only_once_the_chat_is_closed(self) -> None:
+        # The lockout: a finished run whose process is still alive holds the
+        # shell. While the chat is open the registry link protects it; closing
+        # the chat unlinks the row and the survivor becomes reapable.
+        _conversation, _message, run_id = self.add_run(protected=True)
+        self.finish_succeeded(run_id, "2026-08-02 11:59:30")
+        store = ReaperStore(self.db_path, clock=self.clock)
+
+        self.assertEqual([], [c.run_id for c in store.candidates()])
+
+        self.unlink_registry()
+
+        self.assertEqual([run_id], [c.run_id for c in store.candidates()])
+
+    def test_reaping_a_lingering_run_only_records_the_outcome(self) -> None:
+        conversation_id, message_id, run_id = self.add_run()
+        self.finish_succeeded(run_id, "2026-08-02 11:59:30")
+        reaper = self.build_reaper(None)          # the process is gone
+
+        self.assertEqual(reaper.sweep_once(), 1)
+        self.assertEqual(reaper.sweep_once(), 0)  # exactly once, never a loop
+
+        con = self.connect()
+        run = con.execute(
+            "SELECT state,ended_at,error_code FROM conversation_runs "
+            "WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        message_state = con.execute(
+            "SELECT state FROM conversation_messages WHERE message_id=?",
+            (message_id,),
+        ).fetchone()[0]
+        conversation_state = con.execute(
+            "SELECT state FROM conversations WHERE conversation_id=?",
+            (conversation_id,),
+        ).fetchone()[0]
+        events = con.execute(
+            "SELECT event_type,payload FROM conversation_events WHERE run_id=? "
+            "ORDER BY sequence",
+            (run_id,),
+        ).fetchall()
+        con.close()
+        # The broker's terminal is the run's terminal — the reaper never
+        # overwrites a proven outcome with its own guess.
+        self.assertEqual(tuple(run), ("succeeded", "2026-08-02 11:59:30", None))
+        self.assertEqual(message_state, "running")
+        self.assertEqual(conversation_state, "running")
+        self.assertEqual([row["event_type"] for row in events], ["run.reaped"])
+        self.assertIn('"run_state":"succeeded"', events[0]["payload"])
+        self.assertIn(
+            '"reason":"recorded process exited before reaper signal"',
+            events[0]["payload"],
+        )
+
+    def test_lingering_candidate_climbs_the_same_ladder(self) -> None:
+        _conversation, _message, run_id = self.add_run()
+        self.finish_succeeded(run_id, "2026-08-02 11:59:30")
+        snapshot = ProcessSnapshot(4242, 9001, 4242)
+        interrupted: list[int] = []
+        signals: list[tuple[int, signal.Signals]] = []
+
+        def reaper() -> ConversationReaper:
+            return self.build_reaper(
+                snapshot,
+                native_interrupt=interrupted.append,
+                signal_group=lambda group, value: signals.append((group, value)),
+            )
+
+        self.assertEqual(reaper().sweep_once(), 1)
+        self.clock.advance(15)
+        self.assertEqual(reaper().sweep_once(), 1)
+        self.clock.advance(15)
+        self.assertEqual(reaper().sweep_once(), 1)
+        self.assertEqual(interrupted, [run_id])
+        self.assertEqual(signals, [(4242, signal.SIGTERM), (4242, signal.SIGKILL)])
+
+        con = self.connect()
+        run = con.execute(
+            "SELECT state,reaper_last_signal FROM conversation_runs WHERE run_id=?",
+            (run_id,),
+        ).fetchone()
+        events = con.execute(
+            "SELECT event_type FROM conversation_events WHERE run_id=?",
+            (run_id,),
+        ).fetchall()
+        con.close()
+        self.assertEqual(tuple(run), ("succeeded", "SIGKILL"))
+        self.assertEqual([row[0] for row in events], ["run.reaped"])
+
     def test_exact_registry_identity_is_the_only_protection(self) -> None:
         _conversation, _message, protected_run = self.add_run(protected=True)
         snapshot = ProcessSnapshot(4242, 9001, 4242)
@@ -306,7 +416,7 @@ class ConversationReaperTest(unittest.TestCase):
         self.assertEqual(conversation_state, "error")
         self.assertEqual(
             [row["event_type"] for row in events],
-            ["run.unknown", "run.interrupted"],
+            ["run.unknown", "run.reaped"],
         )
 
     def test_unknown_run_without_process_identity_is_untouched(self) -> None:

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -19,6 +19,7 @@ FOUNDATION = MIGRATIONS / "0132_conversation_foundation.sql"
 GIT_TARGETS = MIGRATIONS / "0142_conversation_git_targets.sql"
 ACTIVE_REGISTRY = MIGRATIONS / "0162_active_chat_registry.sql"
 REAPER_IDENTITY = MIGRATIONS / "0163_conversation_run_process_identity.sql"
+TRANSCRIPT_OFFSET = MIGRATIONS / "0249_conversation_run_transcript_offset.sql"
 TOPOLOGY_RETIREMENT = MIGRATIONS / "0168_retire_sprint_conversation_topology.sql"
 LIVE_NATIVE_ROUTES = MIGRATIONS / "0238_final_schema_rebaseline.sql"
 
@@ -451,6 +452,79 @@ class MigrationAndShapeTest(ConversationDbCase):
                 row,
                 ("running", None, None, None, None, None),
             )
+
+    def test_transcript_migration_frees_only_finished_run_identity(self) -> None:
+        with closing(sqlite3.connect(":memory:")) as con:
+            con.row_factory = sqlite3.Row
+            apply_schema(con, through="0248_reseed_sprint_pln_orientation.sql")
+            con.execute("INSERT INTO users (user_id,username) VALUES (7,'live')")
+            con.execute(
+                "INSERT INTO shells "
+                "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+                "VALUES (7,'Live','live7','dev','prompt',7)"
+            )
+            con.execute(
+                "INSERT INTO conversations "
+                "(conversation_id,shell_id,owner_user_id,harness,worktree,state,"
+                "creation_idempotency_key,creation_request_hash) VALUES "
+                "('cv_transcript',7,7,'claude','/tmp/live','running',"
+                "'transcript','transcript-hash')"
+            )
+            message_id = con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state) VALUES "
+                "('cv_transcript','user','7','prompt','hello','m','h','running')"
+            ).lastrowid
+            for attempt, state in (
+                (1, "succeeded"),
+                (2, "unknown"),
+                (3, "running"),
+            ):
+                con.execute(
+                    "INSERT INTO conversation_runs "
+                    "(conversation_id,shell_id,trigger_message_id,attempt,state,"
+                    "lease_owner,lease_expires_at,started_at,ended_at,"
+                    "process_pid,process_start_ticks,process_group_id) VALUES "
+                    "('cv_transcript',7,?,?,?,'broker','2999-01-01 00:00:00',"
+                    "'2026-09-01 00:00:00',?,4321,99,4321)",
+                    (
+                        message_id,
+                        attempt,
+                        state,
+                        None if state == "running" else "2026-09-01 00:01:00",
+                    ),
+                )
+            con.commit()
+
+            migrate.apply(con, TRANSCRIPT_OFFSET)
+
+            columns = {
+                row["name"]: row["type"]
+                for row in con.execute("PRAGMA table_info(conversation_runs)")
+            }
+            self.assertEqual(columns.get("transcript_path"), "TEXT")
+            self.assertEqual(columns.get("transcript_offset"), "INTEGER")
+            self.assertEqual(
+                [
+                    tuple(row)
+                    for row in con.execute(
+                        "SELECT state,process_pid,process_start_ticks,"
+                        "process_group_id,transcript_path,transcript_offset "
+                        "FROM conversation_runs ORDER BY attempt"
+                    )
+                ],
+                [
+                    ("succeeded", None, None, None, None, None),
+                    ("unknown", 4321, 99, 4321, None, None),
+                    ("running", 4321, 99, 4321, None, None),
+                ],
+            )
+            with self.assertRaises(sqlite3.IntegrityError):
+                con.execute(
+                    "UPDATE conversation_runs SET transcript_offset=-1 "
+                    "WHERE attempt=3"
+                )
 
     def test_star_migration_defaults_legacy_rows_and_enforces_boolean_values(self) -> None:
         with closing(sqlite3.connect(":memory:")) as con:

--- a/tests/test_conversation_schema.py
+++ b/tests/test_conversation_schema.py
@@ -19,7 +19,7 @@ FOUNDATION = MIGRATIONS / "0132_conversation_foundation.sql"
 GIT_TARGETS = MIGRATIONS / "0142_conversation_git_targets.sql"
 ACTIVE_REGISTRY = MIGRATIONS / "0162_active_chat_registry.sql"
 REAPER_IDENTITY = MIGRATIONS / "0163_conversation_run_process_identity.sql"
-TRANSCRIPT_OFFSET = MIGRATIONS / "0249_conversation_run_transcript_offset.sql"
+TRANSCRIPT_OFFSET = MIGRATIONS / "0251_conversation_run_transcript_offset.sql"
 TOPOLOGY_RETIREMENT = MIGRATIONS / "0168_retire_sprint_conversation_topology.sql"
 LIVE_NATIVE_ROUTES = MIGRATIONS / "0238_final_schema_rebaseline.sql"
 

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -553,7 +553,10 @@ def test_retained_unavailable_harness_keeps_controls_but_not_composer():
     assert "unavailable.textContent = unavailableReason || \"\"" in open_chat
     assert "composer.disabled = Boolean(unavailableReason)" in open_chat
     assert "send.disabled = Boolean(unavailableReason)" in open_chat
-    assert "stop.disabled = conversation.state !== \"running\"" in open_chat
+    assert (
+        'stop.disabled = (conversation.state !== "running" && !lingering)'
+        in open_chat
+    )
     assert "close.disabled = sprintManaged || closed || closing" in open_chat
     assert 'textContent: "Analytics"' in open_chat
     assert "chatReviewWorkspace(reviewHost, conversation)" in open_chat
@@ -870,8 +873,8 @@ def test_composer_is_retry_safe_and_has_turn_controls():
     assert '"POST", {}, stopRequest.key' in stop_handler
     assert "stopRequest = null" in stop_handler
     assert (
-        'stop.disabled = conversation.state !== "running" || closing '
-        "|| Boolean(stopRequest)"
+        'stop.disabled = (conversation.state !== "running" && !lingering)\n'
+        "      || closing || Boolean(stopRequest)"
         in interface
     )
     assert 'stop.textContent = stopRequest ? "Stopping…" : "Stop"' in interface
@@ -1394,3 +1397,110 @@ def test_layout_retains_shell_rail_chat_history_and_bubble_transcript():
     assert ".chat-working-dots" in STYLE
     assert "@keyframes chat-working-dot" in STYLE
     assert ".chat-queue-state" in STYLE
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_state_pill_names_a_lingering_process_by_pid():
+    pill = APP[APP.index("function chatWorkingDots"):
+               APP.index("function chatWorkingIndicator")]
+    script = r"""
+const el = (tag, props = {}, ...kids) => ({
+  tag, ...props, kids: [...kids],
+  append(...more) { this.kids.push(...more); },
+});
+""" + pill + r"""
+const shape = (pill) => [pill.className, pill.textContent ?? pill.kids[0]];
+console.log(JSON.stringify({
+  lingering: shape(chatStatePill("idle", {pid: 4242, lingering: true})),
+  idle: shape(chatStatePill("idle", {pid: 4242, lingering: false})),
+  noProcess: shape(chatStatePill("idle")),
+  running: shape(chatStatePill("running", {pid: 4242, lingering: false})),
+}));
+"""
+    assert run_js(script) == {
+        "lingering": [
+            "chat-state state-idle lingering",
+            "process still running · pid 4242",
+        ],
+        "idle": ["chat-state state-idle", "idle"],
+        "noProcess": ["chat-state state-idle", "idle"],
+        "running": ["chat-state state-running", "working"],
+    }
+
+
+def test_stop_stays_available_while_a_process_lingers():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert (
+        "const lingering = Boolean(conversation.process?.lingering)" in interface
+    )
+    stop_handler = interface[
+        interface.index("stop.onclick ="):
+        interface.index("composer.onkeydown", interface.index("stop.onclick ="))
+    ]
+    assert (
+        'if (conversation.state !== "running" && !conversation.process?.lingering)'
+        in stop_handler
+    )
+    assert "/interruptions`" in stop_handler
+    history = APP[APP.index("function chatPaintHistoryItem"):
+                  APP.index("function chatQueuedCount")]
+    assert (
+        'chatStatePill(conversation.state || "idle", conversation.process)'
+        in history
+    )
+    assert "item.state.className !== next.className" in history
+    assert ".chat-state.lingering" in STYLE
+
+
+def test_run_resumed_puts_the_message_and_chat_back_to_running():
+    interface = APP[APP.index("const CHAT_HARNESSES"):
+                    APP.index("// ── Tabs + boot")]
+    assert '"run.resumed"' in interface
+    assert (
+        'if (message && type === "run.resumed") message.state = "running"'
+        in interface
+    )
+    resumed = interface[
+        interface.index('if (type === "run.resumed") {'):
+        interface.index('if (type === "conversation.updated"')
+    ]
+    assert 'conversation.state = "running"' in resumed
+    assert "conversation.active_run_id = event.run_id" in resumed
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_shell_busy_toast_names_the_holding_chat_and_pid():
+    busy = APP[APP.index("function chatBusyToast"):
+               APP.index("function chatModeHash")]
+    script = r"""
+const toasted = [];
+const el = (tag, props = {}, ...kids) => ({
+  tag, ...props, kids: [...kids],
+  append(...more) { this.kids.push(...more); },
+});
+const toast = (msg) => toasted.push(msg);
+const location = { hash: "" };
+const chatHash = (shortname, id) => `interface/${shortname}/${id}`;
+""" + busy + r"""
+chatBusyToast({
+  code: "SHELL_BUSY",
+  message: "held",
+  details: {conversation_id: "cv_b", pid: 4242},
+}, "dev");
+const named = toasted[0];
+named.kids[1].onclick();
+chatBusyToast({code: "VALIDATION_ERROR", message: "bad", details: {}}, "dev");
+console.log(JSON.stringify({
+  text: named.kids[0],
+  link: named.kids[1].textContent,
+  hash: location.hash,
+  plain: toasted[1],
+}));
+"""
+    assert run_js(script) == {
+        "text": "SHELL_BUSY: cv_b (pid 4242) still holds this shell — ",
+        "link": "open that chat",
+        "hash": "interface/dev/cv_b",
+        "plain": "VALIDATION_ERROR: bad",
+    }

--- a/tests/test_db_driver_sync.py
+++ b/tests/test_db_driver_sync.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""The durability PRAGMAs `db_driver.connect` must hand every caller.
+
+WAL keeps the file intact on power loss, and NORMAL keeps a stalled host fsync
+from holding the write lock through COMMIT.
+
+Run:
+    python3 -m unittest tests.test_db_driver_sync
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "scripts"))
+
+import db_driver  # noqa: E402
+
+
+class ConnectPragmaTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "engine.db"
+
+    def test_connect_uses_wal_with_normal_synchronous(self) -> None:
+        con = db_driver.connect(self.path)
+        self.addCleanup(con.close)
+        self.assertEqual(
+            con.execute("PRAGMA journal_mode").fetchone()[0].lower(), "wal"
+        )
+        self.assertEqual(con.execute("PRAGMA synchronous").fetchone()[0], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_log_timestamps.py
+++ b/tests/test_server_log_timestamps.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""server.log line stamps: one UTC prefix per line, never two.
+
+Covers the shapes server.py actually produces — `print` in whole lines, chunked
+partial writes, and `logging` warnings from the scripts through basicConfig.
+
+Run:
+    python3 -m unittest tests.test_server_log_timestamps
+"""
+from __future__ import annotations
+
+import io
+import logging
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / ".super-coder" / "api"))
+
+import log_lines  # noqa: E402
+
+STAMP = "2026-09-04T12:00:00Z "
+
+
+def fixed_clock() -> datetime:
+    return datetime(2026, 9, 4, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class CountingStream(io.StringIO):
+    """A stream that records flushes, which StringIO otherwise swallows."""
+
+    flushes = 0
+
+    def flush(self) -> None:
+        self.flushes += 1
+
+
+class TimestampedWriterTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.buf = io.StringIO()
+        self.writer = log_lines.TimestampedWriter(self.buf, clock=fixed_clock)
+
+    def test_each_line_gets_one_prefix(self) -> None:
+        self.writer.write("first\nsecond\n")
+        self.assertEqual(self.buf.getvalue(), f"{STAMP}first\n{STAMP}second\n")
+
+    def test_partial_writes_share_one_prefix(self) -> None:
+        self.writer.write("Subfloor review ")
+        self.writer.write("layer starting")
+        self.writer.write("\n")
+        self.writer.write("next\n")
+        self.assertEqual(
+            self.buf.getvalue(),
+            f"{STAMP}Subfloor review layer starting\n{STAMP}next\n",
+        )
+
+    def test_reports_written_length_and_passes_through_flush(self) -> None:
+        counting = CountingStream()
+        writer = log_lines.TimestampedWriter(counting, clock=fixed_clock)
+        self.assertEqual(writer.write("hi\n"), 3)
+        writer.flush()
+        self.assertEqual(counting.flushes, 1)
+
+    def test_delegates_stream_attributes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "server.log"
+            with path.open("w", encoding="utf-8") as handle:
+                writer = log_lines.TimestampedWriter(handle, clock=fixed_clock)
+                self.assertEqual(writer.fileno(), handle.fileno())
+                self.assertFalse(writer.isatty())
+                self.assertEqual(writer.encoding, "utf-8")
+
+    def test_install_is_idempotent(self) -> None:
+        real_out, real_err = sys.stdout, sys.stderr
+        self.addCleanup(setattr, sys, "stdout", real_out)
+        self.addCleanup(setattr, sys, "stderr", real_err)
+        sys.stdout, sys.stderr = io.StringIO(), io.StringIO()
+
+        log_lines.install(clock=fixed_clock)
+        wrapped_out, wrapped_err = sys.stdout, sys.stderr
+        log_lines.install(clock=fixed_clock)
+
+        self.assertIs(sys.stdout, wrapped_out)
+        self.assertIs(sys.stderr, wrapped_err)
+        print("hello")
+        self.assertEqual(sys.stdout._stream.getvalue(), f"{STAMP}hello\n")
+
+
+class LoggingThroughWriterTest(unittest.TestCase):
+    def test_warning_is_prefixed_exactly_once(self) -> None:
+        stream = io.StringIO()
+        writer = log_lines.TimestampedWriter(stream, clock=fixed_clock)
+        handler = logging.StreamHandler(writer)
+        handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+        log = logging.getLogger("super_coder.db.test")
+        log.addHandler(handler)
+        log.setLevel(logging.WARNING)
+        self.addCleanup(log.removeHandler, handler)
+
+        log.warning("slow write held the lock")
+
+        self.assertEqual(
+            stream.getvalue(),
+            f"{STAMP}WARNING super_coder.db.test: slow write held the lock\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell_liveness.py
+++ b/tests/test_shell_liveness.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import sqlite3
 import sys
 import tempfile
 import unittest
@@ -22,6 +23,7 @@ from unittest import mock
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 sys.path.insert(0, str(ENGINE / "scripts"))
+import run
 import shell_liveness  # noqa: E402
 
 
@@ -656,6 +658,182 @@ class ComputeWithClaimsTest(unittest.TestCase):
         snap = shell_liveness.compute()
         self.assertIsNone(shell_liveness.session_state("dev6", snap))
         self.assertIsNone(shell_liveness.record_state("dev6", snap))
+
+
+class BrowserSessionTest(unittest.TestCase):
+    """A browser turn is a harness child of the API server whose cwd is the
+    shell's worktree. Unnamed it reads as an anonymous CLI session and locks
+    the shell out with nothing to point at; joined against the registry and the
+    run rows by pid + start_ticks it is a NAMED hold."""
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.proc = self.root / "proc"
+        self.proc.mkdir()
+        self.worktree = self.root / ".sc-worktrees" / "dev6"
+        self.worktree.mkdir(parents=True)
+        self.db = self.root / "shell.db"
+        for patch in (
+            mock.patch.object(shell_liveness, "PROC", self.proc),
+            mock.patch.object(shell_liveness, "REPO_ROOT", self.root),
+            mock.patch.object(shell_liveness, "DB_PATH", self.db),
+            mock.patch.object(shell_liveness, "harness_binaries",
+                              return_value={"codex"}),
+            mock.patch.object(shell_liveness, "_shell_labels", return_value={}),
+            mock.patch.object(shell_liveness, "_launch_claims", return_value={}),
+            mock.patch.object(shell_liveness, "_self_harness_pid",
+                              return_value=None),
+        ):
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def _db(self, *, registry=(), runs=(), tables: bool = True) -> None:
+        """A DB carrying only the two tables the scan reads, best-effort style."""
+        con = sqlite3.connect(self.db)
+        if tables:
+            con.executescript(
+                "CREATE TABLE active_shell_chats (shell_id INTEGER,"
+                "chat_id TEXT,process_pid INTEGER,process_start_ticks INTEGER);"
+                "CREATE TABLE conversation_runs (run_id INTEGER PRIMARY KEY,"
+                "conversation_id TEXT,state TEXT,process_pid INTEGER,"
+                "process_start_ticks INTEGER);")
+            con.executemany(
+                "INSERT INTO active_shell_chats "
+                "(shell_id,chat_id,process_pid,process_start_ticks) "
+                "VALUES (1,?,?,?)", registry)
+            con.executemany(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,state,process_pid,process_start_ticks) "
+                "VALUES (?,?,?,?)", runs)
+        else:
+            con.execute("CREATE TABLE unrelated (x INTEGER)")
+        con.commit()
+        con.close()
+
+    def test_registry_identity_names_the_conversation(self):
+        _proc_entry(self.proc, 700, cwd=self.worktree, start_ticks=5150)
+        self._db(registry=[("cv_abc", 700, 5150)],
+                 runs=[("cv_abc", "running", 700, 5150)])
+
+        snap = shell_liveness.compute()
+
+        self.assertEqual("cv_abc", snap["processes"][0]["browser_conversation"])
+        self.assertFalse(snap["processes"][0]["lingering"])
+        self.assertEqual(
+            {"dev6": [{"pid": 700, "conversation_id": "cv_abc",
+                       "lingering": False}]},
+            snap["browser_sessions"])
+
+    def test_terminal_run_identity_is_lingering(self):
+        # The incident's shape: the run finished, the process kept working.
+        _proc_entry(self.proc, 700, cwd=self.worktree, start_ticks=5150)
+        self._db(runs=[("cv_abc", "succeeded", 700, 5150)])
+
+        snap = shell_liveness.compute()
+
+        self.assertEqual("cv_abc", snap["processes"][0]["browser_conversation"])
+        self.assertTrue(snap["processes"][0]["lingering"])
+        self.assertTrue(snap["browser_sessions"]["dev6"][0]["lingering"])
+
+    def test_recycled_pid_is_not_tagged(self):
+        # Same pid number, a different process — identity is pid + start ticks,
+        # and tagging on the number alone would name a stranger's conversation.
+        _proc_entry(self.proc, 700, cwd=self.worktree, start_ticks=99999)
+        self._db(registry=[("cv_abc", 700, 5150)],
+                 runs=[("cv_abc", "running", 700, 5150)])
+
+        snap = shell_liveness.compute()
+
+        self.assertIsNone(snap["processes"][0]["browser_conversation"])
+        self.assertEqual({}, snap["browser_sessions"])
+
+    def test_absent_db_leaves_the_scan_untagged(self):
+        _proc_entry(self.proc, 700, cwd=self.worktree, start_ticks=5150)
+
+        snap = shell_liveness.compute()
+
+        self.assertIsNone(snap["processes"][0]["browser_conversation"])
+        self.assertEqual({}, snap["browser_sessions"])
+
+    def test_db_without_the_tables_is_not_fatal(self):
+        # An un-migrated fork, or a DB we cannot read: best-effort, exactly as
+        # _launch_claims degrades.
+        _proc_entry(self.proc, 700, cwd=self.worktree, start_ticks=5150)
+        self._db(tables=False)
+
+        snap = shell_liveness.compute()
+
+        self.assertIsNone(snap["processes"][0]["browser_conversation"])
+        self.assertEqual({}, snap["browser_sessions"])
+
+
+class BrowserSessionStateTest(unittest.TestCase):
+    """session_state's fourth answer: 'browser' when every live pid holding the
+    worktree is one the engine launched itself."""
+
+    def _snap(self, processes, browser) -> dict:
+        return {"supported": True, "processes": processes,
+                "browser_sessions": browser}
+
+    def test_all_browser_pids_are_a_browser_hold(self):
+        snap = self._snap(
+            [{"pid": 700, "shortname": "dev6", "orphaned": None}],
+            {"dev6": [{"pid": 700, "conversation_id": "cv_abc",
+                       "lingering": True}]})
+        self.assertEqual("browser", shell_liveness.session_state("DEV6", snap))
+
+    def test_a_plain_cli_pid_alongside_is_still_busy(self):
+        # One human session among browser turns → someone is working there.
+        snap = self._snap(
+            [{"pid": 700, "shortname": "dev6", "orphaned": None},
+             {"pid": 701, "shortname": "dev6", "orphaned": None}],
+            {"dev6": [{"pid": 700, "conversation_id": "cv_abc",
+                       "lingering": False}]})
+        self.assertEqual("busy", shell_liveness.session_state("dev6", snap))
+
+    def test_orphans_still_win_over_the_browser_verdict(self):
+        snap = self._snap(
+            [{"pid": 700, "shortname": "dev6", "orphaned": "detached"}],
+            {"dev6": [{"pid": 700, "conversation_id": "cv_abc",
+                       "lingering": False}]})
+        self.assertEqual("orphan", shell_liveness.session_state("dev6", snap))
+
+    def test_browser_sessions_lookup_is_case_insensitive(self):
+        snap = self._snap(
+            [], {"dev6": [{"pid": 700, "conversation_id": "cv_abc",
+                           "lingering": False}]})
+        self.assertEqual([700], [s["pid"] for s in
+                                 shell_liveness.browser_sessions("DEV6", snap)])
+        self.assertEqual([], shell_liveness.browser_sessions("ghost", snap))
+
+
+class BrowserRefusalTest(unittest.TestCase):
+    """The CLI still refuses a browser-held slot — but it names the turn and
+    the two ways out instead of leaving a pid to hunt by hand."""
+
+    def setUp(self):
+        self.snap = {
+            "supported": True,
+            "processes": [{"pid": 700, "shortname": "dev6", "orphaned": None}],
+            "browser_sessions": {
+                "dev6": [{"pid": 700, "conversation_id": "cv_abc",
+                          "lingering": True}]},
+        }
+
+    def test_refusal_names_the_conversation_the_pid_and_the_exits(self):
+        message = run.browser_refusal("dev6", self.snap)
+        self.assertIn("cv_abc", message)
+        self.assertIn("pid 700", message)
+        self.assertIn("lingering", message)
+        self.assertIn("interrupt the turn from that GUI chat", message)
+        self.assertIn("close that chat", message)
+
+    def test_the_picker_paints_a_browser_hold_rather_than_available(self):
+        shell = {"flavor": "dev", "shortname": "dev6", "display_name": "Dev",
+                 "browser_active": 0}
+        self.assertIn("BROWSER", run._shell_status(shell, self.snap))
 
 
 class ComputeSmokeTest(unittest.TestCase):


### PR DESCRIPTION
Feature #68 · spec #214 · decision #314. Follows #1498 (#1497).

## Problem

A browser turn is a `claude -p … --resume` child of the API server, and the broker believed only its stdout pipe. One early `result` line finished the run with an empty reply, the producer stopped reading, and the child kept working unobserved for 14 minutes. Because its cwd was the shell's worktree, liveness then counted it as an anonymous CLI session: follow-ups, new chats, and `subfloor enter` all refused with a bare `SHELL_BUSY`, and nothing named the pid. After a server restart the run could not be recovered either, because Claude session transcripts never contain the `result` entry `inspect()` looked for.

## Principle

The process is the source of truth for "running". The stdout pipe is the fast path. The native transcript on disk is the durable channel. A run finishes on verified process exit, or on FnB close plus the reaper. Nothing alive is invisible; nothing visible is nameless.

## What changes

**A. Process exit is the terminal (broker).** The producer runs the adapter iterator to exhaustion. A terminal is held pending, last one wins, and the run finishes on stream end. If the process lingers silently past `linger_grace_seconds` (3 s), the run finishes early so the reply shows, but the registry keeps naming the process; later output opens a continuation run (`attempt + 1`, event `run.resumed`) under the same message, and verified exit clears the link and the run's process identity.

**B. Browser-owned processes are named (liveness, reaper, CLI).** `shell_liveness.compute()` joins harness pids against the registry and run rows by pid + start ticks; `session_state` answers `"browser"` for an engine-launched turn. `sc run` refuses such a slot naming the conversation and pid with the two ways out. The reaper sweeps a lingering process once its chat is closed and records `run.reaped` without touching the broker's verdict.

**C. The GUI and API expose the process and a way out.** Conversation projection gains `process {pid, start_ticks, alive, lingering, since}`. Interrupt is accepted while lingering (SIGINT to the process group). `SHELL_BUSY` names the holding chat and pid; the toast links to it. A follow-up on a chat whose own previous turn still runs is refused with `SHELL_LINGERING` rather than spawning a second process on one session file, and the broker defers the turn (`run.deferred`, message stays queued) until the process exits or Stop is pressed.

**D. Transcript adoption.** Migration 0251 records `transcript_path` and `transcript_offset` per run and clears stale process identity on historical terminal runs. `ClaudeAdapter.attach` tails the session JSONL from the offset and normalizes assistant text and tool calls; verified identity loss is its terminal. Recovery after a restart or lost pipe adopts a live run through attach instead of reconciling it as unknown. `inspect()` reads idle from the transcript's shape instead of a `result` entry that never exists.

**E. DB and log hardening.** WAL connections use `synchronous=NORMAL` so a stalled fsync (host NVMe timeouts of 30 s held the write lock through COMMIT and starved every daemon) cannot hold the write lock. Every server.log line carries a UTC stamp.

## Trade-offs stated

- A completed message cannot return to `running` on continuation: migration 0132's trigger and CHECK forbid it. The conversation reopens and the GUI shows the continuation through `run.resumed`; relaxing the message machine is a follow-up flag, not built here.
- `unknown` runs keep their previous reaper record (`run.interrupted`); `run.reaped` is reserved for runs the broker proved finished.
- Nothing kills a lingering process automatically. Stop, close, and the reaper ladder remain the operator's tools.

## Verification

Focused modules on the integrated branch: release gate, API, broker, adapters, reaper, schema, liveness, migrate, migration management, driver sync, log stamps: 369 pass. Launch, UI, and boot under pytest: 76 pass, 1 pre-existing environment-bound failure (`test_recovery_view_masks_private_state_and_parent_root_alias`, needs the restricted execution view; CI has it). Ruff: no new findings on changed lines across all units.

Built by four Opus 5 agents (units A, B, C, E) and one for D, each in an isolated worktree, reviewed and integrated commit by commit; integration corrections are their own commits with rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwN8zYGA4pin6fz4RDHHQN
