### PR TITLE
fix(watcher): deliver every non-Sprint green owner wake

### DIFF
--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1286,8 +1286,8 @@ pending -> native wake; red -> fix/push; green -> judge/request review; none or
 untrustworthy watcher after one bounded read -> report + block. Follow
 context: armed -> fix red + judge/pass green + merged -> post-merge handoff;
 paused -> fix red now + judge green, review after resume; no active Sprint ->
-fix red if needed, green arrives only as red recovery, merged -> git skill
-after-merge cleanup. Planner/Reviewer get none.
+fix red if needed, green -> merge only on a standing FnB directive naming the
+PR, merged -> git skill after-merge cleanup. Planner/Reviewer get none.
 
 If the same registered PR was externally closed, then reopened, rebased, and
 pushed, replay the exact `register-pr` command. Require `created: false`, which

--- a/.super-coder/migrations/0258_reseed_non_sprint_green_wake.sql
+++ b/.super-coder/migrations/0258_reseed_non_sprint_green_wake.sql
@@ -1,15 +1,24 @@
----
-name: sprint_dev
-description: Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge under the Sprint grant once live authorization returns, and record judgment without overlapping edits.
-category: workflow
-common: false
----
+-- 0258 — reseed sprint_dev for non-Sprint green owner wakes (decision #317
+-- superseded). Outside an armed or paused Sprint the FnB merges a named PR on
+-- green, so green is the actionable fact: the watcher now delivers every
+-- non-Sprint green (not only red-to-green recovery) with a body that names the
+-- FnB merge directive as the gate. No schema change: a full-body UPSERT
+-- converges upgraded installations on the same text a fresh seed produces.
+-- Idempotent.
 
-# sprint_dev — own one editing lane
+BEGIN;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_dev',
+  'Execute a Sprints v2 Developer lane — accept one assignment, implement and verify it, own the PR through green and review, merge under the Sprint grant once live authorization returns, and record judgment without overlapping edits.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_dev — own one editing lane
 
 Load `sprint_protocol` first; it holds the lifecycle, wake types, inbox
 commands, relay contract, body limits, artifact paths, receipt recovery, and
-authority boundary. This skill holds only the Developer's steps.
+authority boundary. This skill holds only the Developer''s steps.
 
 ## Route the entry
 
@@ -25,10 +34,10 @@ authority boundary. This skill holds only the Developer's steps.
 expected output, linked tasks, bound revision id, active decisions,
 dependencies, unit blockers, roles, worktree, lifecycle walls, resources. Read
 the full bound revision or broader indexes only for an unresolved need. Own
-one active unit; never start another lane or edit another shell's worktree.
+one active unit; never start another lane or edit another shell''s worktree.
 Resolve ambiguity to shippable in-scope work + rationale. Ask the Planner
 before changing boundary, interface, deliverable, priority, or scope; ask the
-Reviewer about review evidence. Use the relay's unit question/blocker form and
+Reviewer about review evidence. Use the relay''s unit question/blocker form and
 stop at a decision boundary until the answer arrives.
 
 A Developer does not pause the Sprint. Report blocker or integrity evidence to
@@ -108,7 +117,7 @@ Complete each round in order:
 2. Perform the once-only inbox check; handle and `accept` new messages.
 3. Use `submit` first or `resubmit` after changes requested. The engine injects
    the PR URL, registered id, exact green head, and work-unit id into the
-   Reviewer's canonical bare one-line locator. Create no readiness file. Send
+   Reviewer''s canonical bare one-line locator. Create no readiness file. Send
    no scope narrative, verification evidence, rationale, or review-focus
    steering in the request. The PR body carries the work-unit id and spec
    reference plus your rationale (decisions, rejected trade-offs): each verdict
@@ -173,4 +182,12 @@ Report broken bases, destructive ambiguity, unavailable GitHub, untrustworthy
 runners, provider exhaustion, or unrecoverable environment with evidence,
 impact, and recommendation. Stop when merged + reported, declined, returned to
 review, paused for a native wake, or awaiting Planner/FnB recovery. Ask for
