### PR TITLE
docs(windows_testing): state Planner ownership of the skill import

### DIFF
--- a/.super-coder/docs/skills/windows_testing/SKILL.md
+++ b/.super-coder/docs/skills/windows_testing/SKILL.md
@@ -135,9 +135,13 @@ status/acquire/start/push/exec/pull/reset/release run, then confirm lease
 conflicts, protected snapshot refusal, and failed-promotion preservation.
 
 After the reviewed engine revision is installed in active dos-arch, import this
-file as a fork-local skill:
+file as a fork-local skill. Every `sc skill` mutation is Planner-owned: the
+Admin repins the engine, then a launched Planner shell runs the import and
+grants. When no Planner is booted, the Admin asks the FnB to boot one rather
+than running these commands from the Admin seat, where they are refused.
 
 ```bash
+# on a launched Planner shell
 sc skill put --file .super-coder/docs/skills/windows_testing/SKILL.md
 sc skill grant windows_testing <dev-shortname> <reviewer-shortname>
 sc skill list


### PR DESCRIPTION
## Summary
- The windows_testing install block told the Admin to run `sc skill put` and `sc skill grant` after the engine repin. Every `sc skill` mutation is Planner-owned by recorded decision, enforced in both the local lane (`require_planner`) and the API lane, so the Admin seat gets `put is Planner-owned; shell ADM1 has flavor admin`.
- Doc-only fix: name the handoff. Admin repins, a launched Planner imports and grants, and the Admin asks the FnB to boot a Planner when none is up. No authority change.

Closes #1524

## Test plan
- [x] Doc-only change; the code block content is unchanged apart from a lane comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)