### PR TITLE
Fix Windows controller exec and push IO

### DIFF
--- a/.super-coder/scripts/windows_test_controller.py
+++ b/.super-coder/scripts/windows_test_controller.py
@@ -680,7 +680,12 @@ try {{
   $p = Start-Process powershell.exe -WorkingDirectory $target -ArgumentList @('-NoProfile','-NonInteractive','-File',('"' + $scriptPath + '"')) -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
   $finished = $p.WaitForExit({wait * 1000})
   if (-not $finished) {{ $null = & taskkill.exe /PID $p.Id /T /F; $p.WaitForExit() }}
-  $result = @{{ exit_code = $(if ($finished) {{ $p.ExitCode }} else {{ 124 }}); stdout = $(if (Test-Path $stdoutPath) {{ [IO.File]::ReadAllText($stdoutPath) }} else {{ '' }}); stderr = $(if (Test-Path $stderrPath) {{ [IO.File]::ReadAllText($stderrPath) }} else {{ '' }}); timed_out = (-not $finished) }}
+  if ($finished) {{
+    $p.WaitForExit()
+    $exitCode = $p.ExitCode
+    if ($null -eq $exitCode) {{ throw 'child process exit code is unavailable' }}
+  }} else {{ $exitCode = 124 }}
+  $result = @{{ exit_code = $exitCode; stdout = $(if (Test-Path $stdoutPath) {{ [IO.File]::ReadAllText($stdoutPath) }} else {{ '' }}); stderr = $(if (Test-Path $stderrPath) {{ [IO.File]::ReadAllText($stderrPath) }} else {{ '' }}); timed_out = (-not $finished) }}
   $result | ConvertTo-Json -Compress
 }} finally {{ Remove-Item -LiteralPath $scriptPath,$stdoutPath,$stderrPath -Force -ErrorAction SilentlyContinue }}
 """
@@ -696,8 +701,23 @@ try {{
                     state["uncertain_exec"] = True
                     self._save_state(state)
                 raise
+            raw_exit_code = result.get("exit_code")
+            if isinstance(raw_exit_code, bool) or not isinstance(
+                raw_exit_code, (int, str)
+            ):
+                raise ControllerError(
+                    "guest_response_invalid",
+                    "guest PowerShell returned an invalid child exit code",
+                )
+            try:
+                exit_code = int(raw_exit_code)
+            except (TypeError, ValueError) as exc:
+                raise ControllerError(
+                    "guest_response_invalid",
+                    "guest PowerShell returned an invalid child exit code",
+                ) from exc
             return {
-                "exit_code": int(result.get("exit_code", -1)),
+                "exit_code": exit_code,
                 "stdout": str(result.get("stdout", "")),
                 "stderr": str(result.get("stderr", "")),
                 "timed_out": bool(result.get("timed_out")),
@@ -861,10 +881,11 @@ try {{
                 "push payload_bytes must be a non-negative integer",
             )
         wait = _validated_timeout(timeout, 300)
-        body = """
-$input = [Console]::OpenStandardInput()
+        body = f"""
+$stdinStream = [Console]::OpenStandardInput()
 $file = [IO.File]::Open($target, [IO.FileMode]::Create, [IO.FileAccess]::Write, [IO.FileShare]::None)
-try { $input.CopyTo($file) } finally { $file.Dispose() }
+try {{ $stdinStream.CopyTo($file) }} finally {{ $file.Dispose() }}
+if ((Get-Item -LiteralPath $target).Length -ne {size}) {{ throw 'uploaded file size mismatch' }}
 """
         script = self._workspace_script(dest, body, must_exist=False)
         with self._locked():
