### PR TITLE
fix(claude): grant shell bypass through a launch flag, not a settings merge

### DIFF
--- a/.super-coder/adapters/claude/README.md
+++ b/.super-coder/adapters/claude/README.md
@@ -15,7 +15,19 @@ the launch command. No extra config file to emit at v1.
 | `model` | `{ "flag": "--model" }` — run.py appends `--model <id>` for the flavor's claude model (alias: `sonnet`/`haiku`/`opus`) |
 | `headless.effort` | `{ "flag": "--effort" }` — applies an explicitly requested headless effort level |
 | `merge_json` | always-on: project-scoped JSON deep-merged every launch (preserves fork keys). Installs the branch-guard hook into `.claude/settings.local.json`. |
-| `sandbox` | `merge_json`: project-scoped config patched in-sandbox only (allow-all permissions) |
+| `launch_flags` / `headless_flags` | always-on argv appended to the interactive / headless launch — `--dangerously-skip-permissions` in both |
+| `sandbox` | `env`: `IS_SANDBOX=1`, required because the rootless container runs claude as uid 0 and it refuses bypass as root without it |
+
+## Permission stance
+
+Every launched shell runs with `--dangerously-skip-permissions`, on the host as
+well as in the sandbox — the same bypass browser chats already get from the
+conversation adapter. This is a launch flag, not a settings merge, because
+Claude Code 2.1.256 ignores a project-scoped `permissions.defaultMode` of
+`bypassPermissions` (in `.claude/settings.json` or `.claude/settings.local.json`);
+only user/managed settings or the CLI flag grant it, and the engine never edits
+the operator's user settings. The branch-guard hook fires in bypass mode too,
+so the default-branch protection is unchanged.
 
 ## Branch-guard hook
 

--- a/.super-coder/adapters/claude/adapter.json
+++ b/.super-coder/adapters/claude/adapter.json
@@ -102,14 +102,9 @@
       }
     }
   },
+  "launch_flags": ["--dangerously-skip-permissions"],
+  "headless_flags": ["--dangerously-skip-permissions"],
   "sandbox": {
-    "env": { "IS_SANDBOX": "1" },
-    "merge_json": {
-      ".claude/settings.local.json": {
-        "permissions": { "defaultMode": "bypassPermissions" },
-        "skipDangerousModePermissionPrompt": true
-      }
-    },
-    "headless_flags": ["--dangerously-skip-permissions"]
+    "env": { "IS_SANDBOX": "1" }
   }
 }

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -507,13 +507,13 @@ def headless_command(
     adapter: dict,
     prompt: str,
     model: "str | None" = None,
-    sandbox_flags: "list[str] | None" = None,
+    launch_flags: "list[str] | None" = None,
     effort: "str | None" = None,
     transport: "route_transport.TransportProjection | None" = None,
     conversation_owned: bool = False,
 ) -> "list[str] | None":
     """The non-interactive exec argv from the adapter's `headless` block —
-    launch prefix + model flag + sandbox flags + the prompt as the final
+    launch prefix + model flag + launch-mode flags + the prompt as the final
     positional. None when the harness declares no headless block (e.g. vibe,
     which takes no model from the launch seam — see the spec's non-goals)."""
     hcfg = adapter.get("headless")
@@ -555,7 +555,7 @@ def headless_command(
         if transport is not None
         else _headless_effort_args(hcfg, effort, adapter.get("harness", "?"))
     )
-    cmd += list(sandbox_flags or [])
+    cmd += list(launch_flags or [])
     if hcfg.get("prompt_flag"):
         cmd += [hcfg["prompt_flag"], prompt]
     else:
