### PR TITLE
fix(models): keep sandbox commands on API lane

### DIFF
--- a/.super-coder/scripts/models.py
+++ b/.super-coder/scripts/models.py
@@ -23,13 +23,12 @@ import db_driver  # noqa: E402
 import instance_state  # noqa: E402
 import mem  # noqa: E402
 
-DB_PATH = instance_state.active_database_path(ENGINE)
-
 
 def _open_db():
-    if not DB_PATH.exists():
-        raise SystemExit(f"models: no DB at {DB_PATH} — run `sc rebuild`")
-    return db_driver.connect(DB_PATH)
+    db_path = instance_state.active_database_path(ENGINE)
+    if not db_path.exists():
+        raise SystemExit(f"models: no DB at {db_path} — run `sc rebuild`")
+    return db_driver.connect(db_path)
 
 
 def _shell_api_enabled() -> bool:
@@ -57,6 +56,15 @@ def _api_routes(*, harness: str | None = None,
     return _api_route_projection(harness=harness, selector=selector).get(
         "routes"
     ) or []
+
+
+def _refresh(payload: dict) -> int:
+    print("models: " + (
+        "stale — " + payload.get("error", "refresh failed")
+        if payload.get("stale")
+        else "refreshed from " + ", ".join(payload.get("sources") or [])
+    ))
+    return 2 if payload.get("stale") else 0
 
 
 def _route(con, harness: str, selector: str):
@@ -274,6 +282,8 @@ def main(argv: list[str] | None = None) -> int:
               "[--shell <shortname>] [--json]")
         return 0
     command = args[0]
+    if command == "refresh" and _shell_api_enabled():
+        return _refresh(mem._api("GET", "/api/models?refresh=1"))
     if command == "list" and _shell_api_enabled():
         return _print_routes(_api_routes(
             harness=args[1] if len(args) > 1 else None
@@ -305,11 +315,7 @@ def main(argv: list[str] | None = None) -> int:
     con = _open_db()
     try:
         if args[0] == "refresh":
-            payload = model_catalog.catalog(refresh=True, con=con)
-            print("models: " + ("stale — " + payload.get("error", "refresh failed")
-                                if payload.get("stale") else
-                                "refreshed from " + ", ".join(payload.get("sources") or [])))
-            return 2 if payload.get("stale") else 0
+            return _refresh(model_catalog.catalog(refresh=True, con=con))
         if args[0] == "list":
             return _list(con, args[1] if len(args) > 1 else None)
         if args[0] != "resolve":

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -18,6 +18,7 @@ Run:
 from __future__ import annotations
 
 import contextlib
+import importlib.util
 import io
 import json
 import sqlite3
@@ -1230,6 +1231,21 @@ class RouteCliConnectionTest(unittest.TestCase):
         "adapter_metadata": "{}",
     }
 
+    def test_import_does_not_resolve_private_database(self):
+        spec = importlib.util.spec_from_file_location(
+            "models_import_probe",
+            ROOT / ".super-coder" / "scripts" / "models.py",
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+
+        with mock.patch.object(
+            routes_cli.instance_state,
+            "active_database_path",
+            side_effect=AssertionError("must not resolve private state at import"),
+        ):
+            spec.loader.exec_module(module)
+
     @classmethod
     def controlled_route(cls, harness: str) -> dict:
         versions = {
@@ -1735,11 +1751,31 @@ class RouteCliConnectionTest(unittest.TestCase):
         con = mock.Mock()
         payload = {"stale": False, "sources": ["test-source"]}
         with (
+            mock.patch.object(routes_cli.mem, "SC_API_TOKEN", ""),
             mock.patch.object(routes_cli, "_open_db", return_value=con) as opened,
             mock.patch.object(routes_cli.model_catalog, "catalog", return_value=payload),
         ):
             self.assertEqual(routes_cli.main(["refresh"]), 0)
         opened.assert_called_once_with()
+
+    def test_authenticated_refresh_uses_api_without_opening_database(self):
+        payload = {"stale": False, "sources": ["test-source"]}
+        output = io.StringIO()
+        with (
+            mock.patch.object(routes_cli.mem, "SC_API_TOKEN", "shell-token"),
+            mock.patch.object(routes_cli.mem, "SC_API_BASE", "http://engine"),
+            mock.patch.object(
+                routes_cli.mem, "_api", return_value=payload
+            ) as api,
+            mock.patch.object(
+                routes_cli, "_open_db", side_effect=AssertionError("opened DB")
+            ),
+            contextlib.redirect_stdout(output),
+        ):
+            self.assertEqual(routes_cli.main(["refresh"]), 0)
+
+        api.assert_called_once_with("GET", "/api/models?refresh=1")
+        self.assertEqual(output.getvalue(), "models: refreshed from test-source\n")
 
 
 class CatalogCacheTest(NoCLI):


### PR DESCRIPTION
Fixes #1516

## What changed
- resolve the private engine DB lazily, only for no-token local/Admin operations
- route authenticated `sc models refresh` through the existing live `/api/models?refresh=1` endpoint
- cover import-time private-state independence and authenticated refresh without a DB open

## Verification
- `./sc test tests/test_model_catalog.py tests/test_api_endpoints.py` — 116 passed
- `python3 .super-coder/scripts/models.py --help` — usage printed successfully
- `python3 -m py_compile .super-coder/scripts/models.py tests/test_model_catalog.py`
- `git diff --check`

## Existing gate debt
- focused lint reports 23 pre-existing Ruff findings in these files (including executable-bit/import-order debt and existing test patterns)
- focused typecheck reports 10 pre-existing findings in `mem.py` plus dynamic-import stub resolution