@@ -1149,7 +1170,22 @@ def client_request(
         with input_path.open("rb") as source:
             shutil.copyfileobj(source, process_stdin, CHUNK_SIZE)
     process_stdin.close()
-    response = _read_header(process_stdout)
+    try:
+        response = _read_header(process_stdout)
+    except ControllerError as exc:
+        if exc.code != "protocol_header_invalid":
+            raise
+        rc = process.wait()
+        stderr = (
+            process.stderr.read(2000).decode("utf-8", "replace")
+            if process.stderr
+            else ""
+        )
+        raise ControllerError(
+            "transport_failed",
+            "controller transport exited without a valid response",
+            {"exit_code": rc, "stderr": stderr},
+        ) from exc
     expected = int((response.get("result") or {}).get("payload_bytes", 0))
     tmp: Path | None = None
     try:

--- a/tests/test_windows_test_controller.py
+++ b/tests/test_windows_test_controller.py
@@ -261,7 +261,41 @@ def test_exec_is_encoded_admin_powershell_and_never_host_shell(subject):
     decoded = base64.b64decode(ssh_call[-1].rsplit(" ", 1)[-1]).decode("utf-16-le")
     assert "WindowsBuiltInRole]::Administrator" in decoded
     assert "taskkill.exe /PID $p.Id /T /F" in decoded
+    assert "$p.WaitForExit()" in decoded
+    assert "$null -eq $exitCode" in decoded
     assert "-WorkingDirectory $target" in decoded
+
+
+def test_exec_rejects_null_guest_exit_code_with_structured_error(subject):
+    controller, runner, _popen, _clock = subject
+    token = acquire(subject)
+    original_call = runner.__call__
+
+    def null_exit_code(argv, **kwargs):
+        if argv[0] == "ssh":
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                '{"exit_code":null,"stdout":"","stderr":"","timed_out":false}\n',
+                "",
+            )
+        return original_call(argv, **kwargs)
+
+    controller.run = null_exit_code
+    stdin = io.BytesIO(
+        json.dumps(
+            {"operation": "exec", "lease": token, "command": "Get-Date", "cwd": "run"}
+        ).encode()
+        + b"\n"
+    )
+    stdout = io.BytesIO()
+
+    assert controller_mod.serve_once(stdin, stdout, controller) == 1
+    response = json.loads(stdout.getvalue())
+    assert response["error"]["code"] == "guest_response_invalid"
+    assert response["error"]["message"] == (
+        "guest PowerShell returned an invalid child exit code"
+    )
 
 
 def test_uncertain_transport_timeout_blocks_reset_until_explicit_stop(subject):
@@ -302,6 +336,9 @@ def test_push_and_pull_stream_without_halo_paths(subject):
     )
     assert "ReparsePoint" in push_script
     assert "ReparsePoint" in pull_script
+    assert "$stdinStream = [Console]::OpenStandardInput()" in push_script
+    assert "$input =" not in push_script
+    assert "Length -ne 4" in push_script
 
 
 @pytest.mark.parametrize(
@@ -482,6 +519,28 @@ def test_failed_pull_transport_does_not_replace_existing_result(tmp_path, monkey
 
     assert caught.value.code == "transport_failed"
     assert target.read_bytes() == b"old"
+
+
+def test_client_preserves_child_error_when_response_frame_is_missing(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    controller_mod._atomic_json(
+        tmp_path / ".sc-state/local/windows-test-client.json",
+        {"transport": "local"},
+    )
+    process = FakeProcess(response=b"", rc=1)
+    process.stderr = io.BytesIO(b"TypeError: null exit code\n")
+    monkeypatch.setattr(controller_mod, "_client_process", lambda _cfg: process)
+
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller_mod.client_request({"operation": "status"})
+
+    assert caught.value.code == "transport_failed"
+    assert caught.value.details == {
+        "exit_code": 1,
+        "stderr": "TypeError: null exit code\n",
+    }
 
 
 def test_fork_local_skill_template_is_ready_for_supported_import():


### PR DESCRIPTION
Closes #1533
Closes #1534

## Summary
- stabilize PowerShell child exit-code collection and frame invalid guest results
- preserve controller child stderr when a response frame is missing
- avoid PowerShell automatic `$input` during uploads and verify the guest file size

## Verification
- `./.subfloor/dev-kit test tests/test_windows_test_controller.py` (22 passed)
- `uv run ruff check .super-coder/scripts/windows_test_controller.py tests/test_windows_test_controller.py`
- `uv run mypy --follow-imports=skip .super-coder/scripts/windows_test_controller.py`
- `git diff --check`

Full repository lint/typecheck remain red on pre-existing unrelated findings; the changed files pass focused lint and type checking.