### PR TITLE
fix(job): kill verifies the recorded pid is still the job's process

### DIFF
--- a/.super-coder/scripts/job.py
+++ b/.super-coder/scripts/job.py
@@ -118,6 +118,43 @@ def next_job_id(label: "str | None") -> str:
     return f"{n}-{label}" if label else str(n)
 
 
+def _start_ticks(pid: int) -> "int | None":
+    """Field 22 of /proc/<pid>/stat — the process's start time in clock ticks
+    since boot. Together with the pid it names one process incarnation: a
+    recycled pid carries a different value. None when the pid is gone or the
+    host has no procfs."""
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        return int(stat.rsplit(")", 1)[1].split()[19])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def _has_procfs() -> bool:
+    return Path("/proc/self/stat").exists()
+
+
+def kill_refusal(meta: dict, pid: int) -> "str | None":
+    """Why `kill` must not signal `pid`, or None when it is still the job's own
+    process. A recorded pid is only an identity while its incarnation matches;
+    once the OS recycles it, killpg would hit a stranger's process group (#954
+    — a foreign install's watchers died this way). Mismatch, gone, or
+    unverifiable all count as 'not ours to kill'."""
+    recorded = meta.get("start_ticks")
+    live = _start_ticks(pid)
+    if live is None:
+        if _has_procfs():
+            return f"pid {pid} is gone — nothing to kill; the supervisor records the exit"
+        return None   # no procfs: nothing to verify against; legacy behavior
+    if recorded is None:
+        return (f"pid {pid} has no recorded identity (job started before this "
+                f"engine version) — refusing to signal it blind; verify and kill it by hand")
+    if int(recorded) != live:
+        return (f"pid {pid} was recycled by the OS (recorded start {recorded}, live "
+                f"{live}) — it is no longer this job's process; nothing killed")
+    return None
+
+
 def is_finished(meta: dict) -> bool:
     return meta.get("finished_at") is not None
 
@@ -215,6 +252,7 @@ def supervise(jobdir: Path, notify=send_completion) -> int:
         return 127
 
     meta["pid"] = child.pid
+    meta["start_ticks"] = _start_ticks(child.pid)
     write_meta(jobdir, meta)
 
     timeout = meta.get("timeout")
@@ -387,6 +425,9 @@ def cmd_kill(args) -> int:
     pid = meta.get("pid")
     if not pid:
         die(f"job '{args.id}' has no recorded pid yet — try again in a moment")
+    refusal = kill_refusal(meta, int(pid))
+    if refusal:
+        die(f"job '{args.id}': {refusal}")
     meta["killed"] = True
     write_meta(jobdir, meta)
     _kill_group(int(pid))

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -208,6 +208,71 @@ class WaitTest(unittest.TestCase):
         self.assertEqual(1, job.cmd_wait(self._args(jd.name)))
 
 
+class KillIdentityTest(unittest.TestCase):
+    """`sc job kill` signals a recorded pid only while it is still the job's
+    own process incarnation (#954: a recycled pid must never be killpg'd)."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.old_jobs = job.JOBS
+        job.JOBS = self.tmp
+
+    def tearDown(self):
+        job.JOBS = self.old_jobs
+
+    def _live_job(self, **meta_extra) -> Path:
+        # This test process stands in for the job's live child.
+        jd = start_job(self.tmp, ["sh", "-c", "sleep 60"])
+        meta = job.read_meta(jd)
+        meta.update(pid=os.getpid(), supervisor_pid=os.getpid(), **meta_extra)
+        job.write_meta(jd, meta)
+        return jd
+
+    def _refused_kill(self, jd) -> str:
+        with (
+            mock.patch.object(job, "_kill_group") as kill_group,
+            self.assertRaises(SystemExit) as caught,
+        ):
+            job.cmd_kill(SimpleNamespace(id=jd.name))
+        kill_group.assert_not_called()
+        self.assertFalse(job.read_meta(jd).get("killed"))
+        return str(caught.exception)
+
+    @unittest.skipUnless(job._has_procfs(), "needs procfs")
+    def test_supervisor_records_the_child_incarnation(self):
+        jd = start_job(self.tmp, ["sh", "-c", "exit 0"])
+        job.supervise(jd, notify=lambda m: True)
+        meta = job.read_meta(jd)
+        self.assertIsInstance(meta["start_ticks"], int)
+        self.assertIsInstance(meta["pid"], int)
+
+    @unittest.skipUnless(job._has_procfs(), "needs procfs")
+    def test_matching_incarnation_is_killed(self):
+        jd = self._live_job(start_ticks=job._start_ticks(os.getpid()))
+        with mock.patch.object(job, "_kill_group") as kill_group:
+            self.assertEqual(0, job.cmd_kill(SimpleNamespace(id=jd.name)))
+        kill_group.assert_called_once_with(os.getpid())
+        self.assertTrue(job.read_meta(jd).get("killed"))
+
+    @unittest.skipUnless(job._has_procfs(), "needs procfs")
+    def test_recycled_pid_is_never_signalled(self):
+        jd = self._live_job(start_ticks=job._start_ticks(os.getpid()) + 1)
+        self.assertIn("recycled", self._refused_kill(jd))
+
+    @unittest.skipUnless(job._has_procfs(), "needs procfs")
+    def test_unrecorded_identity_is_never_signalled(self):
+        jd = self._live_job()   # legacy meta: pid without start_ticks
+        self.assertIn("no recorded identity", self._refused_kill(jd))
+
+    @unittest.skipUnless(job._has_procfs(), "needs procfs")
+    def test_gone_pid_is_reported_not_signalled(self):
+        jd = self._live_job(start_ticks=1)
+        meta = job.read_meta(jd)
+        meta["pid"] = 2**22 + 1234567   # not a real pid
+        job.write_meta(jd, meta)
+        self.assertIn("gone", self._refused_kill(jd))
+
+
 class CompletionRowTest(unittest.TestCase):
     """send_completion against the real API server: the result row lands in
     the starting shell's own inbox, and the dedupe_key makes a resend a no-op."""


### PR DESCRIPTION
## Summary
- `supervise` records the child's `/proc/<pid>/stat` start ticks as `start_ticks` beside `pid` in `meta.json`.
- `sc job kill` runs `kill_refusal` before stamping `killed` or signalling: it refuses when the live start ticks differ (pid recycled), the pid is gone, or the meta has no recorded identity (job started before this engine version). Each refusal says why and what to do.
- Hosts without procfs keep the prior behavior; there is nothing to verify against there.
- The supervisor's own `--timeout` kill is unchanged: it holds the unreaped `Popen` handle, so that pid cannot be recycled.

Closes #954. The original incident is still unreproduced; this closes the confirmed unsafe path (kill-by-recorded-PID without identity verification) the issue names.

## Trade-off
Considered importing `conversation_reaper.read_process_snapshot`; rejected because `job.py` is deliberately stdlib-only and standalone (it runs detached as the supervisor). The 8-line `_start_ticks` duplicates the field-22 read instead.

## Verification
`python3 -m unittest tests.test_job` — 19 tests, OK. New `KillIdentityTest`: incarnation recorded at spawn; matching incarnation is killed and stamped; recycled pid, unrecorded identity, and gone pid are all refused with `_kill_group` never called and `killed` never stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)