### PR TITLE
fix(cli): committed skill and sprint writes carry a real receipt budget

### DIFF
--- a/.super-coder/scripts/mem.py
+++ b/.super-coder/scripts/mem.py
@@ -261,6 +261,11 @@ _TIMEOUT = 10         # default per-request HTTP timeout (seconds)
 # the generic timeout a slow success surfaced as "API unreachable" and a PATCH
 # retry re-ran the whole serialize (SC-013). Doc writes carry their own budget.
 _DOC_WRITE_TIMEOUT = 420
+# Skill mutations (put/grant/revoke/rm/retire/unretire) commit and then run
+# the same synchronous snapshot+render pipeline, fanning the projection out to
+# every shell worktree; the generic timeout reported a landed put as
+# "unreachable" (#1507). Same budget as doc writes.
+_SKILL_WRITE_TIMEOUT = _DOC_WRITE_TIMEOUT
 
 
 def _api(method: str, path: str, payload: "dict | None" = None,
@@ -319,9 +324,13 @@ def _api(method: str, path: str, payload: "dict | None" = None,
             if timed_out and idempotent and not last:
                 time.sleep(_RETRY_PAUSE)
                 continue
-            hint = (" — the write MAY have landed server-side; check before "
-                    "resending" if timed_out and not idempotent else "")
-            die(f"API unreachable ({SC_API_BASE}): {exc}{hint}")
+            if timed_out and not idempotent:
+                # The server accepted the request and is still working; this
+                # is a lost receipt, never an unreachable API (#1507, #1379).
+                die(f"API {method} {path} gave no receipt within {timeout:g}s — "
+                    "the write MAY have landed server-side; verify with a read "
+                    "before resending")
+            die(f"API unreachable ({SC_API_BASE}): {exc}")
 
 
 def _finish_api(summary: str) -> int:

--- a/.super-coder/scripts/skill.py
+++ b/.super-coder/scripts/skill.py
@@ -437,7 +437,7 @@ def cmd_put_api(path: Path) -> int:
     except DraftValidationError as exc:
         sys.exit(f"sc skill: draft {path}: {exc}")
     result = mem._api(
-        "POST", "/_sc/skills/put", {"content": text}, idempotent=False
+        "POST", "/_sc/skills/put", {"content": text}, idempotent=False, timeout=mem._SKILL_WRITE_TIMEOUT
     )
     print(f"put: {result['name']} {result['verb']} (via engine API); "
           "grants unchanged")
@@ -447,7 +447,7 @@ def cmd_put_api(path: Path) -> int:
 def cmd_grant_api(name: str, shell_refs: list[str]) -> int:
     result = mem._api(
         "POST", "/_sc/skills/grant",
-        {"name": name, "shells": shell_refs}, idempotent=False,
+        {"name": name, "shells": shell_refs}, idempotent=False, timeout=mem._SKILL_WRITE_TIMEOUT,
     )
     for row in result.get("results") or []:
         suffix = "" if row["changed"] else "  (already granted)"
@@ -459,7 +459,7 @@ def cmd_grant_api(name: str, shell_refs: list[str]) -> int:
 def cmd_revoke_api(name: str, shell_refs: list[str]) -> int:
     result = mem._api(
         "POST", "/_sc/skills/revoke",
-        {"name": name, "shells": shell_refs}, idempotent=False,
+        {"name": name, "shells": shell_refs}, idempotent=False, timeout=mem._SKILL_WRITE_TIMEOUT,
     )
     for row in result.get("results") or []:
         suffix = "" if row["changed"] else "  (was not granted)"
@@ -470,7 +470,7 @@ def cmd_revoke_api(name: str, shell_refs: list[str]) -> int:
 
 def cmd_rm_api(name: str) -> int:
     result = mem._api(
-        "POST", "/_sc/skills/rm", {"name": name}, idempotent=False
+        "POST", "/_sc/skills/rm", {"name": name}, idempotent=False, timeout=mem._SKILL_WRITE_TIMEOUT
     )
     suffix = " (already removed; persistence reconciled)" if result.get(
         "already_removed") else ""
@@ -483,7 +483,7 @@ def cmd_rm_api(name: str) -> int:
 
 def cmd_retire_api(name: str) -> int:
     result = mem._api(
-        "POST", "/_sc/skills/retire", {"name": name}, idempotent=False
+        "POST", "/_sc/skills/retire", {"name": name}, idempotent=False, timeout=mem._SKILL_WRITE_TIMEOUT
     )
     listed = "  (already listed)" if result.get("already_listed") else ""
     print(f"retire: {result['name']}{listed} — retired fork-wide; "
@@ -494,7 +494,7 @@ def cmd_retire_api(name: str) -> int:
 
 def cmd_unretire_api(name: str) -> int:
     result = mem._api(
-        "POST", "/_sc/skills/unretire", {"name": name}, idempotent=False
+        "POST", "/_sc/skills/unretire", {"name": name}, idempotent=False, timeout=mem._SKILL_WRITE_TIMEOUT
     )
     print(f"unretire: {result['name']} — restored with {result['grants']} "
           "grant(s) live again. (via engine API)")

--- a/.super-coder/scripts/sprint_cli.py
+++ b/.super-coder/scripts/sprint_cli.py
@@ -44,8 +44,16 @@ def _integer_list(values: list[int] | None) -> list[int]:
     return list(dict.fromkeys(values or ()))
 
 
+# Sprint writes commit atomically but do real work before the receipt: arm
+# probes every bound harness CLI in preflight and queues the initial wakes.
+# The generic 10s budget reported a committed arm as "unreachable" (#1379).
+_WRITE_TIMEOUT = 120
+
+
 def _post(path: str, payload: dict, *, idempotent: bool = False) -> dict:
-    return mem._api("POST", path, payload, idempotent=idempotent)
+    return mem._api(
+        "POST", path, payload, idempotent=idempotent, timeout=_WRITE_TIMEOUT
+    )
 
 
 def cmd_declare(args: argparse.Namespace) -> int:

--- a/tests/test_local_skill_persistence.py
+++ b/tests/test_local_skill_persistence.py
@@ -666,9 +666,11 @@ class SkillApiLaneTest(unittest.TestCase):
         """A masked DB path raises OSError/PermissionError — the call reroutes."""
         draft = self.write_draft("loc_api")
         api_calls: list[tuple[str, str, dict]] = []
+        api_kwargs: list[dict] = []
 
         def fake_api(method, path, payload, *, idempotent=None, **kwargs):
             api_calls.append((method, path, payload))
+            api_kwargs.append({"idempotent": idempotent, **kwargs})
             if path == "/_sc/skills/put":
                 return {
                     "ok": True,
@@ -687,6 +689,14 @@ class SkillApiLaneTest(unittest.TestCase):
         self.assertEqual(api_calls[0][0], "POST")
         self.assertEqual(api_calls[0][1], "/_sc/skills/put")
         self.assertIn("loc_api", api_calls[0][2].get("content", ""))
+        # #1507: put commits then renders every shell; it carries the render
+        # budget, never the generic 10s timeout that reported a landed put as
+        # "unreachable".
+        self.assertEqual(
+            {"idempotent": False, "timeout": skill_mod.mem._SKILL_WRITE_TIMEOUT},
+            api_kwargs[0],
+        )
+        self.assertGreater(skill_mod.mem._SKILL_WRITE_TIMEOUT, skill_mod.mem._TIMEOUT)
 
     def test_api_fallback_does_not_swallow_no_db(self):
         """`no live DB` (a missing/empty engine DB on a host seat) still dies."""

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -26,6 +26,7 @@ import unittest
 import urllib.request
 from http.server import ThreadingHTTPServer
 from pathlib import Path
+from unittest import mock
 
 ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
 SCHEMA = ENGINE / "schema.sql"
@@ -41,6 +42,37 @@ PEER_TOKEN = "peer-token-cafebabe"   # second shell — cross-shell read coverag
 REVIEW_TOKEN = "review-token-012345"
 PLANNER_TOKEN = "planner-token-6789ab"
 
+
+
+class TimeoutReceiptTest(unittest.TestCase):
+    """A timed-out write is a lost receipt, not an unreachable API (#1507, #1379)."""
+
+    def setUp(self):
+        self._pause = mem._RETRY_PAUSE
+        mem._RETRY_PAUSE = 0.0
+
+    def tearDown(self):
+        mem._RETRY_PAUSE = self._pause
+
+    def _timeout_message(self, method, path, **kwargs):
+        stderr = io.StringIO()
+        with mock.patch.object(
+            mem.urllib.request, "urlopen", side_effect=TimeoutError("timed out")
+        ), contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as caught:
+            mem._api(method, path, {"x": 1} if method == "POST" else None, **kwargs)
+        return str(caught.exception)
+
+    def test_non_idempotent_timeout_names_the_write_and_budget(self):
+        message = self._timeout_message("POST", "/_sc/skills/put", timeout=420)
+        self.assertIn("POST /_sc/skills/put", message)
+        self.assertIn("420s", message)
+        self.assertIn("MAY have landed", message)
+        self.assertNotIn("unreachable", message)
+
+    def test_idempotent_timeout_still_reports_unreachable(self):
+        message = self._timeout_message("GET", "/_sc/mem/whoami")
+        self.assertIn("API unreachable", message)
+        self.assertNotIn("MAY have landed", message)
 
 class MemMessageHelpContractTest(unittest.TestCase):
     def test_authored_send_help_matches_parser_options(self):

--- a/tests/test_sprint_cli.py
+++ b/tests/test_sprint_cli.py
@@ -114,6 +114,7 @@ class SprintCliDispatcherTest(unittest.TestCase):
                 "reason": "Reviewer decision 1667",
             },
             idempotent=True,
+            timeout=sprint_cli._WRITE_TIMEOUT,
         )
         self.assertEqual(response, json.loads(output.getvalue()))
 
@@ -167,6 +168,7 @@ class SprintCliDispatcherTest(unittest.TestCase):
                     "adopt_legacy": True,
                 },
                 idempotent=True,
+                timeout=sprint_cli._WRITE_TIMEOUT,
             ),
             api.call_args_list[1],
         )
