### PR TITLE
fix: make maintenance help exit before mutations

### DIFF
--- a/.super-coder/scripts/seed_skills.py
+++ b/.super-coder/scripts/seed_skills.py
@@ -35,6 +35,7 @@ Usage:
 """
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
 import re
@@ -548,7 +549,9 @@ def _upsert_live(skills: list[dict]) -> None:
         print("seed_skills: live DB already current.")
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="sc seed-skills", description=__doc__.split("\n")[0])
+    parser.parse_args(argv)
     instance_state.active_database_path(ENGINE)
     if not SKILLS_DIR.exists():
         sys.exit(f"seed_skills: no {SKILLS_DIR}")

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -52,6 +52,7 @@ Usage:
 """
 from __future__ import annotations
 
+import argparse
 import ast
 import importlib
 import importlib.util
@@ -1851,23 +1852,16 @@ def reconcile_under_cutover(
 
 
 def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="sc update", description=__doc__.split("\n")[0])
+    parser.add_argument("--no-fetch", action="store_true", help="reconcile the current tree")
+    parser.add_argument("--force", action="store_true", help="discard local engine edits")
+    target = parser.add_mutually_exclusive_group()
+    target.add_argument("--branch", default="main", help="upstream branch to track")
+    target.add_argument("--ref", help="exact upstream tag or commit")
+    args = parser.parse_args(argv)
+    no_fetch, force, branch, ref = args.no_fetch, args.force, args.branch, args.ref
     reset_update_report()
     run_update_compat()
-    no_fetch = "--no-fetch" in argv
-    force = "--force" in argv
-    branch = "main"
-    if "--branch" in argv:
-        i = argv.index("--branch")
-        if i + 1 < len(argv):
-            branch = argv[i + 1]
-    ref = None
-    if "--ref" in argv:
-        i = argv.index("--ref")
-        if i + 1 < len(argv):
-            ref = argv[i + 1]
-        if "--branch" in argv:
-            sys.exit("update: --ref and --branch are mutually exclusive — a ref "
-                     "IS the pin; a branch is what to track.")
 
     source = is_source_repo()
     if EJECTED_MARKER.exists() and not source:

--- a/tests/test_maintenance_help.py
+++ b/tests/test_maintenance_help.py
@@ -1,0 +1,33 @@
+"""Maintenance argument parsing must exit before reaching mutation boundaries."""
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / '.super-coder/scripts'))
+import seed_skills
+import update
+
+
+class MaintenanceHelpTest(unittest.TestCase):
+    def test_update_help_and_invalid_arguments_do_not_reconcile(self):
+        for argv, code in [(['--help'], 0), (['-h'], 0), (['--unknown'], 2),
+                           (['--ref'], 2), (['--branch'], 2),
+                           (['--branch', 'main', '--ref', 'HEAD'], 2)]:
+            with self.subTest(argv=argv), mock.patch.object(update, 'run_update_compat') as run:
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                    with self.assertRaises(SystemExit) as caught:
+                        update.main(argv)
+                self.assertEqual(caught.exception.code, code)
+                run.assert_not_called()
+
+    def test_seed_help_and_invalid_arguments_do_not_open_state_or_write(self):
+        for argv, code in [(['--help'], 0), (['-h'], 0), (['--unknown'], 2), (['extra'], 2)]:
+            with self.subTest(argv=argv), mock.patch.object(seed_skills.instance_state, 'active_database_path') as state:
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                    with self.assertRaises(SystemExit) as caught:
+                        seed_skills.main(argv)
+                self.assertEqual(caught.exception.code, code)
+                state.assert_not_called()

--- a/tests/test_skill_tombstones.py
+++ b/tests/test_skill_tombstones.py
@@ -312,7 +312,7 @@ class ReservedAssetTest(unittest.TestCase):
         seed_skills._fork_mode = lambda: False
         try:
             with self.assertRaisesRegex(ValueError, "retired_name"):
-                seed_skills.main()
+                seed_skills.main([])
         finally:
             seed_skills.SKILLS_DIR = saved_skills_dir
             seed_skills._fork_mode = saved_fork_mode


### PR DESCRIPTION
`update --help` and `seed-skills --help` now print usage and exit before maintenance actions. Both commands reject unknown arguments; update also rejects missing option values and conflicting branch/ref targets before compatibility reconciliation.

Validation: `./sc test tests/test_maintenance_help.py tests/test_update_source_sync.py tests/test_skill_tombstones.py -q` — 26 passed, 46 subtests passed. Regression tests assert argument exits never reach the first maintenance/state boundary.

Fixes #1343. Fixes #1422.
