### PR TITLE
fix(watcher): superseded cancelled check runs no longer read as red

### DIFF
--- a/.super-coder/scripts/github_pull_requests.py
+++ b/.super-coder/scripts/github_pull_requests.py
@@ -144,16 +144,47 @@ def _sha_value(value: Any) -> str | None:
     return text
 
 
+def _check_identity(item: dict[str, Any]) -> str | None:
+    name = item.get("name") or item.get("context")
+    return str(name) if name else None
+
+
+def _item_state(item: dict[str, Any]) -> str | None:
+    state = item.get("conclusion") or item.get("state") or item.get("status")
+    return str(state).upper() if state else None
+
+
+def _drop_superseded_cancellations(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Ignore a cancelled run whose check name has another, non-cancelled run.
+
+    GitHub keeps every check run recorded against the head commit in the
+    rollup, so a duplicate workflow run cancelled by concurrency control sits
+    beside its replacement under the same name. GitHub's own gate reads the
+    replacement; a cancelled run only counts when no other run of that check
+    exists (#1376).
+    """
+    replaced: set[str] = set()
+    for item in items:
+        name = _check_identity(item)
+        if name is not None and _item_state(item) != "CANCELLED":
+            replaced.add(name)
+    return [
+        item
+        for item in items
+        if not (
+            _item_state(item) == "CANCELLED"
+            and _check_identity(item) in replaced
+        )
+    ]
+
+
 def _check_state(raw: Any) -> tuple[str | None, bool]:
     if not isinstance(raw, list):
         return None, False
-    states: list[str] = []
-    for item in raw:
-        if not isinstance(item, dict):
-            continue
-        state = item.get("conclusion") or item.get("state") or item.get("status")
-        if state:
-            states.append(str(state).upper())
+    items = _drop_superseded_cancellations(
+        [item for item in raw if isinstance(item, dict)]
+    )
+    states = [state for state in map(_item_state, items) if state]
     if any(state in _FAILED_CHECKS for state in states):
         return "FAILURE", True
     if any(state in _PENDING_CHECKS for state in states):

--- a/tests/test_git_review.py
+++ b/tests/test_git_review.py
@@ -76,6 +76,36 @@ class GitHubReaderTest(unittest.TestCase):
             with self.subTest(rollup=rollup):
                 self.assertEqual(expected, _check_state(rollup))
 
+    def test_cancelled_duplicate_run_is_superseded_by_same_named_run(self) -> None:
+        # #1376: concurrency control cancels a duplicate workflow run; GitHub
+        # keeps it in the rollup beside its replacement under the same name.
+        cancelled = {"name": "gitleaks", "status": "COMPLETED", "conclusion": "CANCELLED"}
+        green = {"name": "gitleaks", "status": "COMPLETED", "conclusion": "SUCCESS"}
+        queued = {"name": "gitleaks", "status": "QUEUED", "conclusion": None}
+        other = {"name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"}
+        cases = (
+            ([cancelled, green, other], ("SUCCESS", False)),
+            ([green, cancelled, other], ("SUCCESS", False)),
+            ([cancelled, queued, other], ("PENDING", False)),
+            ([cancelled, other], ("FAILURE", True)),
+            ([cancelled, cancelled, other], ("FAILURE", True)),
+            # A cancelled run of one check never borrows another check's success.
+            ([{"name": "lint", "conclusion": "CANCELLED"}, green], ("FAILURE", True)),
+            # Legacy status contexts supersede by context the same way.
+            (
+                [
+                    {"context": "ci/scan", "state": "CANCELLED"},
+                    {"context": "ci/scan", "state": "SUCCESS"},
+                ],
+                ("SUCCESS", False),
+            ),
+            # Unnamed items keep their verdict.
+            ([{"conclusion": "CANCELLED"}, green], ("FAILURE", True)),
+        )
+        for rollup, expected in cases:
+            with self.subTest(rollup=rollup):
+                self.assertEqual(expected, _check_state(rollup))
+
     def test_list_normalizes_full_projection_with_read_only_command(self) -> None:
         payload = json.dumps(MockGitHub().list_prs()).encode()
         calls = []


### PR DESCRIPTION
## Summary
- \`_check_state\` drops a \`CANCELLED\` rollup item when another run of the same check name (or legacy status \`context\`) exists; a cancelled run with no sibling still fails.
- Tests cover both orderings, a queued replacement (pending), lone/duplicate cancellations, cross-check isolation, legacy contexts, and unnamed items.

Closes #1376.

## Trade-off
Considered "latest run per name wins" (GitHub's gate semantics). Rejected for now: \`startedAt\` is absent on a queued replacement and on some fixtures, so ordering is ambiguous and could hide a real latest failure. The cancelled-superseded rule matches the observed incident exactly without that risk.

## Verification
\`python3 -m unittest tests.test_git_review tests.test_sprint_pr_watcher tests.test_review_contract_fixtures\` — 98 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)