### PR TITLE
feat(vm): add fixed Windows testing controller

### DIFF
--- a/.super-coder/docs/skills/windows_testing/SKILL.md
+++ b/.super-coder/docs/skills/windows_testing/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: windows_testing
+description: Drive the supplied disposable W10C-Testing guest through the fixed Halo controller. Use for Windows build/test runs, artifact transfer, testing snapshots, or working-baseline promotion; do not use for canonical W10C, Dev, or VM provisioning.
+category: substrate
+common: false
+---
+
+# windows_testing — use the disposable Windows test guest
+
+The controller exposes one guest, `W10C-Testing`, with the same commands from
+Halo and Dev. It cannot select another domain or run commands/read files on
+Halo. Cash/Jed own installation, guest credentials, the immutable recovery
+snapshot, and live provisioning.
+
+## Initialize once per checkout
+
+On Halo:
+
+```bash
+sc vm test init local
+```
+
+On Dev, use the operator-supplied SSH alias whose key is restricted to the
+controller ForceCommand:
+
+```bash
+sc vm test init ssh halo-windows-test
+```
+
+Initialization changes only the transport. Every later verb is identical. If
+the controller or guest is unconfigured, surface the structured error; do not
+change SSH, libvirt, networking, credentials, or snapshots to repair it.
+
+## Run one test session
+
+```bash
+sc vm test status
+sc vm test acquire --owner "<shell/task>"
+sc vm test start
+sc vm test push <local-file> artifacts/test.zip
+sc vm test exec --cwd run --command-file <local-script.ps1>
+sc vm test pull results/result.json <local-result>
+sc vm test reset working
+sc vm test release
+```
+
+`acquire` saves an owner-only opaque lease locally; later commands use it
+without putting it in argv or logs. Keep the lease for the whole push/exec/pull
+and reset sequence. A competing mutation fails rather than joining the active
+session. Report the test result and reset/release result separately.
+
+Guest paths are relative to the configured workspace. `exec` always requires
+an explicit `--cwd` there and runs PowerShell under the configured
+administrator account. Prefer `--command-file` for non-trivial scripts. A
+normal test timeout kills the tracked guest process tree. If the SSH result is
+instead uncertain, reset and promotion remain blocked; run an explicit stop to
+confirm power-off before continuing.
+
+`stop` first requests a graceful Windows shutdown and waits a bounded time.
+Use `--force` only when the operator explicitly chooses to hard-stop this
+disposable guest; the flag is the confirmation.
+
+## Testing snapshots
+
+```bash
+sc vm test snapshot list
+sc vm test snapshot create <name>
+sc vm test reset <name>
+sc vm test snapshot delete <name>
+```
+
+Snapshot creation and reset shut the guest down cleanly and leave it powered
+off. The controller refuses deletion or replacement of the recovery snapshot
+and current working baseline. Snapshot names are simple letters/digits with
+dot, underscore, or dash.
+
+After installing and verifying a dependency that should survive later resets:
+
+```bash
+sc vm test baseline promote [new-name]
+```
+
+Promotion creates and verifies a new offline snapshot before changing the
+working-baseline reference. Failure leaves the prior reference selected; a
+successful promotion also retains the previous snapshot.
+
+## Installation (Cash/Jed only)
+
+Do not run this section during an ordinary test session. Keep the existing
+libvirt NAT network and provision only `W10C-Testing`; verify UUID
+`0b314d1a-bd03-47b9-8155-01a6d470f7a9`. Canonical `W10C` and Dev stay out of
+scope.
+
+The current dos-arch Windows project targets .NET 8 for Windows on x64. The
+guest needs Windows OpenSSH, an SSH account in local Administrators, PowerShell,
+the .NET 8 SDK, package restore access, and a writable workspace such as
+`C:\\SubfloorTest`. Git is optional when a shell pushes prepared artifacts.
+Create the immutable recovery snapshot and initial offline working snapshot as
+an operator.
+
+On Halo, create `~/.config/subfloor/windows-test-controller.json` for `jedi`
+with mode `0600` and its parent directory mode `0700`:
+
+```json
+{
+  "guest": {
+    "host": "<W10C-Testing address on libvirt NAT>",
+    "port": 22,
+    "user": "<Windows administrator account>",
+    "key_path": "/home/jedi/.ssh/<guest-key>",
+    "workspace": "C:\\SubfloorTest"
+  },
+  "recovery_snapshot": "<immutable-recovery-name>",
+  "initial_working_baseline": "<working-baseline-name>",
+  "lease_seconds": 14400
+}
+```
+
+Keep the guest key owner-only and register its host key for `jedi`; the
+controller uses strict host-key checking. It has no daemon and opens no
+listener.
+
+For Dev, add a dedicated public key to Halo `jedi` with the reviewed `sc` path
+as a ForceCommand. The command has no shell operators and does not depend on
+Fish syntax:
+
+```text
+restrict,command="/home/jedi/Repos/subfloor/sc vm test serve" ssh-ed25519 <public-key> windows-test-controller
+```
+
+Keep the private key on Dev and point an SSH alias such as
+`halo-windows-test` at it with `RequestTTY no`. Do not reuse an unrestricted
+Halo login key. Verify both init modes with the same small
+status/acquire/start/push/exec/pull/reset/release run, then confirm lease
+conflicts, protected snapshot refusal, and failed-promotion preservation.
+
+After the reviewed engine revision is installed in active dos-arch, import this
+file as a fork-local skill:
+
+```bash
+sc skill put --file .super-coder/docs/skills/windows_testing/SKILL.md
+sc skill grant windows_testing <dev-shortname> <reviewer-shortname>
+sc skill list
+```
+
+Grant it only to the shells that use this seat.

