### PR TITLE
fix(codex): grant host Admin filesystem authority

### DIFF
--- a/.super-coder/adapters/codex/README.md
+++ b/.super-coder/adapters/codex/README.md
@@ -24,6 +24,7 @@ billing. opencode stays as the universal metered catch-all.
 | `env` | extra env merged into the launch environment |
 | `model` | `{ "flag": "--model" }` — run.py appends `--model <id>` for the flavor's codex model |
 | `headless.effort` | maps requested effort to `-c model_reasoning_effort="<level>"` |
+| `host_admin.launch_flags` | grants the direct-host Admin the unrestricted filesystem policy its maintenance mandate requires |
 | `sandbox.launch_flags` | flags appended ONLY inside the docker sandbox (`SC_SANDBOX`) |
 
 ## Branch-guard hook
@@ -63,6 +64,11 @@ the cwd-branch check.
 mounted from the host — so `codex` must be installed + logged in on the host once:
 `curl -fsSL https://chatgpt.com/codex/install.sh | sh` then `codex` and sign in
 with ChatGPT. That writes `~/.codex/auth.json`, which `./sc launch` mounts in.
+
+The direct-host Admin launch adds `--sandbox danger-full-access` and
+`--ask-for-approval never`. This is scoped to `subfloor admin`: ordinary host
+shells retain Codex's default filesystem sandbox, while the Admin can update the
+owner-private engine state required by its maintenance mandate.
 
 ## Conversation capability
 

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -31,6 +31,9 @@
     "model_flag": "-m",
     "effort": { "config_flag": "-c", "config_key": "model_reasoning_effort" }
   },
+  "host_admin": {
+    "launch_flags": ["--sandbox", "danger-full-access", "--ask-for-approval", "never"]
+  },
   "conversation": {
     "contract_version": 1,
     "minimum_cli_version": "0.145.0",

--- a/.super-coder/scripts/run.py
+++ b/.super-coder/scripts/run.py
@@ -766,10 +766,13 @@ def apply_sandbox(adapter: dict, root: Path = REPO_ROOT) -> list[str]:
     return _merge_json_spec((adapter.get("sandbox") or {}).get("merge_json") or {}, root)
 
 
-def launch_mode_flags(adapter: dict, headless: bool) -> list[str]:
+def launch_mode_flags(
+    adapter: dict, headless: bool, *, host_admin: bool = False
+) -> list[str]:
     """The permission flags for this launch mode: the adapter's always-on set
-    at its top level, then the sandbox-only set when booting inside the docker
-    sandbox (SC_SANDBOX). The two flag sets are disjoint by launch mode:
+    at its top level, the direct-host Admin set when requested, then the
+    sandbox-only set when booting inside the docker sandbox (SC_SANDBOX). The
+    flag sets are disjoint by launch mode:
     `launch_flags` for interactive, `headless_flags` for headless — a
     non-interactive run can't answer a permission prompt (it auto-denies and
     the worker silently stalls). They are NOT folded together because a
@@ -785,6 +788,8 @@ def launch_mode_flags(adapter: dict, headless: bool) -> list[str]:
     harnesses whose bypass is safe only behind the container boundary."""
     key = "headless_flags" if headless else "launch_flags"
     flags = list(adapter.get(key) or [])
+    if host_admin:
+        flags += list((adapter.get("host_admin") or {}).get(key) or [])
     if os.environ.get("SC_SANDBOX"):
         flags += list((adapter.get("sandbox") or {}).get(key) or [])
     return flags
@@ -2564,7 +2569,7 @@ def main() -> None:
     # top level (claude's bypass, which a settings merge can no longer grant)
     # plus sandbox-only ones such as codex's approval/sandbox bypass, safe
     # because the container is the safety boundary. See launch_mode_flags.
-    mode_flags = launch_mode_flags(adapter, headless)
+    mode_flags = launch_mode_flags(adapter, headless, host_admin=host_admin)
     if mode_flags:
         print(f"→ launch flags → {' '.join(mode_flags)}")
     sandbox_env: dict[str, str] = {}

--- a/tests/test_codex_permission_flags.py
+++ b/tests/test_codex_permission_flags.py
@@ -1,0 +1,51 @@
+"""Codex host Admin gets its declared direct-host maintenance authority."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import run
+
+ADMIN_FLAGS = [
+    "--sandbox",
+    "danger-full-access",
+    "--ask-for-approval",
+    "never",
+]
+BYPASS = "--dangerously-bypass-approvals-and-sandbox"
+
+
+def _codex() -> dict:
+    return json.loads((run.ADAPTERS / "codex" / "adapter.json").read_text())
+
+
+class CodexPermissionFlagsTest(unittest.TestCase):
+    def test_host_admin_gets_unrestricted_filesystem_without_bypass_flag(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                run.launch_mode_flags(_codex(), headless=False, host_admin=True),
+                ADMIN_FLAGS,
+            )
+
+    def test_ordinary_host_shell_keeps_codex_defaults(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(run.launch_mode_flags(_codex(), headless=False), [])
+
+    def test_container_keeps_external_sandbox_bypass(self) -> None:
+        with mock.patch.dict(os.environ, {"SC_SANDBOX": "1"}, clear=True):
+            self.assertEqual(
+                run.launch_mode_flags(_codex(), headless=False),
+                [BYPASS],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1523.

Direct-host Codex Admin launches now receive `--sandbox danger-full-access --ask-for-approval never`, matching the Admin maintenance mandate while leaving ordinary host shells and Docker-contained launches unchanged. The adapter contract and README document the scoped policy.

Verification:
- `./sc test tests/test_codex_permission_flags.py tests/test_claude_permission_flags.py tests/test_run_session.py tests/test_admin_host_launch.py` — 59 passed
- `./sc lint tests/test_codex_permission_flags.py` — passed
- `python3 -m py_compile .super-coder/scripts/run.py tests/test_codex_permission_flags.py` — passed
- `python3 -m json.tool .super-coder/adapters/codex/adapter.json` — passed
- `git diff --check` — passed
- installed `codex-cli 0.153.3` accepts the exact flag combination

Repository-wide lint/typecheck remain red on the existing baseline (1,283 Ruff findings; 720 mypy findings); no new-file Ruff findings.