@@ -757,13 +757,37 @@ def apply_sandbox(adapter: dict, root: Path = REPO_ROOT) -> list[str]:
     """Sandbox-only: elevate harness permissions to allow-all when booting
     INSIDE the docker sandbox (SC_SANDBOX, set by `sc launch`'s docker run). The
     container is the safety boundary, so permission prompts inside it are pure
-    friction; the no-docker host escape hatch (`./sc boot` with SC_SANDBOX
-    unset) keeps normal prompts. Each adapter declares sandbox.merge_json:
+    friction; on the host (SC_SANDBOX unset) only the adapter's always-on
+    launch flags apply (launch_mode_flags). Each adapter declares sandbox.merge_json:
     {repo-relative-path: patch}; we deep-merge the patch into that
     project-scoped file (preserving any keys the fork set)."""
     if not os.environ.get("SC_SANDBOX"):
         return []
     return _merge_json_spec((adapter.get("sandbox") or {}).get("merge_json") or {}, root)
+
+
+def launch_mode_flags(adapter: dict, headless: bool) -> list[str]:
+    """The permission flags for this launch mode: the adapter's always-on set
+    at its top level, then the sandbox-only set when booting inside the docker
+    sandbox (SC_SANDBOX). The two flag sets are disjoint by launch mode:
+    `launch_flags` for interactive, `headless_flags` for headless — a
+    non-interactive run can't answer a permission prompt (it auto-denies and
+    the worker silently stalls). They are NOT folded together because a
+    harness's interactive flag can be invalid headless — `kimi -p` hard-errors
+    on `--yolo`/`--auto` (prompt mode is always auto-permission, no flag
+    needed).
+
+    Always-on flags are the only elevation that still reaches Claude Code:
+    since 2.1.256 a project-scoped `permissions.defaultMode` of
+    `bypassPermissions` is ignored, so a settings merge cannot grant it. The
+    host route grants shells the same bypass browser chats already run with
+    (conversation_adapters/claude.py); the sandbox-only set stays for
+    harnesses whose bypass is safe only behind the container boundary."""
+    key = "headless_flags" if headless else "launch_flags"
+    flags = list(adapter.get(key) or [])
+    if os.environ.get("SC_SANDBOX"):
+        flags += list((adapter.get("sandbox") or {}).get(key) or [])
+    return flags
 
 
 def execution_mode() -> str:
@@ -1958,14 +1982,12 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
                 cfg[key] = session_model
                 atomic_write(mfile, json.dumps(cfg, indent=2) + "\n")
 
-    # Sandbox elevation, main()'s split kept: launch_flags for the TUI,
+    # Permission flags, main()'s split kept: launch_flags for the TUI,
     # headless_flags for a non-interactive plan, plus sandbox-only env.
-    sandbox_flags: list[str] = []
+    mode_flags = launch_mode_flags(adapter, headless)
     sandbox_env: dict[str, str] = {}
     if os.environ.get("SC_SANDBOX"):
         scfg = adapter.get("sandbox") or {}
-        key = "headless_flags" if headless else "launch_flags"
-        sandbox_flags = list(scfg.get(key) or [])
         sandbox_env = {k: str(v) for k, v in (scfg.get("env") or {}).items()}
 
     name_args: list[str] = []
@@ -1976,7 +1998,7 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
     if headless:
         argv = headless_command(
             adapter, headless_prompt, session_model,
-            sandbox_flags, session_effort, transport=route_projection,
+            mode_flags, session_effort, transport=route_projection,
             conversation_owned=conversation_owned,
         )
         if argv is None:
