### PR TITLE
fix(skill): unretire drops stale entries for removed engine skills

### DIFF
--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -731,7 +731,11 @@ def _retire_spec(con, name: str) -> tuple[bool, int]:
 
 
 def _unretire_spec(con, name: str) -> int:
-    """Restore one retired engine skill. Returns the grants live again."""
+    """Restore one retired engine skill. Returns the grants live again.
+
+    A listed name with no `skills` row (upstream removed the engine skill, or
+    a typo) is a stale entry: drop it from the list and return 0 — the list
+    is the fork's to keep tidy, and `unretire` is its only supported writer."""
     names = seed_skills.retired_skill_names()
     if name not in names:
         raise SkillConflictError(
@@ -743,9 +747,11 @@ def _unretire_spec(con, name: str) -> int:
         skill_projection.reconcile_existing_checkouts(con)
     except skill_projection.ProjectionError as exc:
         sys.exit(skill_projection.partial_failure_message(f"unretire {name}", exc))
-    return grant_count(
-        con, con.execute(
-            "SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()[0])
+    row = con.execute(
+        "SELECT skill_id FROM skills WHERE name=?", (name,)).fetchone()
+    if row is None:
+        return 0
+    return grant_count(con, row[0])
 
 
 def _retire_list_note() -> str:
@@ -770,7 +776,11 @@ def cmd_unretire(con, name: str) -> int:
         grants = _unretire_spec(con, name)
     except SkillConflictError as exc:
         sys.exit(f"sc skill: {exc}")
-    print(f"unretire: {name} — restored with {grants} grant(s) live again.")
+    if name not in set(seed_skills.seeded_skill_names()):
+        print(f"unretire: {name} — removed stale entry; no engine skill by "
+              "that name exists to restore.")
+    else:
+        print(f"unretire: {name} — restored with {grants} grant(s) live again.")
     print(_retire_list_note())
     return 0
 

--- a/tests/test_skill_retire.py
+++ b/tests/test_skill_retire.py
@@ -261,6 +261,29 @@ class RetireTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             skill_cli.cmd_unretire(self.con, "onboard")
 
+    def test_cmd_unretire_removed_engine_skill_drops_stale_entry(self):
+        # Upstream removed `test_authoring`; the fork list still names it.
+        self._retire_file(["redline_review", "test_authoring"])
+        seed_skills.apply_retired(self.con)
+        with mock.patch("builtins.print") as printed:
+            self.assertEqual(
+                skill_cli.cmd_unretire(self.con, "test_authoring"), 0)
+        self.assertEqual(json.loads(seed_skills.RETIRED_FILE.read_text()),
+                         ["redline_review"])
+        self.assertEqual(self._deleted("redline_review"), 1)
+        self.assertIn("removed stale entry",
+                      printed.call_args_list[0].args[0])
+
+    def test_api_unretire_removed_engine_skill_reports_zero_grants(self):
+        self._retire_file(["test_authoring"])
+        status, body = server._skills_mutation_report(
+            server.api_skill_unretire, self.con, "test_authoring")
+        self.assertEqual((status, body), (200, {
+            "ok": True, "action": "unretire", "name": "test_authoring",
+            "grants": 0,
+        }))
+        self.assertEqual(json.loads(seed_skills.RETIRED_FILE.read_text()), [])
+
     # ── the Planner API lane shares the spec helpers ─────────────────────────
     def test_spec_helpers_raise_conflicts_instead_of_exiting(self):
         with self.assertRaisesRegex(skill_cli.SkillConflictError, "LOCAL skill"):


### PR DESCRIPTION
## Summary
- `sc skill unretire <name>` crashed with `TypeError: NoneType object is not subscriptable` when the listed name had no `skills` row, i.e. upstream removed the engine skill (`test_authoring` in dos-arch). The retire list was already rewritten before the crash, so the file was fixed while the command failed loudly.
- `_unretire_spec` now fetches the row first and returns 0 grants when it is missing. The CLI prints that the stale entry was removed and nothing exists to restore; the API lane returns `grants: 0`.
- Trade-off: I chose to drop the stale entry rather than refuse. The update warning already tells the operator to fix the list, and `unretire` is the list's only supported writer, so refusing would force the manual JSON edit the reporter used as a workaround.

Closes #1526

## Test plan
- [x] `python3 tests/test_skill_retire.py` — 30 pass, incl. new CLI and API stale-entry cases
- [x] `python3 tests/test_local_skill_persistence.py` — 26 pass
- [x] `sc lint` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)