### PR TITLE
fix(tests): stop the worktree fixture inheriting live instance state

### DIFF
--- a/tests/test_worktree_targets.py
+++ b/tests/test_worktree_targets.py
@@ -48,9 +48,19 @@ import model_catalog  # noqa: E402
 
 # Copied engine minus caches and anything instance-owned: the fixture's live
 # state is the sentinel this module writes, never a real fork's.
+#
+# Two of these matter only once state is relocated out of the checkout:
+#   instance.json  binds an engine to a private state directory, so a fixture
+#                  that inherits the host's copy resolves the HOST's live DB
+#                  instead of its own sentinel — the isolation this module exists
+#                  to prove.
+#   run            holds the running engine's unix sockets (ts-broker.sock),
+#                  which copy2 cannot copy at all: "[Errno 6] No such device or
+#                  address", failing the whole copytree — and, because that
+#                  raises in setUpClass, orphaning the ~400MB fixture.
 IGNORE = shutil.ignore_patterns(
     "__pycache__", "*.pyc", "shell_db.db*", "backups", "node_modules",
-    "logs",
+    "logs", "run", "instance.json",
 )
 
 # A skill row in a migration only one checkout holds exercises that checkout's
@@ -196,6 +206,9 @@ class WorktreeFixture(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._tmp = tempfile.mkdtemp(prefix="sc_wt_")
+        # Registered before anything can fail: unittest skips tearDownClass
+        # when setUpClass raises, and this fixture is a ~400MB engine copy.
+        cls.addClassCleanup(shutil.rmtree, cls._tmp, ignore_errors=True)
         tmp = Path(cls._tmp)
         cls.main = tmp / "main"
         cls.main.mkdir()
@@ -232,10 +245,6 @@ class WorktreeFixture(unittest.TestCase):
         cls.pristine = tmp / "pristine"
         cls.pristine.mkdir()
         shutil.copy2(cls.live_db, cls.pristine / "shell_db.db")
-
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls._tmp, ignore_errors=True)
 
     def setUp(self):
         """Restore the live state so each test meets the same instance."""


### PR DESCRIPTION
## What

On a host with relocated state and a live engine, **every `WorktreeFixture`
subclass errored in `setUpClass`** and orphaned its ~400MB engine copy under
`/tmp`. Seven classes per `./sc test` run; two runs filled a 7.6G tmpfs on
`sc-cachy` and took unrelated tooling down with ENOSPC.

Three defects, all newly consequential once instance state moved out of the
checkout:

**1. `IGNORE` did not exclude `run/`.** It holds the running engine's unix
sockets (`ts-broker.sock`). `shutil.copy2` cannot copy a socket:

```
shutil.Error: [(... '/.super-coder/run/ts-broker.sock', ...,
  "[Errno 6] No such device or address")]
```

`copytree` raises, `setUpClass` dies. Only reproducible with the engine
running — which is why CI never saw it.

**2. `IGNORE` did not exclude `instance.json`.** That file binds an engine to
its private state directory (`instance_state._bound_private_state` reads it),
so the fixture inherited the **host's** instance identity. `./sc migrate` from
a throwaway `/tmp` checkout resolved the host's live database:

```
migrate: db  /home/…/state/subfloor/instances/<id>/shell_db.db
migrate: backed up existing DB -> …/db_backups/shell_db.premigrate.….db
```

That is exactly the isolation `test_worktree_targets.py` exists to prove. The
socket crash in (1) had been masking it — the classes never got far enough to
assert. No live data was altered (migrations were current, so nothing applied),
but the fixture did write backups into the host's instance directory.

**3. Cleanup lived in `tearDownClass`,** which unittest skips when
`setUpClass` raises — so every error leaked the whole 400MB tree.
`addClassCleanup`, registered immediately after `mkdtemp`, holds on both the
success and failure paths and makes the separate `tearDownClass` redundant.

## Verification

- `pytest tests/test_worktree_targets.py` → **30 passed, 33 subtests passed**
  (was: 12 failed / 21 errored), with zero `/tmp` residue afterward.
- Full suite on a clean `/tmp`: **3115 passed, 2 skipped, 1428 subtests
  passed, 9 failed**. The 9 are pre-existing and untouched by this diff, which
  changes only `tests/test_worktree_targets.py`:
  `test_backup_dir`, `test_engine_sql::test_missing_identity_does_not_adopt_an_admin_credential`,
  `test_harness_epoch::test_update_rolls_the_epoch`, and 6
  `test_operator_surface::EnterPreAttachPrintTest` subtests. Reported
  separately.

## Found by

Post-update validation of the live floor on `sc-cachy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmG6nM6DrcMQ8ZWZMvkfZu
