### PR TITLE
fix(vm-test): sandbox SSH client seam, and never strand the lease

### DIFF
--- a/.super-coder/docs/skills/windows_testing/SKILL.md
+++ b/.super-coder/docs/skills/windows_testing/SKILL.md
@@ -49,6 +49,18 @@ without putting it in argv or logs. Keep the lease for the whole push/exec/pull
 and reset sequence. A competing mutation fails rather than joining the active
 session. Report the test result and reset/release result separately.
 
+If `acquire` cannot save the token it hands the lease straight back and reports
+`lease_not_saved` with `lease_released`; fix the local state directory rather
+than retrying blindly. When a lease is held with its token lost anyway —
+`lease_released: false`, a killed process, a rebuilt checkout — clear it:
+
+```bash
+sc vm test release --force
+```
+
+The flag is the confirmation that no session is running, exactly as with
+`stop --force`; it names the owner it displaced. Never wait out the lease TTL.
+
 Guest paths are relative to the configured workspace. `exec` always requires
 an explicit `--cwd` there and runs PowerShell under the configured
 administrator account. Prefer `--command-file` for non-trivial scripts. A

--- a/.super-coder/docs/skills/windows_testing/SKILL.md
+++ b/.super-coder/docs/skills/windows_testing/SKILL.md
@@ -162,11 +162,32 @@ Fish syntax:
 restrict,command="/home/jedi/Repos/subfloor/sc vm test serve" ssh-ed25519 <public-key> windows-test-controller
 ```
 
-Keep the private key on Dev and point an SSH alias such as
-`halo-windows-test` at it with `RequestTTY no`. Do not reuse an unrestricted
-Halo login key. Verify both init modes with the same small
-status/acquire/start/push/exec/pull/reset/release run, then confirm lease
-conflicts, protected snapshot refusal, and failed-promotion preservation.
+Keep the private key on Dev and put the alias in the dedicated client seam —
+`~/.config/subfloor/windows-test-client/`, mode `0700`, holding only the
+restricted key (`0600`), the single alias, and the pinned Halo host key:
+
+```text
+# ~/.config/subfloor/windows-test-client/config
+Host halo-windows-test
+    HostName <Halo address>
+    User jedi
+    RequestTTY no
+    IdentitiesOnly yes
+    IdentityFile ~/.config/subfloor/windows-test-client/sc_win_test
+    UserKnownHostsFile ~/.config/subfloor/windows-test-client/known_hosts
+    StrictHostKeyChecking yes
+```
+
+`sc vm test` passes this file to `ssh -F`, so the transport does not depend on
+the caller's own `~/.ssh` — which a sandbox shell does not have, and which
+OpenSSH would resolve from the container's uid rather than `$HOME` anyway.
+`sc launch` bind-mounts the directory read-only at the same path when it
+exists, so sandboxed shells get the same transport and it survives a rebuild;
+the operator's general `~/.ssh` is never mounted. `sc vm test init ssh <alias>`
+reports the selected `ssh_config` (`null` = no seam, per-user config in use).
+Do not reuse an unrestricted Halo login key. Verify both init modes with the
+same small status/acquire/start/push/exec/pull/reset/release run, then confirm
+lease conflicts, protected snapshot refusal, and failed-promotion preservation.
 
 After the reviewed engine revision is installed in active dos-arch, import this
 file as a fork-local skill. Every `sc skill` mutation is Planner-owned: the

--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -1413,6 +1413,18 @@ case "$cmd" in
           fi ;;
       esac
     fi
+    # Windows-test SSH client seam. A sandbox shell holding `windows_testing`
+    # reaches the fixed Halo controller with `ssh <alias>`, but the sandbox has
+    # no per-user SSH material — and OpenSSH resolves `~` from the container
+    # process's uid (root), not $HOME, so a home-directory mount would not be
+    # read either. Bind ONLY the dedicated controller directory — restricted
+    # key, single alias, pinned host key — read-only at the same path; `sc vm
+    # test` points ssh at it with -F. The operator's general ~/.ssh is never
+    # mounted. Absent directory = no seam and no mount; the host path keeps
+    # using its own per-user config.
+    wintest_mount=""
+    wintest_dir="$HOME/.config/subfloor/windows-test-client"
+    [ -d "$wintest_dir" ] && wintest_mount="-v $wintest_dir:$wintest_dir:ro"
     # Docker's init shim is PID 1 so orphaned harness/worker subprocesses are
     # reaped. Without it the Python API server becomes PID 1, never wait()s on
     # reparented children, and long-running multi-shell work exhausts the
