### PR TITLE
feat(search): Tavily web search verb with GUI-managed host-side key

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -99,6 +99,7 @@ from quota_probes import dispatch as quota_dispatch  # noqa: E402  (account quot
 import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
 import ts as ts_mod  # noqa: E402  (tailnet — config + live checks)
 import pm2 as pm2_mod  # noqa: E402  (host pm2 stack — config + live checks)
+import web_search as web_search_mod  # noqa: E402  (Tavily — key store + client, doc #215)
 sys.path.insert(0, str(ENGINE / "render"))
 import flat as flat_render  # noqa: E402  (document render-path ownership)
 
@@ -2687,7 +2688,7 @@ class Handler(BaseHTTPRequestHandler):
             return None
         return shell_id
 
-    def _require_browser_operator(self, con):
+    def _require_browser_operator(self, con, what: str = "the Sprint board"):
         """Accept the loopback browser operator and reject shell credentials."""
         token = self._bearer_token()
         if token:
@@ -2704,7 +2705,7 @@ class Handler(BaseHTTPRequestHandler):
             else:
                 self._send(403, {"error": {
                     "code": "fnb_operator_required",
-                    "message": "the Sprint board is owned by the browser FnB operator",
+                    "message": f"{what} is owned by the browser FnB operator",
                     "details": {},
                 }})
             return False
@@ -2729,7 +2730,8 @@ class Handler(BaseHTTPRequestHandler):
             }})
         return self._fail(exc)
 
-    def _require_browser_mutation_origin(self) -> bool:
+    def _require_browser_mutation_origin(
+            self, what: str = "Sprint lifecycle actions") -> bool:
         origin = self.headers.get("Origin")
         host = self.headers.get("Host") or ""
         if origin:
@@ -2744,14 +2746,14 @@ class Handler(BaseHTTPRequestHandler):
             ):
                 self._send(403, {"error": {
                     "code": "same_origin_required",
-                    "message": "Sprint lifecycle actions require the browser origin",
+                    "message": f"{what} require the browser origin",
                     "details": {},
                 }})
                 return False
         if self.headers.get("Sec-Fetch-Site") not in {None, "same-origin", "none"}:
             self._send(403, {"error": {
                 "code": "same_origin_required",
-                "message": "Sprint lifecycle actions require the browser origin",
+                "message": f"{what} require the browser origin",
                 "details": {},
             }})
             return False
@@ -3912,6 +3914,26 @@ class Handler(BaseHTTPRequestHandler):
             return self._fail(exc)
         finally:
             con.close()
+
+    # -- /_sc/search — token-scoped web search (doc #215) --
+
+    def _search_post(self, body: dict):
+        """A shell searches through the host: the stored key never leaves this
+        process. Errors are {error: <secret-free message>, code} at the status
+        web_search picked, so `sc search` prints them verbatim."""
+        if self._require_shell_auth() is None:
+            return
+        max_results = body.get("max_results", web_search_mod.DEFAULT_MAX_RESULTS)
+        depth = body.get("depth", "basic")
+        try:
+            out = web_search_mod.search(
+                str(body.get("query") or ""),
+                max_results=max_results, depth=depth)
+        except ValueError as exc:
+            return self._send(400, {"error": str(exc), "code": "bad_request"})
+        except web_search_mod.WebSearchError as exc:
+            return self._send(exc.status, {"error": exc.message, "code": exc.code})
+        return self._send(200, out)
 
     # -- /mem/* token-scoped shell memory endpoints --
 
@@ -5139,6 +5161,12 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, {"scripts": script_list()})
             if path == "/api/vm":
                 return self._send(200, {"vm": vm_mod.read()})
+            if path == "/api/web-search":
+                # Status only — configured / provider / last-four hint / when.
+                # The key itself never crosses this boundary (doc #215).
+                if not self._require_browser_operator(con, "web search config"):
+                    return
+                return self._send(200, web_search_mod.status())
             if path == "/api/ts":
                 return self._send(200, {"ts": ts_mod.read()})
             if path == "/api/ts/status":
@@ -5188,8 +5216,20 @@ class Handler(BaseHTTPRequestHandler):
             return self._pr_post(path, self._body())
         if path.startswith("/_sc/sprint/"):
             return self._sprint_post(path, self._body())
+        if path == "/_sc/search":
+            return self._search_post(self._body())
         con = db()
         try:
