### PR TITLE
feat(sprint): approval binds to the PR, verdicts open a fresh chat, eight-round ceiling pauses

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -3785,6 +3785,7 @@ class Handler(BaseHTTPRequestHandler):
                     "wake_id": receipt.wake_id,
                     "disposition": receipt.disposition,
                     "created": receipt.created,
+                    "sprint_paused": receipt.sprint_paused,
                 })
             if path == "/_sc/sprint/merge-authorize":
                 authorization = sprint_review_loop.SprintReviewLoopStore(

--- a/.super-coder/assets/skills/sprint_close/SKILL.md
+++ b/.super-coder/assets/skills/sprint_close/SKILL.md
@@ -38,8 +38,8 @@ changed it or the next command requires live revalidation.
 - **FnB directs a fallback or follow-up disposition.** Use the bounded surfaces
   below and name FnB authority in the evidence.
 
-Assignments and review requests use Force-new delivery; role results use
-Re-enter. Neither displaces a live turn; the runtime owns delivery, rotation,
+Assignments, review requests, and verdicts use Force-new delivery; Planner-bound
+results and PR events use Re-enter. Neither displaces a live turn; the runtime owns delivery, rotation,
 and recovery. A successful typed handoff is the last action of that role's
 turn.
 

--- a/.super-coder/assets/skills/sprint_dev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_dev/SKILL.md
@@ -38,7 +38,7 @@ name the defect next handoff. NEVER infer assignment ownership, review outcome,
 merge authorization, lifecycle/work-unit transition, governing revision, PR
 head/green state, or cleanup authority. An unproved postcondition stops.
 
-Assignments and review requests use Force-new delivery; verdicts and PR-event
+Assignments, review requests, and verdicts use Force-new delivery; PR-event
 wakes use Re-enter. Delivery waits for a natural boundary; the runtime owns
 bundling, rotation, and recovery. Stop after a successful typed handoff.
 
@@ -171,8 +171,10 @@ Complete each round in order:
    the PR URL, registered id, exact green head, and work-unit id into the
    Reviewer's canonical bare one-line locator. Create no readiness file. Send
    no scope narrative, verification evidence, rationale, or review-focus
-   steering. Put only the work-unit id and spec reference in the PR body; write
-   no PR comments or annotations.
+   steering in the request. The PR body carries the work-unit id and spec
+   reference plus your rationale (decisions, rejected trade-offs): each verdict
+   opens a fresh chat with only GitHub to read. Write no PR comments or
+   annotations.
 4. As the literal final action, run:
 
 ```text
@@ -184,24 +186,25 @@ sc sprint request-review \
 5. Require confirmation of the durable write + Reviewer wake; run no trailing
    command and stop and await the native verdict wake.
 
-Changes requested returns by Re-enter. Apply every blocking finding,
-re-establish green, and resubmit with a new review-round key. Do not narrate
-cleared findings; the Reviewer verifies the full diff at the engine-injected
-head. Record disagreements as judgment. Reviewer owns scope/severity; Planner
+Changes requested arrives as a fresh chat: orient from the PR body, diff, and
+verdict; do not re-litigate choices the rationale explains. Apply every
+blocking finding, re-establish green, and resubmit with a new review-round key.
+Do not narrate cleared findings; the Reviewer verifies the full diff. Record disagreements as judgment. Reviewer owns scope/severity; Planner
 executes resulting action.
 
 ## Merge boundary
 
-Approval is stale evidence. Immediately before merge, re-read live GitHub,
-grant, ownership, unit state, approved head, and checks through:
+Immediately before merge, re-read live GitHub, grant, ownership, unit state,
+and checks through:
 
 ```text
 sc sprint authorize-merge \
   --sprint <id> --registered-pr <registered-id>
 ```
 
-Merge only the returned repository, PR, and head SHA. A refusal means wait for
-the watcher or re-enter the appropriate loop; never bypass it.
+Merge only the returned repository, PR, and head SHA. A refusal means not
+green, not approved, or not yours; fix that, never bypass it. A rebase does not
+undo approval.
 
 ## Post-merge handoff
 

--- a/.super-coder/assets/skills/sprint_pln/SKILL.md
+++ b/.super-coder/assets/skills/sprint_pln/SKILL.md
@@ -74,8 +74,8 @@ Do not poll. Armed runtime owns scheduled dispatch + unread wake recovery;
 registered-PR watcher owns subscription observation. Developer-owned subscriptions send
 red/green/closed/merged facts to Developers, never Planner.
 
-Assignments/review requests use Force-new delivery; Planner-bound results use
-Re-enter. Delivery waits for a natural boundary; runtime owns bundling,
+Assignments, review requests, and verdicts use Force-new delivery;
+Planner-bound results use Re-enter. Delivery waits for a natural boundary; runtime owns bundling,
 rotation, recovery, and coordinate mode. Stop after a successful typed handoff.
 
 ## Durable running loop

--- a/.super-coder/assets/skills/sprint_rev/SKILL.md
+++ b/.super-coder/assets/skills/sprint_rev/SKILL.md
@@ -55,7 +55,7 @@ recovery to infer assignment ownership, review outcome, merge authorization,
 lifecycle/work-unit transition, governing revision, PR head/green state, or
 cleanup authority. An unproved postcondition stops.
 
-Review requests use Force-new delivery. Verdicts and Planner decisions use
+Review requests and verdicts use Force-new delivery. Planner decisions use
 Re-enter. Delivery waits for a natural boundary; the runtime owns bundling,
 rotation, and recovery. Stop after a successful typed handoff. Reviewers never
 receive PR-event wakes.
@@ -152,8 +152,9 @@ verification, rationale, or focus steering is a protocol defect. PR comments
 and annotations are forbidden; PR body contains only unit id + spec reference.
 
 Bind inspection/verdict to the accepted request's message id, registered PR,
-work unit, and exact head. Review each request explicitly. Read the exact spec
-revision + full diff at that head, then checks, tests, relevant runtime facts,
+and work unit. Review the live PR head; a rebase since the locator's head is
+not a defect. Read the exact spec revision + full diff, then checks, tests,
+relevant runtime facts,
 and ratified judgments. Each round is clean: no prior Developer evidence or
 prose; prior findings clear only when the new head proves it. Trace code paths,
 failure cases, and spec behavior rather than names or PR prose.
@@ -191,11 +192,11 @@ sc sprint record-review \
   --verdict changes_requested --body-file <path> --key <stable-key>
 ```
 
-5. Require durable judgment evidence + Developer Re-enter wake. Run no trailing command;
+5. Require durable judgment evidence + Developer Force-new wake. Run no trailing command;
    stop.
 
 Use `approved` only with no Critical/Major/Medium finding. Engine validation
-requires the accepted request and reviewed head. Do not message around the
+requires the accepted request. Do not message around the
 surface; an unrecorded verdict cannot unlock merge.
 
 ## Delivery-terminal closeout

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1688,6 +1688,10 @@ The launcher auto-syncs at boot when provably nothing can be lost (on base branc
    ```
 3. Push -> open a PR -> stop. Do NOT merge without an explicit FnB directive — opening is the default, merging is a separate gate.
 
+## The engine watches your PR — you don''t
+
+Nothing to enrol. The installation watcher sees which branch your worktree has checked out and subscribes you to the newest PR on it within about a minute of it existing. From then on it wakes you with a self-describing Re-enter fact — inside or outside a Sprint — on red checks, merge, close-without-merge, and red-to-green recovery. Never poll GitHub, schedule a watcher, or ask another shell to relay; stop on the pushed PR and let the fact come to you. Opened the PR from a branch that is not your worktree''s checkout? Enrol it by hand: `sc pr subscribe --repository <owner/name> --pr <number>`. A Sprint lane runs `sc sprint register-pr` (same owner subscription; attaches if discovery got there first).
+
 ## Merging a stack (only when the FnB hands you one)
 
 Merge bottom-up, retargeting before each merge — never rely on GitHub''s auto-retarget:
@@ -1715,7 +1719,9 @@ Pass = tree clean, or on a pushed branch with a PR. A dirty/unpushed tree forces
 
 ## After a merge — clean up local
 
-Only after the PR is merged:
+Only after the PR is merged. The `event=merged` wake from your subscription is
+what starts this; confirm it on the remote (`gh pr view <n> --json state,mergedAt`)
+before deleting anything:
 
 A managed worktree whose Sprint is already `completed` is the exception: the
 Sprint cleanup service owns its reset after live turns exit. Do not race that
@@ -2884,8 +2890,8 @@ changed it or the next command requires live revalidation.
 - **FnB directs a fallback or follow-up disposition.** Use the bounded surfaces
   below and name FnB authority in the evidence.
 
-Assignments and review requests use Force-new delivery; role results use
-Re-enter. Neither displaces a live turn; the runtime owns delivery, rotation,
+Assignments, review requests, and verdicts use Force-new delivery; Planner-bound
+results and PR events use Re-enter. Neither displaces a live turn; the runtime owns delivery, rotation,
 and recovery. A successful typed handoff is the last action of that role''s
 turn.
 
@@ -3025,7 +3031,7 @@ name the defect next handoff. NEVER infer assignment ownership, review outcome,
 merge authorization, lifecycle/work-unit transition, governing revision, PR
 head/green state, or cleanup authority. An unproved postcondition stops.
 
-Assignments and review requests use Force-new delivery; verdicts and PR-event
+Assignments, review requests, and verdicts use Force-new delivery; PR-event
 wakes use Re-enter. Delivery waits for a natural boundary; the runtime owns
 bundling, rotation, and recovery. Stop after a successful typed handoff.
 
@@ -3120,11 +3126,13 @@ sc sprint register-pr --sprint <id> --repository <owner/name> \
 
 Register complete code even when a local gate is unavailable; registration
 obtains evidence, not review. After `register-pr` succeeds, retain ownership;
-Red/green/closed Re-enter wakes continue. Required checks: pending -> native
+Red/green/closed/merged Re-enter wakes continue (the engine may already have
+discovered the PR from your worktree branch; `register-pr` attaches it). Required checks: pending -> native
 wake; red -> fix/push; green -> judge/request review; none or untrustworthy
 watcher after one bounded read -> report + block. Follow context: armed -> fix
-red + judge/pass green; paused -> fix red now + judge green, review after
-resume; no active Sprint -> fix red if needed + no action on green.
+red + judge/pass green + merged -> post-merge handoff; paused -> fix red now +
+judge green, review after resume; no active Sprint -> fix red if needed, green
+arrives only as red recovery, merged -> git skill after-merge cleanup.
 Planner/Reviewer get none.
 
 If the same registered PR was externally closed, then reopened, rebased, and
@@ -3156,8 +3164,10 @@ Complete each round in order:
    the PR URL, registered id, exact green head, and work-unit id into the
    Reviewer''s canonical bare one-line locator. Create no readiness file. Send
    no scope narrative, verification evidence, rationale, or review-focus
-   steering. Put only the work-unit id and spec reference in the PR body; write
-   no PR comments or annotations.
+   steering in the request. The PR body carries the work-unit id and spec
+   reference plus your rationale (decisions, rejected trade-offs): each verdict
+   opens a fresh chat with only GitHub to read. Write no PR comments or
+   annotations.
 4. As the literal final action, run:
 
 ```text
@@ -3169,24 +3179,25 @@ sc sprint request-review \
 5. Require confirmation of the durable write + Reviewer wake; run no trailing
    command and stop and await the native verdict wake.
 
-Changes requested returns by Re-enter. Apply every blocking finding,
-re-establish green, and resubmit with a new review-round key. Do not narrate
-cleared findings; the Reviewer verifies the full diff at the engine-injected
-head. Record disagreements as judgment. Reviewer owns scope/severity; Planner
+Changes requested arrives as a fresh chat: orient from the PR body, diff, and
+verdict; do not re-litigate choices the rationale explains. Apply every
+blocking finding, re-establish green, and resubmit with a new review-round key.
+Do not narrate cleared findings; the Reviewer verifies the full diff. Record disagreements as judgment. Reviewer owns scope/severity; Planner
 executes resulting action.
 
 ## Merge boundary
 
-Approval is stale evidence. Immediately before merge, re-read live GitHub,
-grant, ownership, unit state, approved head, and checks through:
+Immediately before merge, re-read live GitHub, grant, ownership, unit state,
+and checks through:
 
 ```text
 sc sprint authorize-merge \
   --sprint <id> --registered-pr <registered-id>
 ```
 
-Merge only the returned repository, PR, and head SHA. A refusal means wait for
-the watcher or re-enter the appropriate loop; never bypass it.
+Merge only the returned repository, PR, and head SHA. A refusal means not
+green, not approved, or not yours; fix that, never bypass it. A rebase does not
+undo approval.
 
 ## Post-merge handoff
 
@@ -3294,10 +3305,10 @@ Load `sprint_pln` on every entry, then classify:
 
 Do not poll. Armed runtime owns scheduled dispatch + unread wake recovery;
 registered-PR watcher owns subscription observation. Developer-owned subscriptions send
-red/green/closed facts to Developers, never Planner.
+red/green/closed/merged facts to Developers, never Planner.
 
-Assignments/review requests use Force-new delivery; Planner-bound results use
-Re-enter. Delivery waits for a natural boundary; runtime owns bundling,
+Assignments, review requests, and verdicts use Force-new delivery;
+Planner-bound results use Re-enter. Delivery waits for a natural boundary; runtime owns bundling,
 rotation, recovery, and coordinate mode. Stop after a successful typed handoff.
 
 ## Durable running loop
@@ -3903,7 +3914,7 @@ recovery to infer assignment ownership, review outcome, merge authorization,
 lifecycle/work-unit transition, governing revision, PR head/green state, or
 cleanup authority. An unproved postcondition stops.
 
-Review requests use Force-new delivery. Verdicts and Planner decisions use
+Review requests and verdicts use Force-new delivery. Planner decisions use
 Re-enter. Delivery waits for a natural boundary; the runtime owns bundling,
 rotation, and recovery. Stop after a successful typed handoff. Reviewers never
 receive PR-event wakes.
@@ -4000,8 +4011,9 @@ verification, rationale, or focus steering is a protocol defect. PR comments
 and annotations are forbidden; PR body contains only unit id + spec reference.
 
 Bind inspection/verdict to the accepted request''s message id, registered PR,
-work unit, and exact head. Review each request explicitly. Read the exact spec
-revision + full diff at that head, then checks, tests, relevant runtime facts,
+and work unit. Review the live PR head; a rebase since the locator''s head is
+not a defect. Read the exact spec revision + full diff, then checks, tests,
+relevant runtime facts,
 and ratified judgments. Each round is clean: no prior Developer evidence or
 prose; prior findings clear only when the new head proves it. Trace code paths,
 failure cases, and spec behavior rather than names or PR prose.
@@ -4039,11 +4051,11 @@ sc sprint record-review \
   --verdict changes_requested --body-file <path> --key <stable-key>
 ```
 
-5. Require durable judgment evidence + Developer Re-enter wake. Run no trailing command;
+5. Require durable judgment evidence + Developer Force-new wake. Run no trailing command;
    stop.
 
 Use `approved` only with no Critical/Major/Medium finding. Engine validation
-requires the accepted request and reviewed head. Do not message around the
+requires the accepted request. Do not message around the
 surface; an unrecorded verdict cannot unlock merge.
 
 ## Delivery-terminal closeout

--- a/.super-coder/migrations/0253_reseed_sprint_review_flexibility.sql
+++ b/.super-coder/migrations/0253_reseed_sprint_review_flexibility.sql
@@ -1,0 +1,1102 @@
+-- 0253 — reseed the Sprint role skills for review flexibility.
+-- Verdicts now deliver Force-new (a fresh Developer chat per review round);
+-- approval binds to the PR, not to a head or base SHA, so rebases no longer
+-- force phantom review rounds; the PR body carries implementation rationale.
+-- No schema change: a full-body UPSERT converges upgraded installations on the
+-- same text a fresh seed produces.
+
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_close',
+  'Route Sprints v2 closeout to the owning role — Reviewer conformance, Planner control actions or completion receipt, and explicit FnB fallbacks — without creating a second close workflow.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_close — route the terminal boundary
+
+Use as a closeout router, not as a second operating workflow. The Reviewer owns
+conformance and final-report judgment; the Planner executes Reviewer control
+decisions; clean conformance closes atomically; the FnB owns explicit fallback
+and follow-up disposition.
+
+Use the simplest path supported by current durable state. Treat authority,
+lifecycle preconditions, durable writes, and typed handoffs as hard boundaries;
+use judgment within them. Repeat a read only when later activity could have
+changed it or the next command requires live revalidation.
+
+## Route the entry
+
+- **Selected conformance Reviewer receives `sprint.delivery_terminal`.** Confirm
+  the notification''s owner shell and generation match the current Sprint.
+  Load `sprint_rev` and follow **Delivery-terminal closeout**. Inspect the Sprint
+  inbox once, compile bounded evidence, and choose between in-Sprint re-entry,
+  abort, or the atomic clean `record-conformance` path. Any other Reviewer
+  records no conformance. The Planner does not initiate this pass.
+- **Planner receives a Sprint-scoped Reviewer decision.** Load `sprint_pln` and
+  follow **Reviewer decision actions**. Inspect and handle the durable inbox
+  message once, then execute the exact requested transition without
+  re-adjudicating it.
+- **Planner receives an engine-wide completion or cleanup receipt.** Load
+  `sprint_pln` and follow **Conclude or abort**. Inspect the self-contained
+  receipt and terminal Sprint state directly. The completion receipt leaves
+  cleanup pending; the later cleanup receipt makes reuse or recovery explicit.
+  Do not run the Sprint inbox, accept the receipt, compile another report, or
+  run `complete`.
+- **FnB directs a fallback or follow-up disposition.** Use the bounded surfaces
+  below and name FnB authority in the evidence.
+
+Assignments, review requests, and verdicts use Force-new delivery; Planner-bound
+results and PR events use Re-enter. Neither displaces a live turn; the runtime owns delivery, rotation,
+and recovery. A successful typed handoff is the last action of that role''s
+turn.
+
+## Authority boundary
+
+The Reviewer decides whether evidence warrants re-entry, pause, re-plan,
+cancellation, abort, or clean completion. The Planner executes control
+decisions. The Reviewer''s clean `record-conformance` command is the one narrow
+exception: it stores conformance, findings, and the Reviewer-authored final
+report, completes the Sprint, and publishes the informational Planner receipt
+atomically. FnB retains the board-level override from decision #46.
+
+Any successful completion automatically closes other active participant chats
+immutably linked to that Sprint while retaining the originating Planner and the
+report-authoring Reviewer. Do not manually close peer chats as an extra
+closeout step. Pause, abort, re-entry, failed conformance, and rejected fallback
+completion never invoke this cleanup.
+
+Successful close schedules exact participant-worktree and Sprint-artifact
+cleanup. No role manually resets those targets after completion. The initial
+Planner receipt reports pending cleanup; the System later sends succeeded or
+failed cleanup evidence. A failed receipt names the bounded status and retry
+commands.
+
+If a command rejects a decision, preserve the returned durable state. Do not
+substitute another transition or invent an alternate handoff. Return the
+conflict to the deciding role, or surface it to FnB when the relay itself is
+unavailable.
+
+## FnB-directed fallbacks
+
+The participating Reviewer normally compiles the bounded packet. Planner or
+FnB compilation is valid only when FnB explicitly directs it:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Raise the limit only when truncation counters omit needed evidence; 200 is the
+maximum. The packet supplies facts, not judgment. The standalone `complete`
+surface is likewise an FnB-directed recovery fallback, never the normal clean
+close path.
+
+FnB may inspect any completed Sprint''s bounded cleanup state, retry failed
+targets, or explicitly adopt exactly one historical completed Sprint that has
+no targets. Target identities are System-derived; never supply a path or add a
+confirmation handshake:
+
+```text
+sc sprint cleanup-status --sprint <id>
+sc sprint cleanup --sprint <id> --key <stable-retry-key>
+sc sprint cleanup --sprint <legacy-id> --adopt-legacy \
+  --key <stable-adoption-key>
+```
+
+Require the cleanup request id, `created`, action, exact target ids, and
+aggregate projection. Reuse a key only for the identical request.
+
+Abort remains a Planner action on a Reviewer decision or FnB override and
+deletes nothing:
+
+```text
+sc sprint abort --sprint <id> --reason <reason> [--outcome <outcome>]
+```
+
+After closure, FnB records one disposition per pending follow-up. `accepted`
+acknowledges ship-as-is; `resolved` and `dismissed` require a bounded resolution
+file.
+
+```text
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition accepted
+sc sprint disposition-followup --sprint <id> --followup <id> \
+  --disposition resolved --resolution-file <path>
+```
+
+## Sprint artifact paths
+
+Sprint working artifacts (per-unit review notes, raw diffs, evidence packets,
+report drafts, and Dev scratch proof) go to the gitignored
+`shared/sprints/sprint-<n>/` directory. They are never committed, branched, or
+PR''d in the work repo; a review-notes commit is a finding.
+
+DB rows stay the durable record: judgments via `record-review`, report bodies in
+`sprint_reports`, and decisions in the durable relay. Files in the Sprint
+artifact directory are working material only.
+
+## Stop
+
+After routing, continue in the owning role skill. Stop when the typed handoff or
+terminal receipt has been handled. Do not perform a second close action or
+duplicate another role''s report.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_dev',
+  'Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge only after live authorization, and record judgment without overlapping edits.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_dev — own one editing lane
+
+Use for an actionable armed-Sprint assignment. Use the simplest path supported
+by current durable state. Treat ownership, lifecycle, writes, and handoffs as
+hard boundaries. Repeat a read only when later activity could have changed it
+or a command requires live revalidation.
+
+## Route the entry
+
+Load `sprint_dev` on every entry, then classify it:
+
+| Trigger | First read / action |
+|---|---|
+| Assignment, verdict, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; accept or handle the relevant message. |
+| Self-describing engine-wide PR fact | Inspect the fact + registered PR directly. Do not manufacture a Sprint inbox item; check the inbox once immediately before the next typed handoff. |
+| Live FnB instruction | Preserve its authority; read only durable state needed for safe action. |
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Accepting starts ownership; decline concretely. After an informational message,
+`accept` marks the message read and does not change Sprint or work-unit state.
+
+For an unusable bookkeeping receipt, retry the exact command once, then use its
+normal read surface once to prove the postcondition. For informational `accept`,
+prior inbox presence + absence of that exact message id proves the read landed;
+name the defect next handoff. NEVER infer assignment ownership, review outcome,
+merge authorization, lifecycle/work-unit transition, governing revision, PR
+head/green state, or cleanup authority. An unproved postcondition stops.
+
+Assignments, review requests, and verdicts use Force-new delivery; PR-event
+wakes use Re-enter. Delivery waits for a natural boundary; the runtime owns
+bundling, rotation, and recovery. Stop after a successful typed handoff.
+
+## Bound the lane
+
+Read assignment, output, bound revision, dependencies, roles, worktree, grant,
+and judgments. Own one active unit; never start another lane or edit another
+shell''s worktree. Resolve ambiguity to shippable in-scope work + rationale. Ask
+Planner before changing boundary, interface, deliverable, priority, or scope.
+
+Put one question, blocker, decision, answer, or useful context item in a short
+body file. Unit questions/blockers require a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level decisions:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Reply through the original message; the server inherits its scope, so never add
+`--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Ask the Reviewer about review evidence and the Planner about scope or
+cross-unit authority. Confirm the durable reply, then `accept` the incoming
+message. At a decision boundary, stop until the required answer arrives;
+unread recovery re-wakes, so send no duplicate reminder.
+
+Stable key = recipient + exact body + intent + reply + scope. Reuse it only for
+the same failed/ambiguous write; when any of those fields changes, use a new
+key. Keep bodies near 6,000 characters and below
+8,000; run `wc -m < <path>`. Handoff completes only when the command exits
+successfully and confirms durable state + wake. If a command is rejected or
+transport fails, correct/retry. If relay itself fails, give FnB command +
+evidence + impact + recommendation; invent no alternate protocol.
+
+A Developer does not pause the Sprint. Report blocker or integrity evidence to
+the Planner, continue safe independent work, and stop at the unsafe boundary.
+The Reviewer decides continue/replan/pause; the Planner executes the decision.
+
+Scratch proof/diffs/reports -> gitignored `shared/sprints/sprint-<n>/`; never
+commit/PR them. Durable judgment -> `record-review`; reports -> `sprint_reports`;
+decisions -> relay.
+
+## Build and verify
+
+Sync + branch; implement the smallest complete change. Per boot `TESTING
+POSTURE`, finish code + run every available smallest affected gate. If the
+selected interpreter, runner, or declared dependency cannot execute one,
+record exact seat evidence; the registered PR supplies only that proof. Test
+assertion/source collection red or incomplete code = failure. Optional browser
+skip = non-failing. Keep external calls outside DB transactions; preserve
+durable identities and append-only evidence. Record failures, anomalies,
+retries, review friction, and departures for closeout.
+
+Immediately before `complete-unit`, `register-pr`, or `request-review`, re-run
+`sc sprint inbox --sprint <id>` once and act on new messages. After the typed
+handoff confirms its durable write, stop without another inbox pass. The
+reopened-PR route below is the sole exception.
+
+## Report-only or no-code completion
+
+Only an explicitly planned report/no-code lane may finish without a PR. Keep
+the result near 6,000 characters and below 8,000; run `wc -m < <path>`, perform
+the pre-handoff inbox check, then require a durable completion receipt:
+
+```text
+sc sprint complete-unit --sprint <id> --work-unit <id> \
+  --result-file <path>
+```
+
+Stop after success. A code lane continues through merge observation.
+
+## Register and observe the PR
+
+```text
+sc sprint register-pr --sprint <id> --repository <owner/name> \
+  --pr <number> --work-unit <id>
+```
+
+Register complete code even when a local gate is unavailable; registration
+obtains evidence, not review. After `register-pr` succeeds, retain ownership;
+Red/green/closed/merged Re-enter wakes continue (the engine may already have
+discovered the PR from your worktree branch; `register-pr` attaches it). Required checks: pending -> native
+wake; red -> fix/push; green -> judge/request review; none or untrustworthy
+watcher after one bounded read -> report + block. Follow context: armed -> fix
+red + judge/pass green + merged -> post-merge handoff; paused -> fix red now +
+judge green, review after resume; no active Sprint -> fix red if needed, green
+arrives only as red recovery, merged -> git skill after-merge cleanup.
+Planner/Reviewer get none.
+
+If the same registered PR was externally closed, then reopened, rebased, and
+pushed, replay the exact `register-pr` command. Require `created: false`, which
+keeps identity/ownership and takes a fresh snapshot. Its one pre-handoff inbox
+check covers registration replay + the immediately following review request.
+Do not wait for a second PR-fact wake: immediately request review. Green
+proceeds; any other snapshot returns the watcher diagnostic without partial
+handoff. Never register a replacement PR or ask the Planner to bypass observed
+green.
+
+Otherwise, when no local action remains, stop for the native PR fact. Start no
+recurring loop, scheduled job, daemon, or external watcher. A stalled gate
+permits one bounded read, then stop or report its evidence:
+
+```text
+sc sprint watcher-state --sprint <id>
+```
+
+Do not repeat this read as a polling loop.
+
+## Review handoff and correction
+
+Complete each round in order:
+
+1. Finish readiness judgment + available local proof; require observed green.
+2. Perform the once-only inbox check; handle and `accept` new messages.
+3. Use `submit` first or `resubmit` after changes requested. The engine injects
+   the PR URL, registered id, exact green head, and work-unit id into the
+   Reviewer''s canonical bare one-line locator. Create no readiness file. Send
+   no scope narrative, verification evidence, rationale, or review-focus
+   steering in the request. The PR body carries the work-unit id and spec
+   reference plus your rationale (decisions, rejected trade-offs): each verdict
+   opens a fresh chat with only GitHub to read. Write no PR comments or
+   annotations.
+4. As the literal final action, run:
+
+```text
+sc sprint request-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --intent <submit|resubmit> --key <stable-key>
+```
+
+5. Require confirmation of the durable write + Reviewer wake; run no trailing
+   command and stop and await the native verdict wake.
+
+Changes requested arrives as a fresh chat: orient from the PR body, diff, and
+verdict; do not re-litigate choices the rationale explains. Apply every
+blocking finding, re-establish green, and resubmit with a new review-round key.
+Do not narrate cleared findings; the Reviewer verifies the full diff. Record disagreements as judgment. Reviewer owns scope/severity; Planner
+executes resulting action.
+
+## Merge boundary
+
+Immediately before merge, re-read live GitHub, grant, ownership, unit state,
+and checks through:
+
+```text
+sc sprint authorize-merge \
+  --sprint <id> --registered-pr <registered-id>
+```
+
+Merge only the returned repository, PR, and head SHA. A refusal means not
+green, not approved, or not yours; fix that, never bypass it. A rebase does not
+undo approval.
+
+## Post-merge handoff
+
+After the authorized merge:
+
+1. Clean the worktree; put merged PR + SHA, unit result, verification,
+   judgments, and departures in the handoff file.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle and `accept` new items.
+3. Run `wc -m < <path>`; keep the body near 6,000 characters and below 8,000.
+4. As the literal final action, send:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --intent handoff --key <stable-merged-handoff-key>
+```
+
+5. Require the durable message + Planner wake, then stop immediately. Run no trailing Git,
+   Sprint, inbox, cleanup, or status command. Automatic merge
+   observation records the PR transition; this handoff releases the next wave.
+
+## Report and stop
+
+Report broken bases, destructive ambiguity, unavailable GitHub, untrustworthy
+runners, provider exhaustion, or unrecoverable environment with evidence,
+impact, and recommendation. Stop when merged + reported, declined, returned to
+review, paused for a native wake, or awaiting Planner/FnB recovery. Ask for
+later work only after this editing lane is terminal.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
+
+Use after `sprint_prep` arms Sprint. System records; Reviewer judges/reports;
+Planner structures/controls; FnB board override = decision #46.
+
+Use the simplest path supported by current durable state. Treat authority,
+lifecycle, writes, and handoffs as hard boundaries. Repeat a read only when
+later activity could have changed it or a command requires revalidation.
+
+## How a Sprint runs
+
+One Sprint binds one roadmap feature, exact governing spec revisions, a
+participant set (you, Developers, Reviewers) each on one harness/model/Thinking
+level (`effort`) route, and work units: editing lanes made of spec tasks, each
+with one Developer and one Reviewer, ordered by dependencies and planned waves.
+
+Lifecycle: `prepared` (editable, `sprint_prep`) → `armed` (the runtime
+dispatches every dependency-ready lane as a Force-new Developer wake) ⇄
+`paused` (relay is off; restructuring and rerouting happen here) →
+`completed` or `aborted` (terminal; nothing is deleted). One Sprint is armed at
+a time.
+
+A lane''s life: dispatched → Developer builds on a branch, registers the PR,
+requests review → Reviewer records a verdict → Developer authorizes the merge
+on live green → the merged-work handoff wakes you → you dispatch whatever
+became ready. After the last lane the conformance Reviewer records the
+whole-Sprint report; the engine closes the Sprint and cleans worktrees. The
+engine delivers every wake and watches every registered PR; you never poll or
+boot participants.
+
+Authority: Reviewers own verdicts, conformance, and re-enter/abort judgment.
+You own plan structure: lanes, dependencies, waves, assignment, routes, pause,
+resume, dispatch. The FnB can override any of it from the GUI Sprints tab,
+which renders the same projection `sc sprint show` returns.
+
+## What you can read
+
+| Need | Read |
+|---|---|
+| Whole Sprint: lifecycle, participants with current routes, units, dependencies, PRs, health | `sc sprint show --sprint <id>` |
+| Messages addressed to you | `sc sprint inbox --sprint <id>` |
+| Exact bound spec body | `sc sprint spec-revision --sprint <id> --document <id> [--body-only]` |
+| PR-watcher evidence behind a stalled gate | `sc sprint watcher-state --sprint <id>` |
+| Post-Sprint cleanup evidence | `sc sprint cleanup-status --sprint <id>` |
+| Bounded history packet: judgments, pauses, anomalies, follow-ups | `sc sprint compile-report --sprint <id> --limit 50` |
+| Candidate routes and what each supports | `sc models list [<harness>]`; preview one with `sc models resolve <harness> [<model>] [--effort <level>]` |
+| Shell roster, feature, spec tasks, settled decisions | `sc mem get shells`, `sc mem get roadmap`, `sc mem get tasks --feature <id>`, `sc mem get decisions` |
+
+`show` participants carry `shell_id`, `role`, `harness`, `model`, `effort`,
+`binding_status`, and `route_revision`; units carry `developer`, `reviewer`,
+`disposition`, `prerequisite_ids`, and `pull_requests`. A Thinking level
+applies only to controlled routes: `null` model + `null` effort is Harness
+default, and Vibe takes no effort. Nothing else is readable from a shell; the
+engine database is not a surface.
+
+## Route the entry
+
+Load `sprint_pln` on every entry, then classify:
+
+| Trigger | Route |
+|---|---|
+| Sprint decision, merged-work handoff, question, blocker, relay | Inspect `sc sprint inbox --sprint <id>` once; handle that message. |
+| Engine-wide completion or cleanup receipt | Inspect receipt + terminal state directly; it is informational—do not run the Sprint inbox, accept it, or close again. |
+| Live FnB instruction | Act under board override; name FnB authority in durable evidence. |
+
+Do not poll. Armed runtime owns scheduled dispatch + unread wake recovery;
+registered-PR watcher owns subscription observation. Developer-owned subscriptions send
+red/green/closed/merged facts to Developers, never Planner.
+
+Assignments, review requests, and verdicts use Force-new delivery;
+Planner-bound results use Re-enter. Delivery waits for a natural boundary; runtime owns bundling,
+rotation, recovery, and coordinate mode. Stop after a successful typed handoff.
+
+## Durable running loop
+
+Read only trigger-required lifecycle, unit, dependency, route, PR, expectation,
+and anomaly facts. Browser presence is not progress.
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+sc sprint dispatch --sprint <id>
+```
+
+Dispatch every dependency-ready lane; returned ids are wake identities.
+Disposition + messages are release facts. Stable assignment generations and
+occupied lanes make dispatch repeat-safe.
+
+Accept/decline only actionable items. After acting on an informational message,
+run `accept`; it marks the message read and does not change Sprint or work-unit
+state.
+
+An unusable success receipt from idempotent bookkeeping does not stall the
+Sprint. Retry the exact command once, then use its normal read surface once to
+prove the exact postcondition. For informational `accept`, prior inbox presence
++ absence of that exact message id proves the read landed. Continue under that
+proof + name the receipt defect in the next normal handoff. NEVER use this
+recovery to infer assignment ownership, review outcome, merge authorization,
+lifecycle/work-unit transition, governing revision, PR head/green state, or
+cleanup authority. An unproved postcondition stops.
+
+- Keep dependencies as hard sequence; restructure current projection under
+  Planner authority, record why, and never rewrite completed history.
+- Developers own local/PR proof, review/fix/merge. Complete code + unavailable
+  local gate -> registered CI: pending wait, red fix, green review; browser skip
+  is non-failing. With fallback, Planner NEVER mutates packages/toolchains or
+  runs repair. No checks/untrustworthy watcher after one read -> blocker.
+  Reviewers own verdicts/conformance; do not proxy handoffs/judgments.
+- Record Reviewer decision id + exact action + receipt; never rewrite rationale
+  as Planner judgment.
+- Reviewer-approved Planner/FnB spec rebind:
+  pause -> `sc mem doc edit` -> `sc sprint rebind-spec --sprint <id>
+  --document <id> --expected-revision <old-sha256> --reason <decision>` ->
+  replan -> resume. Pass = old/new hashes + changed boolean; conflict -> reread.
+- Use native wakes. Start no recurring loop, scheduled job, manual participant
+  boot, or external watcher. Do not repeat a stalled-gate inspection:
+
+```text
+sc sprint watcher-state --sprint <id>
+```
+
+## Relay contract
+
+Unit question/blocker requiring reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` for a blocked lane. Cross-unit, closeout, or external
+authority rulings are Sprint-level:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Answer through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Confirm reply, then `accept` incoming. A missing answer stops at the decision
+boundary; unread recovery re-wakes, so send no duplicate. Choose a stable key
+for recipient + body + intent + reply + scope; reuse it only for that identical
+write. When any of those fields changes, use a new key.
+
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. Handoff completes only when the command exits successfully
+and confirms durable write + wake. If a command is rejected or transport fails,
+correct/retry safely. If relay itself fails, give FnB attempted command +
+durable evidence; invent no alternate protocol. Relay Developer integrity
+evidence, impact, and recommendation to Reviewer. Send required context before
+pausing because paused Sprint relay is unavailable.
+
+Keep scratch review notes, diffs, evidence, reports, and proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit/branch/PR them. Durable judgment,
+reports, and decisions belong in `record-review`, `sprint_reports`, and relay.
+
+## Reviewer decisions and Planner actions
+
+Review/conformance/re-enter/abort judgment remains Reviewer-owned. Planner
+independently owns operational plan structure: pause-safe recall, cancellation
+of unreleased scope, reassignment, repeated task lanes, and route changes.
+
+For a required-reply Reviewer→Planner Re-enter decision, keep this order:
+
+1. Re-run `sc sprint inbox --sprint <id>`; verify assigned Reviewer + retain id.
+2. Send linked acknowledgement:
+
+```text
+sc sprint send --sprint <id> --to <reviewer-shortname> --body-file <path> \
+  --intent information --reply-to <decision-message-id> \
+  --key <stable-control-reply-key>
+```
+
+3. Require the reply command to confirm its durable message and wake; retry the
+   same command/key if ambiguous.
+4. Accept the decision:
+
+```text
+sc sprint accept --sprint <id> --message <decision-message-id>
+```
+
+5. Only after acceptance, execute the requested transition without
+   re-adjudicating it. The linked reply must precede any pause or
+   abort that makes the Sprint relay unavailable.
+
+Record decision id + reply, acceptance, and action receipts. Clean conformance
+closes atomically and sends informational receipt; no reply/accept is needed.
+
+The FnB board-level override from decision #46 remains distinct. If action
+fails lifecycle/authority/disposition precondition, send refusal + durable state
+to Reviewer (or FnB for override), substitute nothing, and stop.
+
+### Pause or resume
+
+Pause for Reviewer decision or safe Planner restructuring; preserve partial
+artifacts, interrupt intent, judgment, and evidence:
+
+```text
+sc sprint pause --sprint <id> --reason <decision-or-restructure-reason>
+```
+
+Resume only after recording recovery/restructure and reconciling native runs,
+unread messages, wakes, units, PRs, capacity, and spec drift:
+
+```text
+sc sprint resume --sprint <id> [--reason <validated-reconciliation-reason>]
+```
+
+Preserve the current conformance owner on ordinary resume. Replace that owner
+only while paused, only with an eligible participating Reviewer, and always
+record a reason:
+
+```text
+sc sprint resume --sprint <id> \
+  --conformance-reviewer-shell <replacement-shell-id> \
+  --reason <ownership-replacement-reason>
+```
+
+Require the receipt and board projection to show the replacement owner and a
+new ownership generation before treating the Sprint as resumed.
+
+Exhausted recovery wake = bounded manual evidence: preserve unread message +
+failed wake, involve FnB, create no recursive fallback. Drift informs but never
+silently blocks resume.
+
+Aborted-Sprint PR ownership repair belongs to the originating Planner. Keep
+replacement Sprint paused; establish old/new identity. The originating Planner
+may reconcile that identity (FnB may override):
+
+```text
+sc sprint reconcile-pr --sprint <replacement-id> --repository <owner/repo> \
+  --pr <number> --work-unit <replacement-unit-id> --reason <recovery-reason>
+```
+
+It refuses a live source Sprint or target Sprint, a non-originating Planner,
+invalid/owned target, and closed-unmerged PR. Receipt records owners, live head,
+authority, and merged completion when applicable. Require a separate Reviewer
+decision before resuming.
+
+### Modify, recall, repeat, reassign, or reroute
+
+Cancel unreleased scope with retained terminal reason/Reviewer id:
+
+```text
+sc sprint cancel-unit --sprint <id> --work-unit <id> --reason <reason>
+```
+
+Edit an unreleased lane; omitted fields stay, `--clear-dependencies` means none:
+
+```text
+sc sprint replan-unit --sprint <id> --work-unit <id> \
+  [--developer-shell <id>] [--reviewer-shell <id>] [--title <title>] \
+  [--expected-output-file <path>] [--task <task-id>] [--wave <n>] \
+  [--depends-on <work-unit-id> | --clear-dependencies] \
+  [--output-kind code|report-only|no-code]
+```
+
+Never edit a released lane in place. Pause → recall unmerged lane → replan →
+resume:
+
+```text
+sc sprint pause --sprint <id> --reason <restructure-reason>
+sc sprint recall-unit --sprint <id> --work-unit <id> --reason <obsolete-reason>
+sc sprint replan-unit --sprint <id> --work-unit <id> <changed-fields>
+sc sprint resume --sprint <id> --reason <validated-replan-reason>
+```
+
+Recall preserves message/event history, returns only unmerged work to planned,
+and refuses terminal/PR-bound work. PR-bound work stays; plan replacement or use
+reconciliation. Resume creates fresh assignment generation. One spec task may
+govern repeated verification/replacement lanes; each lane lists it once. Do not
+duplicate the spec task.
+
+Close a released lane terminal when its work finished out-of-band (a PR that
+merged while paused) or its lane is abandoned — the PR-bound case recall
+refuses:
+
+```text
+sc sprint resolve-unit --sprint <id> --work-unit <id> \
+  --to completed|cancelled --reason <reason>
+```
+
+Paused-only; retires the lane''s open expectations, supersedes its PR links
+(registration kept for reconcile-pr), and wakes both seats. Recall+replan
+ships revised work; resolve only closes the lane.
+
+To change future assignment/review model, pause armed Sprint, take each
+participant''s `shell_id` and current route from `sc sprint show`, preview the
+replacement with `sc models resolve`, then replace the route and resume:
+
+```text
+sc sprint reroute-participant --sprint <id> --participant-shell <id> \
+  --harness <harness> [--model <model>] [--effort <effort>] \
+  [--route <display-route>]
+```
+
+Prepared Sprints may reroute directly. Paused reroute retires the
+participant''s own released expectations and queues fresh ones on the
+replacement route at resume; another seat''s open turn still blocks. Existing
+chats/runs remain history; next Force-new delivery uses replacement. Reroute
+declared participants only. On decline, preserve reason and choose
+replacement from current capacity; ask Reviewer only if review/conformance
+judgment changes.
+
+### Re-enter after conformance
+
+Reviewer decision names findings; governing tasks (existing for same scope,
+new title/description for new scope); and grouping, waves, dependencies,
+routing, capacity. Preserve it; do not absorb extra/post-Sprint scope or
+maximize occupancy.
+
+```text
+sc mem task add "<task-title>" --feature <feature-id> \
+  --doc <governing-spec-document-id> --seq <next-seq> \
+  --desc "<task-description>"
+
+sc sprint plan-unit --sprint <id> \
+  --developer-shell <id> --reviewer-shell <id> --title <title> \
+  --expected-output-file <path> --task <task-id> \
+  [--task <task-id>] [--wave <n>] [--depends-on <work-unit-id>] \
+  [--output-kind code|report-only|no-code]
+```
+
+Reuse task for exact repair/repeat; add only genuinely new scope. Bind every
+task, then confirm routes + dependency graph and capacity plan match the
+decision. Planner may reassign or reroute for operational capacity; tell
+Reviewer if conflict changes scope/judgment. Release ready lanes with
+`sc sprint dispatch --sprint <id>`. Engine sends next delivery-terminal wake;
+Planner does not initiate conformance.
+
+### Conclude or abort
+
+The clean `record-conformance` command atomically stores conformance, follow-ups,
+Reviewer-authored final report, completion, and informational engine-wide
+Planner receipt. On Re-enter, verify Sprint/reports/outcome/completed state.
+Do not run `complete`; notification is informational because closure is already
+terminal. Planner does not author a second report. The originating Planner and
+report-authoring Reviewer remain open. Do not manually close peer chats. Pause,
+abort, re-entry, failed conformance, and rejected fallback retain no-cleanup
+behavior.
+
+The initial completion receipt reports `cleanup_state=pending`. Delivery is
+finished, but managed worktrees are not reusable. Stop for the engine-wide
+cleanup receipt; do not poll or manually reset participant trees. On
+`cleanup_state=succeeded`, treat the slots as reusable. On failure, inspect once
+and retry only after correcting the named condition:
+
+```text
+sc sprint cleanup-status --sprint <id>
+sc sprint cleanup --sprint <id> --key <stable-retry-key>
+```
+
+Require `created`, cleanup request id, action, exact target ids, and aggregate
+projection. Reuse the key only for the same request. FnB alone may add
+`--adopt-legacy` for a completed Sprint with no scheduled targets; neither caller
+supplies a path.
+
+Do not compile or editorialize by default; Reviewer owns evidence/report. Only
+FnB-directed fallback may run:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Abort only on Reviewer decision/FnB override; it is terminal and deletes
+nothing.
+
+## Handoffs and stop
+
+Planner receives no PR-event wakes. Never dispatch the next wave from merge
+observation. The merged-work handoff wake is the only normal next-wave dispatch trigger.
+On it:
+
+1. Run `sc sprint inbox --sprint <id>`; inspect merged handoff + unit/dependency state.
+2. Handle earlier informational items and `accept` each, including handoff.
+3. Finish reconciliation and Planner bookkeeping; no work remains.
+4. As literal final action run `sc sprint dispatch --sprint <id>`.
+5. Require durable assignments + New wakes, then stop. Run no trailing command.
+   Empty dispatch remains final; investigate only on a later durable wake.
+
+On an initial clean completion receipt, verify the named Sprint is terminal and
+record `cleanup_state=pending`; run no close command. Stop until the
+engine-authored cleanup success or failure receipt arrives. The Planner does
+not author a second report, accept an actionable handoff, poll cleanup, or ask
+another role to reset a worktree.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_rev',
+  'Review Sprints v2 work and whole-Sprint conformance — own review, re-enter, abort, and conclude judgments, author the conformance and Sprint reports, and direct safety actions through durable messages.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_rev — independent review and conformance
+
+Use for pre-declaration QAQC, one work-unit review, or whole-Sprint
+conformance. The Reviewer decides review/conformance; the Planner owns
+operational plan structure + control execution. FnB retains the board-level
+override from decision #46.
+
+Use the simplest path supported by current durable state. Treat independence,
+authority, lifecycle preconditions, durable writes, and typed handoffs as hard
+boundaries. Repeat a read only when later activity could have changed it or the
+next command requires live revalidation.
+
+## Route the entry
+
+Classify the entry before reading an inbox:
+
+| Entry | Route |
+|---|---|
+| Explicit pre-declaration request | Read/sign the exact current spec directly; there is no Sprint id or Sprint inbox to inspect yet. |
+| Work-unit review / `sprint.delivery_terminal` | Inspect the Sprint inbox once; accept the actionable request. |
+| Live FnB instruction | Preserve board-level authority; read only durable state needed for independent judgment. |
+
+QAQC precedes all Sprint inbox commands:
+
+```text
+sc sprint record-qaqc --document <spec-document-id> \
+  --verdict pass [--findings-document <document-id>]
+```
+
+For an armed Sprint, load `sprint_rev` on every entry:
+
+```text
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Decline actionable work only with a concrete reason. After handling an
+informational message, run `accept`; it marks the message read and does not
+change Sprint or work-unit state.
+
+An unusable success receipt from idempotent bookkeeping does not stall the
+Sprint. Retry the exact command once, then use its normal read surface once to
+prove the exact postcondition. For informational `accept`, prior inbox presence
++ absence of that exact message id proves the read landed. Continue under that
+proof + name the receipt defect in the next normal handoff. NEVER use this
+recovery to infer assignment ownership, review outcome, merge authorization,
+lifecycle/work-unit transition, governing revision, PR head/green state, or
+cleanup authority. An unproved postcondition stops.
+
+Review requests and verdicts use Force-new delivery. Planner decisions use
+Re-enter. Delivery waits for a natural boundary; the runtime owns bundling,
+rotation, and recovery. Stop after a successful typed handoff. Reviewers never
+receive PR-event wakes.
+
+## Relay contract and authority
+
+Ask the Developer for unit evidence with a unit-scoped question/blocker:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Use `--intent blocker` when the unit cannot advance. Cross-unit, closeout,
+re-enter, abort, and safety rulings are Sprint-level decisions:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Reply through the original message; the server inherits its scope, so never
+add `--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Confirm a reply, then `accept` its incoming message. Missing facts stop review
+at the decision boundary; unread recovery re-wakes, so send no duplicate.
+A stable key identifies recipient + exact body + intent + reply + scope. Reuse
+it only for the same failed/ambiguous write; when any of those fields changes,
+use a new key.
+
+Keep bodies near 6,000 characters and below the 8,000 hard maximum; run
+`wc -m < <path>`. A handoff completes only when the command exits successfully
+and confirms the durable write + wake. If a command is rejected or transport fails,
+the verdict/handoff is incomplete. Correct and retry safely. If the relay itself fails,
+give FnB the attempted command, evidence, impact, and recommendation; invent no
+alternate protocol.
+
+## Sprint artifact paths
+
+Keep review notes, diffs, evidence, reports, and scratch proof in gitignored
+`shared/sprints/sprint-<n>/`; never commit, branch, or PR them. Durable records
+belong in `record-review`, `sprint_reports`, and the relay.
+
+## Conformance decisions and Planner controls
+
+Reviewer owns review, re-enter, abort, and conclude judgments. Planner
+independently owns operational plan structure: safe-edit pauses, recalling
+unreleased work, lane changes/repeats, assignment/routing, unreleased-scope
+cancellation, and validated resume. Reviewer never runs standalone pause,
+replan, recall, reroute, cancel, resume, complete, or abort actions; clean
+`record-conformance` alone performs its narrow atomic close.
+
+Base judgment on durable Sprint state, bound revisions, current work/PR facts,
+progress-carrier evidence, and ratified judgments. Every Reviewer→Planner route
+is Re-enter. A decision body names:
+
+- `decision`: `re-enter`, `abort`, or the exact safety-critical recommendation;
+- Reviewer-owned evidence + rationale;
+- exact Sprint/unit ids, reason, outcome, and complete action arguments;
+- immediate safety impact for FnB.
+
+Planner verifies Reviewer identity and executes the transition without
+surrendering plan authority. A rejected action requires a revised judgment
+supported by returned durable state, never an improvised bypass. A live FnB
+instruction supersedes as distinct FnB board-level override authority under
+decision #46.
+
+## Severity rubric
+
+- **Critical** — active security/authority violation, destructive corruption,
+  or unsafe continued operation.
+- **Major** — wrong behavior, data loss, broken invariant, material spec
+  violation, or silently wedged delivery/recovery.
+- **Medium** — concrete normal-use correctness/recovery gap, missing negative
+  enforcement, or unreliable handoff.
+- **Low** — bounded cleanup, clarity, test-depth, or resilience improvement;
+  delivered behavior remains correct.
+
+Critical/Major/Medium block unit approval; Low is a report note. At closeout,
+severity does not decide timing: Reviewer judges whether each finding requires in-Sprint patching
+or acceptable post-Sprint follow-up.
+
+## Work-unit review
+
+Accept the request and retain that exact message id. Its body is a bare locator:
+intent, PR URL, registered PR id, exact head, work-unit id. Scope narrative,
+verification, rationale, or focus steering is a protocol defect. PR comments
+and annotations are forbidden; PR body contains only unit id + spec reference.
+
+Bind inspection/verdict to the accepted request''s message id, registered PR,
+and work unit. Review the live PR head; a rebase since the locator''s head is
+not a defect. Read the exact spec revision + full diff, then checks, tests,
+relevant runtime facts,
+and ratified judgments. Each round is clean: no prior Developer evidence or
+prose; prior findings clear only when the new head proves it. Trace code paths,
+failure cases, and spec behavior rather than names or PR prose.
+
+### Red-check doctrine
+
+Accepted-red is not a legal review outcome. A departure that leaves checks
+failing is never acceptable; the handoff remains green-only, without exception
+or waiver: do not note the failure and approve anyway.
+
+- In-scope failure -> record `changes_requested` so the Developer fixes them and restores green.
+- Out-of-scope failure -> keep the lane unapproved and send the Planner a `replan`
+  decision naming the failures; Planner widens the lane or cuts follow-up work.
+
+Read cited and feature-scoped resolved flag evidence through memory, never SQL:
+
+```text
+sc mem get flags <flag-id>
+sc mem get flags --feature <feature-id> --resolved
+```
+
+Each finding pins severity/title, violated invariant, exact location/evidence,
+reproducible consequence, and fix boundary without unnecessary architecture.
+
+Complete a unit verdict in this exact order:
+
+1. Finish every inspection, finding, and verdict body.
+2. Re-run `sc sprint inbox --sprint <id>` once; handle + `accept` new items.
+3. Run `wc -m < <path>`; require near 6,000 and below 8,000 characters.
+4. As the literal final action, run:
+
+```text
+sc sprint record-review \
+  --sprint <id> --registered-pr <registered-id> \
+  --verdict changes_requested --body-file <path> --key <stable-key>
+```
+
+5. Require durable judgment evidence + Developer Force-new wake. Run no trailing command;
+   stop.
+
+Use `approved` only with no Critical/Major/Medium finding. Engine validation
+requires the accepted request. Do not message around the
+surface; an unrecorded verdict cannot unlock merge.
+
+## Delivery-terminal closeout
+
+Retain the exact notification message id + delivered wake as this closeout
+episode''s identity. Proceed only when the notification names this shell as the
+selected conformance owner for its current ownership generation. A different
+Reviewer accepts the informational notification if received and records no
+conformance. Inspect inbox, lifecycle, and units first:
+
+- Already completed/aborted -> `accept` notification and stop.
+- If any non-terminal unit is visible, the wake is stale -> `accept`, stop, and
+  await a fresh delivery-terminal episode.
+- Only an armed Sprint whose units are all terminal enters conformance.
+
+Compile the bounded evidence packet first, yourself:
+
+```text
+sc sprint compile-report --sprint <id> --limit 50 \
+  > shared/sprints/sprint-<n>/evidence.json
+```
+
+Increase only when truncation omitted needed evidence; maximum 200. Judge
+integrated `main` against every bound/current revision + ratified judgment. All
+units cancelled and nothing shipped -> `abort`, not `conclude`.
+
+Choose one branch:
+
+- **In-Sprint patching required.** Do not run `record-conformance`. Send Planner
+  a durable `re-enter` decision with every blocking finding; each spec task''s
+  title and description; grouping, waves, dependencies, routing, and capacity
+  rationale. State independent lanes, expected review overlap, useful reserve,
+  and critical-path effect. After three re-entry episodes, escalate
+  non-convergence to FnB.
+- **Clean or post-Sprint-only findings.** Prepare conformance report, findings,
+  final report, reason, and outcome; submit the atomic close below. Send no
+  conclude message.
+
+## Whole-Sprint conformance
+
+Review the integrated system, not unit diffs. Classify every requirement
+`as-specced`, `deviated-intentionally` with ratified judgment,
+`deviated-silently`, or `unimplemented`; the last two are findings. Include
+spec document + work-unit ids when known.
+
+For the clean branch, write a conformance report and JSON findings array with
+`severity`, `title`, `body`, `spec_document_id`, and `work_unit_id`. Keep the
+report and each body near 6,000 and below 8,000 characters; run
+`wc -m < <report>` and validate each body.
+
+Before recording conformance, author the final Sprint report. Name Reviewer as
+author and cover governing scope/revisions, shipped units/PRs, judgments +
+ratified deviations, failures/retries/recovery/anomalies, conclusion,
+follow-ups, and evidence location. Keep it near 6,000 and below 8,000; preserve
+discrepancies.
+
+Record one atomic final write:
+
+```text
+sc sprint record-conformance \
+  --sprint <id> --body-file <report> --findings-file <json> \
+  --final-report-file <final-report> --reason <reason> --outcome <outcome> \
+  --key <stable-pass-key>
+```
+
+Require receipt: conformance report id, final report id, follow-up ids,
+completed state, Planner message id, and Planner wake id. The transaction adds
+append-only evidence, follow-ups, terminal state, and one informational engine-wide Planner Re-enter;
+send no conclude message. Require cleanup projection `pending`; cleanup runs
+after participant turns exit. Do not reset a worktree, poll cleanup, or wait
+before stopping. The Planner receives the later engine-authored receipt.
+Successful conformance also closes other Sprint-linked
+chats while the originating Planner + report-authoring Reviewer stay open. Do
+not manually close peer chats. Pause, abort, re-entry, failed conformance, and
+rejected fallback retain no-cleanup behavior. Never reopen editing after recording; a re-enter defers
+reports until new scope is terminal and a fresh delivery-terminal wake arrives.
+
+## Stop
+
+Unit review ends with the ordered `record-review` write as the literal final
+action.
+
+For closeout, first re-run `sc sprint inbox --sprint <id>`, handle + `accept`
+new messages, then confirm every artifact/body is final and below 8,000.
+
+- Clean conclude -> run the atomic `record-conformance` command above as the
+  literal final action. When it confirms completed state, pending cleanup, and
+  all receipt identities, stop immediately; Planner is notified.
+- Re-enter/abort -> as literal final action send:
+
+```text
+sc sprint send --sprint <id> --to <planner-shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level \
+  --key <stable-decision-handoff-key>
+```
+
+Require durable write + Planner wake, then stop immediately. Run no trailing
+command until another native wake.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -217,16 +217,6 @@ _EVENT_FIELDS = {
             "previous_head_sha",
         }
     ),
-    "review.approval_invalidated": frozenset(
-        {
-            "work_unit_id",
-            "registered_pr_id",
-            "invalidated_message_id",
-            "head_sha",
-            "previous_head_sha",
-            "transition_key",
-        }
-    ),
     "merge.authorized": frozenset(
         {"work_unit_id", "registered_pr_id", "pr_number", "head_sha"}
     ),

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1335,11 +1335,6 @@ class SprintPRWatcher:
             transition_key,
             state,
             pull_request,
-            previous_head_sha=(
-                str(latest["observed_head_sha"])
-                if latest is not None and latest["observed_head_sha"] is not None
-                else None
-            ),
             previous_state=(
                 str(latest["normalized_state"]) if latest is not None else None
             ),
@@ -1404,14 +1399,8 @@ class SprintPRWatcher:
         transition_key: str,
         state: str,
         pull_request: PullRequest,
-        previous_head_sha: str | None,
         previous_state: str | None,
     ) -> tuple[int, ...]:
-        sprint_id = (
-            int(registered["sprint_id"])
-            if registered["sprint_id"] is not None
-            else None
-        )
         registered_pr_id = registered["sprint_registered_pr_id"]
         unit_rows = self.con.execute(
             "SELECT l.work_unit_id,u.disposition "
@@ -1443,65 +1432,6 @@ class SprintPRWatcher:
                     "registered_pr.merged_grant_bypassed",
                 )
             )
-        head_changed = (
-            previous_head_sha is not None
-            and previous_head_sha != pull_request.head_sha
-        )
-        if (
-            head_changed
-            and pull_request.head_sha is not None
-            and state not in {"merged", "closed"}
-            and sprint_id is not None
-            and registered_pr_id is not None
-            and len(unit_rows) == 1
-            and unit_rows[0]["disposition"] == "in_review"
-        ):
-            invalidated_message_id = (
-                self.review_loop.invalidate_review_request_for_head_change_in_transaction(
-                    int(sprint_id),
-                    int(registered_pr_id),
-                    pull_request.head_sha,
-                )
-            )
-            if invalidated_message_id is not None:
-                resolved_review_message_ids = (invalidated_message_id,)
-        if (
-            head_changed
-            and state not in {"merged", "closed"}
-            and len(unit_rows) == 1
-            and unit_rows[0]["disposition"] == "merge_ready"
-        ):
-            work_unit_id = int(unit_rows[0]["work_unit_id"])
-            invalidated_message_id = self._invalidate_stale_approval(
-                sprint_id,
-                work_unit_id,
-            )
-            self.con.execute(
-                "UPDATE sprint_work_units SET disposition='fixing',"
-                "updated_at=datetime('now') WHERE work_unit_id=? "
-                "AND disposition='merge_ready'",
-                (work_unit_id,),
-            )
-            self.con.execute(
-                "INSERT INTO sprint_events "
-                "(sprint_id,event_type,actor_kind,payload) "
-                "VALUES (?,'review.approval_invalidated','system',?)",
-                (
-                    sprint_id,
-                    json.dumps(
-                        {
-                            "head_sha": pull_request.head_sha,
-                            "invalidated_message_id": invalidated_message_id,
-                            "previous_head_sha": previous_head_sha,
-                            "registered_pr_id": registered_pr_id,
-                            "transition_key": transition_key,
-                            "work_unit_id": work_unit_id,
-                        },
-                        sort_keys=True,
-                    ),
-                ),
-            )
-
         lifecycle = registered["lifecycle"]
         if lifecycle in {"armed", "paused"}:
             instructions = {
@@ -1583,26 +1513,6 @@ class SprintPRWatcher:
                 ),
             )
         return resolved_review_message_ids
-
-    def _invalidate_stale_approval(
-        self,
-        sprint_id: int,
-        work_unit_id: int,
-    ) -> int | None:
-        approval = self.con.execute(
-            "SELECT payload FROM sprint_events WHERE sprint_id=? "
-            "AND event_type='review.approved' "
-            "AND json_extract(payload,'$.work_unit_id')=? "
-            "ORDER BY event_id DESC LIMIT 1",
-            (sprint_id, work_unit_id),
-        ).fetchone()
-        if approval is None:
-            return None
-        message_id = json.loads(approval["payload"]).get("message_id")
-        if not isinstance(message_id, int):
-            return None
-        self.messages.resolve_in_transaction(message_id)
-        return message_id
 
     def _poll_failed(
         self,

--- a/.super-coder/scripts/sprint_review_loop.py
+++ b/.super-coder/scripts/sprint_review_loop.py
@@ -12,12 +12,21 @@ import db_driver
 import sprint_liveness
 from github_pull_requests import GitHubPullRequestReader, PullRequest
 from sprint_domain import (
+    LifecycleActor,
     PauseReceipt,
     SprintAuthorityError,
     SprintInvariantError,
+    SprintLifecycleStore,
     SprintWorkUnitStore,
 )
 from sprint_message_delivery import MessageReceipt, SprintMessageStore
+
+# Completed unit-review verdicts a Sprint PR may accumulate before the engine
+# pauses the Sprint for FnB attention. Eight rounds without approval means the
+# Developer lane cannot converge on its own; the ceiling is a safety stop, not
+# a quality target, so no Reviewer-facing surface mentions it.
+REVIEW_ROUND_CEILING = 8
+REVIEW_ROUNDS_EXHAUSTED = "review_rounds_exhausted"
 
 
 @dataclass(frozen=True)
@@ -36,6 +45,7 @@ class ReviewOutcomeReceipt:
     wake_id: int
     disposition: str
     created: bool
+    sprint_paused: bool = False
 
 
 @dataclass(frozen=True)
@@ -127,10 +137,6 @@ class SprintReviewLoopStore:
                     raise SprintInvariantError(
                         "in-review lane has no durable review request"
                     )
-                if previous_request.head_sha == transition["observed_head_sha"]:
-                    raise SprintInvariantError(
-                        "review handoff already targets the current PR head"
-                    )
                 self._invalidate_review_request_in_transaction(
                     lane,
                     previous_request,
@@ -161,31 +167,6 @@ class SprintReviewLoopStore:
             )
             return self._handoff_receipt(lane, receipt)
 
-    def invalidate_review_request_for_head_change_in_transaction(
-        self,
-        sprint_id: int,
-        registered_pr_id: int,
-        head_sha: str,
-    ) -> int | None:
-        """Return an in-review lane to its Developer when its PR head moves."""
-        if not self.con.in_transaction:
-            raise RuntimeError("review invalidation requires an active transaction")
-        lane = self._lane(sprint_id, registered_pr_id)
-        if lane["disposition"] != "in_review":
-            return None
-        request = self._latest_review_request(lane)
-        if request is None:
-            raise SprintInvariantError("in-review lane has no durable review request")
-        if request.head_sha == head_sha:
-            return None
-        self._invalidate_review_request_in_transaction(
-            lane,
-            request,
-            head_sha,
-            actor_shell_id=None,
-        )
-        return request.message_id
-
     def record_review(
         self,
         sprint_id: int,
@@ -201,6 +182,7 @@ class SprintReviewLoopStore:
             raise ValueError("review verdict must be changes_requested or approved")
         body = self._required(body, "review body")
         idempotency_key = self._required(idempotency_key, "idempotency key", 255)
+        pause_receipt: PauseReceipt | None = None
         with db_driver.write_transaction(self.con, "sprint.review.outcome"):
             lane = self._lane(sprint_id, registered_pr_id)
             self._require_armed(lane)
@@ -225,7 +207,7 @@ class SprintReviewLoopStore:
                 message_kind="notification",
                 body=notification,
                 actionable=verdict == "changes_requested",
-                declared_type="re-enter",
+                declared_type="force-new",
                 idempotency_key=idempotency_key,
             )
             if receipt.wake_id is None:
@@ -239,9 +221,6 @@ class SprintReviewLoopStore:
                     raise SprintInvariantError(
                         f"review verdict cannot start from {lane['disposition']}"
                     )
-                transition = self._latest_transition(registered_pr_id)
-                if transition["observed_head_sha"] != requested_head:
-                    raise SprintInvariantError("review request is stale for the PR head")
                 self._record_judgment(
                     lane,
                     reviewer_shell_id,
@@ -265,14 +244,50 @@ class SprintReviewLoopStore:
                         "work_unit_id": int(lane["work_unit_id"]),
                     },
                 )
+                if verdict == "changes_requested":
+                    pause_receipt = self._pause_when_rounds_exhausted(lane)
                 outcome = self._outcome_receipt(
-                    lane, receipt, disposition
+                    lane, receipt, disposition, sprint_paused=pause_receipt is not None
                 )
             sprint_liveness.SprintLivenessMonitor(self.con).resolve_in_transaction(
                 review_message_id,
                 f"review submitted: {verdict}",
             )
+        if pause_receipt is not None:
+            SprintLifecycleStore(self.con).signal_pause_receipt(pause_receipt)
         return outcome
+
+    def _pause_when_rounds_exhausted(self, lane: sqlite3.Row) -> PauseReceipt | None:
+        """Pause the Sprint once a PR has burned its review-round ceiling."""
+        rounds = int(
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events WHERE sprint_id=? "
+                "AND event_type IN ('review.changes_requested','review.approved') "
+                "AND json_extract(payload,'$.work_unit_id')=?",
+                (self._sprint_id(lane), lane["work_unit_id"]),
+            ).fetchone()[0]
+        )
+        if rounds < REVIEW_ROUND_CEILING:
+            return None
+        lifecycle = SprintLifecycleStore(self.con)
+        detail = {
+            "work_unit_id": int(lane["work_unit_id"]),
+            "registered_pr_id": int(lane["registered_pr_id"]),
+            "pr_number": int(lane["pr_number"]),
+            "review_rounds": rounds,
+        }
+        return lifecycle._pause_in_transaction(
+            lifecycle._sprint(self._sprint_id(lane)),
+            LifecycleActor("system"),
+            reason=REVIEW_ROUNDS_EXHAUSTED,
+            detail=detail,
+            notice_body=(
+                f"Sprint {self._sprint_id(lane)} paused: PR #{lane['pr_number']} "
+                f"(work unit {lane['work_unit_id']}) has received {rounds} review "
+                "rounds without approval. The Developer lane is not converging; "
+                "FnB review is needed, possibly a stronger coding model."
+            ),
+        )
 
     def authorize_merge(
         self,
@@ -280,7 +295,7 @@ class SprintReviewLoopStore:
         registered_pr_id: int,
         developer_shell_id: int,
     ) -> MergeAuthorization:
-        """Re-read GitHub, then authorize only the approved head with live green."""
+        """Re-read GitHub, then authorize the approved unit's live green head."""
         identity = self.con.execute(
             "SELECT repository,pr_number FROM sprint_registered_prs "
             "WHERE sprint_id=? AND registered_pr_id=?",
@@ -292,7 +307,6 @@ class SprintReviewLoopStore:
             int(identity["pr_number"])
         )
         self._require_live_green(identity, live)
-        refusal: str | None = None
         with db_driver.write_transaction(self.con, "sprint.merge.authorize"):
             lane = self._lane(sprint_id, registered_pr_id)
             self._require_armed(lane)
@@ -301,44 +315,18 @@ class SprintReviewLoopStore:
                 raise SprintInvariantError("Sprint merge grant is not enabled")
             if lane["disposition"] != "merge_ready":
                 raise SprintInvariantError("merge requires an approved work unit")
-            approved_head = self._approved_head(lane)
-            if approved_head != live.head_sha:
-                raise SprintInvariantError(
-                    "review approval is stale for the live PR head"
-                )
-            approved_base = self._approved_base_sha(lane)
-            refusal = self._base_refusal(approved_base, live.base_sha, live.number)
-            if refusal is not None:
-                approved_key = approved_base or "legacy"
-                live_key = live.base_sha or "missing"
-                self.messages.send_in_transaction(
-                    sprint_id,
-                    to_participant_id=int(lane["developer_participant_id"]),
-                    work_unit_id=int(lane["work_unit_id"]),
-                    message_kind="notification",
-                    body=refusal,
-                    actionable=True,
-                    declared_type="re-enter",
-                    idempotency_key=(
-                        f"merge-base-stale:{registered_pr_id}:"
-                        f"{approved_key}:{live_key}"
-                    ),
-                )
-            else:
-                self._event(
-                    sprint_id,
-                    "merge.authorized",
-                    developer_shell_id,
-                    {
-                        "base_sha": live.base_sha,
-                        "head_sha": live.head_sha,
-                        "pr_number": live.number,
-                        "registered_pr_id": registered_pr_id,
-                        "work_unit_id": int(lane["work_unit_id"]),
-                    },
-                )
-        if refusal is not None:
-            raise SprintInvariantError(refusal)
+            self._event(
+                sprint_id,
+                "merge.authorized",
+                developer_shell_id,
+                {
+                    "base_sha": live.base_sha,
+                    "head_sha": live.head_sha,
+                    "pr_number": live.number,
+                    "registered_pr_id": registered_pr_id,
+                    "work_unit_id": int(lane["work_unit_id"]),
+                },
+            )
         return MergeAuthorization(
             registered_pr_id,
             str(identity["repository"]),
@@ -467,14 +455,6 @@ class SprintReviewLoopStore:
         if int(lane["assigned_shell_id"]) != shell_id:
             raise SprintAuthorityError("only the owning Developer controls the PR")
 
-    def _latest_transition(self, registered_pr_id: int) -> sqlite3.Row:
-        row = self._latest_transition_row(registered_pr_id)
-        if row is None:
-            raise SprintInvariantError("registered PR has no observed state")
-        if row["observed_head_sha"] is None:
-            raise SprintInvariantError("registered PR has no exact observed head")
-        return row
-
     def _latest_transition_row(self, registered_pr_id: int) -> sqlite3.Row | None:
         row = self.con.execute(
             "SELECT transition_id,normalized_state,observed_head_sha,evidence,"
@@ -594,11 +574,11 @@ class SprintReviewLoopStore:
     ) -> None:
         self.messages.supersede_actionable_in_transaction(
             request.message_id,
-            "superseded by PR head change",
+            "superseded by a newer review request",
         )
         sprint_liveness.SprintLivenessMonitor(self.con).resolve_in_transaction(
             request.message_id,
-            "review request invalidated by PR head change",
+            "review request superseded by a newer request",
         )
         changed = self.con.execute(
             "UPDATE sprint_work_units SET disposition='fixing',"
@@ -654,60 +634,6 @@ class SprintReviewLoopStore:
             ),
         )
 
-    def _approved_head(self, lane: sqlite3.Row) -> str | None:
-        row = self.con.execute(
-            "SELECT payload FROM sprint_events WHERE sprint_id=? "
-            "AND event_type='review.approved' "
-            "AND json_extract(payload,'$.work_unit_id')=? "
-            "ORDER BY event_id DESC LIMIT 1",
-            (self._sprint_id(lane), lane["work_unit_id"]),
-        ).fetchone()
-        return json.loads(row["payload"]).get("head_sha") if row is not None else None
-
-    def _approved_base_sha(self, lane: sqlite3.Row) -> str | None:
-        approval = self.con.execute(
-            "SELECT payload FROM sprint_events WHERE sprint_id=? "
-            "AND event_type='review.approved' "
-            "AND json_extract(payload,'$.work_unit_id')=? "
-            "ORDER BY event_id DESC LIMIT 1",
-            (self._sprint_id(lane), lane["work_unit_id"]),
-        ).fetchone()
-        if approval is None:
-            return None
-        transition_id = json.loads(approval["payload"]).get("transition_id")
-        if not isinstance(transition_id, int):
-            return None
-        transition = self.con.execute(
-            "SELECT evidence FROM sprint_pr_transitions "
-            "WHERE registered_pr_id=? AND transition_id=?",
-            (lane["registered_pr_id"], transition_id),
-        ).fetchone()
-        if transition is None:
-            return None
-        evidence = json.loads(transition["evidence"])
-        base_sha = evidence.get("base_sha") if isinstance(evidence, dict) else None
-        return base_sha if isinstance(base_sha, str) and base_sha else None
-
-    @staticmethod
-    def _base_refusal(
-        approved_base: str | None,
-        live_base: str | None,
-        pr_number: int,
-    ) -> str | None:
-        if approved_base is None:
-            return (
-                f"Merge authorization refused for PR #{pr_number}: approval "
-                "predates base-tracking; sync with base to mint current evidence."
-            )
-        if live_base != approved_base:
-            live_detail = live_base or "missing"
-            return (
-                f"Merge authorization refused for PR #{pr_number}: approved base "
-                f"{approved_base} differs from live base {live_detail}; sync with "
-                "base and return through green review."
-            )
-        return None
-
     @staticmethod
     def _require_live_green(identity: sqlite3.Row, live: PullRequest) -> None:
         if live.number != int(identity["pr_number"]):
@@ -737,6 +663,8 @@ class SprintReviewLoopStore:
         lane: sqlite3.Row,
         receipt: MessageReceipt,
         disposition: str,
+        *,
+        sprint_paused: bool = False,
     ) -> ReviewOutcomeReceipt:
         return ReviewOutcomeReceipt(
             int(lane["work_unit_id"]),
@@ -745,6 +673,7 @@ class SprintReviewLoopStore:
             int(receipt.wake_id),
             disposition,
             receipt.created,
+            sprint_paused,
         )
 
     def _event(

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -109,8 +109,9 @@ delivery:
 | idle registry chat | any coalesced New rotates; all-Re-enter resumes the chat |
 | no registry row | create a chat and deliver as New |
 
-Sprint routing uses those literals: Planner→Developer and Developer→Reviewer
-are New; Developer/Reviewer→Planner and Reviewer→Developer are Re-enter. FnB
+Sprint routing uses those literals: Planner→Developer assignments,
+Developer→Reviewer requests, and Reviewer→Developer verdicts are Force-new;
+Developer/Reviewer→Planner results and PR-event wakes are Re-enter. FnB
 can close the Planner chat during an armed Sprint to set coordinate mode (idle
 Planner Re-enters become fresh ticket chats); FnB pause/resume returns to
 supervise, while automatic pauses preserve the dial. Developer-owned PR

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -151,7 +151,8 @@
     ".super-coder/migrations/0249_reseed_docs_frozen_render_path.sql",
     ".super-coder/migrations/0250_reseed_fork_skill_design_planner_lane.sql",
     ".super-coder/migrations/0251_conversation_run_transcript_offset.sql",
-    ".super-coder/migrations/0252_reseed_universal_pr_owner_wakes.sql"
+    ".super-coder/migrations/0252_reseed_universal_pr_owner_wakes.sql",
+    ".super-coder/migrations/0253_reseed_sprint_review_flexibility.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,

--- a/tests/test_focused_dev_verification.py
+++ b/tests/test_focused_dev_verification.py
@@ -19,6 +19,7 @@ MIGRATIONS = (
     ENGINE / "migrations" / "0240_reseed_sprint_spec_rebinding.sql",
     ENGINE / "migrations" / "0248_reseed_sprint_pln_orientation.sql",
     ENGINE / "migrations" / "0252_reseed_universal_pr_owner_wakes.sql",
+    ENGINE / "migrations" / "0253_reseed_sprint_review_flexibility.sql",
 )
 sys.path.insert(0, str(ENGINE / "scripts"))
 

--- a/tests/test_sprint_live_proof.py
+++ b/tests/test_sprint_live_proof.py
@@ -2272,8 +2272,10 @@ class SprintLiveProof(unittest.TestCase):
         self.assertEqual(2, event_types.count("review.approved"))
         self.assertEqual("lifecycle.completed", event_types[-1])
         self.assertEqual(2, packet["pr_outcomes"]["total"])
+        # One New chat per assignment plus one Force-new chat for the
+        # changes_requested verdict on the first unit.
         self.assertEqual(
-            2,
+            3,
             self.con.execute(
                 "SELECT COUNT(*) FROM sprint_participant_conversations link "
                 "JOIN sprint_participants p "

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -1124,7 +1124,7 @@ class TransitionRoutingTest(SprintPRWatcherCase):
             ).fetchone()[0],
         )
 
-    def test_head_change_invalidates_approval_without_waking_reviewer(self):
+    def test_head_change_keeps_approval_and_merge_ready(self):
         self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
         self.register()
         green_message_id = self.con.execute(
@@ -1171,23 +1171,30 @@ class TransitionRoutingTest(SprintPRWatcherCase):
         self.assertTrue(self.watcher.poll_once())
 
         self.assertEqual(
-            "fixing",
+            "merge_ready",
             self.con.execute(
                 "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
                 (self.unit_id,),
             ).fetchone()[0],
         )
-        self.assertIsNotNone(
+        self.assertIsNone(
             self.con.execute(
                 "SELECT read_at FROM wake_message WHERE message_id=?",
                 (approval_notice.message_id,),
             ).fetchone()[0]
         )
         self.assertEqual(
-            "cancelled",
+            "pending",
             self.con.execute(
                 "SELECT state FROM sprint_wake_outbox WHERE wake_id=?",
                 (approval_notice.wake_id,),
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            0,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='review.approval_invalidated'"
             ).fetchone()[0],
         )
         self.assertEqual(

--- a/tests/test_sprint_review_loop.py
+++ b/tests/test_sprint_review_loop.py
@@ -628,13 +628,14 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             idempotency_key="changes-1",
         )
         self.assertEqual(
-            "re-enter",
+            "force-new",
             self.con.execute(
                 "SELECT declared_type FROM wake_message WHERE message_id=?",
                 (changed.message_id,),
             ).fetchone()[0],
         )
         self.assertEqual("fixing", changed.disposition)
+        self.assertFalse(changed.sprint_paused)
         self.assertIsNone(changed.conversation_id)
         self.assertEqual(
             0,
@@ -644,6 +645,11 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
                 "WHERE name IN ('purpose','parent_conversation_id')"
             ).fetchone()[0],
         )
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "has not been delivered"
+        ):
+            self.messages.mark_read(changed.message_id, 1)
+        self.deliver_message(changed.message_id)
         self.assertEqual("accepted", self.messages.mark_read(changed.message_id, 1))
         changed_expectation = self.con.execute(
             "SELECT resolved_at,resolution,next_evaluation_at "
@@ -769,90 +775,45 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             ],
         )
 
-    def test_in_review_same_head_rejects_a_second_handoff_key(self):
+    def test_in_review_second_handoff_key_supersedes_the_first_request(self):
         first = self.request_review("first-review-key")
+        self.accept_review(first.message_id)
+        self.seed_historical_expectation(first.message_id)
 
-        with self.assertRaisesRegex(
-            sprint_domain.SprintInvariantError,
-            "review handoff already targets the current PR head",
-        ):
-            self.request_review("different-review-key")
+        second = self.request_review("second-review-key")
 
+        self.assertTrue(second.created)
         self.assertEqual(
-            [(first.message_id, "first-review-key")],
+            [
+                (first.message_id, "declined", "superseded by a newer review request"),
+                (second.message_id, "pending", None),
+            ],
             [
                 tuple(row)
                 for row in self.con.execute(
-                    "SELECT message_id,idempotency_key FROM wake_message "
-                    "WHERE work_unit_id=? AND message_kind='review_request'",
+                    "SELECT message_id,disposition,decline_reason FROM wake_message "
+                    "WHERE work_unit_id=? AND message_kind='review_request' "
+                    "ORDER BY message_id",
                     (self.unit_id,),
                 )
             ],
         )
         self.assertEqual(
-            1,
+            "in_review",
             self.con.execute(
-                "SELECT COUNT(*) FROM sprint_events "
-                "WHERE event_type='review.requested'"
+                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
+                (self.unit_id,),
             ).fetchone()[0],
         )
-
-    def test_request_review_repairs_a_pre_update_stale_in_review_lane(self):
-        stale = self.request_review("stale-review-key")
-        self.accept_review(stale.message_id)
-        self.seed_historical_expectation(stale.message_id)
-        self.con.execute(
-            "INSERT INTO sprint_pr_transitions "
-            "(registered_pr_id,normalized_state,transition_key,"
-            "observed_head_sha,evidence) VALUES (?,?,?,?,?)",
-            (
-                self.registered_pr_id,
-                "green",
-                "historical-head-change",
-                "b" * 40,
-                json.dumps(
-                    {
-                        "base_sha": "c" * 40,
-                        "checks": "SUCCESS",
-                        "checks_failed": False,
-                    },
-                    sort_keys=True,
-                ),
-            ),
-        )
-        self.con.commit()
-
-        refreshed = self.request_review("replacement-review-key")
-
-        self.assertTrue(refreshed.created)
         self.assertEqual(
-            (
-                "in_review",
-                (
-                    "Submitting PR for review: "
-                    "https://github.com/acme/repo/pull/42; registered Sprint PR "
-                    f"{self.registered_pr_id}; exact head {'b' * 40}; work unit "
-                    f"{self.unit_id}."
-                ),
-            ),
+            ("review request superseded by a newer request", None),
             tuple(
                 self.con.execute(
-                    "SELECT unit.disposition,message.body "
-                    "FROM sprint_work_units unit JOIN wake_message message "
-                    "ON message.work_unit_id=unit.work_unit_id "
-                    "WHERE unit.work_unit_id=? AND message.message_id=?",
-                    (self.unit_id, refreshed.message_id),
+                    "SELECT resolution,next_evaluation_at "
+                    "FROM sprint_liveness_expectations WHERE message_id=?",
+                    (first.message_id,),
                 ).fetchone()
             ),
-        )
-        stale_expectation = self.con.execute(
-            "SELECT resolution,next_evaluation_at "
-            "FROM sprint_liveness_expectations WHERE message_id=?",
-            (stale.message_id,),
-        ).fetchone()
-        self.assertEqual(
-            ("review request invalidated by PR head change", None),
-            tuple(stale_expectation),
         )
         invalidated = json.loads(
             self.con.execute(
@@ -860,14 +821,7 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
                 "WHERE event_type='review.request_invalidated'"
             ).fetchone()[0]
         )
-        self.assertEqual(
-            (stale.message_id, "a" * 40, "b" * 40),
-            (
-                invalidated["invalidated_message_id"],
-                invalidated["previous_head_sha"],
-                invalidated["head_sha"],
-            ),
-        )
+        self.assertEqual(first.message_id, invalidated["invalidated_message_id"])
         with self.assertRaisesRegex(
             sprint_domain.SprintInvariantError, "accepted request"
         ):
@@ -876,16 +830,9 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
                 self.registered_pr_id,
                 2,
                 verdict="approved",
-                body="The obsolete acceptance must not authorize this head.",
-                idempotency_key="premature-refreshed-approval",
+                body="The superseded acceptance must not authorize the new request.",
+                idempotency_key="premature-second-approval",
             )
-        self.assertEqual(
-            0,
-            self.con.execute(
-                "SELECT COUNT(*) FROM wake_message "
-                "WHERE idempotency_key='premature-refreshed-approval'"
-            ).fetchone()[0],
-        )
 
     def test_outcome_requires_assigned_reviewer_and_accepted_request(self):
         handoff = self.request_review()
@@ -936,6 +883,7 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             body="Medium: update the implementation.",
             idempotency_key="changes-before-new-request",
         )
+        self.deliver_message(changed.message_id)
         self.messages.mark_read(changed.message_id, 1)
         self.reader.current = pull_request(
             checks="FAILURE", checks_failed=True, head_sha="b" * 40
@@ -981,7 +929,7 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
             ).fetchone()[0],
         )
 
-    def test_approval_rejects_a_head_that_changed_after_review_acceptance(self):
+    def test_head_change_after_acceptance_keeps_the_review_live(self):
         handoff = self.request_review()
         self.accept_review(handoff.message_id)
         self.reader.current = pull_request(
@@ -989,57 +937,118 @@ class ReviewOutcomeTest(SprintReviewLoopCase):
         )
         self.watcher.poll_once()
 
-        with self.assertRaisesRegex(
-            sprint_domain.SprintInvariantError,
-            "review verdict requires an accepted request",
-        ):
-            self.loop.record_review(
-                self.sprint_id,
-                self.registered_pr_id,
-                2,
-                verdict="approved",
-                body="must re-request on the changed head",
-                idempotency_key="stale-review-head",
-            )
-
         self.assertEqual(
-            0,
-            self.con.execute(
-                "SELECT COUNT(*) FROM wake_message "
-                "WHERE idempotency_key='stale-review-head'"
-            ).fetchone()[0],
-        )
-        self.assertEqual(
-            ("declined", "superseded by PR head change"),
+            ("in_review", "accepted"),
             tuple(
                 self.con.execute(
-                    "SELECT disposition,decline_reason FROM wake_message "
-                    "WHERE message_id=?",
-                    (handoff.message_id,),
+                    "SELECT unit.disposition,message.disposition "
+                    "FROM sprint_work_units unit JOIN wake_message message "
+                    "ON message.work_unit_id=unit.work_unit_id "
+                    "WHERE unit.work_unit_id=? AND message.message_id=?",
+                    (self.unit_id, handoff.message_id),
                 ).fetchone()
             ),
         )
+        outcome = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="approved",
+            body="Approved on the live head after a rebase.",
+            idempotency_key="approved-after-head-move",
+        )
+        self.assertEqual("merge_ready", outcome.disposition)
         self.assertEqual(
-            "fixing",
+            0,
             self.con.execute(
-                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
-                (self.unit_id,),
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='review.request_invalidated'"
             ).fetchone()[0],
         )
+
+
+class ReviewRoundCeilingTest(SprintReviewLoopCase):
+    def changes_round(self, index: int):
+        handoff = self.request_review(f"round-{index}:request")
+        self.accept_review(handoff.message_id)
+        changed = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="changes_requested",
+            body=f"Medium: round {index} still has findings.",
+            idempotency_key=f"round-{index}",
+        )
+        self.deliver_message(changed.message_id)
+        self.messages.mark_read(changed.message_id, 1)
+        return changed
+
+    def sprint_lifecycle(self) -> str:
+        return self.con.execute(
+            "SELECT lifecycle FROM sprints WHERE sprint_id=?", (self.sprint_id,)
+        ).fetchone()[0]
+
+    def test_rounds_below_the_ceiling_leave_the_sprint_armed(self):
+        for index in range(1, sprint_review_loop.REVIEW_ROUND_CEILING):
+            changed = self.changes_round(index)
+            self.assertFalse(changed.sprint_paused)
+        self.assertEqual("armed", self.sprint_lifecycle())
         self.assertEqual(
-            self.developer_conversation_id,
+            0,
             self.con.execute(
-                "SELECT active.chat_id FROM sprint_participants participant "
-                "JOIN active_shell_chats active "
-                "ON active.shell_id=participant.shell_id "
-                "WHERE participant.participant_id=?",
-                (self.developer_id,),
+                "SELECT COUNT(*) FROM sprint_events WHERE event_type='lifecycle.paused'"
             ).fetchone()[0],
         )
+
+    def test_eighth_changes_requested_pauses_the_sprint_for_fnb(self):
+        for index in range(1, sprint_review_loop.REVIEW_ROUND_CEILING):
+            self.changes_round(index)
+
+        final = self.changes_round(sprint_review_loop.REVIEW_ROUND_CEILING)
+
+        self.assertTrue(final.sprint_paused)
+        self.assertEqual("fixing", final.disposition)
+        self.assertEqual("paused", self.sprint_lifecycle())
+        paused = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE event_type='lifecycle.paused'"
+            ).fetchone()[0]
+        )
+        self.assertEqual(
+            (
+                sprint_review_loop.REVIEW_ROUNDS_EXHAUSTED,
+                self.unit_id,
+                self.registered_pr_id,
+                sprint_review_loop.REVIEW_ROUND_CEILING,
+            ),
+            (
+                paused["reason"],
+                paused["work_unit_id"],
+                paused["registered_pr_id"],
+                paused["review_rounds"],
+            ),
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM sprint_reports "
+                "WHERE sprint_id=? AND report_kind='pause'",
+                (self.sprint_id,),
+            ).fetchone()[0],
+        )
+        notice = self.con.execute(
+            "SELECT body FROM wake_message "
+            "WHERE idempotency_key LIKE 'sprint-pause:%'"
+        ).fetchone()
+        self.assertIn("8 review rounds without approval", notice["body"])
+        with self.assertRaisesRegex(
+            sprint_domain.SprintInvariantError, "requires an armed Sprint"
+        ):
+            self.request_review("round-9:request")
 
 
 class MergeGateAndAdvanceTest(SprintReviewLoopCase):
-    def test_merge_gate_rechecks_live_green_and_exact_approved_head(self):
+    def test_merge_gate_rechecks_live_green_only(self):
         approved = self.approve()
         authorization = self.loop.authorize_merge(
             self.sprint_id, self.registered_pr_id, 1
@@ -1064,10 +1073,8 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
         self.reader.current = pull_request(
             checks="SUCCESS", checks_failed=False, head_sha="b" * 40
         )
-        with self.assertRaisesRegex(
-            sprint_domain.SprintInvariantError, "approval is stale"
-        ):
-            self.loop.authorize_merge(self.sprint_id, self.registered_pr_id, 1)
+        rebased = self.loop.authorize_merge(self.sprint_id, self.registered_pr_id, 1)
+        self.assertEqual("b" * 40, rebased.head_sha)
         self.assertEqual(
             "merge_ready",
             self.con.execute(
@@ -1076,7 +1083,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             ).fetchone()[0],
         )
 
-    def test_moved_base_refuses_authorization_and_wakes_developer_once(self):
+    def test_moved_base_does_not_refuse_authorization(self):
         approved = self.approve()
         self.reader.current = pull_request(
             checks="SUCCESS",
@@ -1085,125 +1092,31 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             base_sha="d" * 40,
         )
 
-        for _ in range(2):
-            with self.assertRaisesRegex(
-                sprint_domain.SprintInvariantError,
-                "approved base .* differs from live base",
-            ):
-                self.loop.authorize_merge(self.sprint_id, self.registered_pr_id, 1)
-
-        wake = self.con.execute(
-            "SELECT sprint_id,to_participant_id,work_unit_id,message_kind,body,"
-            "actionable,disposition,declared_type FROM wake_message "
-            "WHERE idempotency_key LIKE 'merge-base-stale:%'"
-        ).fetchall()
-        self.assertEqual(1, len(wake))
-        self.assertEqual(
-            (
-                self.sprint_id,
-                self.developer_id,
-                self.unit_id,
-                "notification",
-                "Merge authorization refused for PR #42: approved base "
-                + "c" * 40
-                + " differs from live base "
-                + "d" * 40
-                + "; sync with base and return through green review.",
-                1,
-                "pending",
-                "re-enter",
-            ),
-            tuple(wake[0]),
+        authorization = self.loop.authorize_merge(
+            self.sprint_id, self.registered_pr_id, 1
         )
+
+        self.assertEqual("a" * 40, authorization.head_sha)
+        authorized = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events "
+                "WHERE event_type='merge.authorized'"
+            ).fetchone()[0]
+        )
+        self.assertEqual("d" * 40, authorized["base_sha"])
         self.assertEqual(
             ("merge_ready", 0),
             tuple(
                 self.con.execute(
-                    "SELECT disposition,(SELECT COUNT(*) FROM sprint_events "
-                    "WHERE event_type='merge.authorized') "
+                    "SELECT disposition,(SELECT COUNT(*) FROM wake_message "
+                    "WHERE idempotency_key LIKE 'merge-base-stale:%') "
                     "FROM sprint_work_units WHERE work_unit_id=?",
                     (approved.work_unit_id,),
                 ).fetchone()
             ),
         )
 
-    def test_legacy_missing_base_evidence_refuses_then_converges_after_rebase(self):
-        self.reader.current = pull_request(
-            checks="FAILURE", checks_failed=True, base_sha=None
-        )
-        self.assertTrue(self.watcher.poll_once())
-        self.reader.current = pull_request(
-            checks="SUCCESS", checks_failed=False, base_sha=None
-        )
-        self.assertTrue(self.watcher.poll_once())
-        self.approve()
-        self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
-
-        with self.assertRaisesRegex(
-            sprint_domain.SprintInvariantError, "approval predates base-tracking"
-        ):
-            self.loop.authorize_merge(self.sprint_id, self.registered_pr_id, 1)
-
-        legacy_wake = self.con.execute(
-            "SELECT message_id,body FROM wake_message "
-            "WHERE idempotency_key LIKE 'merge-base-stale:%:legacy:%'"
-        ).fetchone()
-        self.assertEqual(
-            "Merge authorization refused for PR #42: approval predates "
-            "base-tracking; sync with base to mint current evidence.",
-            legacy_wake["body"],
-        )
-        self.assertEqual("accepted", self.messages.mark_read(legacy_wake["message_id"], 1))
-
-        self.reader.current = pull_request(
-            checks="SUCCESS",
-            checks_failed=False,
-            head_sha="b" * 40,
-            base_sha="d" * 40,
-        )
-        self.assertTrue(self.watcher.poll_once())
-        self.assertEqual(
-            "fixing",
-            self.con.execute(
-                "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
-                (self.unit_id,),
-            ).fetchone()[0],
-        )
-        invalidation = json.loads(
-            self.con.execute(
-                "SELECT payload FROM sprint_events "
-                "WHERE event_type='review.approval_invalidated'"
-            ).fetchone()[0]
-        )
-        self.assertEqual(("a" * 40, "b" * 40), (
-            invalidation["previous_head_sha"], invalidation["head_sha"]
-        ))
-
-        handoff = self.request_review("legacy-base-review")
-        self.accept_review(handoff.message_id)
-        outcome = self.loop.record_review(
-            self.sprint_id,
-            self.registered_pr_id,
-            2,
-            verdict="approved",
-            body="Rebased head and current base evidence are clean.",
-            idempotency_key="legacy-base-approved",
-        )
-        self.assertEqual("merge_ready", outcome.disposition)
-        authorization = self.loop.authorize_merge(
-            self.sprint_id, self.registered_pr_id, 1
-        )
-        self.assertEqual("b" * 40, authorization.head_sha)
-        evidence = json.loads(
-            self.con.execute(
-                "SELECT evidence FROM sprint_pr_transitions "
-                "WHERE registered_pr_id=? ORDER BY transition_id DESC LIMIT 1",
-                (self.registered_pr_id,),
-            ).fetchone()[0]
-        )
-        self.assertEqual("d" * 40, evidence["base_sha"])
-
-    def test_same_state_head_move_returns_readiness_judgment_to_developer(self):
+    def test_same_state_head_move_keeps_approval(self):
         approved = self.approve()
         self.reader.current = pull_request(
             checks="SUCCESS", checks_failed=False, head_sha="b" * 40
@@ -1222,7 +1135,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             ],
         )
         self.assertEqual(
-            "fixing",
+            "merge_ready",
             self.con.execute(
                 "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
                 (self.unit_id,),
@@ -1231,45 +1144,16 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
         self.assertEqual(
             0,
             self.con.execute(
-                "SELECT COUNT(*) FROM wake_message "
-                "WHERE idempotency_key LIKE 'pr-head-change:%:delta-review'"
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='review.approval_invalidated'"
             ).fetchone()[0],
         )
-        owner_event = self.con.execute(
-            "SELECT receiver_shell_id,body FROM wake_message "
-            "WHERE idempotency_key LIKE 'pr-transition:%' "
-            "ORDER BY message_id DESC LIMIT 1"
-        ).fetchone()
-        self.assertEqual(1, owner_event["receiver_shell_id"])
-        self.assertIn("event=green", owner_event["body"])
-        self.assertIn("judge readiness", owner_event["body"])
-        invalidated = json.loads(
-            self.con.execute(
-                "SELECT payload FROM sprint_events "
-                "WHERE event_type='review.approval_invalidated'"
-            ).fetchone()[0]
-        )
-        self.assertEqual("a" * 40, invalidated["previous_head_sha"])
-        self.assertEqual("b" * 40, invalidated["head_sha"])
-        self.assertEqual(approved.message_id, invalidated["invalidated_message_id"])
-        self.assertIsNotNone(
+        self.assertIsNone(
             self.con.execute(
                 "SELECT read_at FROM wake_message WHERE message_id=?",
                 (approved.message_id,),
             ).fetchone()[0]
         )
-
-        handoff = self.request_review("review-after-head-move")
-        self.accept_review(handoff.message_id)
-        outcome = self.loop.record_review(
-            self.sprint_id,
-            self.registered_pr_id,
-            2,
-            verdict="approved",
-            body="Delta review is clean on the replacement head.",
-            idempotency_key="approved-after-head-move",
-        )
-        self.assertEqual("merge_ready", outcome.disposition)
         self.assertEqual(
             "b" * 40,
             self.loop.authorize_merge(
@@ -1277,8 +1161,8 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
             ).head_sha,
         )
 
-    def test_head_move_invalidates_an_active_review_request(self):
-        stale = self.request_review("review-before-head-move")
+    def test_head_move_keeps_an_active_review_request(self):
+        handoff = self.request_review("review-before-head-move")
         self.reader.current = pull_request(
             checks="SUCCESS", checks_failed=False, head_sha="b" * 40
         )
@@ -1286,87 +1170,42 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
         self.assertTrue(self.watcher.poll_once())
 
         self.assertEqual(
-            "fixing",
+            "in_review",
             self.con.execute(
                 "SELECT disposition FROM sprint_work_units WHERE work_unit_id=?",
                 (self.unit_id,),
             ).fetchone()[0],
         )
         self.assertEqual(
-            (1, "declined", "superseded by PR head change", "cancelled"),
+            ("pending", None, "pending"),
             tuple(
                 self.con.execute(
-                    "SELECT message.read_at IS NOT NULL,message.disposition,"
-                    "message.decline_reason,outbox.state "
+                    "SELECT message.disposition,message.decline_reason,outbox.state "
                     "FROM wake_message message "
                     "JOIN sprint_wake_messages link USING(message_id) "
                     "JOIN sprint_wake_outbox outbox USING(wake_id) "
                     "WHERE message.message_id=?",
-                    (stale.message_id,),
+                    (handoff.message_id,),
                 ).fetchone()
             ),
         )
-        invalidated = json.loads(
-            self.con.execute(
-                "SELECT payload FROM sprint_events "
-                "WHERE event_type='review.request_invalidated'"
-            ).fetchone()[0]
-        )
-        self.assertEqual(
-            (
-                stale.message_id,
-                self.registered_pr_id,
-                self.unit_id,
-                "a" * 40,
-                "b" * 40,
-            ),
-            (
-                invalidated["invalidated_message_id"],
-                invalidated["registered_pr_id"],
-                invalidated["work_unit_id"],
-                invalidated["previous_head_sha"],
-                invalidated["head_sha"],
-            ),
-        )
-        refreshed = self.request_review("review-after-active-head-move")
-        self.assertEqual(
-            (
-                "in_review",
-                (
-                    "Submitting PR for review: "
-                    "https://github.com/acme/repo/pull/42; registered Sprint PR "
-                    f"{self.registered_pr_id}; exact head {'b' * 40}; work unit "
-                    f"{self.unit_id}."
-                ),
-            ),
-            tuple(
-                self.con.execute(
-                    "SELECT unit.disposition,message.body "
-                    "FROM sprint_work_units unit JOIN wake_message message "
-                    "ON message.work_unit_id=unit.work_unit_id "
-                    "WHERE unit.work_unit_id=? AND message.message_id=?",
-                    (self.unit_id, refreshed.message_id),
-                ).fetchone()
-            ),
-        )
-        with self.assertRaisesRegex(
-            sprint_domain.SprintInvariantError, "accepted request"
-        ):
-            self.loop.record_review(
-                self.sprint_id,
-                self.registered_pr_id,
-                2,
-                verdict="approved",
-                body="The stale review acceptance cannot cross the head change.",
-                idempotency_key="stale-acceptance-after-head-move",
-            )
         self.assertEqual(
             0,
             self.con.execute(
-                "SELECT COUNT(*) FROM wake_message "
-                "WHERE idempotency_key='stale-acceptance-after-head-move'"
+                "SELECT COUNT(*) FROM sprint_events "
+                "WHERE event_type='review.request_invalidated'"
             ).fetchone()[0],
         )
+        self.accept_review(handoff.message_id)
+        outcome = self.loop.record_review(
+            self.sprint_id,
+            self.registered_pr_id,
+            2,
+            verdict="approved",
+            body="Approved on the moved head.",
+            idempotency_key="approved-after-active-head-move",
+        )
+        self.assertEqual("merge_ready", outcome.disposition)
 
     def test_merged_head_move_completes_without_requesting_dead_delta_review(self):
         self.approve()
@@ -1857,6 +1696,7 @@ class MergeGateAndAdvanceTest(SprintReviewLoopCase):
 
     def test_observed_merge_completes_board_and_assigns_next_in_fresh_active_lane(self):
         approved = self.approve()
+        self.deliver_message(approved.message_id)
         self.messages.mark_read(approved.message_id, 1)
         document = self.con.execute(
             "SELECT document_id FROM sprint_specs WHERE sprint_id=?",

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -55,7 +55,9 @@ CONFORMANCE_OWNER_SKILLS = {
 
 SPEC_SKILL = ENGINE / "assets" / "skills" / "spec" / "SKILL.md"
 CONTEXT_EFFICIENT_SKILLS = ("sprint_dev", "sprint_rev", "sprint_pln", "spec")
-CONTEXT_EFFICIENT_SKILL_BYTE_CEILING = 47_414
+# Raised 47_414 -> 47_612 with 0253: verdicts open a fresh Developer chat, so
+# sprint_dev now tells the Developer to carry rationale in the PR body.
+CONTEXT_EFFICIENT_SKILL_BYTE_CEILING = 47_612
 CONTEXT_EFFICIENT_RESEED = (
     ENGINE / "migrations" / "0202_reseed_context_efficient_skills.sql"
 )
@@ -79,6 +81,9 @@ DISPOSITION_VERBS_RESEED = (
 )
 ROLE_AWARE_BOOT_RESEED = (
     ENGINE / "migrations" / "0243_role_aware_boot_contract.sql"
+)
+REVIEW_FLEXIBILITY_RESEED = (
+    ENGINE / "migrations" / "0253_reseed_sprint_review_flexibility.sql"
 )
 SUBFLOOR_COMMAND_RESEED = (
     ENGINE / "migrations" / "0247_reseed_subfloor_command.sql"
@@ -207,6 +212,7 @@ class SprintSkillTest(unittest.TestCase):
             con.executescript(INFORMATIONAL_RECEIPT_RESEED.read_text())
             con.executescript(BINDING_GUIDANCE_RESEED.read_text())
             con.executescript(DISPOSITION_VERBS_RESEED.read_text())
+            con.executescript(REVIEW_FLEXIBILITY_RESEED.read_text())
 
             for name in sorted(CONFORMANCE_OWNER_SKILLS):
                 with self.subTest(name=name):
@@ -262,6 +268,7 @@ class SprintSkillTest(unittest.TestCase):
             con.executescript(migration)
             con.executescript(migration)
             con.executescript(DISPOSITION_VERBS_RESEED.read_text())
+            con.executescript(REVIEW_FLEXIBILITY_RESEED.read_text())
 
             for name in sorted(HANDOFF_ROLE_SKILLS):
                 with self.subTest(name=name):
@@ -799,6 +806,39 @@ class SprintSkillTest(unittest.TestCase):
         finally:
             con.close()
 
+    def test_review_flexibility_reseed_matches_assets_and_replays_idempotently(self):
+        name = "0253_reseed_sprint_review_flexibility.sql"
+        con = sqlite3.connect(":memory:")
+        try:
+            con.executescript((ENGINE / "schema.sql").read_text())
+            for migration in sorted((ENGINE / "migrations").glob("*.sql")):
+                if migration.name >= name:
+                    break
+                con.executescript(migration.read_text())
+            placeholders = ",".join("?" for _ in POLISHED_SPRINT_SKILLS)
+            con.execute(
+                f"UPDATE skills SET content='verdicts re-enter; approval binds to head',"
+                f"is_deleted=1 WHERE name IN ({placeholders})",
+                tuple(sorted(POLISHED_SPRINT_SKILLS)),
+            )
+
+            migration = (ENGINE / "migrations" / name).read_text()
+            con.executescript(migration)
+            con.executescript(migration)
+
+            for skill in sorted(POLISHED_SPRINT_SKILLS):
+                with self.subTest(name=skill):
+                    parsed = seed_skills.parse_skill(ASSETS / skill / "SKILL.md")
+                    rows = con.execute(
+                        "SELECT content,is_deleted FROM skills WHERE name=?",
+                        (skill,),
+                    ).fetchall()
+                    self.assertEqual([(parsed["content"], 0)], [tuple(r) for r in rows])
+                    self.assertNotIn("approved head", parsed["content"])
+                    self.assertNotIn("Approval is stale evidence", parsed["content"])
+        finally:
+            con.close()
+
     def test_successful_chat_cleanup_reseed_matches_assets_and_is_idempotent(self):
         con = sqlite3.connect(":memory:")
         try:
@@ -901,6 +941,7 @@ class SprintSkillTest(unittest.TestCase):
             con.executescript(ROLE_AWARE_BOOT_RESEED.read_text())
             con.executescript(SUBFLOOR_COMMAND_RESEED.read_text())
             con.executescript(UNIVERSAL_PR_WAKES_RESEED.read_text())
+            con.executescript(REVIEW_FLEXIBILITY_RESEED.read_text())
 
             self.assertIsNotNone(
                 con.execute(
@@ -1570,7 +1611,7 @@ class SprintSkillTest(unittest.TestCase):
         reviewer = " ".join(bodies["sprint_rev"].split())
         self.assertIn("retain that exact message id", reviewer)
         self.assertIn(
-            "accepted request's message id, registered PR, work unit, and exact head",
+            "accepted request's message id, registered PR, and work unit",
             reviewer,
         )
         self.assertIn("exact notification message id", reviewer)


### PR DESCRIPTION
## Why

FnB direction (2026-09-05): Sprint posture is a toolkit, not a bureaucracy. If a PR is green and passes review it is good to go. Exact-head and base binding forced phantom review rounds whenever `main` moved under an in-review or approved PR (stacked PRs especially), burning verdicts and tokens without the patch changing.

## What changes

**Approval binds to the PR, not a head or base SHA** (`sprint_review_loop.py`, `sprint_pr_watcher.py`)
- A head change during review no longer invalidates the accepted request; the Reviewer reads the live head.
- A head or base change on an approved unit no longer invalidates the approval or drops the lane to `fixing`.
- `authorize_merge` requires only: armed Sprint, owning Developer, merge grant, `merge_ready`, live green. The approved-head check, the base refusal, and its `merge-base-stale` Developer wake are deleted.
- A Developer may `request-review` again while `in_review`; the earlier request is superseded (no head equality check).
- Deleted: `invalidate_review_request_for_head_change_in_transaction`, `_invalidate_stale_approval`, `_approved_head`, `_approved_base_sha`, `_base_refusal`, the `review.approval_invalidated` emitter and its board projection entry.

**Verdicts deliver Force-new; PR events stay Re-enter**
- Reviewer→Developer `record_review` wakes are now `force-new`. Verdicts arrive after a cold review cycle, so a fresh chat reading the PR is cheaper and cleaner than re-entering a long stale one. Red/green/closed PR events land minutes after a push and keep `re-enter` on the warm authoring chat.
- `sprint_dev` now tells the Developer to put implementation rationale in the PR body so the fresh chat does not re-litigate settled choices. Boot template routing sentence updated to match.

**Eight-round ceiling auto-pauses** (replaces decision #282, which was never implemented)
- `REVIEW_ROUND_CEILING = 8`. When the eighth `changes_requested` lands on one work-unit PR, the engine pauses the Sprint (`review_rounds_exhausted`), files the pause report, and notifies the Planner. No forced merge of unresolved findings. `record-review` response gains `sprint_paused`.
- Decisions: #319 supersedes #282 (ceiling); #320 records binding + routing.

**Skills / migration**
- `0253_reseed_sprint_review_flexibility.sql` reseeds `sprint_dev`, `sprint_rev`, `sprint_pln`, `sprint_close`; `0001` regenerated from assets (this also picks up the `git` skill text #1505 changed without regenerating the seed).
- `CONTEXT_EFFICIENT_SKILL_BYTE_CEILING` 47,414 → 47,612 (the ceiling was pinned to the exact prior total; the PR-body rationale rule is deliberate growth of 198 bytes on top of #1505's raise).

## Trade-offs stated

- The engine no longer protects against a Developer pushing substantive changes after approval and merging without re-review. That is repo policy: GitHub branch protection ("dismiss stale approvals on new commits") covers it per fork if wanted.
- Ceiling triggers on the 8th `changes_requested` rather than on a 9th request, so the pause lands before another round is spent.
- Kept `review.request_invalidated` (now emitted on Developer resubmit) and the historical `approval_invalidated` health/board handling for old rows.

## Rebase onto #1505 (2026-09-05)

`main` landed universal PR owner wakes (#1505) with its own `0252`. This PR's reseed is renumbered `0253` and regenerated from the merged `sprint_dev` / `sprint_pln` assets; the watcher keeps #1505's `previous_state` argument in `_route_transition` while still dropping the head-invalidation path; both migrations are listed in the removal manifest and focused-verification fixture.

CI fix: `test_serial_sprint_runs_correction_merge_dispatch_and_close` expected 2 Developer chats per serial Sprint. With Force-new verdicts the `changes_requested` round opens a third chat, which is this PR's intended behavior, so the assertion now expects 3.

## Verification

Local (worktree interpreter, pytest):
- `tests/test_sprint_review_loop.py` (rewritten head-binding tests; new `ReviewRoundCeilingTest` ×2), `test_sprint_pr_watcher.py`, `test_sprint_skills.py` (new 0252 reseed test), `test_sprint_health.py`, `test_sprint_board_api.py`, `test_focused_dev_verification.py`, `test_sprint_liveness.py`, `test_sprint_message_delivery.py`, `test_sprint_cli.py`, `test_migration_management.py`, `test_skill_tombstones.py`, `test_skill_retire.py`, `test_web_search.py`, `test_conversation_schema.py` — all green (314 + 154 passed across the two batches).
- `ruff check` on touched engine files: only the pre-existing TRY004 on `main` remains.
- Local `render_check.py` reports the untracked `skills_sc/` mirror stale, as expected before `./sc rebuild && ./sc render flat`; CI regenerates before checking.

After rebase: `test_sprint_live_proof.py`, `test_sprint_skills.py`, `test_sprint_pr_watcher.py`, `test_sprint_review_loop.py`, `test_focused_dev_verification.py`, `test_migration_management.py` — 175 passed, 130 subtests. `ruff check` on touched files: only findings already present on `main`.

Full suite left to CI (authoritative gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