--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -1836,6 +1836,10 @@ Subfloor — forkable shell substrate — full command reference (./sc help for 
                            inspect, start+verify, or stop the managed MCP tunnel and relay
   ./sc vm reset --off [--json]
                            restore the testing snapshot and confirm the VM is powered off
+  ./sc vm test init local | ./sc vm test init ssh HOST
+                           select Halo-local or Dev-through-ForceCommand transport
+  ./sc vm test status|acquire|release|start|stop|exec|push|pull|snapshot|reset|baseline
+                           drive the fixed W10C-Testing controller; run --help for exact forms
   ./sc vm-broker           run the broker in the foreground (unix socket)
   ./sc vm-bake             HOST-side: graceful shutdown + (re)bake the clean snapshot after provisioning
                              (deliberately NOT a broker verb — the sandbox must never redefine 'clean')

--- a/.super-coder/scripts/vm.py
+++ b/.super-coder/scripts/vm.py
@@ -2183,11 +2183,19 @@ def _human_result(value: dict) -> str:
 
 
 def client_main(argv: list[str]) -> int:
+    if argv[:1] == ["test"]:
+        import windows_test_controller
+
+        return windows_test_controller.main(argv[1:])
     parser = argparse.ArgumentParser(
         prog="./sc vm",
         description="Observe and control the configured Windows test VM.",
     )
     commands = parser.add_subparsers(dest="operation", required=True)
+    commands.add_parser(
+        "test",
+        help="control the fixed W10C-Testing guest locally or through constrained SSH",
+    )
     status = commands.add_parser(
         "status",
         help="observe VM readiness without mutation",

--- a/.super-coder/scripts/windows_test_controller.py
+++ b/.super-coder/scripts/windows_test_controller.py
@@ -1,0 +1,1329 @@
+#!/usr/bin/env python3
+"""Fixed-target controller for the disposable W10C-Testing guest.
+
+The controller runs on Halo.  A caller either starts ``serve`` locally or
+reaches the same command through an SSH ForceCommand.  Requests are one JSON
+line followed by an optional exact-length byte stream; responses use the same
+framing.  No request can select a libvirt connection, domain, host command, or
+host path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import fcntl
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+from typing import BinaryIO, cast
+
+SCHEMA_VERSION = 1
+LIBVIRT_URI = "qemu:///system"
+DOMAIN = "W10C-Testing"
+DOMAIN_UUID = "0b314d1a-bd03-47b9-8155-01a6d470f7a9"
+CONFIG_PATH = Path.home() / ".config" / "subfloor" / "windows-test-controller.json"
+CLIENT_PATH = Path(".sc-state/local/windows-test-client.json")
+NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+SSH_ALIAS_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+MAX_HEADER_BYTES = 64 * 1024
+MAX_TIMEOUT = 4 * 60 * 60
+DEFAULT_STOP_TIMEOUT = 120
+CHUNK_SIZE = 1024 * 1024
+
+
+class ControllerError(RuntimeError):
+    def __init__(self, code: str, message: str, details: dict | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.details = details or {}
+
+
+def _error(operation: str, exc: ControllerError) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": False,
+        "operation": operation,
+        "result": None,
+        "error": {
+            "code": exc.code,
+            "message": str(exc)[:500],
+            "details": exc.details,
+        },
+    }
+
+
+def _success(operation: str, result: dict) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": True,
+        "operation": operation,
+        "result": result,
+        "error": None,
+    }
+
+
+def _result_error(operation: str, code: str, message: str, result: dict) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": False,
+        "operation": operation,
+        "result": result,
+        "error": {"code": code, "message": message[:500], "details": {}},
+    }
+
+
+def _require_owner_file(path: Path, label: str) -> None:
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError as exc:
+        raise ControllerError(
+            "configuration_unavailable", f"{label} is unavailable"
+        ) from exc
+    if mode & 0o077:
+        raise ControllerError(
+            "configuration_permissions",
+            f"{label} must not be readable or writable by group or other users",
+        )
+
+
+def _require_owner_directory(path: Path, label: str) -> None:
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError as exc:
+        raise ControllerError(
+            "configuration_unavailable", f"{label} is unavailable"
+        ) from exc
+    if not path.is_dir() or mode & 0o077:
+        raise ControllerError(
+            "configuration_permissions",
+            f"{label} must be a private directory",
+        )
+
+
+def _read_json(path: Path, label: str, *, required: bool = True) -> dict:
+    if not path.exists() and not required:
+        return {}
+    _require_owner_file(path, label)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ControllerError(
+            "configuration_invalid", f"{label} is not valid JSON"
+        ) from exc
+    if not isinstance(value, dict):
+        raise ControllerError(
+            "configuration_invalid", f"{label} must contain a JSON object"
+        )
+    return value
+
+
+def _atomic_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, raw_tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp = Path(raw_tmp)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, separators=(",", ":"), sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _validated_timeout(value: object, default: int) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise ControllerError(
+            "timeout_invalid", "timeout must be an integer number of seconds"
+        )
+    try:
+        timeout = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ControllerError(
+            "timeout_invalid", "timeout must be an integer number of seconds"
+        ) from exc
+    if timeout < 1 or timeout > MAX_TIMEOUT:
+        raise ControllerError(
+            "timeout_invalid", f"timeout must be between 1 and {MAX_TIMEOUT} seconds"
+        )
+    return timeout
+
+
+def _snapshot_name(value: object, *, allow_working: bool = False) -> str:
+    name = str(value or "")
+    if allow_working and name == "working":
+        return name
+    if not NAME_RE.fullmatch(name):
+        raise ControllerError(
+            "snapshot_name_invalid",
+            "snapshot name must use 1-64 letters, digits, dot, underscore, or dash",
+        )
+    return name
+
+
+def _guest_relative(value: object) -> str:
+    raw = str(value or "")
+    path = PureWindowsPath(raw)
+    if (
+        not raw
+        or path.is_absolute()
+        or path.drive
+        or any(part in ("", ".", "..") for part in path.parts)
+    ):
+        raise ControllerError(
+            "guest_path_invalid",
+            "guest path must be a relative path inside the configured workspace",
+        )
+    return str(path)
+
+
+def _ps_encoded(script: str) -> str:
+    return base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+
+
+def _ps_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+@dataclass(frozen=True)
+class PullPlan:
+    operation: str
+    command: list[str]
+    size: int
+    timeout: int
+    lock_fd: int
+
+
+class Controller:
+    def __init__(
+        self,
+        config_path: Path = CONFIG_PATH,
+        *,
+        run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+        popen: Callable[..., subprocess.Popen] = subprocess.Popen,
+        now: Callable[[], float] = time.time,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.config_path = config_path
+        self.state_path = config_path.with_name("windows-test-controller-state.json")
+        self.lock_path = config_path.with_name("windows-test-controller.lock")
+        self.run = run
+        self.popen = popen
+        self.now = now
+        self.monotonic = monotonic
+        self.sleep = sleep
+        self.config = self._load_config()
+
+    def _load_config(self) -> dict:
+        _require_owner_directory(
+            self.config_path.parent, "controller configuration directory"
+        )
+        cfg = _read_json(self.config_path, "controller configuration")
+        guest = cfg.get("guest")
+        required = ("host", "user", "key_path", "workspace")
+        if not isinstance(guest, dict) or any(
+            not str(guest.get(k, "")).strip() for k in required
+        ):
+            raise ControllerError(
+                "configuration_invalid",
+                "controller configuration requires guest host, user, key_path, and workspace",
+            )
+        recovery = _snapshot_name(cfg.get("recovery_snapshot"))
+        initial = _snapshot_name(cfg.get("initial_working_baseline"))
+        if recovery == initial:
+            raise ControllerError(
+                "configuration_invalid",
+                "recovery and initial working baseline snapshots must differ",
+            )
+        key = Path(os.path.expanduser(str(guest["key_path"])))
+        if not key.is_absolute():
+            raise ControllerError(
+                "configuration_invalid", "guest key_path must be absolute"
+            )
+        _require_owner_file(key, "guest SSH key")
+        port = guest.get("port", 22)
+        if (
+            isinstance(port, bool)
+            or not isinstance(port, int)
+            or not 1 <= port <= 65535
+        ):
+            raise ControllerError(
+                "configuration_invalid", "guest port must be an integer from 1 to 65535"
+            )
+        lease_seconds = cfg.get("lease_seconds", 4 * 60 * 60)
+        if (
+            isinstance(lease_seconds, bool)
+            or not isinstance(lease_seconds, int)
+            or not 60 <= lease_seconds <= MAX_TIMEOUT
+        ):
+            raise ControllerError(
+                "configuration_invalid",
+                f"lease_seconds must be an integer from 60 to {MAX_TIMEOUT}",
+            )
+        cfg["recovery_snapshot"] = recovery
+        cfg["initial_working_baseline"] = initial
+        guest["key_path"] = str(key)
+        guest["port"] = port
+        return cfg
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        fd = self._acquire_lock()
+        try:
+            yield
+        finally:
+            self._release_lock(fd)
+
+    def _acquire_lock(self) -> int:
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        fd = os.open(self.lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        os.fchmod(fd, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            os.close(fd)
+            raise ControllerError(
+                "controller_busy", "another controller operation is still running"
+            ) from exc
+        return fd
+
+    @staticmethod
+    def _release_lock(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+    def _state(self) -> dict:
+        state = _read_json(self.state_path, "controller state", required=False)
+        if "working_baseline" not in state:
+            state["working_baseline"] = self.config["initial_working_baseline"]
+        state.setdefault("lease", None)
+        state.setdefault("uncertain_exec", False)
+        return state
+
+    def _save_state(self, state: dict) -> None:
+        _atomic_json(self.state_path, state)
+
+    def _run(self, argv: list[str], timeout: int) -> subprocess.CompletedProcess:
+        try:
+            return self.run(
+                argv,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise ControllerError(
+                "host_tool_unavailable", f"required host tool is unavailable: {argv[0]}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise ControllerError(
+                "host_command_timeout", f"host operation exceeded {timeout} seconds"
+            ) from exc
+
+    def _virsh(self, *args: str, timeout: int = 30) -> subprocess.CompletedProcess:
+        return self._run(["virsh", "--connect", LIBVIRT_URI, *args], timeout)
+
+    def _verify_target(self) -> None:
+        proc = self._virsh("domuuid", DOMAIN)
+        observed = proc.stdout.strip().lower()
+        if proc.returncode != 0 or observed != DOMAIN_UUID:
+            raise ControllerError(
+                "target_identity_mismatch",
+                "configured W10C-Testing domain identity could not be verified",
+                {"domain": DOMAIN, "expected_uuid": DOMAIN_UUID},
+            )
+
+    def _domain_state(self) -> str:
+        proc = self._virsh("domstate", DOMAIN)
+        if proc.returncode != 0:
+            raise ControllerError(
+                "domain_state_failed", "could not read W10C-Testing state"
+            )
+        raw = proc.stdout.strip().lower()
+        return {
+            "shut off": "powered_off",
+            "running": "running",
+            "paused": "paused",
+            "in shutdown": "shutting_down",
+            "crashed": "crashed",
+        }.get(raw, "unknown")
+
+    def _ssh_argv(self, script: str) -> list[str]:
+        guest = self.config["guest"]
+        remote = f"powershell.exe -NoProfile -NonInteractive -EncodedCommand {_ps_encoded(script)}"
+        return [
+            "ssh",
+            "-T",
+            "-i",
+            guest["key_path"],
+            "-p",
+            str(guest["port"]),
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            f"{guest['user']}@{guest['host']}",
+            remote,
+        ]
+
+    def _run_ps(self, script: str, timeout: int) -> dict:
+        proc = self._run(self._ssh_argv(script), timeout)
+        if proc.returncode != 0:
+            raise ControllerError(
+                "guest_command_failed",
+                "guest PowerShell transport failed",
+                {"exit_code": proc.returncode, "stderr": proc.stderr[-500:]},
+            )
+        try:
+            value = json.loads(proc.stdout.strip().splitlines()[-1])
+        except (IndexError, json.JSONDecodeError) as exc:
+            raise ControllerError(
+                "guest_response_invalid",
+                "guest PowerShell returned an invalid response",
+            ) from exc
+        if not isinstance(value, dict):
+            raise ControllerError(
+                "guest_response_invalid", "guest PowerShell response was not an object"
+            )
+        return value
+
+    def _guest_probe(self) -> dict:
+        result = self._run_ps(
+            """
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+@{ administrator = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator); powershell = $PSVersionTable.PSVersion.ToString() } | ConvertTo-Json -Compress
+""",
+            15,
+        )
+        if result.get("administrator") is not True:
+            raise ControllerError(
+                "guest_not_administrator",
+                "configured guest SSH account is not an administrator",
+            )
+        return {
+            "ready": True,
+            "administrator": True,
+            "powershell": str(result.get("powershell", "unknown")),
+        }
+
+    def _wait_guest(self, timeout: int) -> tuple[dict | None, str | None]:
+        deadline = self.monotonic() + timeout
+        last_error = "guest readiness was not attempted"
+        while self.monotonic() < deadline:
+            try:
+                return self._guest_probe(), None
+            except ControllerError as exc:
+                last_error = str(exc)
+            self.sleep(min(2, max(0, deadline - self.monotonic())))
+        return None, last_error
+
+    def _workspace_script(self, relative: str, body: str, *, must_exist: bool) -> str:
+        root = _ps_literal(str(self.config["guest"]["workspace"]))
+        rel = _ps_literal(relative)
+        existence = (
+            "if (-not (Test-Path -LiteralPath $target -PathType Leaf)) { throw 'file not found' }; "
+            "if (((Get-Item -LiteralPath $target -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { throw 'reparse point refused' }"
+            if must_exist
+            else "if ((Test-Path -LiteralPath $target) -and (((Get-Item -LiteralPath $target -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)) { throw 'reparse point refused' }; [IO.Directory]::CreateDirectory([IO.Path]::GetDirectoryName($target)) | Out-Null"
+        )
+        return f"""
+$ErrorActionPreference = 'Stop'
+$root = [IO.Path]::GetFullPath({root}).TrimEnd('\\')
+$target = [IO.Path]::GetFullPath((Join-Path $root {rel}))
+if (-not $target.StartsWith($root + '\\', [StringComparison]::OrdinalIgnoreCase)) {{ throw 'path escapes workspace' }}
+$cursor = [IO.Path]::GetDirectoryName($target)
+while ($cursor -and $cursor.Length -ge $root.Length) {{
+  if (Test-Path -LiteralPath $cursor) {{
+    $item = Get-Item -LiteralPath $cursor -Force
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {{ throw 'reparse point refused' }}
+  }}
+  if ($cursor -eq $root) {{ break }}
+  $cursor = [IO.Path]::GetDirectoryName($cursor)
+}}
+{existence}
+{body}
+"""
+
+    def _lease(self, state: dict, token: object) -> dict:
+        lease = state.get("lease")
+        if (
+            not isinstance(lease, dict)
+            or float(lease.get("expires_at", 0)) <= self.now()
+        ):
+            raise ControllerError(
+                "lease_required", "an active controller lease is required"
+            )
+        if not secrets.compare_digest(str(lease.get("token", "")), str(token or "")):
+            raise ControllerError(
+                "lease_conflict", "the controller is leased by another session"
+            )
+        return lease
+
+    def _wait_state(self, expected: str, timeout: int) -> str:
+        deadline = self.monotonic() + timeout
+        observed = self._domain_state()
+        while observed != expected and self.monotonic() < deadline:
+            self.sleep(min(1, max(0, deadline - self.monotonic())))
+            observed = self._domain_state()
+        return observed
+
+    def _stop(self, *, force: bool, timeout: int, state: dict) -> dict:
+        self._verify_target()
+        observed = self._domain_state()
+        forced = False
+        if observed == "powered_off":
+            state["uncertain_exec"] = False
+            self._save_state(state)
+            return {
+                "domain": DOMAIN,
+                "state": observed,
+                "forced": False,
+                "changed": False,
+            }
+        proc = self._virsh("shutdown", DOMAIN)
+        if proc.returncode != 0:
+            raise ControllerError(
+                "stop_failed", "graceful shutdown request was rejected"
+            )
+        observed = self._wait_state("powered_off", timeout)
+        if observed != "powered_off" and force:
+            proc = self._virsh("destroy", DOMAIN)
+            if proc.returncode != 0:
+                raise ControllerError(
+                    "forced_stop_failed", "explicit forced stop was rejected"
+                )
+            forced = True
+            observed = self._wait_state("powered_off", 30)
+        if observed != "powered_off":
+            raise ControllerError(
+                "stop_timeout",
+                "guest did not stop before the bounded timeout; no forced stop was performed",
+                {"state": observed, "force_requested": force},
+            )
+        state["uncertain_exec"] = False
+        self._save_state(state)
+        return {"domain": DOMAIN, "state": observed, "forced": forced, "changed": True}
+
+    def status(self) -> dict:
+        self._verify_target()
+        state = self._state()
+        lease = state.get("lease")
+        active_lease = (
+            lease
+            if (
+                isinstance(lease, dict)
+                and float(lease.get("expires_at", 0)) > self.now()
+            )
+            else None
+        )
+        snapshots = self._snapshot_list()
+        domain_state = self._domain_state()
+        guest: dict[str, object] = {
+            "ready": False,
+            "administrator": None,
+            "powershell": None,
+        }
+        guest_error: dict[str, str] | None = None
+        if domain_state == "running":
+            try:
+                guest = self._guest_probe()
+            except ControllerError as exc:
+                guest_error = {"code": exc.code, "message": str(exc)[:500]}
+        guest["error"] = guest_error
+        return {
+            "domain": DOMAIN,
+            "uuid": DOMAIN_UUID,
+            "state": domain_state,
+            "guest": guest,
+            "working_baseline": state["working_baseline"],
+            "recovery_snapshot": self.config["recovery_snapshot"],
+            "uncertain_exec": bool(state.get("uncertain_exec")),
+            "lease": {
+                "active": active_lease is not None,
+                "owner": active_lease.get("owner") if active_lease else None,
+                "expires_at": active_lease.get("expires_at") if active_lease else None,
+            },
+            "snapshots": snapshots,
+        }
+
+    def acquire(self, owner: object) -> dict:
+        name = str(owner or "shell").strip()
+        if not name or len(name) > 80 or any(ord(ch) < 32 for ch in name):
+            raise ControllerError(
+                "lease_owner_invalid", "lease owner must be 1-80 printable characters"
+            )
+        with self._locked():
+            state = self._state()
+            current = state.get("lease")
+            if (
+                isinstance(current, dict)
+                and float(current.get("expires_at", 0)) > self.now()
+            ):
+                raise ControllerError(
+                    "lease_conflict",
+                    "the controller is already leased",
+                    {
+                        "owner": current.get("owner"),
+                        "expires_at": current.get("expires_at"),
+                    },
+                )
+            ttl = int(self.config.get("lease_seconds", 4 * 60 * 60))
+            ttl = min(MAX_TIMEOUT, max(60, ttl))
+            lease = {
+                "token": secrets.token_urlsafe(32),
+                "owner": name,
+                "acquired_at": self.now(),
+                "expires_at": self.now() + ttl,
+            }
+            state["lease"] = lease
+            self._save_state(state)
+            return dict(lease)
+
+    def release(self, token: object) -> dict:
+        with self._locked():
+            state = self._state()
+            self._lease(state, token)
+            state["lease"] = None
+            self._save_state(state)
+            return {"released": True}
+
+    def start(self, token: object, timeout: object) -> dict:
+        wait = _validated_timeout(timeout, 120)
+        with self._locked():
+            state = self._state()
+            self._lease(state, token)
+            self._verify_target()
+            observed = self._domain_state()
+            changed = False
+            if observed == "powered_off":
+                proc = self._virsh("start", DOMAIN)
+                if proc.returncode != 0:
+                    raise ControllerError(
+                        "start_failed", "W10C-Testing could not be started"
+                    )
+                changed = True
+                observed = self._wait_state("running", wait)
+            if observed != "running":
+                raise ControllerError(
+                    "start_state_invalid",
+                    "W10C-Testing did not reach running state",
+                    {"state": observed},
+                )
+            guest, last_error = self._wait_guest(wait)
+            if guest is None:
+                raise ControllerError(
+                    "guest_readiness_timeout",
+                    f"guest did not become ready within {wait} seconds",
+                    {"last_error": last_error},
+                )
+            return {
+                "domain": DOMAIN,
+                "state": observed,
+                "changed": changed,
+                "guest": guest,
+            }
+
+    def stop(self, token: object, timeout: object, force: object) -> dict:
+        wait = _validated_timeout(timeout, DEFAULT_STOP_TIMEOUT)
+        if force not in (None, False, True):
+            raise ControllerError("force_invalid", "force must be boolean")
+        with self._locked():
+            state = self._state()
+            self._lease(state, token)
+            return self._stop(force=bool(force), timeout=wait, state=state)
+
+    def exec(
+        self, token: object, command: object, cwd: object, timeout: object
+    ) -> dict:
+        command_text = str(command or "")
+        if not command_text.strip():
+            raise ControllerError(
+                "exec_command_invalid", "PowerShell command must not be empty"
+            )
+        relative = _guest_relative(cwd)
+        wait = _validated_timeout(timeout, 120)
+        command_b64 = base64.b64encode(command_text.encode("utf-8")).decode("ascii")
+        body = f"""
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {{ throw 'guest account is not an administrator' }}
+$id = [Guid]::NewGuid().ToString('N')
+$scriptPath = Join-Path $env:TEMP ("sc-test-" + $id + ".ps1")
+$stdoutPath = Join-Path $env:TEMP ("sc-test-" + $id + ".out")
+$stderrPath = Join-Path $env:TEMP ("sc-test-" + $id + ".err")
+try {{
+  [IO.File]::WriteAllText($scriptPath, [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{command_b64}')), [Text.UTF8Encoding]::new($false))
+  $p = Start-Process powershell.exe -WorkingDirectory $target -ArgumentList @('-NoProfile','-NonInteractive','-File',('"' + $scriptPath + '"')) -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
+  $finished = $p.WaitForExit({wait * 1000})
+  if (-not $finished) {{ $null = & taskkill.exe /PID $p.Id /T /F; $p.WaitForExit() }}
+  $result = @{{ exit_code = $(if ($finished) {{ $p.ExitCode }} else {{ 124 }}); stdout = $(if (Test-Path $stdoutPath) {{ [IO.File]::ReadAllText($stdoutPath) }} else {{ '' }}); stderr = $(if (Test-Path $stderrPath) {{ [IO.File]::ReadAllText($stderrPath) }} else {{ '' }}); timed_out = (-not $finished) }}
+  $result | ConvertTo-Json -Compress
+}} finally {{ Remove-Item -LiteralPath $scriptPath,$stdoutPath,$stderrPath -Force -ErrorAction SilentlyContinue }}
+"""
+        script = self._workspace_script(relative, body, must_exist=False)
+        with self._locked():
+            state = self._state()
+            self._lease(state, token)
+            self._verify_target()
+            try:
+                result = self._run_ps(script, wait + 30)
+            except ControllerError as exc:
+                if exc.code == "host_command_timeout":
+                    state["uncertain_exec"] = True
+                    self._save_state(state)
+                raise
+            return {
+                "exit_code": int(result.get("exit_code", -1)),
+                "stdout": str(result.get("stdout", "")),
+                "stderr": str(result.get("stderr", "")),
+                "timed_out": bool(result.get("timed_out")),
+            }
+
+    def _snapshot_list(self) -> list[str]:
+        proc = self._virsh("snapshot-list", DOMAIN, "--name")
+        if proc.returncode != 0:
+            raise ControllerError(
+                "snapshot_list_failed", "could not list W10C-Testing snapshots"
+            )
+        return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+    def snapshot_list(self) -> dict:
+        self._verify_target()
+        state = self._state()
+        return {
+            "snapshots": self._snapshot_list(),
+            "working_baseline": state["working_baseline"],
+            "recovery_snapshot": self.config["recovery_snapshot"],
+        }
+
+    def _ensure_off(self, state: dict) -> None:
+        if self._domain_state() != "powered_off":
+            self._stop(force=False, timeout=DEFAULT_STOP_TIMEOUT, state=state)
+
+    def _create_snapshot(self, name: str) -> None:
+        proc = self._virsh(
+            "snapshot-create-as",
+            DOMAIN,
+            name,
+            "--description",
+            "Subfloor disposable Windows testing snapshot",
+            timeout=300,
+        )
+        if proc.returncode != 0:
+            raise ControllerError(
+                "snapshot_create_failed", f"snapshot '{name}' could not be created"
+            )
+        verify = self._virsh("snapshot-info", DOMAIN, "--snapshotname", name)
+        if verify.returncode != 0:
+            raise ControllerError(
+                "snapshot_verify_failed", f"snapshot '{name}' could not be verified"
+            )
+
+    def snapshot_create(self, token: object, name: object) -> dict:
+        snapshot = _snapshot_name(name)
+        with self._locked():
+            state = self._state()
+            self._lease(state, token)
+            self._verify_target()
+            if snapshot in (
+                self.config["recovery_snapshot"],
+                state["working_baseline"],
+            ):
+                raise ControllerError(
+                    "snapshot_protected",
+                    "recovery and working baseline snapshots cannot be replaced",
+                )
+            self._ensure_off(state)
+            self._create_snapshot(snapshot)
+            return {"snapshot": snapshot, "state": "powered_off"}
+
+    def snapshot_delete(self, token: object, name: object) -> dict:
+        snapshot = _snapshot_name(name)
+        with self._locked():
+            state = self._state()
+            self._lease(state, token)
+            self._verify_target()
+            if snapshot in (
+                self.config["recovery_snapshot"],
+                state["working_baseline"],
+            ):
+                raise ControllerError(
+                    "snapshot_protected",
+                    "recovery and working baseline snapshots cannot be deleted",
+                )
+            proc = self._virsh(
+                "snapshot-delete", DOMAIN, "--snapshotname", snapshot, timeout=120
+            )
+            if proc.returncode != 0:
+                raise ControllerError(
+                    "snapshot_delete_failed",
+                    f"snapshot '{snapshot}' could not be deleted",
+                )
+            return {"snapshot": snapshot, "deleted": True}
+
+    def reset(self, token: object, name: object) -> dict:
+        requested = _snapshot_name(name, allow_working=True)
+        with self._locked():
+            state = self._state()
+            self._lease(state, token)
+            if state.get("uncertain_exec"):
+                raise ControllerError(
+                    "exec_outcome_uncertain",
+                    "reset is blocked until an explicit stop confirms the guest is powered off",
+                )
+            self._verify_target()
+            snapshot = (
+                state["working_baseline"] if requested == "working" else requested
+            )
+            self._ensure_off(state)
+            proc = self._virsh(
+                "snapshot-revert", DOMAIN, "--snapshotname", snapshot, timeout=180
+            )
+            if proc.returncode != 0:
+                raise ControllerError(
+                    "snapshot_reset_failed",
+                    f"snapshot '{snapshot}' could not be restored",
+                )
+            observed = self._domain_state()
+            if observed != "powered_off":
+                raise ControllerError(
+                    "snapshot_reset_state",
+                    "snapshot reset did not leave the guest powered off",
+                    {"state": observed},
+                )
+            return {"snapshot": snapshot, "state": observed}
+
+    def promote(self, token: object, name: object) -> dict:
+        candidate = _snapshot_name(
+            name or f"working-{time.strftime('%Y%m%d-%H%M%S', time.gmtime(self.now()))}"
+        )
+        with self._locked():
+            state = self._state()
+            self._lease(state, token)
+            if state.get("uncertain_exec"):
+                raise ControllerError(
+                    "exec_outcome_uncertain",
+                    "promotion is blocked until an explicit stop confirms power-off",
+                )
+            self._verify_target()
+            previous = state["working_baseline"]
+            if candidate in (self.config["recovery_snapshot"], previous):
+                raise ControllerError(
+                    "snapshot_protected", "promotion requires a fresh snapshot name"
+                )
+            self._ensure_off(state)
+            self._create_snapshot(candidate)
+            state["working_baseline"] = candidate
+            self._save_state(state)
+            return {
+                "working_baseline": candidate,
+                "previous_baseline": previous,
+                "previous_preserved": True,
+                "state": "powered_off",
+            }
+
+    def push(
+        self,
+        token: object,
+        relative: object,
+        payload: BinaryIO,
+        size: object,
+        timeout: object,
+    ) -> dict:
+        dest = _guest_relative(relative)
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            raise ControllerError(
+                "payload_size_invalid",
+                "push payload_bytes must be a non-negative integer",
+            )
+        wait = _validated_timeout(timeout, 300)
+        body = """
+$input = [Console]::OpenStandardInput()
+$file = [IO.File]::Open($target, [IO.FileMode]::Create, [IO.FileAccess]::Write, [IO.FileShare]::None)
+try { $input.CopyTo($file) } finally { $file.Dispose() }
+"""
+        script = self._workspace_script(dest, body, must_exist=False)
+        with self._locked():
+            state = self._state()
+            self._lease(state, token)
+            self._verify_target()
+            process = self.popen(
+                self._ssh_argv(script),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            assert process.stdin is not None
+            remaining = size
+            try:
+                while remaining:
+                    chunk = payload.read(min(CHUNK_SIZE, remaining))
+                    if not chunk:
+                        raise ControllerError(
+                            "payload_incomplete",
+                            "push payload ended before payload_bytes",
+                        )
+                    process.stdin.write(chunk)
+                    remaining -= len(chunk)
+                process.stdin.close()
+                rc = process.wait(timeout=wait)
+            except ControllerError:
+                process.kill()
+                process.wait()
+                raise
+            except subprocess.TimeoutExpired as exc:
+                process.kill()
+                process.wait()
+                raise ControllerError(
+                    "push_timeout", f"push exceeded {wait} seconds"
+                ) from exc
+            if rc != 0:
+                stderr = (
+                    process.stderr.read(500).decode("utf-8", "replace")
+                    if process.stderr
+                    else ""
+                )
+                raise ControllerError(
+                    "push_failed",
+                    "guest artifact upload failed",
+                    {"exit_code": rc, "stderr": stderr},
+                )
+            return {"path": dest, "bytes": size}
+
+    def pull_plan(self, token: object, relative: object, timeout: object) -> PullPlan:
+        source = _guest_relative(relative)
+        wait = _validated_timeout(timeout, 300)
+        size_script = self._workspace_script(
+            source,
+            "@{ size = (Get-Item -LiteralPath $target).Length } | ConvertTo-Json -Compress",
+            must_exist=True,
+        )
+        lock_fd = self._acquire_lock()
+        try:
+            state = self._state()
+            self._lease(state, token)
+            self._verify_target()
+            meta = self._run_ps(size_script, 30)
+            size = int(meta.get("size", -1))
+            if size < 0:
+                raise ControllerError(
+                    "guest_response_invalid", "guest returned an invalid file size"
+                )
+            stream_script = self._workspace_script(
+                source,
+                "$output = [Console]::OpenStandardOutput(); $file = [IO.File]::OpenRead($target); try { $file.CopyTo($output) } finally { $file.Dispose() }",
+                must_exist=True,
+            )
+            return PullPlan("pull", self._ssh_argv(stream_script), size, wait, lock_fd)
+        except Exception:
+            self._release_lock(lock_fd)
+            raise
+
+    def stream_pull(self, plan: PullPlan, output: BinaryIO) -> None:
+        try:
+            process = self.popen(
+                plan.command,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            assert process.stdout is not None
+            remaining = plan.size
+            try:
+                while remaining:
+                    chunk = process.stdout.read(min(CHUNK_SIZE, remaining))
+                    if not chunk:
+                        break
+                    output.write(chunk)
+                    output.flush()
+                    remaining -= len(chunk)
+                rc = process.wait(timeout=plan.timeout)
+            except subprocess.TimeoutExpired as exc:
+                process.kill()
+                process.wait()
+                raise ControllerError(
+                    "pull_timeout", f"pull exceeded {plan.timeout} seconds"
+                ) from exc
+            if rc != 0 or remaining:
+                raise ControllerError(
+                    "pull_failed",
+                    "guest artifact download did not complete",
+                    {"exit_code": rc, "missing_bytes": remaining},
+                )
+        finally:
+            self._release_lock(plan.lock_fd)
+
+    def dispatch(self, request: dict, payload: BinaryIO) -> dict | PullPlan:
+        operation = str(request.get("operation", ""))
+        token = request.get("lease")
+        if operation == "status":
+            return _success(operation, self.status())
+        if operation == "acquire":
+            return _success(operation, self.acquire(request.get("owner")))
+        if operation == "release":
+            return _success(operation, self.release(token))
+        if operation == "start":
+            return _success(operation, self.start(token, request.get("timeout")))
+        if operation == "stop":
+            return _success(
+                operation,
+                self.stop(token, request.get("timeout"), request.get("force")),
+            )
+        if operation == "exec":
+            result = self.exec(
+                token,
+                request.get("command"),
+                request.get("cwd"),
+                request.get("timeout"),
+            )
+            if result["timed_out"]:
+                return _result_error(
+                    operation,
+                    "exec_timeout",
+                    "guest PowerShell exceeded its timeout and its process tree was stopped",
+                    result,
+                )
+            if result["exit_code"] != 0:
+                return _result_error(
+                    operation,
+                    "exec_failed",
+                    f"guest PowerShell exited {result['exit_code']}",
+                    result,
+                )
+            return _success(operation, result)
+        if operation == "push":
+            return _success(
+                operation,
+                self.push(
+                    token,
+                    request.get("path"),
+                    payload,
+                    request.get("payload_bytes"),
+                    request.get("timeout"),
+                ),
+            )
+        if operation == "pull":
+            return self.pull_plan(token, request.get("path"), request.get("timeout"))
+        if operation == "snapshot_list":
+            return _success(operation, self.snapshot_list())
+        if operation == "snapshot_create":
+            return _success(operation, self.snapshot_create(token, request.get("name")))
+        if operation == "snapshot_delete":
+            return _success(operation, self.snapshot_delete(token, request.get("name")))
+        if operation == "reset":
+            return _success(operation, self.reset(token, request.get("name")))
+        if operation == "baseline_promote":
+            return _success(operation, self.promote(token, request.get("name")))
+        raise ControllerError("operation_unknown", "unknown controller operation")
+
+
+def _read_header(stream: BinaryIO) -> dict:
+    raw = stream.readline(MAX_HEADER_BYTES + 1)
+    if not raw or len(raw) > MAX_HEADER_BYTES or not raw.endswith(b"\n"):
+        raise ControllerError(
+            "protocol_header_invalid", "request header must be one bounded JSON line"
+        )
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ControllerError(
+            "protocol_header_invalid", "request header is not valid JSON"
+        ) from exc
+    if not isinstance(value, dict):
+        raise ControllerError(
+            "protocol_header_invalid", "request header must be a JSON object"
+        )
+    return value
+
+
+def _write_header(stream: BinaryIO, value: dict) -> None:
+    stream.write(json.dumps(value, separators=(",", ":")).encode("utf-8") + b"\n")
+    stream.flush()
+
+
+def serve_once(
+    stdin: BinaryIO, stdout: BinaryIO, controller: Controller | None = None
+) -> int:
+    operation = "unknown"
+    try:
+        active_controller = controller or Controller()
+        request = _read_header(stdin)
+        operation = str(request.get("operation", "unknown"))
+        result = active_controller.dispatch(request, stdin)
+    except ControllerError as exc:
+        _write_header(stdout, _error(operation, exc))
+        return 1
+    if isinstance(result, PullPlan):
+        header = _success(
+            result.operation, {"bytes": result.size, "payload_bytes": result.size}
+        )
+        _write_header(stdout, header)
+        try:
+            active_controller.stream_pull(result, stdout)
+        except ControllerError:
+            return 1
+    else:
+        _write_header(stdout, result)
+    return 0
+
+
+def _client_config_path() -> Path:
+    return Path.cwd() / CLIENT_PATH
+
+
+def _load_client() -> dict:
+    return _read_json(_client_config_path(), "Windows test client configuration")
+
+
+def _client_process(cfg: dict) -> subprocess.Popen:
+    transport = cfg.get("transport")
+    if transport == "local":
+        argv = [sys.executable, str(Path(__file__).resolve()), "serve"]
+    elif transport == "ssh":
+        host = str(cfg.get("host", ""))
+        if not SSH_ALIAS_RE.fullmatch(host):
+            raise ControllerError(
+                "client_configuration_invalid", "SSH controller alias is invalid"
+            )
+        argv = [
+            "ssh",
+            "-T",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=2",
+            host,
+        ]
+    else:
+        raise ControllerError(
+            "client_configuration_invalid", "transport must be local or ssh"
+        )
+    return subprocess.Popen(
+        argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+
+
+def client_request(
+    request: dict, *, input_path: Path | None = None, output_path: Path | None = None
+) -> dict:
+    cfg = _load_client()
+    token = cfg.get("lease")
+    if token and "lease" not in request:
+        request["lease"] = token
+    if input_path is not None:
+        request["payload_bytes"] = input_path.stat().st_size
+    process = _client_process(cfg)
+    assert process.stdin is not None and process.stdout is not None
+    process_stdin = cast(BinaryIO, process.stdin)
+    process_stdout = cast(BinaryIO, process.stdout)
+    _write_header(process_stdin, request)
+    if input_path is not None:
+        with input_path.open("rb") as source:
+            shutil.copyfileobj(source, process_stdin, CHUNK_SIZE)
+    process_stdin.close()
+    response = _read_header(process_stdout)
+    expected = int((response.get("result") or {}).get("payload_bytes", 0))
+    tmp: Path | None = None
+    try:
+        if output_path is not None and response.get("ok"):
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            fd, raw_tmp = tempfile.mkstemp(
+                prefix=f".{output_path.name}.", dir=output_path.parent
+            )
+            tmp = Path(raw_tmp)
+            with os.fdopen(fd, "wb") as target:
+                remaining = expected
+                while remaining:
+                    chunk = process_stdout.read(min(CHUNK_SIZE, remaining))
+                    if not chunk:
+                        raise ControllerError(
+                            "response_incomplete",
+                            "controller response payload was incomplete",
+                        )
+                    target.write(chunk)
+                    remaining -= len(chunk)
+                target.flush()
+                os.fsync(target.fileno())
+        rc = process.wait()
+        if rc != 0 and response.get("ok"):
+            raise ControllerError(
+                "transport_failed",
+                "controller transport exited before completing a successful response",
+            )
+        if tmp is not None and output_path is not None:
+            os.replace(tmp, output_path)
+            tmp = None
+            response["result"]["path"] = str(output_path)
+    finally:
+        if tmp is not None:
+            tmp.unlink(missing_ok=True)
+    if response.get("ok") and request["operation"] == "acquire":
+        cfg["lease"] = response["result"]["token"]
+        _atomic_json(_client_config_path(), cfg)
+        response["result"].pop("token", None)
+        response["result"]["lease_saved"] = True
+    if response.get("ok") and request["operation"] == "release":
+        cfg.pop("lease", None)
+        _atomic_json(_client_config_path(), cfg)
+    return response
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="./sc vm test", description="Control the fixed W10C-Testing guest."
+    )
+    commands = parser.add_subparsers(dest="operation", required=True)
+    init = commands.add_parser(
+        "init", help="select Halo-local or constrained SSH transport"
+    )
+    init_sub = init.add_subparsers(dest="transport", required=True)
+    init_sub.add_parser("local")
+    ssh = init_sub.add_parser("ssh")
+    ssh.add_argument(
+        "host", help="SSH config alias whose server key has the controller ForceCommand"
+    )
+    commands.add_parser("status")
+    acquire = commands.add_parser("acquire")
+    acquire.add_argument("--owner", default="shell")
+    commands.add_parser("release")
+    for verb in ("start", "stop"):
+        item = commands.add_parser(verb)
+        item.add_argument("--timeout", type=int)
+        if verb == "stop":
+            item.add_argument("--force", action="store_true")
+    execute = commands.add_parser("exec")
+    execute.add_argument("--cwd", required=True)
+    execute.add_argument("--timeout", type=int)
+    execute.add_argument("--command-file")
+    execute.add_argument("command", nargs=argparse.REMAINDER)
+    push = commands.add_parser("push")
+    push.add_argument("source")
+    push.add_argument("destination")
+    push.add_argument("--timeout", type=int)
+    pull = commands.add_parser("pull")
+    pull.add_argument("source")
+    pull.add_argument("destination")
+    pull.add_argument("--timeout", type=int)
+    snapshot = commands.add_parser("snapshot")
+    snapshot_sub = snapshot.add_subparsers(dest="snapshot_action", required=True)
+    snapshot_sub.add_parser("list")
+    for verb in ("create", "delete"):
+        item = snapshot_sub.add_parser(verb)
+        item.add_argument("name")
+    reset = commands.add_parser("reset")
+    reset.add_argument("name", help="snapshot name or 'working'")
+    baseline = commands.add_parser("baseline")
+    baseline_sub = baseline.add_subparsers(dest="baseline_action", required=True)
+    promote = baseline_sub.add_parser("promote")
+    promote.add_argument("name", nargs="?")
+    return parser
+
+
+def client_main(argv: list[str]) -> int:
+    args = _parser().parse_args(argv)
+    if args.operation == "init":
+        cfg = {"transport": args.transport}
+        if args.transport == "ssh":
+            if not SSH_ALIAS_RE.fullmatch(args.host):
+                raise ControllerError(
+                    "client_configuration_invalid", "SSH controller alias is invalid"
+                )
+            cfg["host"] = args.host
+        _atomic_json(_client_config_path(), cfg)
+        response = _success(
+            "init", {"transport": args.transport, "host": cfg.get("host")}
+        )
+    else:
+        request: dict = {"operation": args.operation}
+        input_path = output_path = None
+        if args.operation == "acquire":
+            request["owner"] = args.owner
+        elif args.operation in ("start", "stop"):
+            request["timeout"] = args.timeout
+            if args.operation == "stop":
+                request["force"] = args.force
+        elif args.operation == "exec":
+            parts = args.command[1:] if args.command[:1] == ["--"] else args.command
+            if args.command_file and parts:
+                raise ControllerError(
+                    "exec_arguments_invalid",
+                    "use --command-file or command arguments, not both",
+                )
+            if args.command_file:
+                command = Path(args.command_file).read_text(encoding="utf-8")
+            else:
+                command = " ".join(parts)
+            request.update(command=command, cwd=args.cwd, timeout=args.timeout)
+        elif args.operation == "push":
+            input_path = Path(args.source)
+            request.update(path=args.destination, timeout=args.timeout)
+        elif args.operation == "pull":
+            output_path = Path(args.destination)
+            request.update(path=args.source, timeout=args.timeout)
+        elif args.operation == "snapshot":
+            request["operation"] = f"snapshot_{args.snapshot_action}"
+            if args.snapshot_action != "list":
+                request["name"] = args.name
+        elif args.operation == "reset":
+            request["name"] = args.name
+        elif args.operation == "baseline":
+            request["operation"] = "baseline_promote"
+            request["name"] = args.name
+        response = client_request(
+            request, input_path=input_path, output_path=output_path
+        )
+    print(json.dumps(response, separators=(",", ":")))
+    return 0 if response["ok"] else 1
+
+
+def main(argv: list[str]) -> int:
+    try:
+        if argv[:1] == ["serve"]:
+            return serve_once(sys.stdin.buffer, sys.stdout.buffer)
+        return client_main(argv)
+    except BrokenPipeError:
+        raise
+    except (ControllerError, OSError, UnicodeError) as exc:
+        error = (
+            exc
+            if isinstance(exc, ControllerError)
+            else ControllerError("client_io_failed", "client file operation failed")
+        )
+        print(
+            json.dumps(_error("client", error), separators=(",", ":")), file=sys.stderr
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/tests/test_windows_test_controller.py
+++ b/tests/test_windows_test_controller.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+import base64
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+
+import seed_skills
+import windows_test_controller as controller_mod
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.value = 1000.0
+
+    def now(self) -> float:
+        return self.value
+
+    def monotonic(self) -> float:
+        self.value += 1
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class FakeRun:
+    def __init__(self) -> None:
+        self.state = "running"
+        self.snapshots = {"recovery", "working-1", "named"}
+        self.calls: list[list[str]] = []
+        self.fail_snapshot_create = False
+        self.ssh_timeout = False
+        self.shutdown_sticks = False
+
+    @staticmethod
+    def _done(argv, rc=0, stdout="", stderr=""):
+        return subprocess.CompletedProcess(argv, rc, stdout, stderr)
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append(list(argv))
+        if argv[0] == "ssh":
+            if self.ssh_timeout:
+                raise subprocess.TimeoutExpired(argv, kwargs.get("timeout", 1))
+            encoded = argv[-1].rsplit(" ", 1)[-1]
+            script = base64.b64decode(encoded).decode("utf-16-le")
+            if "(Get-Item -LiteralPath $target).Length" in script:
+                return self._done(argv, stdout='{"size":4}\n')
+            if "$PSVersionTable.PSVersion" in script:
+                return self._done(
+                    argv,
+                    stdout='{"administrator":true,"powershell":"5.1"}\n',
+                )
+            return self._done(
+                argv,
+                stdout='{"exit_code":0,"stdout":"ok\\n","stderr":"","timed_out":false}\n',
+            )
+
+        assert argv[:3] == ["virsh", "--connect", "qemu:///system"]
+        command = argv[3]
+        assert controller_mod.DOMAIN in argv or command == "snapshot-list"
+        if command == "domuuid":
+            return self._done(argv, stdout=controller_mod.DOMAIN_UUID + "\n")
+        if command == "domstate":
+            raw = "shut off" if self.state == "powered_off" else self.state
+            return self._done(argv, stdout=raw + "\n")
+        if command == "start":
+            self.state = "running"
+            return self._done(argv)
+        if command == "shutdown":
+            if not self.shutdown_sticks:
+                self.state = "powered_off"
+            return self._done(argv)
+        if command == "destroy":
+            self.state = "powered_off"
+            return self._done(argv)
+        if command == "snapshot-list":
+            return self._done(argv, stdout="\n".join(sorted(self.snapshots)) + "\n")
+        if command == "snapshot-create-as":
+            if self.fail_snapshot_create:
+                return self._done(argv, rc=1, stderr="create failed")
+            self.snapshots.add(argv[5])
+            return self._done(argv)
+        if command == "snapshot-info":
+            return self._done(argv, rc=0 if argv[6] in self.snapshots else 1)
+        if command == "snapshot-delete":
+            self.snapshots.discard(argv[6])
+            return self._done(argv)
+        if command == "snapshot-revert":
+            if argv[6] not in self.snapshots:
+                return self._done(argv, rc=1)
+            self.state = "powered_off"
+            return self._done(argv)
+        raise AssertionError(argv)
+
+
+class KeepBytesIO(io.BytesIO):
+    def close(self) -> None:
+        pass
+
+
+class FakeProcess:
+    def __init__(self, output=b"", response=b"", rc=0) -> None:
+        self.stdin = KeepBytesIO()
+        self.stdout = io.BytesIO(response or output)
+        self.stderr = io.BytesIO()
+        self.killed = False
+        self.rc = rc
+
+    def wait(self, timeout=None):
+        return self.rc
+
+    def kill(self):
+        self.killed = True
+
+
+class FakePopen:
+    def __init__(self) -> None:
+        self.processes: list[FakeProcess] = []
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append(list(argv))
+        output = b"data" if kwargs.get("stdin") is subprocess.DEVNULL else b""
+        process = FakeProcess(output)
+        self.processes.append(process)
+        return process
+
+
+@pytest.fixture
+def subject(tmp_path):
+    key = tmp_path / "guest-key"
+    key.write_text("not-a-real-key")
+    key.chmod(0o600)
+    config = tmp_path / "windows-test-controller.json"
+    config.write_text(
+        json.dumps(
+            {
+                "guest": {
+                    "host": "192.0.2.10",
+                    "port": 22,
+                    "user": "tester",
+                    "key_path": str(key),
+                    "workspace": "C:\\SubfloorTest",
+                },
+                "recovery_snapshot": "recovery",
+                "initial_working_baseline": "working-1",
+                "lease_seconds": 3600,
+            }
+        )
+    )
+    config.chmod(0o600)
+    runner = FakeRun()
+    popen = FakePopen()
+    clock = Clock()
+    controller = controller_mod.Controller(
+        config,
+        run=runner,
+        popen=popen,
+        now=clock.now,
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+    return controller, runner, popen, clock
+
+
+def acquire(subject, owner="dev-shell"):
+    return subject[0].acquire(owner)["token"]
+
+
+def test_status_is_fixed_to_testing_domain_and_hides_lease_token(subject):
+    controller, runner, _popen, _clock = subject
+    token = acquire(subject)
+
+    result = controller.status()
+
+    assert result["domain"] == "W10C-Testing"
+    assert result["uuid"] == controller_mod.DOMAIN_UUID
+    assert result["lease"] == {
+        "active": True,
+        "owner": "dev-shell",
+        "expires_at": 4600.0,
+    }
+    assert token not in json.dumps(result)
+    assert all(
+        "W10C" not in arg or arg == "W10C-Testing"
+        for call in runner.calls
+        for arg in call
+    )
+
+
+def test_lease_rejects_competing_session_and_mutation(subject):
+    controller, _runner, _popen, _clock = subject
+    token = acquire(subject, "first")
+
+    with pytest.raises(controller_mod.ControllerError, match="already leased"):
+        controller.acquire("second")
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller.start("wrong-token", None)
+    assert caught.value.code == "lease_conflict"
+
+    assert controller.release(token) == {"released": True}
+
+
+def test_start_waits_for_administrator_powershell_readiness(subject):
+    controller, runner, _popen, _clock = subject
+    token = acquire(subject)
+    runner.state = "powered_off"
+
+    result = controller.start(token, 20)
+
+    assert result == {
+        "domain": "W10C-Testing",
+        "state": "running",
+        "changed": True,
+        "guest": {
+            "ready": True,
+            "administrator": True,
+            "powershell": "5.1",
+        },
+    }
+
+
+def test_forced_stop_requires_explicit_flag(subject):
+    controller, runner, _popen, _clock = subject
+    token = acquire(subject)
+    runner.shutdown_sticks = True
+
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller.stop(token, 2, False)
+    assert caught.value.code == "stop_timeout"
+    assert runner.state == "running"
+
+    result = controller.stop(token, 2, True)
+    assert result["forced"] is True
+    assert runner.state == "powered_off"
+
+
+def test_exec_is_encoded_admin_powershell_and_never_host_shell(subject):
+    controller, runner, _popen, _clock = subject
+    token = acquire(subject)
+    command = "Write-Output ok; Remove-Item 'C:\\guest-only'"
+
+    result = controller.exec(token, command, "run", 10)
+
+    assert result == {
+        "exit_code": 0,
+        "stdout": "ok\n",
+        "stderr": "",
+        "timed_out": False,
+    }
+    ssh_call = next(call for call in runner.calls if call[0] == "ssh")
+    assert command not in " ".join(ssh_call)
+    decoded = base64.b64decode(ssh_call[-1].rsplit(" ", 1)[-1]).decode("utf-16-le")
+    assert "WindowsBuiltInRole]::Administrator" in decoded
+    assert "taskkill.exe /PID $p.Id /T /F" in decoded
+    assert "-WorkingDirectory $target" in decoded
+
+
+def test_uncertain_transport_timeout_blocks_reset_until_explicit_stop(subject):
+    controller, runner, _popen, _clock = subject
+    token = acquire(subject)
+    runner.ssh_timeout = True
+
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller.exec(token, "Get-Date", "run", 10)
+    assert caught.value.code == "host_command_timeout"
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller.reset(token, "working")
+    assert caught.value.code == "exec_outcome_uncertain"
+
+    runner.ssh_timeout = False
+    assert controller.stop(token, 10, False)["state"] == "powered_off"
+    assert controller.reset(token, "working")["snapshot"] == "working-1"
+
+
+def test_push_and_pull_stream_without_halo_paths(subject):
+    controller, _runner, popen, _clock = subject
+    token = acquire(subject)
+
+    pushed = controller.push(token, "artifacts\\test.zip", io.BytesIO(b"data"), 4, 10)
+    plan = controller.pull_plan(token, "results\\result.json", 10)
+    output = io.BytesIO()
+    controller.stream_pull(plan, output)
+
+    assert pushed == {"path": "artifacts\\test.zip", "bytes": 4}
+    assert popen.processes[0].stdin.getvalue() == b"data"
+    assert output.getvalue() == b"data"
+    assert not hasattr(plan, "host_path")
+    push_script = base64.b64decode(popen.calls[0][-1].rsplit(" ", 1)[-1]).decode(
+        "utf-16-le"
+    )
+    pull_script = base64.b64decode(popen.calls[1][-1].rsplit(" ", 1)[-1]).decode(
+        "utf-16-le"
+    )
+    assert "ReparsePoint" in push_script
+    assert "ReparsePoint" in pull_script
+
+
+@pytest.mark.parametrize(
+    "path",
+    ("../secret", "C:\\Windows\\secret", "\\\\host\\share\\secret", "dir\\..\\secret"),
+)
+def test_transfer_path_validation_rejects_escape(subject, path):
+    controller, _runner, _popen, _clock = subject
+    token = acquire(subject)
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller.push(token, path, io.BytesIO(), 0, 10)
+    assert caught.value.code == "guest_path_invalid"
+
+
+def test_snapshot_guards_and_named_lifecycle(subject):
+    controller, runner, _popen, _clock = subject
+    token = acquire(subject)
+
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller.snapshot_delete(token, "recovery")
+    assert caught.value.code == "snapshot_protected"
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller.snapshot_delete(token, "working-1")
+    assert caught.value.code == "snapshot_protected"
+
+    assert controller.snapshot_create(token, "trial")["snapshot"] == "trial"
+    assert "trial" in controller.snapshot_list()["snapshots"]
+    assert controller.reset(token, "trial") == {
+        "snapshot": "trial",
+        "state": "powered_off",
+    }
+    assert controller.snapshot_delete(token, "trial") == {
+        "snapshot": "trial",
+        "deleted": True,
+    }
+    assert "trial" not in runner.snapshots
+
+
+def test_failed_promotion_preserves_previous_baseline(subject):
+    controller, runner, _popen, _clock = subject
+    token = acquire(subject)
+    runner.fail_snapshot_create = True
+
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller.promote(token, "working-2")
+    assert caught.value.code == "snapshot_create_failed"
+    assert controller._state()["working_baseline"] == "working-1"
+
+    runner.fail_snapshot_create = False
+    result = controller.promote(token, "working-2")
+    assert result["working_baseline"] == "working-2"
+    assert result["previous_baseline"] == "working-1"
+    assert result["previous_preserved"] is True
+    assert "working-1" in runner.snapshots
+
+
+def test_protocol_returns_structured_error(subject):
+    controller, _runner, _popen, _clock = subject
+    stdin = io.BytesIO(b'{"operation":"reset","name":"working"}\n')
+    stdout = io.BytesIO()
+
+    assert controller_mod.serve_once(stdin, stdout, controller) == 1
+    response = json.loads(stdout.getvalue())
+    assert response["schema_version"] == 1
+    assert response["ok"] is False
+    assert response["error"]["code"] == "lease_required"
+
+
+def test_exec_nonzero_is_a_structured_operation_failure(subject, monkeypatch):
+    controller = subject[0]
+    monkeypatch.setattr(
+        controller,
+        "exec",
+        lambda *_args: {
+            "exit_code": 7,
+            "stdout": "partial",
+            "stderr": "failed",
+            "timed_out": False,
+        },
+    )
+
+    response = controller.dispatch(
+        {"operation": "exec", "command": "ignored", "cwd": "run"},
+        io.BytesIO(),
+    )
+
+    assert response["ok"] is False
+    assert response["error"]["code"] == "exec_failed"
+    assert response["result"]["exit_code"] == 7
+
+
+def test_transport_initialization_changes_only_process_transport(monkeypatch):
+    calls = []
+
+    def fake_popen(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return FakeProcess()
+
+    monkeypatch.setattr(controller_mod.subprocess, "Popen", fake_popen)
+
+    controller_mod._client_process({"transport": "local"})
+    controller_mod._client_process({"transport": "ssh", "host": "halo-windows-test"})
+
+    assert calls[0][0][-1] == "serve"
+    assert calls[1][0] == [
+        "ssh",
+        "-T",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        "-o",
+        "ServerAliveInterval=15",
+        "-o",
+        "ServerAliveCountMax=2",
+        "halo-windows-test",
+    ]
+    assert calls[0][1] == calls[1][1]
+
+
+def test_client_uses_same_frame_and_saves_lease_outside_argv(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    client_path = tmp_path / ".sc-state/local/windows-test-client.json"
+    controller_mod._atomic_json(
+        client_path, {"transport": "ssh", "host": "halo-windows-test"}
+    )
+    raw_response = (
+        json.dumps(
+            controller_mod._success(
+                "acquire",
+                {
+                    "token": "opaque-token",
+                    "owner": "dev",
+                    "acquired_at": 1,
+                    "expires_at": 2,
+                },
+            ),
+            separators=(",", ":"),
+        ).encode()
+        + b"\n"
+    )
+    process = FakeProcess(response=raw_response)
+    monkeypatch.setattr(controller_mod, "_client_process", lambda _cfg: process)
+
+    result = controller_mod.client_request({"operation": "acquire", "owner": "dev"})
+
+    assert json.loads(process.stdin.getvalue().splitlines()[0]) == {
+        "operation": "acquire",
+        "owner": "dev",
+    }
+    assert result["result"]["lease_saved"] is True
+    assert "token" not in result["result"]
+    saved = json.loads(client_path.read_text())
+    assert saved["lease"] == "opaque-token"
+    assert client_path.stat().st_mode & 0o077 == 0
+
+
+def test_failed_pull_transport_does_not_replace_existing_result(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    controller_mod._atomic_json(
+        tmp_path / ".sc-state/local/windows-test-client.json",
+        {"transport": "local", "lease": "opaque"},
+    )
+    response = controller_mod._success("pull", {"bytes": 4, "payload_bytes": 4})
+    process = FakeProcess(
+        response=json.dumps(response, separators=(",", ":")).encode() + b"\n" + b"data",
+        rc=1,
+    )
+    monkeypatch.setattr(controller_mod, "_client_process", lambda _cfg: process)
+    target = tmp_path / "result.json"
+    target.write_bytes(b"old")
+
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller_mod.client_request(
+            {"operation": "pull", "path": "results\\result.json"},
+            output_path=target,
+        )
+
+    assert caught.value.code == "transport_failed"
+    assert target.read_bytes() == b"old"
+
+
+def test_fork_local_skill_template_is_ready_for_supported_import():
+    skill_path = ENGINE / "docs/skills/windows_testing/SKILL.md"
+    skill = seed_skills.parse_skill(skill_path)
+    assert skill["name"] == "windows_testing"
+    assert skill["category"] == "substrate"
+    assert skill["common"] == 0
+    assert "no daemon and opens no\nlistener" in skill["content"]
+    assert "sc skill put --file" in skill["content"]
+    assert "./sc vm test" not in skill["content"]
+    assert not (ENGINE / "assets/skills/windows_testing/SKILL.md").exists()
+
+
+def test_controller_refuses_non_private_configuration_directory(subject):
+    controller = subject[0]
+    controller.config_path.parent.chmod(0o755)
+    try:
+        with pytest.raises(controller_mod.ControllerError) as caught:
+            controller_mod.Controller(controller.config_path)
+        assert caught.value.code == "configuration_permissions"
+    finally:
+        controller.config_path.parent.chmod(0o700)


### PR DESCRIPTION
## Outcome

Adds one process-per-request controller for the disposable `W10C-Testing` guest under the existing `sc vm test` surface.

- Halo-local and Dev-over-constrained-SSH initialization use the same framed stdio implementation.
- Fixed domain name, UUID, and `qemu:///system`; no caller-selected Halo command, host path, disk, URI, or domain.
- Status/start/bounded stop, administrator PowerShell exec, streamed push/pull, named snapshots, safe working-baseline promotion, and session leases.
- Recovery/current-baseline protection; failed promotion preserves the old reference and snapshot; uncertain exec transport blocks reset/promotion until explicit stop.
- Fork-local `windows_testing` skill template with exact Cash/Jed installation instructions. It is deliberately not a global/flavor grant.
- No live Halo/Dev/guest deployment or credential change.

## Verification

- `20` controller/transport/boundary tests
- `109` focused tests across controller, legacy VM broker, CLI entrypoints, engine manifest, skill projection, and render checks
- focused Ruff and mypy green
- shell syntax, Python compilation, JSON and diff checks green

Feature #70 · spec #216

Co-authored-by: Code-01 (super-coder) <noreply@super-coder.local>