@@ -1438,6 +1450,7 @@ case "$cmd" in
         $state_namespace_mounts \
         $state_mount \
         $py_mount \
+        $wintest_mount \
         -v "$HOME/.claude:$HOME/.claude" \
         -v "$HOME/.claude.json:$HOME/.claude.json" \
         -v "$HOME/.config/opencode:$HOME/.config/opencode" \

--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -1873,6 +1873,8 @@ Subfloor — forkable shell substrate — full command reference (./sc help for 
                            select Halo-local or Dev-through-ForceCommand transport
   ./sc vm test status|acquire|release|start|stop|exec|push|pull|snapshot|reset|baseline
                            drive the fixed W10C-Testing controller; run --help for exact forms
+  ./sc vm test release --force
+                           clear a lease whose token was lost, so no seat waits out the TTL
   ./sc vm-broker           run the broker in the foreground (unix socket)
   ./sc vm-bake             HOST-side: graceful shutdown + (re)bake the clean snapshot after provisioning
                              (deliberately NOT a broker verb — the sandbox must never redefine 'clean')

--- a/.super-coder/scripts/windows_test_controller.py
+++ b/.super-coder/scripts/windows_test_controller.py
@@ -475,12 +475,15 @@ while ($cursor -and $cursor.Length -ge $root.Length) {{
 {body}
 """
 
-    def _lease(self, state: dict, token: object) -> dict:
+    def _active_lease(self, state: dict) -> dict | None:
         lease = state.get("lease")
-        if (
-            not isinstance(lease, dict)
-            or float(lease.get("expires_at", 0)) <= self.now()
-        ):
+        if not isinstance(lease, dict):
+            return None
+        return lease if float(lease.get("expires_at", 0)) > self.now() else None
+
+    def _lease(self, state: dict, token: object) -> dict:
+        lease = self._active_lease(state)
+        if lease is None:
             raise ControllerError(
                 "lease_required", "an active controller lease is required"
             )
@@ -538,15 +541,7 @@ while ($cursor -and $cursor.Length -ge $root.Length) {{
     def status(self) -> dict:
         self._verify_target()
         state = self._state()
-        lease = state.get("lease")
-        active_lease = (
-            lease
-            if (
-                isinstance(lease, dict)
-                and float(lease.get("expires_at", 0)) > self.now()
-            )
-            else None
-        )
+        active_lease = self._active_lease(state)
         snapshots = self._snapshot_list()
         domain_state = self._domain_state()
         guest: dict[str, object] = {
@@ -585,11 +580,8 @@ while ($cursor -and $cursor.Length -ge $root.Length) {{
             )
         with self._locked():
             state = self._state()
-            current = state.get("lease")
-            if (
-                isinstance(current, dict)
-                and float(current.get("expires_at", 0)) > self.now()
-            ):
+            current = self._active_lease(state)
+            if current is not None:
                 raise ControllerError(
                     "lease_conflict",
                     "the controller is already leased",
@@ -610,13 +602,19 @@ while ($cursor -and $cursor.Length -ge $root.Length) {{
             self._save_state(state)
             return dict(lease)
 
-    def release(self, token: object) -> dict:
+    def release(self, token: object, force: object = False) -> dict:
+        """Hand the lease back.  ``force`` clears it without presenting the
+        token — the operator asserting no session is running, the way
+        ``stop --force`` asserts the guest may be cut.  It is the only recovery
+        when a token is lost with the lease still held, and without it such a
+        loss locks every seat out for the whole TTL."""
         with self._locked():
             state = self._state()
-            self._lease(state, token)
+            lease = self._active_lease(state) if force else self._lease(state, token)
+            owner = lease.get("owner") if lease else None
             state["lease"] = None
             self._save_state(state)
-            return {"released": True}
+            return {"released": True, "forced": bool(force), "owner": owner}
 
     def start(self, token: object, timeout: object) -> dict:
         wait = _validated_timeout(timeout, 120)
@@ -1015,7 +1013,7 @@ if ((Get-Item -LiteralPath $target).Length -ne {size}) {{ throw 'uploaded file s
         if operation == "acquire":
             return _success(operation, self.acquire(request.get("owner")))
         if operation == "release":
-            return _success(operation, self.release(token))
+            return _success(operation, self.release(token, request.get("force")))
         if operation == "start":
             return _success(operation, self.start(token, request.get("timeout")))
         if operation == "stop":
@@ -1169,6 +1167,18 @@ def _client_process(cfg: dict) -> subprocess.Popen:
     )
 
 
+def _hand_back(token: str) -> bool:
+    """Release a lease whose token could not be persisted.  Best effort — the
+    transport may itself be what failed — and `release --force` is the recovery
+    when even this does not land."""
+    try:
+        return bool(
+            client_request({"operation": "release", "lease": token}).get("ok")
+        )
+    except (ControllerError, OSError):
+        return False
+
+
 def client_request(
     request: dict, *, input_path: Path | None = None, output_path: Path | None = None
 ) -> dict:
@@ -1239,12 +1249,28 @@ def client_request(
         if tmp is not None:
             tmp.unlink(missing_ok=True)
     if response.get("ok") and request["operation"] == "acquire":
-        cfg["lease"] = response["result"]["token"]
-        _atomic_json(_client_config_path(), cfg)
+        token = response["result"]["token"]
+        cfg["lease"] = token
+        try:
+            _atomic_json(_client_config_path(), cfg)
+        except OSError as exc:
+            # The controller already holds the lease and this token is the only
+            # copy of it.  Hand it straight back rather than stranding the
+            # controller under an owner whose token exists nowhere.
+            raise ControllerError(
+                "lease_not_saved",
+                "the controller lease could not be saved locally",
+                {"lease_released": _hand_back(token)},
+            ) from exc
         response["result"].pop("token", None)
         response["result"]["lease_saved"] = True
-    if response.get("ok") and request["operation"] == "release":
-        cfg.pop("lease", None)
+    # Only rewrite when a token was actually dropped — a forced release from a
+    # seat that never held one must not fail on the write that stranded it.
+    if (
+        response.get("ok")
+        and request["operation"] == "release"
+        and cfg.pop("lease", None) is not None
+    ):
         _atomic_json(_client_config_path(), cfg)
     return response
 
@@ -1266,7 +1292,13 @@ def _parser() -> argparse.ArgumentParser:
     commands.add_parser("status")
     acquire = commands.add_parser("acquire")
     acquire.add_argument("--owner", default="shell")
-    commands.add_parser("release")
+    release = commands.add_parser("release")
+    release.add_argument(
+        "--force",
+        action="store_true",
+        help="clear the active lease without its token; the flag is the "
+        "confirmation that no session is running",
+    )
     for verb in ("start", "stop"):
         item = commands.add_parser(verb)
         item.add_argument("--timeout", type=int)
@@ -1325,6 +1357,8 @@ def client_main(argv: list[str]) -> int:
         input_path = output_path = None
         if args.operation == "acquire":
             request["owner"] = args.owner
+        elif args.operation == "release":
+            request["force"] = args.force
         elif args.operation in ("start", "stop"):
             request["timeout"] = args.timeout
             if args.operation == "stop":

--- a/.super-coder/scripts/windows_test_controller.py
+++ b/.super-coder/scripts/windows_test_controller.py
@@ -35,6 +35,13 @@ DOMAIN = "W10C-Testing"
 DOMAIN_UUID = "0b314d1a-bd03-47b9-8155-01a6d470f7a9"
 CONFIG_PATH = Path.home() / ".config" / "subfloor" / "windows-test-controller.json"
 CLIENT_PATH = Path(".sc-state/local/windows-test-client.json")
+# The restricted SSH client seam: the dedicated ForceCommand key, the single
+# controller alias, and the pinned Halo host key.  `sc launch` bind-mounts this
+# directory read-only at the same path, so a sandbox shell reaches the
+# controller without the operator's general ~/.ssh — which OpenSSH would not
+# read there anyway, resolving `~` from the container uid rather than $HOME.
+CLIENT_SSH_DIR = Path.home() / ".config" / "subfloor" / "windows-test-client"
+CLIENT_SSH_CONFIG = CLIENT_SSH_DIR / "config"
 NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 SSH_ALIAS_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 MAX_HEADER_BYTES = 64 * 1024
@@ -1122,6 +1129,15 @@ def _load_client() -> dict:
     return _read_json(_client_config_path(), "Windows test client configuration")
 
 
+def _client_ssh_config_argv() -> list[str]:
+    """Select the seam config when it is installed, otherwise the caller's own
+    per-user SSH configuration."""
+    if not CLIENT_SSH_CONFIG.exists():
+        return []
+    _require_owner_directory(CLIENT_SSH_DIR, "Windows test SSH client directory")
+    return ["-F", str(CLIENT_SSH_CONFIG)]
+
+
 def _client_process(cfg: dict) -> subprocess.Popen:
     transport = cfg.get("transport")
     if transport == "local":
@@ -1132,9 +1148,8 @@ def _client_process(cfg: dict) -> subprocess.Popen:
             raise ControllerError(
                 "client_configuration_invalid", "SSH controller alias is invalid"
             )
-        argv = [
-            "ssh",
-            "-T",
+        argv = ["ssh", "-T", *_client_ssh_config_argv()]
+        argv += [
             "-o",
             "BatchMode=yes",
             "-o",
@@ -1296,8 +1311,14 @@ def client_main(argv: list[str]) -> int:
                 )
             cfg["host"] = args.host
         _atomic_json(_client_config_path(), cfg)
+        seam = CLIENT_SSH_CONFIG if args.transport == "ssh" else None
         response = _success(
-            "init", {"transport": args.transport, "host": cfg.get("host")}
+            "init",
+            {
+                "transport": args.transport,
+                "host": cfg.get("host"),
+                "ssh_config": str(seam) if seam and seam.exists() else None,
+            },
         )
     else:
         request: dict = {"operation": args.operation}

--- a/tests/test_windows_test_controller.py
+++ b/tests/test_windows_test_controller.py
@@ -436,7 +436,17 @@ def test_exec_nonzero_is_a_structured_operation_failure(subject, monkeypatch):
     assert response["result"]["exit_code"] == 7
 
 
-def test_transport_initialization_changes_only_process_transport(monkeypatch):
+def _install_client_seam(tmp_path, monkeypatch, *, mode=0o700):
+    seam = tmp_path / "windows-test-client"
+    seam.mkdir(mode=mode)
+    config = seam / "config"
+    config.write_text("Host halo-windows-test\n", encoding="utf-8")
+    monkeypatch.setattr(controller_mod, "CLIENT_SSH_DIR", seam)
+    monkeypatch.setattr(controller_mod, "CLIENT_SSH_CONFIG", config)
+    return seam, config
+
+
+def test_transport_initialization_changes_only_process_transport(tmp_path, monkeypatch):
     calls = []
 
     def fake_popen(argv, **kwargs):
@@ -444,6 +454,7 @@ def test_transport_initialization_changes_only_process_transport(monkeypatch):
         return FakeProcess()
 
     monkeypatch.setattr(controller_mod.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(controller_mod, "CLIENT_SSH_CONFIG", tmp_path / "absent")
 
     controller_mod._client_process({"transport": "local"})
     controller_mod._client_process({"transport": "ssh", "host": "halo-windows-test"})
@@ -463,6 +474,54 @@ def test_transport_initialization_changes_only_process_transport(monkeypatch):
         "halo-windows-test",
     ]
     assert calls[0][1] == calls[1][1]
+
+
+def test_ssh_transport_uses_the_restricted_client_seam(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_popen(argv, **kwargs):
+        calls.append(argv)
+        return FakeProcess()
+
+    monkeypatch.setattr(controller_mod.subprocess, "Popen", fake_popen)
+    _seam, config = _install_client_seam(tmp_path, monkeypatch)
+
+    controller_mod._client_process({"transport": "ssh", "host": "halo-windows-test"})
+
+    assert calls[0][:4] == ["ssh", "-T", "-F", str(config)]
+    assert calls[0][-1] == "halo-windows-test"
+
+
+def test_ssh_transport_refuses_a_readable_client_seam(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        controller_mod.subprocess, "Popen", lambda *a, **k: FakeProcess()
+    )
+    _install_client_seam(tmp_path, monkeypatch, mode=0o755)
+
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller_mod._client_process(
+            {"transport": "ssh", "host": "halo-windows-test"}
+        )
+
+    assert caught.value.code == "configuration_permissions"
+
+
+def test_init_ssh_reports_the_selected_client_seam(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _seam, config = _install_client_seam(tmp_path, monkeypatch)
+
+    assert controller_mod.client_main(["init", "ssh", "halo-windows-test"]) == 0
+    reported = json.loads(capsys.readouterr().out)
+
+    assert reported["result"] == {
+        "transport": "ssh",
+        "host": "halo-windows-test",
+        "ssh_config": str(config),
+    }
+
+    monkeypatch.setattr(controller_mod, "CLIENT_SSH_CONFIG", tmp_path / "absent")
+    assert controller_mod.client_main(["init", "ssh", "halo-windows-test"]) == 0
+    assert json.loads(capsys.readouterr().out)["result"]["ssh_config"] is None
 
 
 def test_client_uses_same_frame_and_saves_lease_outside_argv(tmp_path, monkeypatch):
@@ -547,6 +606,16 @@ def test_client_preserves_child_error_when_response_frame_is_missing(
         "exit_code": 1,
         "stderr": "TypeError: null exit code\n",
     }
+
+
+def test_launch_mounts_only_the_restricted_client_seam():
+    dispatch = (ENGINE / "scripts/dispatch.sh").read_text(encoding="utf-8")
+    seam = '$HOME/.config/subfloor/windows-test-client'
+    assert f'wintest_dir="{seam}"' in dispatch
+    assert '[ -d "$wintest_dir" ] && wintest_mount=' in dispatch
+    assert '"-v $wintest_dir:$wintest_dir:ro"' in dispatch
+    assert "        $wintest_mount \\\n" in dispatch
+    assert "$HOME/.ssh" not in dispatch
 
 
 def test_fork_local_skill_template_is_ready_for_supported_import():

--- a/tests/test_windows_test_controller.py
+++ b/tests/test_windows_test_controller.py
@@ -206,7 +206,11 @@ def test_lease_rejects_competing_session_and_mutation(subject):
         controller.start("wrong-token", None)
     assert caught.value.code == "lease_conflict"
 
-    assert controller.release(token) == {"released": True}
+    assert controller.release(token) == {
+        "released": True,
+        "forced": False,
+        "owner": "first",
+    }
 
 
 def test_start_waits_for_administrator_powershell_readiness(subject):
@@ -559,6 +563,60 @@ def test_client_uses_same_frame_and_saves_lease_outside_argv(tmp_path, monkeypat
     saved = json.loads(client_path.read_text())
     assert saved["lease"] == "opaque-token"
     assert client_path.stat().st_mode & 0o077 == 0
+
+
+def test_forced_release_recovers_a_lease_whose_token_is_lost(subject):
+    controller, _runner, _popen, _clock = subject
+    acquire(subject, "stranded-owner")
+
+    assert controller.release(None, force=True) == {
+        "released": True,
+        "forced": True,
+        "owner": "stranded-owner",
+    }
+    assert controller.status()["lease"]["active"] is False
+    # Idempotent: a second force has nothing to displace and still succeeds.
+    assert controller.release(None, force=True)["owner"] is None
+    controller.acquire("next-owner")
+
+
+def test_unsavable_lease_is_handed_back_instead_of_stranded(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    client_path = tmp_path / ".sc-state/local/windows-test-client.json"
+    controller_mod._atomic_json(client_path, {"transport": "local"})
+    acquired = controller_mod._success(
+        "acquire",
+        {"token": "opaque-token", "owner": "dev", "acquired_at": 1, "expires_at": 2},
+    )
+    released = controller_mod._success(
+        "release", {"released": True, "forced": False, "owner": "dev"}
+    )
+    sent = []
+
+    def fake_client_process(_cfg):
+        body = acquired if not sent else released
+        return FakeProcess(
+            response=json.dumps(body, separators=(",", ":")).encode() + b"\n"
+        )
+
+    def refuse_write(path, _payload):
+        if path == client_path:
+            raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(controller_mod, "_client_process", fake_client_process)
+    monkeypatch.setattr(
+        controller_mod,
+        "_write_header",
+        lambda stream, request: sent.append(request),
+    )
+    monkeypatch.setattr(controller_mod, "_atomic_json", refuse_write)
+
+    with pytest.raises(controller_mod.ControllerError) as caught:
+        controller_mod.client_request({"operation": "acquire", "owner": "dev"})
+
+    assert caught.value.code == "lease_not_saved"
+    assert caught.value.details == {"lease_released": True}
+    assert sent[1] == {"operation": "release", "lease": "opaque-token"}
 
 
 def test_failed_pull_transport_does_not_replace_existing_result(tmp_path, monkeypatch):


### PR DESCRIPTION
Two independent defects in the fixed W10C-Testing controller, both reported from downstream seats. Two commits, reviewable separately.

Closes #1539.

---

## 1. Sandbox shells cannot reach the controller (#1539)

A shell granted `windows_testing` cannot reach the fixed Halo controller from inside the sandbox. The container *does* have `/usr/bin/ssh` and a route to Halo, but no per-user SSH material — and because the sandbox process is uid 0 while `HOME` is the operator's home, OpenSSH resolves `~/.ssh` from `/root`, so even mounting the home directory would not be read. `sc vm test status` returns `transport_failed` / `ssh: Could not resolve hostname halo-windows-test`.

One engine-owned seam rather than a wider credential surface:

- `~/.config/subfloor/windows-test-client/` holds *only* the restricted ForceCommand key, the single controller alias, and the pinned Halo host key.
- `sc vm test` passes that directory's `config` to `ssh -F`, so the transport no longer depends on ambient per-user configuration wherever it runs.
- `sc launch` bind-mounts the directory read-only at the same path when it exists. The operator's general `~/.ssh` is never mounted, and the seam survives a container rebuild — unlike the temporary `/root/.ssh` copy in the issue.
- `sc vm test init ssh <alias>` reports the selected `ssh_config` (`null` = no seam, per-user config in use), so an unreachable transport is diagnosable before the first verb.
- An owner-readable seam directory is refused with `configuration_permissions` rather than leaking a private key through a bind mount.

**Trade-offs.** `-F` rather than mounting into `/root/.ssh`: works identically rootless and rootful and on the host, and `-F` skips OpenSSH's config ownership check that a host-uid file read as container root would otherwise fail. Seam optional, not required: the Halo/Dev host path already works from the caller's own `~/.ssh`, so absent directory = no mount, no `-F`, current behaviour. Not routed through the vm-broker: the broker exists because the container has no route to the canonical W10C guest and must never hold hypervisor control — neither applies here, and a broker hop would add a process to hold a credential that is safe to scope-limit in place.

---

## 2. A failed token write locked the controller for the full TTL

`acquire` takes the lease server-side and *then* writes the token locally. When PLN1's seat could not write its state directory, the controller stayed leased under an owner whose token existed nowhere: `release` answered `lease_conflict`, `acquire` answered already leased, and no verb could clear it. Four hours, guest still powered off. A client-side hiccup should never cost that.

Two changes, so no failure mode ends in waiting out the TTL:

- **The client compensates.** When the token cannot be saved it hands the lease straight back and raises `lease_not_saved` reporting `lease_released`, instead of leaking an `OSError` with the lease still held.
- **`sc vm test release --force`** clears an active lease without presenting its token and names the owner it displaced. It is the backstop for a token lost some other way — a killed process, a rebuilt checkout — where no compensation could have run.

`release` now reports `{released, forced, owner}`, and stops rewriting the client file when no token was dropped, so recovery does not depend on the write that failed in the first place. The three copies of the lease-expiry check collapse into `_active_lease`.

**Trade-off.** `--force` lets one seat evict another mid-run, which the lease exists to prevent. The flag is the confirmation that no session is running — the same posture `stop --force` already takes for cutting the guest — and the displaced owner is reported. Against a guaranteed multi-hour outage of a disposable single-purpose test VM, an explicit operator override is the cheaper failure. Rejected: shortening the default TTL, which shrinks the lockout without removing it.

---

## Verification

`tests/test_windows_test_controller.py` — 28 passed. New coverage: seam selection in the ssh argv, the seam permissions refusal, `init` reporting, a dispatch assertion that launch mounts the seam read-only and mounts no `$HOME/.ssh`, forced-release recovery and idempotence, and the compensating hand-back on an unwritable client file. Affected launch/dispatch suites also green (219 passed). Repo-wide lint/typecheck baselines are dirty and unchanged by these files.

Not verified end-to-end from a downstream sandbox — that needs the operator to install the seam directory on Dev and re-launch there. The stranded lease PLN1 reported is cleared with `sc vm test release --force` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)