-later work only after this editing lane is terminal.
+later work only after this editing lane is terminal.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_pr_watcher.py
+++ b/.super-coder/scripts/sprint_pr_watcher.py
@@ -1466,7 +1466,8 @@ class SprintPRWatcher:
                     "needs attention, otherwise no action is needed."
                 ),
                 "green": (
-                    "Your PR is green outside an active Sprint; no action is needed."
+                    "Your PR is green outside an active Sprint; merge only under "
+                    "a standing FnB directive that names it, otherwise wait for one."
                 ),
                 "closed": (
                     "Your PR was closed without merge outside an active Sprint; "
@@ -1486,11 +1487,6 @@ class SprintPRWatcher:
                     "owns that reset; use its status/retry authority through the "
                     "originating Planner or FnB if needed."
                 )
-            # Outside an armed/paused Sprint green is only actionable as a
-            # red->green recovery; every other green would wake the owner to
-            # say "no action is needed".
-            if previous_state != "red":
-                instructions.pop("green")
         if state in instructions:
             head = pull_request.head_sha or "unknown"
             owner_shell_id = int(registered["owner_shell_id"])

--- a/.super-coder/templates/boot.md
+++ b/.super-coder/templates/boot.md
@@ -124,8 +124,9 @@ reply is a new send with `Re: <topic>` in the body.
 
 A wake is a message delivered into your session at a turn boundary, into your
 idle chat, or as a new chat; read it and act on it. Accepting Sprint work is an
-explicit act (the `sprint_protocol` skill). PR events reach the Developer who
-owns the PR, inside or outside a Sprint, with the fact stated in the message.
+explicit act (the `sprint_protocol` skill). PR events (red, green, closed,
+merged) reach the Developer who owns the PR, inside or outside a Sprint, with
+the fact stated in the message.
 You never poll GitHub, boot participants, or schedule watchers.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -603,8 +603,8 @@ Sprint work explicitly); the mechanics live here for the operator.
   worktree's checked-out branch, `sc sprint register-pr` in a lane, or manual
   `sc pr subscribe`) emit self-describing red/green/closed/merged wakes to the
   owning Developer throughout ownership, inside or outside a Sprint; outside an
-  armed or paused Sprint, green arrives only as red-to-green recovery. Planner
-  and Reviewer receive no PR-event wakes.
+  armed or paused Sprint a green wake names the FnB merge directive as the
+  gate. Planner and Reviewer receive no PR-event wakes.
 - **Coordinate mode.** Closing the Planner chat during an armed Sprint sets
   coordinate mode: idle Planner `re-enter` wakes open fresh ticket chats.
   Pause/resume from the GUI returns to supervise mode; automatic pauses

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -155,7 +155,8 @@
     ".super-coder/migrations/0253_reseed_sprint_review_flexibility.sql",
     ".super-coder/migrations/0255_reseed_merge_gate_one_rule.sql",
     ".super-coder/migrations/0256_current_state_500.sql",