@@ -2089,6 +2091,7 @@ class SprintCliApiTest(unittest.TestCase):
             "/_sc/sprint/qaqc",
             {"document_id": document_id, "verdict": "pass"},
             idempotent=True,
+            timeout=sprint_cli._WRITE_TIMEOUT,
         )
         self.assertTrue(approval["created"])
         mem.SC_API_TOKEN = TOKENS["developer"]
@@ -2098,6 +2101,7 @@ class SprintCliApiTest(unittest.TestCase):
                 "/_sc/sprint/qaqc",
                 {"document_id": document_id, "verdict": "pass"},
                 idempotent=True,
+                timeout=sprint_cli._WRITE_TIMEOUT,
             )
 
         participants = self.write(


### PR DESCRIPTION
## Summary
- `sc skill` mutations (put/grant/revoke/rm/retire/unretire) send with `mem._SKILL_WRITE_TIMEOUT` (= the doc-write budget, 420s): they commit then run the same synchronous snapshot+render fan-out to every shell worktree that doc writes do.
- `sprint_cli._post` sends with a 120s budget: arm probes every bound harness CLI in preflight before queueing wakes.
- `mem._api`: a timed-out non-idempotent request now dies with `API POST <path> gave no receipt within <N>s — the write MAY have landed server-side; verify with a read before resending`. "API unreachable" is reserved for connection failures and exhausted idempotent retries.

Closes #1507. Closes #1379.

## Trade-off
Considered making the server ack the commit and render asynchronously (issue option b). Rejected as a quick fix: it changes the persistence receipt contract that `sc skill` and the projection tests rely on. Extending the client budget matches how SC-013 fixed the identical doc-write symptom.

## Verification
`python3 -m unittest tests.test_mem tests.test_sprint_cli tests.test_local_skill_persistence` — OK. New tests: skill put carries the render budget; timeout receipt names request/budget and omits "unreachable"; idempotent GET timeout still says unreachable; sprint assertions updated for the timeout kwarg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)