### PR TITLE
fix: remove retired engine files during updates

### DIFF
--- a/.super-coder/scripts/rollback.py
+++ b/.super-coder/scripts/rollback.py
@@ -131,9 +131,8 @@ def restore_engine(prev_sha: str) -> None:
         if current_sha
         else set()
     )
-    # materialize_engine overlays an archive and deliberately leaves upstream-
-    # retired files alone during a forward update. Rollback is different: a
-    # target-only migration left behind would make the restored old server
+    # As in forward updates, retire engine-owned files absent from the target.
+    # A target-only migration left behind would make the restored old server
     # demand the new schema again. Remove only files proved upstream-owned by
     # the current pin and absent from the previous pin; fork-local files remain.
     for rel in sorted(current_files - previous_files):

--- a/.super-coder/scripts/update.py
+++ b/.super-coder/scripts/update.py
@@ -641,8 +641,8 @@ def materialize_engine(
     git index — the engine is gitignored, so a `git checkout -- <paths>` (which
     stages) is wrong. `git archive | tar -x` copies the fetched tree over the
     top, leaving the gitignored per-instance files (shell_db.db*, instance.json)
-    in place. (Files deleted upstream linger until a future doctor sweep — same
-    gap the old checkout had; acceptable for a wholesale-overwrite dependency.)"""
+    in place. The update and rollback callers retire proven engine-owned files
+    absent from their target before running migrations."""
     paths = (
         engine_paths
         if engine_paths is not None
@@ -688,7 +688,11 @@ def check_local_edits(force: bool, *, target_ref: str | None = None) -> None:
     edits = engine_manifest.local_edits()
     if target_ref is not None and edits:
         already_target = {
-            rel for rel in edits if _path_matches_ref(rel, target_ref)
+            rel for rel, kind in edits.items()
+            if _path_matches_ref(rel, target_ref)
+            or (kind == "deleted" and not _engine_path_exists_at(
+                target_ref, rel, repo_root=REPO_ROOT
+            ))
         }
         if already_target:
             edits = {
@@ -878,6 +882,12 @@ def materialize_fetched_engine(
     """Lay an already-fetched ref onto the installed floor."""
 
     check_local_edits(force, target_ref=sha)
+    resolved_paths = _engine_paths_for(sha, repo_root=REPO_ROOT)
+    target_files = set(_engine_files_at(
+        sha, repo_root=REPO_ROOT, engine_paths=resolved_paths,
+    ))
+    current_ref = ENGINE_REF.read_text().strip() if ENGINE_REF.exists() else ""
+    current_files = set(_engine_files_at(current_ref, repo_root=REPO_ROOT)) if current_ref else set()
 
     # Restore point (engine half): remember where we were before overwriting.
     STATE_DIR.mkdir(parents=True, exist_ok=True)
@@ -888,8 +898,14 @@ def materialize_fetched_engine(
         # engine ref if discoverable; else leave prev absent (rollback will warn).
         ENGINE_REF_PREV.unlink(missing_ok=True)
 
-    resolved_paths = _engine_paths_for(sha, repo_root=REPO_ROOT)
     materialize_engine(sha, engine_paths=resolved_paths)
+    # Retire only paths whose ownership is proved by the installed pin. Do not
+    # sweep directories: they may also contain fork-local skills or state.
+    for rel in sorted(current_files - target_files):
+        path = REPO_ROOT / rel
+        if path.is_file() or path.is_symlink():
+            path.unlink()
+            print(f"  retired engine file: {rel}")
     materialized_paths = _materialized_engine_paths(REPO_ROOT)
     delta = [path for path in materialized_paths if path not in resolved_paths]
     materializable_delta = [

--- a/tests/test_update_materialize.py
+++ b/tests/test_update_materialize.py
@@ -157,6 +157,63 @@ class EnginePathsAtRefTest(unittest.TestCase):
         ):
             update.engine_manifest.write_manifest(paths)
 
+    def test_update_retires_owned_files_preserves_local_files_and_retries(self):
+        paths = ["sc", ".super-coder/scripts", ".super-coder/migrations",
+                 ".super-coder/assets/skills"]
+        (self.root / "sc").write_text("dispatcher\n")
+        self.write_manifest(paths)
+        retired = [".super-coder/scripts/retired.py",
+                   ".super-coder/migrations/0009_retired.sql",
+                   ".super-coder/assets/skills/retired/SKILL.md"]
+        for rel in retired:
+            path = self.root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("old engine file\n")
+        old_sha = self.commit("old engine files")
+        for rel in retired:
+            (self.root / rel).unlink()
+        (self.scripts / "new.py").write_text("new runtime\n")
+        target_sha = self.commit("retire old engine files")
+        _git(self.root, "checkout", old_sha)
+        local = self.root / ".super-coder/assets/skills/local/SKILL.md"
+        local.parent.mkdir(parents=True)
+        local.write_text("fork-local skill\n")
+        state_file = self.root / ".super-coder/instance.json"
+        state_file.write_text("local instance\n")
+        state = self.root / ".sc-state"
+        state.mkdir()
+        (state / "engine.ref").write_text(old_sha + "\n")
+        engine = self.root / ".super-coder"
+        with mock.patch.multiple(
+            update, REPO_ROOT=self.root, ENGINE=engine, STATE_DIR=state,
+            ENGINE_REF=state / "engine.ref", ENGINE_REF_PREV=state / "engine.ref.prev",
+        ), mock.patch.multiple(
+            update.engine_manifest, REPO_ROOT=self.root, ENGINE=engine,
+            MANIFEST=engine / "engine.manifest",
+        ):
+            update.engine_manifest.write_manifest(paths, files=update._engine_files_at(old_sha))
+            # A modified retired file is still protected by the local-edit guard.
+            (self.root / retired[0]).write_text("local modification\n")
+            with self.assertRaisesRegex(SystemExit, "local engine edits"):
+                update.materialize_fetched_engine(target_sha)
+            self.assertTrue(all((self.root / rel).exists() for rel in retired))
+            # Simulate a failure after extraction/pruning, before manifest and pin publication.
+            with mock.patch.object(update.callable_floor, "require_callable_floor", side_effect=SystemExit("late failure")):
+                with self.assertRaisesRegex(SystemExit, "late failure"):
+                    update.materialize_fetched_engine(target_sha, force=True)
+            self.assertEqual((state / "engine.ref").read_text().strip(), old_sha)
+            self.assertTrue(all(not (self.root / rel).exists() for rel in retired))
+            update.materialize_fetched_engine(target_sha)
+            # --ref may deliberately move backwards; remove newer-only runtime files.
+            update.materialize_fetched_engine(old_sha)
+            self.assertFalse((self.scripts / "new.py").exists())
+            self.assertTrue(all((self.root / rel).exists() for rel in retired))
+            update.materialize_fetched_engine(target_sha)
+        self.assertEqual((state / "engine.ref").read_text().strip(), target_sha)
+        self.assertEqual(local.read_text(), "fork-local skill\n")
+        self.assertEqual(state_file.read_text(), "local instance\n")
+        self.assertEqual((self.scripts / "new.py").read_text(), "new runtime\n")
+
     def test_added_path_resolves_from_target_ref_and_materializes(self):
         installed = ["sc", ".super-coder/scripts"]
         (self.root / "sc").write_text("old dispatcher\n")


### PR DESCRIPTION
Updates now remove files shipped by the installed engine pin but absent from the target ref before migration and catalogue reconciliation. This prevents retired migrations, runtime scripts, and skill assets surviving forward updates or explicit moves to older refs. Fork-local files remain untouched; modified engine files retain the existing force gate. A retry accepts already-completed deletions after a later update failure.

The retirement set comes from the installed and target Git trees. This prevents new ghosts; it does not guess ownership of historical leftovers already absent from the installed pin.

Validation: `./sc test tests/test_update_materialize.py tests/test_engine_manifest.py tests/test_update_service_cutover.py tests/test_update_legacy_compat.py -q` — 74 passed, 2 subtests passed. Disposable Git fixtures cover deletion, preservation, force refusal, retry after failure, and backward exact-ref updates.

Fixes #907. Fixes #1403.
