### PR TITLE
fix(relocation): report a relocated snapshot path instead of crashing

### DIFF
--- a/.super-coder/scripts/artifact_policy.py
+++ b/.super-coder/scripts/artifact_policy.py
@@ -69,6 +69,19 @@ def content_path() -> Path:
     return instance_state.active_snapshot_path(REPO_ROOT)
 
 
+def display_path(path: Path) -> str:
+    """Render a path for humans, repo-relative when it lives in the checkout.
+
+    Relocation moved the per-instance snapshot out of REPO_ROOT, so any
+    artifact path may now be absolute and outside it; `relative_to` would
+    raise. Report the absolute path in that case.
+    """
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
 def render_root() -> Path:
     return LOCAL_DIR / "renders"
 
@@ -186,8 +199,8 @@ def main(argv: list[str]) -> int:
     if command == "show":
         print(json.dumps({
             "artifact_mode": mode(),
-            "snapshot": str(content_path().relative_to(REPO_ROOT)),
-            "renders": str(render_root().relative_to(REPO_ROOT)),
+            "snapshot": display_path(content_path()),
+            "renders": display_path(render_root()),
             "git_publication": False,
         }, indent=2))
         return 0

--- a/.super-coder/scripts/render_check.py
+++ b/.super-coder/scripts/render_check.py
@@ -202,8 +202,8 @@ def main() -> int:
             sys.stderr.write(
                 "✗ render drift: the active flat _sc mirror does not match the\n"
                 "  mirror rendered from the active sources (schema + migrations +\n"
-                f"  {CONTENT.relative_to(REPO_ROOT)}). A source edit was made without\n"
-                "  re-rendering the mirror.\n\n"
+                f"  {artifact_policy.display_path(CONTENT)}). A source edit was made\n"
+                "  without re-rendering the mirror.\n\n"
                 + "".join(f"{line}\n" for line in _target_lines())
                 + "\n  drifted:\n"
                 + "".join(f"    {p}\n" for p in drifted)

--- a/tests/test_artifact_policy.py
+++ b/tests/test_artifact_policy.py
@@ -109,6 +109,22 @@ class ArtifactPolicyTest(unittest.TestCase):
             self.assertEqual(artifact_policy.main(["path", "map-db"]), 0)
         output.assert_called_once_with(self.state / "local" / "map" / "map.db")
 
+    def test_show_reports_a_relocated_snapshot_outside_the_checkout(self):
+        """Relocation puts content.sql outside REPO_ROOT; `show` must not raise."""
+        relocated = self.tmp.parent / "relocated-instance" / "content.sql"
+        with mock.patch.object(artifact_policy, "content_path", return_value=relocated):
+            with mock.patch("builtins.print") as output:
+                self.assertEqual(artifact_policy.main(["show"]), 0)
+        payload = json.loads(output.call_args[0][0])
+        self.assertEqual(payload["snapshot"], str(relocated))
+        self.assertEqual(payload["renders"], ".sc-state/local/renders")
+
+    def test_display_path_is_repo_relative_inside_the_checkout(self):
+        self.assertEqual(
+            artifact_policy.display_path(self.tmp / ".sc-state" / "local" / "x.sql"),
+            ".sc-state/local/x.sql",
+        )
+
     def test_content_write_lock_uses_ignored_local_state(self):
         lock = self.state / "local" / ".content-write.lock"
         with artifact_policy.content_write_lock():

--- a/tests/test_render_check.py
+++ b/tests/test_render_check.py
@@ -2,10 +2,14 @@
 from __future__ import annotations
 
 import hashlib
+import io
+import shutil
 import sqlite3
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / ".super-coder" / "scripts"
@@ -95,6 +99,35 @@ class RenderCheckDocumentDiagnosticsTest(unittest.TestCase):
             diagnostic,
         )
         self.assertNotIn("body_sha256", diagnostic)
+
+
+class RelocatedSnapshotReportTest(unittest.TestCase):
+    """Relocation put content.sql outside the checkout.
+
+    The drift branch names that path; an unguarded relative_to raised there,
+    so the crash replaced the very report the operator needed.
+    """
+
+    def test_drift_report_names_a_snapshot_outside_the_checkout(self):
+        relocated = Path("/var/lib/subfloor/instances/deadbeef/content.sql")
+        mirror = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, mirror, True)
+        (mirror / "roadmap_sc.md").write_text("stale")
+
+        with (
+            mock.patch.object(render_check, "CONTENT", relocated),
+            mock.patch.object(render_check, "ACTIVE_ROOT", mirror),
+            mock.patch.object(render_check, "LIVE_DB", mirror / "absent.db"),
+            mock.patch.object(render_check, "_build_tracked_db"),
+            mock.patch.object(render_check.flat, "render_visibility"),
+            mock.patch.object(render_check.artifact_policy, "prepare_local_state"),
+            mock.patch.object(sys, "stderr", io.StringIO()) as err,
+        ):
+            self.assertEqual(render_check.main(), 1)
+
+        report = err.getvalue()
+        self.assertIn(str(relocated), report)
+        self.assertIn("roadmap_sc.md", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`artifact_policy.content_path()` resolves into the private instance directory
(post-relocation), which is outside `REPO_ROOT`. Two call sites still formatted
it with an unguarded `relative_to(REPO_ROOT)` and raised `ValueError`.

| Command | Before | After |
|---|---|---|
| `sc artifact-mode show` | traceback, every invocation | prints the JSON, absolute path for the relocated snapshot |
| `sc render-check` (drift) | traceback *instead of* the drift report | reports the drifted files, naming the relocated snapshot |

The `render-check` case is the worse of the two: the crash only fires on the
failure branch, so the check correctly detected drift and then replaced the
report with a traceback — you learned it failed but not what drifted.

## How

Add `artifact_policy.display_path()` — the same guarded idiom already used by
`rebuild.py:91`, `snapshot.py:602`, and `server.py:2097` — and route both sites
through it. Paths inside the checkout still display repo-relative; paths
outside display absolute. No behavior change for a non-relocated instance.

## Verification

- `sc artifact-mode show` → exits 0, reports the relocated snapshot path.
- `sc render-check` against a deliberately perturbed mirror → exits 1 with the
  drift report naming `roadmap_sc.md` and the relocated `content.sql`; mirror
  restored, re-run exits 0.
- New regression tests cover both sites with a snapshot path outside the
  checkout: `tests/test_artifact_policy.py` (2), `tests/test_render_check.py` (1).
- `pytest tests/test_artifact_policy.py tests/test_render_check.py
  tests/test_state_relocation.py` → 34 passed.

## Found by

Post-update validation of the live floor on `sc-cachy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmG6nM6DrcMQ8ZWZMvkfZu
