### PR TITLE
fix: validate document writes before committing

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -1724,9 +1724,14 @@ def document_render_path_conflict(
     exclude_document_id: int | None = None,
 ) -> str | None:
     """Return a stable ownership error when a populated document path collides."""
+    try:
+        rel = flat_render.document_rel_path(candidate)
+        flat_render._document_target(REPO_ROOT, rel, candidate["kind"])
+    except (TypeError, ValueError) as exc:
+        return str(exc)
     if not candidate.get("body"):
         return None
-    candidate_path = Path(flat_render.document_rel_path(candidate))
+    candidate_path = Path(rel)
     rows = con.execute(
         "SELECT document_id,feature_id,kind,seq,title,body,render_path "
         "FROM documents WHERE body IS NOT NULL AND body != '' "
@@ -1759,6 +1764,8 @@ def patch_document(
         return False, "no editable fields in payload"
     if "body" in body and not isinstance(body["body"], str):
         return False, "body must be a string"
+    if "body" in body and not body["body"].strip():
+        return False, "document body must not be empty"
     if editor_surface not in {"shell_api", "review_ui"}:
         raise ValueError("unknown document editor surface")
     try:
@@ -4502,6 +4509,8 @@ class Handler(BaseHTTPRequestHandler):
                 # of the contract: the docs/onboard skills and `sc mem doc add`
                 # document them, and forks carry them. The seq scope is per
                 # (feature, kind), with NULL its own scope (`IS ?` matches NULL).
+                if not isinstance(body.get("body"), str) or not body["body"].strip():
+                    return self._send(400, {"error": "document body must be a non-empty string"})
                 fid = body.get("feature_id")
                 fid = int(fid) if fid is not None else None
                 kind = body.get("kind") or "spec"

--- a/.super-coder/render/flat.py
+++ b/.super-coder/render/flat.py
@@ -82,7 +82,7 @@ def _document_target(root: Path, rel: str, kind: str) -> Path:
     """Confine DB-authored render paths to their managed visibility folder."""
     path = Path(rel)
     expected = "specs_sc" if kind == "spec" else "docs_sc"
-    if path.is_absolute() or ".." in path.parts or not path.parts or path.parts[0] != expected:
+    if path.is_absolute() or ".." in path.parts or len(path.parts) < 2 or path.parts[0] != expected:
         raise ValueError(
             f"invalid {kind} render_path {rel!r}; expected a relative path under {expected}/"
         )

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -1258,6 +1258,35 @@ class ApiMemTest(unittest.TestCase):
         self.assertEqual(self.q("SELECT render_path FROM documents "
                                 "WHERE document_id=?", did)[0], "docs_sc/pathless.md")
 
+    def test_doc_invalid_writes_preserve_existing_document(self):
+        did = self.write(
+            "INSERT INTO documents (kind,seq,title,body,render_path) "
+            "VALUES ('doc',1,'validation original','original body','docs_sc/validation.md')"
+        )
+        for payload in ({"body": ""}, {"body": " \n\t"},
+                        {"body": None}, {"render_path": "README.md"},
+                        {"render_path": "/tmp/doc.md"}, {"render_path": "docs_sc"},
+                        {"render_path": "docs_sc/../README.md"}):
+            with self.subTest(payload=payload):
+                with self.assertRaises(SystemExit):
+                    mem._api("PATCH", f"/_sc/mem/docs/{did}",
+                             {"title": "must not commit", **payload})
+                self.assertEqual(tuple(self.q(
+                    "SELECT title,body,render_path FROM documents WHERE document_id=?", did
+                )), ("validation original", "original body", "docs_sc/validation.md"))
+
+    def test_doc_invalid_adds_leave_no_row(self):
+        for payload in ({"body": ""}, {"body": " \n"}, {"body": None},
+                        {"body": "content", "render_path": "README.md"},
+                        {"body": "content", "render_path": "specs_sc/wrong.md"}):
+            with self.subTest(payload=payload):
+                before = self.q("SELECT COUNT(*) FROM documents")[0]
+                with self.assertRaises(SystemExit):
+                    mem._api("POST", "/_sc/mem/docs", {
+                        "kind": "doc", "title": "invalid add", **payload,
+                    })
+                self.assertEqual(self.q("SELECT COUNT(*) FROM documents")[0], before)
+
     def test_doc_add_rejects_duplicate_render_path(self):
         body = self.tmp / "duplicate-add.md"
         body.write_text("# duplicate\n")


### PR DESCRIPTION
Document writes now reject empty or whitespace-only bodies and validate render paths before committing. Failed edits preserve all existing fields; the same edit guard covers the shell API and browser UI. Render paths must name a file beneath the document kind's managed directory.

Validation: `./sc test tests/test_mem.py tests/test_flat_render.py -q` — 64 passed, 20 subtests passed, including rejected adds and atomic rejected edits.

Fixes #365. Fixes #1335.