+            if path == "/api/web-search/validate":
+                # Test-before-save: probe Tavily with the IN-PROGRESS key (or
+                # the stored one when none is supplied). A failed probe is a
+                # normal result the UI renders red — 200 with {ok:false}.
+                if not self._require_browser_operator(con, "web search config"):
+                    return
+                candidate = self._body().get("api_key")
+                if candidate is not None and not isinstance(candidate, str):
+                    return self._send(400, {"error": "api_key must be a string"})
+                return self._send(200, web_search_mod.validate(candidate))
             if path == "/api/flags":
                 fid, err = create_flag(con, self._body())
                 return self._send(400 if err else 201,
@@ -5539,6 +5579,21 @@ class Handler(BaseHTTPRequestHandler):
                 if pb is not None and not isinstance(pb, dict):
                     return self._send(400, {"error": "pm2 must be an object"})
                 return self._send(200, {"ok": True, "pm2": pm2_mod.write(pb)})
+            if path == "/api/web-search":
+                # Set or rotate: replaces the stored key atomically; the next
+                # /_sc/search reads the new one. Operator + same-origin only.
+                if not self._require_browser_operator(con, "web search config"):
+                    return
+                if not self._require_browser_mutation_origin("web search config changes"):
+                    return
+                api_key = self._body().get("api_key")
+                if not isinstance(api_key, str):
+                    return self._send(400, {"error": "api_key must be a string"})
+                try:
+                    st = web_search_mod.write(api_key)
+                except ValueError as exc:
+                    return self._send(400, {"error": str(exc)})
+                return self._send(200, {"ok": True, **st})
             # PUT /api/roadmap/{id}/blockers  {blocked_by: [ids]} — replace the
             # feature's blocker set (empty list clears it).
             if len(parts) == 4 and parts[1] == "roadmap" and parts[3] == "blockers":
@@ -5559,6 +5614,12 @@ class Handler(BaseHTTPRequestHandler):
         path = urlparse(self.path).path
         con = db()
         try:
+            if path == "/api/web-search":
+                if not self._require_browser_operator(con, "web search config"):
+                    return
+                if not self._require_browser_mutation_origin("web search config changes"):
+                    return
+                return self._send(200, {"ok": True, **web_search_mod.clear()})
             if path.startswith("/api/shells/") and path.count("/") == 3:
                 sid = int(path.rsplit("/", 1)[1])
                 cur = con.execute(

--- a/.super-coder/assets/skills/web_search/SKILL.md
+++ b/.super-coder/assets/skills/web_search/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: web_search
+description: Search the web through the engine (`sc search`, Tavily). Use when a task needs current facts, docs, release notes, or error text you cannot find in the repo or your own knowledge. The key lives on the host; you only need your shell token.
+category: substrate
+command: sc search
+common: true
+---
+
+# web_search — look it up through the engine
+
+`sc search` is the one web search verb every shell has, on every harness.
+It posts your query to the engine API with your own bearer token; the host
+calls Tavily with the instance's API key and returns the results. The key never
+reaches a shell, and a sandboxed shell needs no network egress.
+
+## When to search
+
+- A fact that changes: a library's current API, a release note, a CLI flag, a
+  version's known bug, an error message you cannot explain from the code.
+- Before guessing at an external service's protocol or a package's behaviour.
+- Never for anything the repo catalogue or your own memory already answers —
+  map first, memory second, search third.
+
+## The verb
+
+```bash
+sc search "<query>"                      # 5 results + a short synthesized answer
+sc search "<query>" --max 10             # 1..20 results
+sc search "<query>" --depth advanced     # deeper crawl, slower
+sc search "<query>" --json               # raw payload: answer, results[] (title, url, snippet, score)
+```
+
+Output is a numbered list: title, URL, snippet. Treat snippets as leads, not
+proof — open the URL that matters (`curl -sL <url>` or your harness's fetch
+tool) before you rely on it, and cite the URL in what you write.
+
+## When it fails
+
+Every failure names its cause and carries no secret:
+
+| Message starts with | Meaning | Do |
+|---|---|---|
+| `web search is not configured` | no key on this instance | Tell the FnB: set it in the GUI → **Scripts → Web Search**. Do not work around it with a key of your own. |
+| `Tavily rejected the API key` | the stored key is invalid or revoked | Tell the FnB to rotate it in the same GUI card. |
+| `Tavily plan usage limit` / `rate limit` | quota exhausted | Stop searching; say so; continue from what you have. |
+| `Tavily unreachable` | host network failure | Retry once later; then surface it. |
+| `the engine API is required` | your shell is not API-wired | Boot via the launcher with the server up. |
+
+Search results are not persisted anywhere by the engine. What you learn goes
+where any other finding goes: the narrative, a decision, or the work itself.

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -4258,4 +4258,59 @@ ON CONFLICT(name) DO UPDATE SET
   command=excluded.command, common=excluded.common,
   content=excluded.content, is_deleted=0;
 
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'web_search',
+  'Search the web through the engine (`sc search`, Tavily). Use when a task needs current facts, docs, release notes, or error text you cannot find in the repo or your own knowledge. The key lives on the host; you only need your shell token.',
+  'substrate',
+  'sc search',
+  1,
+  '# web_search — look it up through the engine
+
+`sc search` is the one web search verb every shell has, on every harness.
+It posts your query to the engine API with your own bearer token; the host
+calls Tavily with the instance''s API key and returns the results. The key never
+reaches a shell, and a sandboxed shell needs no network egress.
+
+## When to search
+
+- A fact that changes: a library''s current API, a release note, a CLI flag, a
+  version''s known bug, an error message you cannot explain from the code.
+- Before guessing at an external service''s protocol or a package''s behaviour.
+- Never for anything the repo catalogue or your own memory already answers —
+  map first, memory second, search third.
+
+## The verb
+
+```bash
+sc search "<query>"                      # 5 results + a short synthesized answer
+sc search "<query>" --max 10             # 1..20 results
+sc search "<query>" --depth advanced     # deeper crawl, slower
+sc search "<query>" --json               # raw payload: answer, results[] (title, url, snippet, score)
+```
+
+Output is a numbered list: title, URL, snippet. Treat snippets as leads, not
+proof — open the URL that matters (`curl -sL <url>` or your harness''s fetch
+tool) before you rely on it, and cite the URL in what you write.
+
+## When it fails
+
+Every failure names its cause and carries no secret:
+
+| Message starts with | Meaning | Do |
+|---|---|---|
+| `web search is not configured` | no key on this instance | Tell the FnB: set it in the GUI → **Scripts → Web Search**. Do not work around it with a key of your own. |
+| `Tavily rejected the API key` | the stored key is invalid or revoked | Tell the FnB to rotate it in the same GUI card. |
+| `Tavily plan usage limit` / `rate limit` | quota exhausted | Stop searching; say so; continue from what you have. |
+| `Tavily unreachable` | host network failure | Retry once later; then surface it. |
+| `the engine API is required` | your shell is not API-wired | Boot via the launcher with the server up. |
+
+Search results are not persisted anywhere by the engine. What you learn goes
+where any other finding goes: the narrative, a decision, or the work itself.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
 COMMIT;

--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -1061,7 +1061,7 @@ esac
 # migrate) probes first because it executes host Python. Container entry
 # deliberately remains a Docker handoff rather than a host-runtime gate.
 case "$cmd" in
-  install|ensure-harness|doctor|update|update-harnesses|harness-status|docker-cache-gc|rollback|feature|runtime|artifact-mode|eject|remove|init|rebuild|migrate|migration|snapshot|mem|pr|token|persist|job|visual-qa|sql|sql-rw|map-sql|map-sql-rw|map-schema|map-extractor|render|render-check|map|map-setup|analytics|models|seed-skills|skill|ports|url|preview|serve|vm|vm-broker|vm-bake|vm-broker-up|vm-broker-down|vm-broker-sock|vm-mcp-relay|vm-broker-install|vm-broker-uninstall|ts-broker|ts-broker-up|ts-broker-down|ts-broker-sock|ts-broker-install|ts-broker-uninstall|pm2-broker|pm2-broker-up|pm2-broker-down|pm2-broker-sock|pm2-broker-install|pm2-broker-uninstall|db-broker|db-broker-up|db-broker-down|db-broker-sock|db-broker-install|db-broker-uninstall|db-init|pg-init|pg-up|pg-down|admin|boot|boot-*|run|deps|test|lint|typecheck|launch|down|restart|build|verify|health|clean-db)
+  install|ensure-harness|doctor|update|update-harnesses|harness-status|docker-cache-gc|rollback|feature|runtime|artifact-mode|eject|remove|init|rebuild|migrate|migration|snapshot|mem|pr|token|persist|job|visual-qa|sql|sql-rw|map-sql|map-sql-rw|map-schema|map-extractor|render|render-check|map|map-setup|analytics|models|seed-skills|skill|search|ports|url|preview|serve|vm|vm-broker|vm-bake|vm-broker-up|vm-broker-down|vm-broker-sock|vm-mcp-relay|vm-broker-install|vm-broker-uninstall|ts-broker|ts-broker-up|ts-broker-down|ts-broker-sock|ts-broker-install|ts-broker-uninstall|pm2-broker|pm2-broker-up|pm2-broker-down|pm2-broker-sock|pm2-broker-install|pm2-broker-uninstall|db-broker|db-broker-up|db-broker-down|db-broker-sock|db-broker-install|db-broker-uninstall|db-init|pg-init|pg-up|pg-down|admin|boot|boot-*|run|deps|test|lint|typecheck|launch|down|restart|build|verify|health|clean-db)
     case "$cmd" in
       deps|test|lint|typecheck)
         sc_devkit_help_form "$@" || sc_python_probe ;;
@@ -1212,6 +1212,9 @@ case "$cmd" in
   # Skill catalogue write surface — grants/retirement by name, loud on a miss
   # (the raw-SQL grant's silent no-op class). Snapshot is still the persist step.
   skill)        exec "$PY" "$S/skill.py" "$@" ;;
+  # Web search through the engine API (doc #215): the Tavily key stays on
+  # the host; the shell only carries its own bearer token.
+  search)       exec "$PY" "$S/web_search.py" "$@" ;;
   ports)        exec "$PY" "$S/ports.py" show ;;
   url)          sc_urls ;;
   preview)      exec "$PY" "$S/preview.py" "$@" ;;
