### PR TITLE
docs(windows-testing): define disposable security posture

### DIFF
--- a/.super-coder/docs/skills/windows_testing/SKILL.md
+++ b/.super-coder/docs/skills/windows_testing/SKILL.md
@@ -98,6 +98,40 @@ the .NET 8 SDK, package restore access, and a writable workspace such as
 Create the immutable recovery snapshot and initial offline working snapshot as
 an operator.
 
+### Disposable guest execution policy
+
+The controller uploads a generated PowerShell script and invokes it with
+`powershell.exe -File`. A stock `Restricted` execution policy rejects that
+script before the test command starts. For a deliberately disposable test
+image, open **Windows PowerShell as Administrator** and configure the image:
+
+```powershell
+Set-ExecutionPolicy -Scope LocalMachine -ExecutionPolicy Bypass -Force
+Get-ExecutionPolicy -List
+Get-ExecutionPolicy
+```
+
+Pass = the effective policy printed by the final command is `Bypass`. A
+`MachinePolicy` or `UserPolicy` imposed by Group Policy can override the local
+setting; do not promote the baseline until the effective-policy check and an
+actual controller `exec` both pass.
+
+> **Disposable-image boundary:** machine-wide `Bypass` removes PowerShell's
+> script-signing, warning, and prompt guardrails for every account in this
+> guest. The controller's SSH identity is also a local Administrator and can
+> execute arbitrary privileged code in the guest. Use this posture only for a
+> throwaway VM that contains no personal/work data, reusable credentials,
+> authenticated browser sessions, host shares, or other secrets. Do not apply
+> it to canonical `W10C`, a daily-use VM, or any persistent machine. Snapshot
+> reset removes changes made after the snapshot; it does not protect data while
+> the VM is running or remove a secret already baked into a baseline.
+
+After installing the toolchain and setting the policy, run a small
+push/exec/pull test, compare the source and pulled artifact hashes, promote a
+new working baseline, then reset/start/exec once from that baseline. Preserve
+the immutable recovery snapshot and the previous working snapshot. Finish
+powered off with no active lease.
+
 On Halo, create `~/.config/subfloor/windows-test-controller.json` for `jedi`
 with mode `0600` and its parent directory mode `0700`:
 

--- a/.super-coder/docs/windows-test-vm.md
+++ b/.super-coder/docs/windows-test-vm.md
@@ -85,6 +85,34 @@ User: SSH foothold :::class4 -> Admin: install kit :::class1 -> Snapshot = clean
 
 The manifest (a `winget` export — WiX, .NET SDK, MSBuild for dos-arch) is committed in the fork at a known path and rides snapshot/render. `configure_winbox` supplies the *mechanism* (ssh in, `winget import`, verify); the fork supplies the *package list* — so the skill stays generic across forks.
 
+### Disposable Windows security posture
+
+The current fixed controller uploads a generated PowerShell script and runs it
+with `powershell.exe -File`. If the guest's effective execution policy is
+`Restricted`, the command is rejected before the requested test starts. On a
+purpose-built disposable image, the operator may set the machine-wide policy
+from an elevated Windows PowerShell prompt:
+
+```powershell
+Set-ExecutionPolicy -Scope LocalMachine -ExecutionPolicy Bypass -Force
+Get-ExecutionPolicy -List
+Get-ExecutionPolicy
+```
+
+The final command must report effective policy `Bypass`; Group Policy at
+`MachinePolicy` or `UserPolicy` can override `LocalMachine`. Verify with a real
+controller push/exec/pull round trip and repeat exec after restoring the newly
+promoted working baseline.
+
+This is an explicit **disposable-image-only** tradeoff. `Bypass` removes
+PowerShell's script-signing, warning, and prompt guardrails machine-wide, and
+the controller account already has local Administrator authority. Never apply
+this configuration to a daily-use, canonical, or otherwise persistent Windows
+VM. The test image must contain no personal/work data, reusable credentials,
+authenticated browser sessions, host shares, or other secrets. Frequent reset
+limits persistence after the snapshot; it does not limit exposure while the VM
+is running and cannot remove secrets captured in a baseline.
+
 ## Config
 
 Lives in the existing fork-level `instance.json` (where the port is already persisted) under a `vm` key. **No schema migration, no `connections` un-retire, no `SHELL_EDITABLE` plumbing.**


### PR DESCRIPTION
## Summary

- document the machine-wide PowerShell Bypass prerequisite for the fixed Windows controller
- make the weakened posture explicitly disposable-image-only
- describe the real exposure: admin exec, no signing/warning guardrails, and reset limitations
- require effective-policy, push/exec/pull, hash, and post-reset verification before baseline promotion

## Validation

- `./.subfloor/dev-kit test -q tests/test_windows_test_controller.py` — 22 passed
- `git diff --check`