### PR TITLE
fix(vm): cache the guest process handle so exec reports a real exit code

### DIFF
--- a/.super-coder/scripts/windows_test_controller.py
+++ b/.super-coder/scripts/windows_test_controller.py
@@ -678,12 +678,12 @@ $stderrPath = Join-Path $env:TEMP ("sc-test-" + $id + ".err")
 try {{
   [IO.File]::WriteAllText($scriptPath, [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{command_b64}')), [Text.UTF8Encoding]::new($false))
   $p = Start-Process powershell.exe -WorkingDirectory $target -ArgumentList @('-NoProfile','-NonInteractive','-File',('"' + $scriptPath + '"')) -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath -PassThru
+  $null = $p.Handle # redirected Start-Process reports no ExitCode unless the handle is cached
   $finished = $p.WaitForExit({wait * 1000})
   if (-not $finished) {{ $null = & taskkill.exe /PID $p.Id /T /F; $p.WaitForExit() }}
   if ($finished) {{
     $p.WaitForExit()
     $exitCode = $p.ExitCode
-    if ($null -eq $exitCode) {{ throw 'child process exit code is unavailable' }}
   }} else {{ $exitCode = 124 }}
   $result = @{{ exit_code = $exitCode; stdout = $(if (Test-Path $stdoutPath) {{ [IO.File]::ReadAllText($stdoutPath) }} else {{ '' }}); stderr = $(if (Test-Path $stderrPath) {{ [IO.File]::ReadAllText($stderrPath) }} else {{ '' }}); timed_out = (-not $finished) }}
   $result | ConvertTo-Json -Compress
@@ -701,25 +701,27 @@ try {{
                     state["uncertain_exec"] = True
                     self._save_state(state)
                 raise
+            stdout = str(result.get("stdout", ""))
+            stderr = str(result.get("stderr", ""))
             raw_exit_code = result.get("exit_code")
-            if isinstance(raw_exit_code, bool) or not isinstance(
+            invalid = isinstance(raw_exit_code, bool) or not isinstance(
                 raw_exit_code, (int, str)
-            ):
+            )
+            if not invalid:
+                try:
+                    exit_code = int(raw_exit_code)
+                except ValueError:
+                    invalid = True
+            if invalid:
                 raise ControllerError(
                     "guest_response_invalid",
                     "guest PowerShell returned an invalid child exit code",
+                    {"stdout": stdout[-500:], "stderr": stderr[-500:]},
                 )
-            try:
-                exit_code = int(raw_exit_code)
-            except (TypeError, ValueError) as exc:
-                raise ControllerError(
-                    "guest_response_invalid",
-                    "guest PowerShell returned an invalid child exit code",
-                ) from exc
             return {
                 "exit_code": exit_code,
-                "stdout": str(result.get("stdout", "")),
-                "stderr": str(result.get("stderr", "")),
+                "stdout": stdout,
+                "stderr": stderr,
                 "timed_out": bool(result.get("timed_out")),
             }
 

--- a/tests/test_windows_test_controller.py
+++ b/tests/test_windows_test_controller.py
@@ -262,7 +262,8 @@ def test_exec_is_encoded_admin_powershell_and_never_host_shell(subject):
     assert "WindowsBuiltInRole]::Administrator" in decoded
     assert "taskkill.exe /PID $p.Id /T /F" in decoded
     assert "$p.WaitForExit()" in decoded
-    assert "$null -eq $exitCode" in decoded
+    assert "$null = $p.Handle" in decoded
+    assert decoded.index("$null = $p.Handle") < decoded.index("$p.WaitForExit(")
     assert "-WorkingDirectory $target" in decoded
 
 
@@ -276,7 +277,8 @@ def test_exec_rejects_null_guest_exit_code_with_structured_error(subject):
             return subprocess.CompletedProcess(
                 argv,
                 0,
-                '{"exit_code":null,"stdout":"","stderr":"","timed_out":false}\n',
+                '{"exit_code":null,"stdout":"partial\\n",'
+                '"stderr":"child said why","timed_out":false}\n',
                 "",
             )
         return original_call(argv, **kwargs)
@@ -296,6 +298,10 @@ def test_exec_rejects_null_guest_exit_code_with_structured_error(subject):
     assert response["error"]["message"] == (
         "guest PowerShell returned an invalid child exit code"
     )
+    assert response["error"]["details"] == {
+        "stdout": "partial\n",
+        "stderr": "child said why",
+    }
 
 
 def test_uncertain_transport_timeout_blocks_reset_until_explicit_stop(subject):


### PR DESCRIPTION
Closes #1533.

## Root cause

Windows PowerShell does not populate `ExitCode` on the `Process` object returned by `Start-Process -PassThru` when the same call redirects stdout/stderr — the handle is not retained, and the property getter's exception is swallowed, so `$p.ExitCode` evaluates to `$null` ([PowerShell/PowerShell#5421](https://github.com/PowerShell/PowerShell/issues/5421), reproduced on Windows PowerShell 5.1). The guest exec script uses exactly that combination.

That produced both reported failures:

- before #1535 — `exit_code: null` reached `int(result.get("exit_code", -1))`, the child crashed with a `TypeError`, emitted no frame, and the parent masked it as `protocol_header_invalid`;
- after #1535 — the new `throw 'child process exit code is unavailable'` guard fired on every exec, aborting the guest script before its result frame, so the operator saw `guest_command_failed` exit 1 with no artifact.

## Fix

- Read `$p.Handle` immediately after `Start-Process`, which is the documented workaround: touching the property caches the process handle so `ExitCode` is readable after exit.
- Remove the guard `throw`. If an exit code is somehow still unavailable, the script now emits its result frame with the child's stdout/stderr rather than destroying the evidence, and the controller's existing structured `guest_response_invalid` error reports it — now with the stdout/stderr tails in `details`, so the child's own error survives to the client boundary.

Trade-off: the alternative was replacing `Start-Process` with `[Diagnostics.Process]::Start` plus async stream pumping, which sidesteps the quirk entirely but rewrites the whole exec path and its redirection strategy. The one-line handle cache is the documented remedy for this exact combination, so the smaller diff wins.

## Verification

`tests/test_windows_test_controller.py`, `tests/test_windows_vm_skills.py`, `tests/test_windows_mcp_adapters.py` — 34 passed. Tests now assert the handle is cached before any wait, and that a null exit code returns the child's stdout/stderr in the error details. Ruff check/format clean on both changed files.

Live acceptance on the W10C-Testing guest still needs an operator run — this cannot be proven from the host side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)