@@ -1685,7 +1688,7 @@ Subfloor — forkable shell substrate for one repository
 
   Install & upkeep      install · doctor · ensure-harness · update-harnesses · harness-status
                         rollback · runtime · feature · persist · alias · make-cleanup · remove · eject
-  Memory & catalogue    mem · map · map-sql · map-schema · sql · skill · models · job · pr · sprint · token
+  Memory & catalogue    mem · map · map-sql · map-schema · sql · skill · search · models · job · pr · sprint · token
   Engine (Admin)        rebuild · migrate · migration · snapshot · render · render-check · verify
                         seed-skills · engine-ref · clean-db
   Host brokers          vm · vm-broker-* · ts-broker-* · pm2-broker-* · db-broker-* · db-init · pg-*
@@ -1771,6 +1774,8 @@ Subfloor — forkable shell substrate — full command reference (./sc help for 
                            validate + atomically install one Cartographer-authored extractor and write its SHA-256 receipt
   ./sc map-setup           wire the auto-remap git hooks (core.hooksPath) + map — the cartographer's one-shot
   ./sc seed-skills         upsert assets/skills/ into the live DB (+ regenerate the seed migration — source repo only)
+  ./sc search "<query>" [--max N] [--depth basic|advanced] [--json]
+                           web search via the engine API (Tavily; key set in GUI → Scripts → Web Search)
   ./sc init                seed a fresh fork's first user + shell (run once after install)
 
   Sandbox (docker — the default way to run; allow-everything is safe because the

--- a/.super-coder/scripts/web_search.py
+++ b/.super-coder/scripts/web_search.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Web search (Tavily) — host-side key store, search client, `./sc search`.
+
+Three pieces, one module (spec doc #215, feature #69):
+
+  store   The Tavily API key lives in ONE mode-0600 JSON file, `web_search.json`,
+          inside the private instance-state root (legacy floors: .sc-state/local/).
+          Never instance.json (bind-mounted into the sandbox, no-secrets by
+          design), never the engine DB, never the snapshot or a render. Only the
+          browser operator writes it (GUI → Scripts → Web Search); `status()` is
+          the only read other code sees, and it carries at most the last four
+          characters of the key.
+
+  client  `search()` calls Tavily with the stored key from the API PROCESS. A
+          shell never holds the key: it posts to `/_sc/search` with its own
+          bearer token and the host makes the outbound call, so a sandboxed
+          shell needs no egress. Every failure is a `WebSearchError` with an
+          HTTP status the API forwards and a message redacted of the key.
+
+  cli     `./sc search "<query>" [--max N] [--depth basic|advanced] [--json]`
+          — the shell verb, wired through the same API lane as `sc mem`.
+
+Rotation is a replace: `write()` lands a fresh temp inode and renames it over
+the old file; the next `search()` reads the new key. Nothing caches it.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+import instance_state
+
+ENGINE = Path(__file__).resolve().parents[1]
+
+PROVIDER = "tavily"
+TAVILY_URL = "https://api.tavily.com/search"
+STORE_NAME = "web_search.json"
+TIMEOUT = 20.0
+DEFAULT_MAX_RESULTS = 5
+MAX_RESULTS_CAP = 20
+DEPTHS = ("basic", "advanced")
+PROBE_QUERY = "subfloor agent substrate"
+
+UNCONFIGURED = (
+    "web search is not configured — ask the FnB to set the Tavily API key in "
+    "the GUI: Scripts → Web Search"
+)
+
+
+class WebSearchError(Exception):
+    """A secret-free failure carrying the HTTP status the API should return."""
+
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+
+
+# -- store --------------------------------------------------------------------
+
+def store_path() -> Path:
+    """The one file that holds the key: private instance root, else the
+    legacy owner-only `.sc-state/local/` namespace."""
+    return instance_state.maintenance_state(ENGINE).root / STORE_NAME
+
+
+def _redact(text: str, key: str) -> str:
+    return text.replace(key, "***") if key else text
+
+
+def _hint(key: str) -> str | None:
+    if not key:
+        return None
+    return "…" + key[-4:] if len(key) >= 8 else "…"
+
+
+def _load(path: Path | None = None) -> dict:
+    path = path or store_path()
+    if path.is_symlink():
+        raise WebSearchError(500, "store_unsafe",
+                             f"{path} is a symlink — refusing to read the key store")
+    if not path.exists():
+        return {}
+    if not path.is_file():
+        raise WebSearchError(500, "store_unsafe",
+                             f"{path} is not a regular file — refusing to read the key store")
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise WebSearchError(500, "store_unreadable",
+                             f"{path} is unreadable: {exc}") from exc
+    return data if isinstance(data, dict) else {}
+
+
+def status(path: Path | None = None) -> dict:
+    """What the GUI and API may see: never the key itself."""
+    data = _load(path)
+    key = str(data.get("api_key") or "")
+    return {
+        "configured": bool(key),
+        "provider": PROVIDER,
+        "key_hint": _hint(key),
+        "updated_at": data.get("updated_at"),
+    }
+
+
+def write(api_key: str, path: Path | None = None) -> dict:
+    """Set or rotate the key: fresh 0600 inode, renamed over the old file."""
+    api_key = (api_key or "").strip()
+    if not api_key:
+        raise ValueError("api_key is required")
+    if any(ch.isspace() for ch in api_key):
+        raise ValueError("api_key must not contain whitespace")
+    path = path or store_path()
+    if path.is_symlink():
+        raise WebSearchError(500, "store_unsafe",
+                             f"{path} is a symlink — refusing to write the key store")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "provider": PROVIDER,
+        "api_key": api_key,
+        "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    fd, tmp = tempfile.mkstemp(prefix=f".{STORE_NAME}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(payload, fh)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+    return status(path)
+
+
+def clear(path: Path | None = None) -> dict:
+    path = path or store_path()
+    if path.is_symlink():
+        raise WebSearchError(500, "store_unsafe",
+                             f"{path} is a symlink — refusing to touch the key store")
+    path.unlink(missing_ok=True)
+    return status(path)
+
+
+# -- client -------------------------------------------------------------------
+
+def _upstream_error(code: int, body: bytes, key: str) -> WebSearchError:
+    try:
+        detail = json.loads(body or b"")
+        detail = detail.get("detail", detail) if isinstance(detail, dict) else detail
+        if isinstance(detail, dict):
+            detail = detail.get("error") or detail.get("message") or json.dumps(detail)
+        detail = str(detail)
+    except (ValueError, UnicodeDecodeError):
+        detail = (body or b"").decode("utf-8", "replace")
+    detail = _redact(detail, key)[:300]
+    if code in (401, 403):
+        return WebSearchError(
+            502, "key_rejected",
+            f"Tavily rejected the API key (HTTP {code}) — the FnB should rotate it "
+            f"in the GUI: Scripts → Web Search. {detail}".rstrip())
+    if code == 429:
+        return WebSearchError(429, "rate_limited", f"Tavily rate limit hit: {detail}")
+    if code == 432:
+        return WebSearchError(429, "usage_limit",
+                              f"Tavily plan usage limit reached: {detail}")
+    if code == 400:
+        return WebSearchError(400, "bad_request", f"Tavily rejected the query: {detail}")
+    return WebSearchError(502, "upstream_error", f"Tavily HTTP {code}: {detail}")
+
+
+def _normalize(raw: dict, query: str) -> dict:
+    results = []
+    for item in raw.get("results") or []:
+        if not isinstance(item, dict):
+            continue
+        results.append({
+            "title": item.get("title") or "",
+            "url": item.get("url") or "",
+            "snippet": item.get("content") or "",
+            "score": item.get("score"),
+            "published": item.get("published_date"),
+        })
+    return {
+        "provider": PROVIDER,
+        "query": query,
+        "answer": raw.get("answer") or None,
+        "results": results,
+        "response_time": raw.get("response_time"),
+    }
+
+
+def search(query: str, *, max_results: int = DEFAULT_MAX_RESULTS,
+           depth: str = "basic", api_key: str | None = None,
+           path: Path | None = None, opener=None) -> dict:
+    """One Tavily search with the stored key (or an explicit candidate key for
+    the GUI's test-before-save). Raises WebSearchError; never leaks the key."""
+    query = (query or "").strip()
+    if not query:
+        raise ValueError("query is required")
+    if not isinstance(max_results, int) or isinstance(max_results, bool) \
+            or not 1 <= max_results <= MAX_RESULTS_CAP:
+        raise ValueError(f"max_results must be an integer 1..{MAX_RESULTS_CAP}")
+    if depth not in DEPTHS:
+        raise ValueError(f"depth must be one of {', '.join(DEPTHS)}")
+    key = (api_key or "").strip() or str(_load(path).get("api_key") or "")
+    if not key:
+        raise WebSearchError(409, "unconfigured", UNCONFIGURED)
+    body = json.dumps({
+        "query": query,
+        "max_results": max_results,
+        "search_depth": depth,
+        "include_answer": True,
+    }).encode()
+    req = urllib.request.Request(TAVILY_URL, data=body, method="POST", headers={
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    })
+    opener = opener or urllib.request.urlopen
+    try:
+        with opener(req, timeout=TIMEOUT) as resp:
+            raw = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        raise _upstream_error(exc.code, exc.read(), key) from None
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        raise WebSearchError(502, "unreachable",
+                             f"Tavily unreachable: {_redact(str(exc), key)}") from None
+    if not isinstance(raw, dict):
+        raise WebSearchError(502, "upstream_error", "Tavily returned a non-object body")
+    return _normalize(raw, query)
+
+
+def validate(api_key: str | None = None, path: Path | None = None,
+             opener=None) -> dict:
+    """The GUI's test button: {ok, output}, mirroring the vm/ts check contract.
+    Tests the candidate key when given, else the stored one."""
+    try:
+        out = search(PROBE_QUERY, max_results=1, api_key=api_key, path=path,
+                     opener=opener)
+    except WebSearchError as exc:
+        return {"ok": False, "output": exc.message}
+    except ValueError as exc:
+        return {"ok": False, "output": str(exc)}
+    n = len(out["results"])
+    first = out["results"][0]["url"] if n else "(no results)"
+    return {"ok": True, "output": f"Tavily answered: {n} result(s) — {first}"}
+
+
+# -- cli ----------------------------------------------------------------------
+
+def render(payload: dict) -> str:
+    lines = []
+    if payload.get("answer"):
+        lines.append(payload["answer"].strip())
+        lines.append("")
+    results = payload.get("results") or []
+    if not results:
+        lines.append("(no results)")
+    for i, r in enumerate(results, 1):
+        lines.append(f"{i}. {r.get('title') or '(untitled)'}")
+        lines.append(f"   {r.get('url') or ''}")
+        snippet = " ".join((r.get("snippet") or "").split())
+        if snippet:
+            lines.append("   " + (snippet[:297] + "…" if len(snippet) > 300 else snippet))
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sc search",
+        description="Web search through the engine (Tavily); the key stays on the host.")
+    p.add_argument("query", nargs="+", help="what to search for")
+    p.add_argument("--max", type=int, default=DEFAULT_MAX_RESULTS,
+                   help=f"results to return, 1..{MAX_RESULTS_CAP} (default {DEFAULT_MAX_RESULTS})")
+    p.add_argument("--depth", choices=DEPTHS, default="basic",
+                   help="basic (default, fast) or advanced (deeper, slower)")
+    p.add_argument("--json", action="store_true", help="print the raw payload")
+    return p
+
+
+def main(argv: list[str]) -> int:
+    import mem
+    args = build_parser().parse_args(argv)
+    mem._PROG = "search"
+    mem._require_api()
+    payload = mem._api("POST", "/_sc/search", {
+        "query": " ".join(args.query),
+        "max_results": args.max,
+        "depth": args.depth,
+    }, idempotent=True, timeout=TIMEOUT + 10)
+    print(json.dumps(payload, indent=2) if args.json else render(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1881,6 +1881,24 @@ async function renderScripts(root) {
   vmc.append(vmbtn);
   root.append(vmc);
 
+  // Web Search — opt-in. One Tavily API key, held host-side in a 0600 file
+  // under the private instance root (never instance.json, the DB, or a
+  // render). Shells search through `./sc search` → the engine API, so the key
+  // never reaches a shell. Write-only here: status shows a last-four hint.
+  const wsc = el("div", { className: "card" });
+  wsc.append(el("h2", {}, "Web Search",
+    el("span", { className: "pill", textContent: " opt-in" })));
+  const wsStatus = el("div", { className: "muted" }, "loading…");
+  wsc.append(el("div", { className: "muted" },
+    "Give every shell `./sc search` (Tavily). The API key is stored on the host only and is never shown again once saved — " +
+    "set it, test it, rotate it, or clear it here."));
+  wsc.append(wsStatus);
+  const wsbtn = el("button", { className: "act primary", textContent: "configure…" });
+  wsbtn.onclick = () => openWebSearchModal(() => refreshWebSearchStatus(wsStatus));
+  wsc.append(wsbtn);
+  root.append(wsc);
+  refreshWebSearchStatus(wsStatus);
+
   for (const s of scripts) {
     const c = el("div", { className: "card" });
     const h = el("h2", {}, s.name);
@@ -2001,6 +2019,83 @@ async function openWinVmModal() {
     } catch (e) { toast("error: " + e.message); save.disabled = false; }
   };
   cancel.onclick = close;
+}
+
+function webSearchStatusText(st) {
+  if (!st?.configured) return "not configured — shells get a clear 'ask the FnB' error from ./sc search";
+  return `configured (${st.provider}, key ${st.key_hint || "…"}, set ${st.updated_at || "?"})`;
+}
+
+async function refreshWebSearchStatus(node) {
+  try { node.textContent = webSearchStatusText(await api("/web-search")); }
+  catch (e) { node.textContent = "status unavailable: " + e.message; }
+}
+
+// Web Search modal — set / test / rotate / clear the Tavily key. The key field
+// is write-only: the server never echoes a stored key, only its last four
+// characters. "test" probes Tavily with the in-progress key (or the stored one
+// when the field is empty) via POST /api/web-search/validate before any save.
+async function openWebSearchModal(onChange) {
+  let st = null;
+  try { st = await api("/web-search"); } catch { /* status line says so */ }
+
+  const status = el("div", { className: "muted" }, webSearchStatusText(st));
+  const input = el("input", {
+    type: "password", placeholder: "tvly-…", autocomplete: "off",
+    title: "new Tavily API key — saving replaces the current key",
+  });
+  const form = el("div", { className: "modal-form" },
+    el("span", { className: "k" }, "api_key"), input);
+  const result = el("pre", { className: "doc-body", hidden: true });
+  const note = el("div", { className: "muted" },
+    "Saving rotates: the previous key is replaced at once and the next `./sc search` uses the new one. " +
+    "Revoke the old key at Tavily yourself. Keys are stored in a mode-0600 file under the private instance state, never in the repo.");
+
+  const test = el("button", { className: "act", textContent: "test" });
+  test.onclick = async () => {
+    test.disabled = true; result.hidden = false; result.textContent = "probing Tavily…";
+    try {
+      const body = input.value.trim() ? { api_key: input.value.trim() } : {};
+      const r = await api("/web-search/validate", "POST", body);
+      result.textContent = (r.ok ? "✓ " : "✗ ") + (r.output || "(no output)");
+    } catch (e) { result.textContent = "error: " + e.message; }
+    finally { test.disabled = false; }
+  };
+
+  const clear = el("button", { className: "act", textContent: "clear key" });
+  clear.hidden = !st?.configured;
+  clear.onclick = async () => {
+    if (!confirm("Remove the stored Tavily key? Shells lose ./sc search until a new key is saved.")) return;
+    clear.disabled = true; setStatus("clearing web search key…");
+    try {
+      st = await api("/web-search", "DELETE");
+      status.textContent = webSearchStatusText(st);
+      clear.hidden = true; setStatus("web search key cleared");
+      onChange?.();
+    } catch (e) { toast("error: " + e.message); clear.disabled = false; }
+  };
+
+  const save = el("button", { className: "act primary", textContent: st?.configured ? "rotate" : "save" });
+  const cancel = el("button", { className: "act", textContent: "close" });
+  const close = openActionModal({
+    title: "Web Search (Tavily)", width: 620, height: 460,
+    bodyNode: el("div", {}, status, form,
+      el("div", { className: "modal-form-foot" }, test, clear), note, result),
+    dismissNode: cancel, actionNode: save,
+  });
+  save.onclick = async () => {
+    const key = input.value.trim();
+    if (!key) { toast("enter a key first"); return; }
+    save.disabled = true; setStatus("saving web search key…");
+    try {
+      await api("/web-search", "PUT", { api_key: key });
+      setStatus("web search key saved");
+      onChange?.();
+      close();
+    } catch (e) { toast("error: " + e.message); save.disabled = false; }
+  };
+  cancel.onclick = close;
+  input.focus();
 }
 
 // ── Map (dr_* repo catalogue) ───────────────────────────────────────────────────

--- a/docs/README.md
+++ b/docs/README.md
@@ -888,7 +888,7 @@ the FnB-facing review of a shell's UI changes, use
 ## Opt-in features
 
 > [!class2]
-> **UI** Scripts (VM wizard) · **Shells** see fork-local guidance when configured
+> **UI** Scripts (VM wizard · Web Search key) · **Shells** see fork-local guidance when configured
 
 Beyond the core loop, the engine ships **optional infrastructure**: a sidecar
 or host broker controlled by a config block in the gitignored
@@ -1238,6 +1238,39 @@ plus the host steps it prints are the whole setup. Full design:
 > verb (a systemd `--user` unit). `./sc persist` installs and enables every
 > broker linked to this fork, enables linger so they survive logout and reboot,
 > and skips the rest with a reason. Idempotent — re-run any time.
+
+### Web search (Tavily)
+
+> [!class2]
+> **UI** Scripts → **Web Search** (set · test · rotate · clear the key) · **Shells** every flavor that inherits common skills (`web_search`)
+
+Every shell gets one web search verb, on every harness:
+
+```bash
+./sc search "<query>"                    # 5 results + a short synthesized answer
+./sc search "<query>" --max 10 --depth advanced
+./sc search "<query>" --json             # answer, results[] (title, url, snippet, score)
+```
+
+The shell never holds the key. `./sc search` posts the query to the engine API
+with the shell's own bearer token; the **API process** calls Tavily with the
+instance's key and returns the results — so a sandboxed shell needs no egress
+and no credential beyond the one it already has. Nothing is persisted: no query
+log, no result cache.
+
+The key is held **host-side only**, in a mode-0600 `web_search.json` inside the
+private instance-state directory (legacy floors: `.sc-state/local/`). It is
+never written to `instance.json` (which is sandbox-readable), the engine DB,
+the snapshot, or any render, and no API response ever carries more than its
+last four characters. Set, test, rotate, and clear it from the Scripts tab:
+**Web Search → configure…**. *test* probes Tavily with the key in the field (or
+the stored one when the field is empty) before you save; *rotate* replaces the
+stored key at once, and the next `./sc search` uses it — revoking the old key
+at Tavily is yours to do. Shell credentials are refused on every config route.
+
+An unconfigured instance is not an error state: `./sc search` tells the shell
+exactly where the FnB sets the key, and the `web_search` skill tells the shell
+to say so rather than improvise a key of its own.
 
 ## Review GUI
 

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -847,7 +847,7 @@
       ".super-coder/scripts/dispatch.sh": [
         "./sc sprint <cmd>        authenticated Sprints v2 actions (run without a command for the full verb list)",
         "sprint)       sc_python_probe; exec \"$PY\" \"$S/sprint_cli.py\" \"$@\" ;;",
-        "Memory & catalogue    mem · map · map-sql · map-schema · sql · skill · models · job · pr · sprint · token"
+        "Memory & catalogue    mem · map · map-sql · map-schema · sql · skill · search · models · job · pr · sprint · token"
       ]
     },
     "forbidden_pattern": "(?:\\bsprints?\\b|\\bconductor\\b|SC_SPRINT_|pr_event|watched_prs|watch-daemon|interface_(?:generations|sessions|writer_leases|input_state|idempotency_keys|recovery_observations)|planner_(?:wake_batches|wake_items|action_receipts|alerts))",

--- a/tests/test_modal_ui_contract.py
+++ b/tests/test_modal_ui_contract.py
@@ -143,7 +143,7 @@ console.log(JSON.stringify({
 
 def test_all_modal_callers_use_semantic_action_or_named_viewer_slots():
     assert "footNodes" not in APP
-    assert APP.count("const close = openActionModal({") == 6
+    assert APP.count("const close = openActionModal({") == 7
     assert APP.count("footerStart:") == 5  # helper + four viewer callers
     assert APP.count("footerEnd:") == 5
     assert "if (overlay?.closeModal) overlay.closeModal();" in APP

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Web search (Tavily) — key store, client, API routes, CLI (spec doc #215).
+
+The contract under test:
+  • the key lives in ONE 0600 file and never appears in status, API responses,
+    error text, or instance.json;
+  • rotation replaces the file atomically and the next search reads the new key;
+  • browser-operator routes refuse shell credentials and cross-origin mutations;
+  • /_sc/search is shell-token scoped and forwards secret-free failures at the
+    status web_search chose;
+  • `./sc search` renders the payload and is registered in the dispatcher.
+
+Run:
+    python3 tests/test_web_search.py
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sqlite3
+import stat
+import sys
+import tempfile
+import unittest
+import urllib.error
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / ".super-coder"
+sys.path.insert(0, str(ENGINE / "api"))
+sys.path.insert(0, str(ENGINE / "scripts"))
+import server
+import web_search
+
+KEY = "tvly-secret-key-1234abcd"
+NEW_KEY = "tvly-rotated-key-9999wxyz"
+
+
+class _Resp(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+def opener_returning(payload: dict):
+    calls = []
+
+    def opener(req, timeout=None):
+        calls.append(req)
+        return _Resp(json.dumps(payload).encode())
+
+    opener.calls = calls
+    return opener
+
+
+def opener_failing(code: int, body: bytes = b""):
+    def opener(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, code, "err", {}, io.BytesIO(body))
+    return opener
+
+
+TAVILY_OK = {
+    "query": "q",
+    "answer": "An answer.",
+    "response_time": 1.2,
+    "results": [
+        {"title": "One", "url": "https://one.example", "content": "first hit",
+         "score": 0.9, "published_date": "2026-01-01"},
+        {"title": "Two", "url": "https://two.example", "content": "second hit",
+         "score": 0.5},
+    ],
+}
+
+
+class StoreTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "web_search.json"
+
+    def test_unconfigured_status(self):
+        self.assertEqual(web_search.status(self.path), {
+            "configured": False, "provider": "tavily",
+            "key_hint": None, "updated_at": None,
+        })
+
+    def test_write_is_0600_and_status_hides_the_key(self):
+        st = web_search.write(KEY, self.path)
+        mode = stat.S_IMODE(os.stat(self.path).st_mode)
+        self.assertEqual(mode, 0o600)
+        self.assertTrue(st["configured"])
+        self.assertEqual(st["key_hint"], "…abcd")
+        self.assertIsNotNone(st["updated_at"])
+        self.assertNotIn(KEY, json.dumps(st))
+        self.assertEqual(json.loads(self.path.read_text())["api_key"], KEY)
+        self.assertEqual(sorted(os.listdir(self.tmp.name)), ["web_search.json"],
+                         "no temp inode left behind")
+
+    def test_rotate_replaces_the_key(self):
+        web_search.write(KEY, self.path)
+        st = web_search.write(NEW_KEY, self.path)
+        raw = self.path.read_text()
+        self.assertIn(NEW_KEY, raw)
+        self.assertNotIn(KEY, raw)
+        self.assertEqual(st["key_hint"], "…wxyz")
+
+    def test_clear_removes_the_file(self):
+        web_search.write(KEY, self.path)
+        st = web_search.clear(self.path)
+        self.assertFalse(self.path.exists())
+        self.assertFalse(st["configured"])
+        # idempotent
+        self.assertFalse(web_search.clear(self.path)["configured"])
+
+    def test_write_rejects_blank_and_whitespace(self):
+        for bad in ("", "   ", "tvly abc", "tvly\nabc"):
+            with self.assertRaises(ValueError):
+                web_search.write(bad, self.path)
+        self.assertFalse(self.path.exists())
+
+    def test_symlink_store_is_refused(self):
+        target = Path(self.tmp.name) / "elsewhere.json"
+        target.write_text("{}")
+        self.path.symlink_to(target)
+        with self.assertRaises(web_search.WebSearchError):
+            web_search.status(self.path)
+        with self.assertRaises(web_search.WebSearchError):
+            web_search.write(KEY, self.path)
+        with self.assertRaises(web_search.WebSearchError):
+            web_search.clear(self.path)
+        self.assertTrue(self.path.is_symlink(), "clear must not follow a symlink")
+        self.assertTrue(target.exists())
+
+    def test_store_path_lives_under_private_state_not_instance_json(self):
+        path = web_search.store_path()
+        self.assertEqual(path.name, "web_search.json")
+        self.assertNotEqual(path.parent, ENGINE)
+        self.assertNotIn("instance.json", str(path))
+
+
+class ClientTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "web_search.json"
+        web_search.write(KEY, self.path)
+
+    def test_search_sends_bearer_and_normalizes(self):
+        opener = opener_returning(TAVILY_OK)
+        out = web_search.search("q", max_results=2, depth="advanced",
+                                path=self.path, opener=opener)
+        req = opener.calls[0]
+        self.assertEqual(req.full_url, web_search.TAVILY_URL)
+        self.assertEqual(req.get_header("Authorization"), f"Bearer {KEY}")
+        self.assertEqual(json.loads(req.data), {
+            "query": "q", "max_results": 2, "search_depth": "advanced",
+            "include_answer": True,
+        })
+        self.assertEqual(out["answer"], "An answer.")
+        self.assertEqual([r["url"] for r in out["results"]],
+                         ["https://one.example", "https://two.example"])
+        self.assertEqual(out["results"][0]["snippet"], "first hit")
+        self.assertEqual(out["results"][0]["published"], "2026-01-01")
+        self.assertIsNone(out["results"][1]["published"])
+        self.assertNotIn(KEY, json.dumps(out))
+
+    def test_candidate_key_wins_over_stored(self):
+        opener = opener_returning(TAVILY_OK)
+        web_search.search("q", api_key=NEW_KEY, path=self.path, opener=opener)
+        self.assertEqual(opener.calls[0].get_header("Authorization"),
+                         f"Bearer {NEW_KEY}")
+
+    def test_unconfigured_is_409_naming_the_gui(self):
+        web_search.clear(self.path)
+        with self.assertRaises(web_search.WebSearchError) as cm:
+            web_search.search("q", path=self.path, opener=opener_returning({}))
+        self.assertEqual((cm.exception.status, cm.exception.code),
+                         (409, "unconfigured"))
+        self.assertIn("Scripts → Web Search", cm.exception.message)
+
+    def test_rejected_key_is_502_and_redacted(self):
+        body = json.dumps({"detail": {"error": f"bad key {KEY}"}}).encode()
+        with self.assertRaises(web_search.WebSearchError) as cm:
+            web_search.search("q", path=self.path, opener=opener_failing(401, body))
+        self.assertEqual((cm.exception.status, cm.exception.code),
+                         (502, "key_rejected"))
+        self.assertIn("rotate", cm.exception.message)
+        self.assertNotIn(KEY, cm.exception.message)
+
+    def test_limits_map_to_429(self):
+        for code, expect in ((429, "rate_limited"), (432, "usage_limit")):
+            with self.assertRaises(web_search.WebSearchError) as cm:
+                web_search.search("q", path=self.path,
+                                  opener=opener_failing(code, b"limit"))
+            self.assertEqual((cm.exception.status, cm.exception.code),
+                             (429, expect))
+
+    def test_network_failure_is_502_unreachable(self):
+        def opener(req, timeout=None):
+            raise urllib.error.URLError(f"dns down for {KEY}")
+        with self.assertRaises(web_search.WebSearchError) as cm:
+            web_search.search("q", path=self.path, opener=opener)
+        self.assertEqual((cm.exception.status, cm.exception.code),
+                         (502, "unreachable"))
+        self.assertNotIn(KEY, cm.exception.message)
+
+    def test_argument_validation(self):
+        opener = opener_returning(TAVILY_OK)
+        for kwargs in ({"max_results": 0}, {"max_results": 21},
+                       {"max_results": True}, {"depth": "deep"}):
+            with self.assertRaises(ValueError):
+                web_search.search("q", path=self.path, opener=opener, **kwargs)
+        with self.assertRaises(ValueError):
+            web_search.search("   ", path=self.path, opener=opener)
+        self.assertEqual(opener.calls, [])
+
+    def test_validate_reports_ok_and_failure_without_raising(self):
+        ok = web_search.validate(path=self.path, opener=opener_returning(TAVILY_OK))
+        self.assertTrue(ok["ok"])
+        self.assertIn("https://one.example", ok["output"])
+        bad = web_search.validate(api_key="tvly-nope-00000000", path=self.path,
+                                  opener=opener_failing(401, b"{}"))
+        self.assertFalse(bad["ok"])
+        self.assertIn("rejected", bad["output"])
+        web_search.clear(self.path)
+        none = web_search.validate(path=self.path, opener=opener_returning({}))
+        self.assertFalse(none["ok"])
+        self.assertIn("not configured", none["output"])
+
+
+def _build_file_db(path: Path) -> None:
+    source = sqlite3.connect(":memory:")
+    source.executescript((ENGINE / "schema.sql").read_text())
+    for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+        source.executescript(migration.read_text())
+    source.execute("INSERT INTO users (user_id,username,is_active) VALUES (1,'operator',1)")
+    source.execute(
+        "INSERT INTO shells (display_name, system_prompt, flavor, shortname, api_key) "
+        "VALUES ('Dev', 'x', 'dev', 'dev', 'shell-token')")
+    source.commit()
+    target = sqlite3.connect(path)
+    source.backup(target)
+    target.close()
+    source.close()
+
+
+class ApiRouteTest(unittest.TestCase):
+    """Routes through server.dispatch_http with the Tavily call mocked."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.db_path = Path(self.tmp.name) / "engine.db"
+        _build_file_db(self.db_path)
+        self.store = Path(self.tmp.name) / "web_search.json"
+        patcher = mock.patch.object(web_search, "store_path", return_value=self.store)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def connect(self):
+        con = sqlite3.connect(self.db_path)
+        con.row_factory = sqlite3.Row
+        return con
+
+    def request(self, method, path, *, token=None, body=None, origin=None,
+                opener=None):
+        raw = json.dumps(body).encode() if body is not None else b""
+        lines = ["Host: 127.0.0.1:8800", f"Content-Length: {len(raw)}"]
+        if token:
+            lines.append(f"Authorization: Bearer {token}")
+        if origin:
+            lines.append(f"Origin: {origin}")
+            lines.append("Sec-Fetch-Site: same-origin")
+        patches = [mock.patch.object(server, "db", side_effect=self.connect)]
+        if opener is not None:
+            patches.append(mock.patch.object(
+                web_search.urllib.request, "urlopen", side_effect=opener))
+        for p in patches:
+            p.start()
+        try:
+            status, _headers, out = server.dispatch_http(
+                method, path, "\r\n".join(lines), raw)
+        finally:
+            for p in patches:
+                p.stop()
+        return status, json.loads(out)
+
+    SAME = "http://127.0.0.1:8800"
+
+    def test_status_unconfigured_then_set_rotate_clear(self):
+        status, body = self.request("GET", "/api/web-search")
+        self.assertEqual(status, 200)
+        self.assertFalse(body["configured"])
+
+        status, body = self.request("PUT", "/api/web-search",
+                                    body={"api_key": KEY}, origin=self.SAME)
+        self.assertEqual(status, 200, body)
+        self.assertEqual(body["key_hint"], "…abcd")
+        self.assertNotIn(KEY, json.dumps(body))
+        self.assertEqual(stat.S_IMODE(os.stat(self.store).st_mode), 0o600)
+
+        status, body = self.request("PUT", "/api/web-search",
+                                    body={"api_key": NEW_KEY}, origin=self.SAME)
+        self.assertEqual(status, 200)
+        self.assertEqual(body["key_hint"], "…wxyz")
+        self.assertNotIn(KEY, self.store.read_text())
+
+        status, body = self.request("GET", "/api/web-search")
+        self.assertTrue(body["configured"])
+        self.assertNotIn(NEW_KEY, json.dumps(body))
+
+        status, body = self.request("DELETE", "/api/web-search", origin=self.SAME)
+        self.assertEqual(status, 200)
+        self.assertFalse(body["configured"])
+        self.assertFalse(self.store.exists())
+
+    def test_put_validation(self):
+        status, _body = self.request("PUT", "/api/web-search",
+                                     body={"api_key": "  "}, origin=self.SAME)
+        self.assertEqual(status, 400)
+        status, _body = self.request("PUT", "/api/web-search",
+                                     body={"api_key": 5}, origin=self.SAME)
+        self.assertEqual(status, 400)
+        self.assertFalse(self.store.exists())
+
+    def test_shell_credentials_are_refused_on_config_routes(self):
+        for method, body in (("GET", None), ("PUT", {"api_key": KEY}),
+                             ("DELETE", None)):
+            status, out = self.request(method, "/api/web-search", token="shell-token",
+                                       body=body, origin=self.SAME)
+            self.assertEqual(status, 403, (method, out))
+            self.assertEqual(out["error"]["code"], "fnb_operator_required")
+            self.assertIn("web search config", out["error"]["message"])
+        status, out = self.request("POST", "/api/web-search/validate",
+                                   token="shell-token", body={})
+        self.assertEqual(status, 403)
+        self.assertFalse(self.store.exists())
+
+    def test_cross_origin_mutation_is_refused(self):
+        status, out = self.request("PUT", "/api/web-search", body={"api_key": KEY},
+                                   origin="https://attacker.example")
+        self.assertEqual(status, 403)
+        self.assertEqual(out["error"]["code"], "same_origin_required")
+        self.assertFalse(self.store.exists())
+        status, out = self.request("DELETE", "/api/web-search",
+                                   origin="https://attacker.example")
+        self.assertEqual(status, 403)
+
+    def test_validate_probes_candidate_then_stored_key(self):
+        seen = []
+
+        def opener(req, timeout=None):
+            seen.append(req.get_header("Authorization"))
+            return _Resp(json.dumps(TAVILY_OK).encode())
+
+        status, out = self.request("POST", "/api/web-search/validate",
+                                   body={"api_key": NEW_KEY}, opener=opener)
+        self.assertEqual(status, 200)
+        self.assertTrue(out["ok"])
+        self.assertEqual(seen, [f"Bearer {NEW_KEY}"])
+        self.assertFalse(self.store.exists(), "test never saves")
+
+        web_search.write(KEY, self.store)
+        status, out = self.request("POST", "/api/web-search/validate", body={},
+                                   opener=opener)
+        self.assertTrue(out["ok"])
+        self.assertEqual(seen[-1], f"Bearer {KEY}")
+
+        def bad(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 401, "x", {}, io.BytesIO(b"{}"))
+        status, out = self.request("POST", "/api/web-search/validate", body={},
+                                   opener=bad)
+        self.assertEqual(status, 200)
+        self.assertFalse(out["ok"])
+        self.assertNotIn(KEY, out["output"])
+
+    def test_shell_search_requires_token(self):
+        status, _out = self.request("POST", "/_sc/search", body={"query": "q"})
+        self.assertEqual(status, 401)
+        status, _out = self.request("POST", "/_sc/search", token="wrong",
+                                    body={"query": "q"})
+        self.assertEqual(status, 401)
+
+    def test_shell_search_unconfigured_is_409(self):
+        status, out = self.request("POST", "/_sc/search", token="shell-token",
+                                   body={"query": "q"})
+        self.assertEqual(status, 409)
+        self.assertEqual(out["code"], "unconfigured")
+        self.assertIn("Scripts → Web Search", out["error"])
+
+    def test_shell_search_returns_results_and_forwards_failures(self):
+        web_search.write(KEY, self.store)
+        status, out = self.request(
+            "POST", "/_sc/search", token="shell-token",
+            body={"query": "q", "max_results": 2, "depth": "basic"},
+            opener=opener_returning(TAVILY_OK))
+        self.assertEqual(status, 200)
+        self.assertEqual(len(out["results"]), 2)
+        self.assertNotIn(KEY, json.dumps(out))
+
+        status, out = self.request("POST", "/_sc/search", token="shell-token",
+                                   body={"query": "q", "max_results": 99})
+        self.assertEqual(status, 400)
+        self.assertEqual(out["code"], "bad_request")
+
+        status, out = self.request("POST", "/_sc/search", token="shell-token",
+                                   body={"query": "q"},
+                                   opener=opener_failing(401, b"{}"))
+        self.assertEqual(status, 502)
+        self.assertEqual(out["code"], "key_rejected")
+        self.assertNotIn(KEY, out["error"])
+
+    def test_config_status_needs_an_active_operator(self):
+        with self.connect() as con:
+            con.execute("UPDATE users SET is_active=0")
+        status, _out = self.request("GET", "/api/web-search")
+        self.assertEqual(status, 401)
+
+
+class CliTest(unittest.TestCase):
+    def test_render_lists_answer_and_results(self):
+        text = web_search.render(web_search._normalize(TAVILY_OK, "q"))
+        self.assertTrue(text.startswith("An answer."))
+        self.assertIn("1. One\n   https://one.example\n   first hit", text)
+        self.assertIn("2. Two", text)
+        self.assertEqual(web_search.render({"results": []}), "(no results)")
+
+    def test_main_posts_through_the_api_lane(self):
+        import mem
+        calls = []
+
+        def fake_api(method, path, payload=None, **kw):
+            calls.append((method, path, payload, kw))
+            return web_search._normalize(TAVILY_OK, "two words")
+
+        buf = io.StringIO()
+        with (
+            mock.patch.object(mem, "_require_api", return_value=None),
+            mock.patch.object(mem, "_api", side_effect=fake_api),
+            redirect_stdout(buf),
+        ):
+            rc = web_search.main(["two", "words", "--max", "7", "--depth", "advanced"])
+        self.assertEqual(rc, 0)
+        method, path, payload, kw = calls[0]
+        self.assertEqual((method, path), ("POST", "/_sc/search"))
+        self.assertEqual(payload, {"query": "two words", "max_results": 7,
+                                   "depth": "advanced"})
+        self.assertTrue(kw.get("idempotent"))
+        self.assertIn("1. One", buf.getvalue())
+
+        buf = io.StringIO()
+        with (
+            mock.patch.object(mem, "_require_api", return_value=None),
+            mock.patch.object(mem, "_api", side_effect=fake_api),
+            redirect_stdout(buf),
+        ):
+            web_search.main(["--json", "q"])
+        self.assertEqual(json.loads(buf.getvalue())["answer"], "An answer.")
+
+    def test_dispatcher_registers_the_verb(self):
+        text = (ENGINE / "scripts" / "dispatch.sh").read_text()
+        self.assertIn('search)       exec "$PY" "$S/web_search.py" "$@" ;;', text)
+        gate = next(line for line in text.splitlines()
+                    if line.strip().startswith("install|ensure-harness|doctor|"))
+        self.assertIn("|search|", gate)
+
+    def test_skill_asset_is_common_and_names_the_verb(self):
+        text = (ENGINE / "assets" / "skills" / "web_search" / "SKILL.md").read_text()
+        self.assertIn("command: sc search", text)
+        self.assertIn("common: true", text)
+        self.assertIn("Scripts → Web Search", text)
+        seed = (ENGINE / "migrations" / "0001_seed_skills.sql").read_text()
+        self.assertIn("'web_search',", seed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Feature #69 · spec doc #215 · decision #316.

Every shell gets one web search verb, on every harness:

```bash
./sc search "<query>" [--max N] [--depth basic|advanced] [--json]
```

- **Shell lane:** `sc search` → `POST /_sc/search` (shell bearer token). The API process calls Tavily with the instance's key and returns `answer` + `results[]` (title, url, snippet, score). The shell never holds the key; a sandboxed shell needs no egress.
- **Key store:** one mode-0600 `web_search.json` in the private instance-state root (legacy floors: `.sc-state/local/`). Never `instance.json` (sandbox-readable, no-secrets by design), never the engine DB / snapshot / render. Status returns at most the last four characters.
- **GUI:** Scripts tab → **Web Search → configure…**: status, write-only key field, **test** (`POST /api/web-search/validate` probes Tavily with the in-progress key, or the stored one when empty), **save / rotate** (`PUT /api/web-search`, atomic replace, next search reads it, no restart), **clear key** (`DELETE`). All four are browser-operator + same-origin only; shell credentials get 403.
- **Failure paths are distinct and secret-free:** unconfigured → 409 naming *GUI → Scripts → Web Search*; key rejected upstream → 502 "rotate it"; Tavily 429/432 → 429; network → 502. Error text is redacted of the key.
- **Skill:** common engine skill `web_search` (`command: sc search`), seed regenerated (only the new row changed).
- **Docs:** "Web search (Tavily)" section under Opt-in features.

## Trade-offs stated

- `_require_browser_operator` / `_require_browser_mutation_origin` gained a `what` label (default unchanged) so the new routes don't claim "the Sprint board is owned by…". Smallest change that keeps the existing gate.
- No `./sc feature` registry entry and no CLI key-setting verb: the GUI is the only write surface this delivery (the Admin can hand-write the 0600 file). The registry's tests pin it to infrastructure blocks in `instance.json`, which this deliberately is not.
- Tavily `extract`/`crawl` and other providers are out of scope; the store carries `provider` so a second one needs no re-key.

## Verification

- `tests/test_web_search.py` (28 tests): store mode/hint/rotate/clear/symlink refusal, client bearer + normalization + every failure mapping + redaction, all routes incl. auth/origin refusals, CLI render + API lane, dispatcher + skill asset registration.
- Neighbouring suites green: `test_api_endpoints`, `test_sprint_board_api`, `test_feature`, `test_skills_freshness`, `test_skill_projection`, `test_flavor_skill_packs`, `test_skill_tombstones`, `test_skill_convergence_fixture`, `test_sprint_skills` — 233 passed.
- End-to-end against a loopback stand-in of the engine API (dispatch_http + throwaway DB, Tavily stubbed): `sc search` unconfigured → 409 message, bad token → 401, configured → rendered results and `--json`, `--max 50` → 400; `curl` of GET/PUT/validate and the 403 for a shell token.
- **Not verified:** a real Tavily call — no key on this host. The FnB sets one in the GUI after merge + reconcile + restart, then `./sc search "…"` from any shell is the live proof.
- ruff on the new files: clean except the repo-wide `EXE001` shebang finding that every neighbour carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBixbwRYebUc3CUWQZiGpT