@@ -1986,7 +2008,7 @@ def prepare_launch(*, shell_id: int, harness: "str | None" = None,
         argv = (
             list(adapter.get("launch") or [harness])
             + list((managed or {}).get("launch_args") or [])
-            + name_args + model_args + sandbox_flags
+            + name_args + model_args + mode_flags
         )
 
     # Env injection, verbatim from main()'s exec block: adapter env, sandbox
@@ -2536,24 +2558,16 @@ def main() -> None:
     if sandboxed:
         print(f"→ sandbox: allow-all permissions → {', '.join(sandboxed)}")
 
-    # Sandbox-only launch flags — e.g. codex's approval/sandbox bypass, safe
-    # because the container is the safety boundary. The no-docker host path keeps
-    # the harness's normal prompts (SC_SANDBOX unset). The two flag sets are
-    # disjoint by launch mode: `launch_flags` for interactive, `headless_flags`
-    # for headless — a non-interactive run can't answer a permission prompt (it
-    # auto-denies and the worker silently stalls), so e.g. claude gets its bypass
-    # flag there; codex declares the same flag in both. They are NOT folded
-    # together because a harness's interactive flag can be invalid headless —
-    # `kimi -p` hard-errors on `--yolo`/`--auto` (prompt mode is always
-    # auto-permission, no flag needed).
-    sandbox_flags: list[str] = []
+    # Permission flags for this launch mode — always-on ones from the adapter
+    # top level (claude's bypass, which a settings merge can no longer grant)
+    # plus sandbox-only ones such as codex's approval/sandbox bypass, safe
+    # because the container is the safety boundary. See launch_mode_flags.
+    mode_flags = launch_mode_flags(adapter, headless)
+    if mode_flags:
+        print(f"→ launch flags → {' '.join(mode_flags)}")
     sandbox_env: dict[str, str] = {}
     if os.environ.get("SC_SANDBOX"):
         scfg = adapter.get("sandbox") or {}
-        key = "headless_flags" if headless else "launch_flags"
-        sandbox_flags = list(scfg.get(key) or [])
-        if sandbox_flags:
-            print(f"→ sandbox: launch flags → {' '.join(sandbox_flags)}")
         # Sandbox-only launch env — e.g. claude's IS_SANDBOX=1, required because
         # the rootless container runs the harness as uid 0 and claude refuses
         # bypass-permissions mode as root unless the env marks it as sandboxed.
@@ -2568,7 +2582,7 @@ def main() -> None:
         hmodel = session_model  # resolved up front (persisted on the archive row)
         effective_prompt = prompt or DEFAULT_HEADLESS_PROMPT
         headless_cmd = headless_command(
-            adapter, effective_prompt, hmodel, sandbox_flags,
+            adapter, effective_prompt, hmodel, mode_flags,
             session_effort)
         if headless_cmd is None:
             sys.exit(f"sc run: harness '{harness}' has no headless adapter — "
@@ -2605,7 +2619,7 @@ def main() -> None:
         else (
             (adapter.get("launch") or [harness])
             + list((managed or {}).get("launch_args") or [])
-            + name_args + model_args + sandbox_flags
+            + name_args + model_args + mode_flags
         )
     )
     effort_env = headless_effort_env(adapter, session_effort) if headless else {}

--- a/tests/test_claude_permission_flags.py
+++ b/tests/test_claude_permission_flags.py
@@ -1,0 +1,69 @@
+"""Claude shells get their permission bypass from a launch flag, not a
+settings merge — Claude Code 2.1.256 ignores a project-scoped
+`permissions.defaultMode: bypassPermissions`, so the merge that used to carry
+sandbox shells (and, by accident, host shells with a leftover file) is dead."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import run
+
+BYPASS = "--dangerously-skip-permissions"
+
+
+def _claude() -> dict:
+    return json.loads((run.ADAPTERS / "claude" / "adapter.json").read_text())
+
+
+class ClaudePermissionFlagsTest(unittest.TestCase):
+    def test_host_launch_carries_bypass_in_both_modes(self) -> None:
+        adapter = _claude()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("SC_SANDBOX", None)
+            self.assertEqual(run.launch_mode_flags(adapter, headless=False), [BYPASS])
+            self.assertEqual(run.launch_mode_flags(adapter, headless=True), [BYPASS])
+
+    def test_sandbox_adds_no_second_copy(self) -> None:
+        adapter = _claude()
+        with mock.patch.dict(os.environ, {"SC_SANDBOX": "1"}, clear=True):
+            self.assertEqual(run.launch_mode_flags(adapter, headless=False), [BYPASS])
+            self.assertEqual(run.launch_mode_flags(adapter, headless=True), [BYPASS])
+
+    def test_headless_argv_ends_with_bypass_then_prompt(self) -> None:
+        adapter = _claude()
+        with mock.patch.dict(os.environ, {}, clear=True), \
+                mock.patch.object(run, "linked_vm_configured", return_value=False):
+            argv = run.headless_command(
+                adapter, "first turn", None,
+                run.launch_mode_flags(adapter, headless=True),
+            )
+        self.assertEqual(argv[-3:], [BYPASS, "-p", "first turn"])
+
+    def test_no_project_settings_merge_claims_bypass(self) -> None:
+        # The ignored knob must not linger in anything the adapter writes.
+        adapter = _claude()
+        merged = json.dumps(adapter.get("merge_json") or {})
+        self.assertNotIn("bypassPermissions", merged)
+        self.assertNotIn("skipDangerousModePermissionPrompt", merged)
+        self.assertEqual(adapter["sandbox"], {"env": {"IS_SANDBOX": "1"}})
+
+    def test_sandbox_only_flags_stay_sandbox_only(self) -> None:
+        adapter = {"sandbox": {"launch_flags": ["--yolo"]}}
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(run.launch_mode_flags(adapter, headless=False), [])
+        with mock.patch.dict(os.environ, {"SC_SANDBOX": "1"}, clear=True):
+            self.assertEqual(run.launch_mode_flags(adapter, headless=False), ["--yolo"])
+            self.assertEqual(run.launch_mode_flags(adapter, headless=True), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Claude Code 2.1.256 changed `defaultMode: "bypassPermissions"` in `.claude/settings.json` / `.claude/settings.local.json` to be ignored (changelog: "set it in user or managed settings"). The claude adapter's sandbox `merge_json` that wrote exactly that is now dead, and host shells that had been riding on a leftover copy of the file fell through to the operator's user-level `auto` mode and started prompting. Recent terminal transcripts show `default` / `acceptEdits` / `auto` where bypass was expected; browser chats were unaffected because the conversation adapter already passes `--dangerously-skip-permissions` on the command line.

## What

- `adapters/claude/adapter.json`: elevation moves to always-on top-level `launch_flags` / `headless_flags` (`--dangerously-skip-permissions`). The sandbox block keeps only `IS_SANDBOX=1` (still needed for bypass as root in the container).
- `run.py`: one `launch_mode_flags(adapter, headless)` helper reads the always-on set plus the sandbox-only set under `SC_SANDBOX`, used by both `main()` and `prepare_launch()`. `headless_command`'s `sandbox_flags` parameter is renamed `launch_flags` (positional callers only).
- README: documents the permission stance and the 2.1.256 reason it is a flag, not a merge.
- New `tests/test_claude_permission_flags.py`.

## Trade-off stated

This changes the engine's host posture for claude from "normal prompts" (the old `apply_sandbox` docstring) to bypass. Chosen because browser chats on the host already run unrestricted by engine design, so terminal shells now match rather than carrying a second posture; the FnB picked this over setting bypass in user settings machine-wide. Other harnesses' sandbox-only flags are unchanged. The branch-guard hook fires regardless of permission mode.

## Verification

- `pytest tests/test_claude_permission_flags.py tests/test_route_transport.py tests/test_windows_mcp_adapters.py tests/test_opencode_model_preservation.py tests/test_style_spinner.py tests/test_run_session.py tests/test_admin_host_launch.py tests/test_conversation_adapters.py` → 169 passed.
- ruff on `run.py`: same finding count as `origin/main`; new test file clean.
- Live effect needs the FnB's floor update + restart; stale `permissions` keys in worktree `settings.local.json` files are now inert and can be left or stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