-    ".super-coder/migrations/0257_guidance_reconciliation.sql"
+    ".super-coder/migrations/0257_guidance_reconciliation.sql",
+    ".super-coder/migrations/0258_reseed_non_sprint_green_wake.sql"
   ],
   "baseline_migration_ledger": {
     "count": 142,
@@ -864,7 +865,7 @@
         "opens a fresh one. Sprint assignments, review requests, and verdicts are",
         "worktree's checked-out branch, `sc sprint register-pr` in a lane, or manual",
         "owning Developer throughout ownership, inside or outside a Sprint; outside an",
-        "armed or paused Sprint, green arrives only as red-to-green recovery. Planner",
+        "armed or paused Sprint a green wake names the FnB merge directive as the",
         "- **Coordinate mode.** Closing the Planner chat during an armed Sprint sets",
         "### Sprint fallbacks (operator)",
         "./sc sprint compile-report --sprint <id> --limit 50 > shared/sprints/sprint-<n>/evidence.json",

--- a/tests/test_focused_dev_verification.py
+++ b/tests/test_focused_dev_verification.py
@@ -22,6 +22,7 @@ MIGRATIONS = (
     ENGINE / "migrations" / "0254_reseed_task_context_projection.sql",
     ENGINE / "migrations" / "0255_reseed_merge_gate_one_rule.sql",
     ENGINE / "migrations" / "0257_guidance_reconciliation.sql",
+    ENGINE / "migrations" / "0258_reseed_non_sprint_green_wake.sql",
 )
 sys.path.insert(0, str(ENGINE / "scripts"))
 

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -552,10 +552,10 @@ class SprintCliApiTest(unittest.TestCase):
         finally:
             con.close()
         self.assertEqual((1, "acme/outside", 85, None), subscription)
-        # The initial snapshot is durable, but a first green outside a Sprint
-        # is not actionable and wakes nobody (spec #188).
+        # The initial snapshot is durable and a first green outside a Sprint
+        # wakes the owner: the FnB merges on green (decision #327).
         self.assertEqual(["green"], transitions)
-        self.assertIsNone(message)
+        self.assertIsNotNone(message)
 
     def test_reconcile_pr_allows_originating_planner_and_projects_receipt(self):
         argv = (

--- a/tests/test_sprint_pr_watcher.py
+++ b/tests/test_sprint_pr_watcher.py
@@ -1363,8 +1363,9 @@ class RecoveryAndFailureTest(SprintPRWatcherCase):
         self.assertEqual(
             "GitHub PR event: repository=acme/repo, number=42, head_sha="
             + "a" * 40
-            + ", event=green. Your PR is green outside an active Sprint; "
-            "no action is needed.",
+            + ", event=green. Your PR is green outside an active Sprint; merge "
+            "only under a standing FnB directive that names it, otherwise wait "
+            "for one.",
             message["body"],
         )
 
@@ -1818,10 +1819,10 @@ class EngineWideSubscriptionTest(SprintPRWatcherCase):
 
         self.assertTrue(self.watcher.poll_once())
         self.assertEqual(calls + 2, len(self.reader.get_calls))
-        # Reopened green outside a Sprint is durable but not actionable: only
-        # the closed fact woke the owner.
+        # Reopened green outside a Sprint is actionable again: the FnB merges
+        # on green, so the owner hears the closed fact and then the green one.
         self.assertEqual(
-            ["closed"],
+            ["closed", "green"],
             [
                 re.search(r"event=([a-z_]+)", str(row[0])).group(1)
                 for row in self.con.execute(
@@ -2247,28 +2248,31 @@ class OwnerMergedAndGreenWakeTest(SprintPRWatcherCase):
             self._last_wake()["body"],
         )
 
-    def test_green_outside_sprint_wakes_only_as_red_recovery(self):
+    def test_green_outside_sprint_wakes_on_first_green_and_on_recovery(self):
         self.reader.current = pull_request(checks="PENDING", checks_failed=False)
         self.watcher.subscribe(owner_shell_id=1, repository="acme/repo", pr_number=42)
         self.assertEqual([], self._wake_events())
 
+        # Outside a Sprint the FnB merges on green, so the first green is the
+        # actionable fact — not only a red->green recovery.
         self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
         self.assertTrue(self.watcher.poll_once())
-        self.assertEqual([], self._wake_events())
-
-        self.reader.current = pull_request()
-        self.assertTrue(self.watcher.poll_once())
-        self.assertEqual(["red"], self._wake_events())
-
-        self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
-        self.assertTrue(self.watcher.poll_once())
-        self.assertEqual(["red", "green"], self._wake_events())
+        self.assertEqual(["green"], self._wake_events())
         self.assertIn(
-            "event=green. Your PR is green outside an active Sprint",
+            "event=green. Your PR is green outside an active Sprint; merge only "
+            "under a standing FnB directive that names it",
             self._last_wake()["body"],
         )
 
-        # Every observation is still durable even when nobody is woken.
+        self.reader.current = pull_request()
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual(["green", "red"], self._wake_events())
+
+        self.reader.current = pull_request(checks="SUCCESS", checks_failed=False)
+        self.assertTrue(self.watcher.poll_once())
+        self.assertEqual(["green", "red", "green"], self._wake_events())
+
+        # Every observation is durable, pending included.
         self.assertEqual(
             ["pending", "green", "red", "green"],
             [

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -32,7 +32,12 @@ ROLE_SKILLS = {
     "sprint_rev": {"reviewer"},
 }
 SKILLS = {PROTOCOL: {"planner", "dev", "reviewer"}, **ROLE_SKILLS}
-RECONCILIATION = ENGINE / "migrations" / "0257_guidance_reconciliation.sql"
+# Every reseed since the guidance reconciliation, applied in order: the test
+# proves the trailing migrations converge on the current asset text.
+RECONCILIATION = (
+    ENGINE / "migrations" / "0257_guidance_reconciliation.sql",
+    ENGINE / "migrations" / "0258_reseed_non_sprint_green_wake.sql",
+)
 RETIRED = (
     "memory", "db_map", "bootstrap", "surface_catalogue", "messaging", "flags",
     "spec", "review", "docs", "admin_git", "cartographer", "sprint_close",
@@ -252,7 +257,7 @@ class SprintSkillTest(unittest.TestCase):
             con.execute("INSERT INTO shell_skills VALUES (7, ?)", (index,))
             con.execute("INSERT INTO flavor_skills VALUES ('dev', ?)", (index,))
         con.execute("UPDATE skills SET is_deleted=0, category='fork' WHERE name='fork_only'")
-        migration = RECONCILIATION.read_text()
+        migration = "\n".join(path.read_text() for path in RECONCILIATION)
         con.executescript(migration)
         first = con.execute(
             "SELECT name, description, category, command, common, content, is_deleted "

--- a/tests/test_task_context.py
+++ b/tests/test_task_context.py
@@ -741,9 +741,10 @@ class GuidanceTest(unittest.TestCase):
             "PRIMARY KEY(flavor, skill_id));")
         con.executescript(path.read_text())
         con.executescript(path.read_text())          # idempotent
-        # 0255 then 0257 (F72) re-own sprint_dev; compare once both replayed.
+        # 0255, 0257 (F72), then 0258 re-own sprint_dev; compare once all replayed.
         for later in ("0255_reseed_merge_gate_one_rule.sql",
-                      "0257_guidance_reconciliation.sql"):
+                      "0257_guidance_reconciliation.sql",
+                      "0258_reseed_non_sprint_green_wake.sql"):
             text = (ENGINE / "migrations" / later).read_text()
             con.executescript(text)
             con.executescript(text)


### PR DESCRIPTION
## Why

Outside an armed or paused Sprint the PR watcher woke the owner on green only as a red-to-green recovery (decision #317). The non-Sprint merge gate is "merge once green after an FnB directive names the PR", so the first green is exactly the actionable fact. Suppressing it forced the FnB to poll GitHub and relay by hand on #1527/#1528 today.

## What

- `sprint_pr_watcher._route_transition`: remove the `previous_state != "red"` suppression. Non-Sprint green body now reads "merge only under a standing FnB directive that names it, otherwise wait for one." Sprint red/green/closed/merged routing is unchanged.
- `sprint_dev` skill, boot template WAKES paragraph, `docs/README.md`: state red/green/closed/merged uniformly.
- `0001_seed_skills.sql` regenerated from assets; `0258_reseed_non_sprint_green_wake.sql` reseeds `sprint_dev` (full-body UPSERT, idempotent).
- Tests: green-outside-Sprint and reopen tests updated; reseed-chain tests (`test_sprint_skills`, `test_focused_dev_verification`, `test_task_context`) extended with 0258; sprint-removal manifest v2 line rebound.

Decision #327 supersedes #317.

## Verification

Focused local gate: 159 pass across `test_sprint_pr_watcher`, `test_sprint_skills`, `test_focused_dev_verification`, `test_task_context`, `test_git_sync_policy`, `test_role_aware_boot_contract`, `test_skill_lifecycle_convergence`, `test_sprint_removal_manifest`, `test_migration_management`, `test_boot_project_vs_engine`. Ruff clean on every changed Python file (one pre-existing EXE001 on `tests/test_task_context.py:1`, untouched). 0258 applied twice against a fresh `skills` table converges.

The 0001 regen ran with the DB resolver stubbed because this launched seat cannot read the private instance state; the file diff is exactly the two changed `sprint_dev` lines.