### PR TITLE
docs: prepare public documentation refresh (F73)

### DIFF
--- a/maintainer/public-documentation-refresh.md
+++ b/maintainer/public-documentation-refresh.md
@@ -1,0 +1,82 @@
+# Public documentation refresh: preparation evidence
+
+Feature #73, Spec #219, task #795. This is implementation evidence, not the
+public user guide or a declaration that the refresh has shipped.
+
+## Source baseline
+
+Frozen source ref: `706eaa3da0ce2fe5e6a77644e0e520b43e92c374`.
+Verified against remote `origin/main` on 2026-09-07. Paths below are relative
+to the source repository and refer to that commit. Recheck changed owners
+before final review; the running engine checkout is not evidence of remote
+freshness.
+
+| Contract | Source anchor | Documentation consequence |
+|---|---|---|
+| Five adapters | `.super-coder/adapters/{claude,codex,kimi,opencode,vibe}/adapter.json` | Name all five; read each manifest's `surfaces` before claiming browser or Sprint support. |
+| Six flavors | `.super-coder/templates/shells/{admin,planner,dev,reviewer,devops,cartographer}.json`; `scripts/shell_factory.py` under the engine | Distinguish available flavors from the initial roster; Bespoke is untemplated. |
+| Ten initial shells | `.super-coder/scripts/init_fork.py`, `TEAM_ROSTER` and separate Cartographer creation | Two Planners, four Developers, two Reviewers, one Admin, one Cartographer. DevOps is available but not initially seeded. |
+| Installer interview | `.super-coder/scripts/init_fork.py`, `main`; `.super-coder/scripts/install.py`, `print_help` and seeding phase | Interactive input is the operator username; primary-shell customization is optional via flags. |
+| Worktree examples | `.super-coder/scripts/init_fork.py`, `TEAM_ROSTER`; `.super-coder/assets/skills/git/SKILL.md` | Use a real roster shortname, such as `DEV1`, and `.sc-worktrees/dev1` / `shell/dev1`. Admin is the main-checkout exception. |
+| Ten GUI tabs | `.super-coder/ui/index.html`, header navigation | Chats, Sprints, Shells, Roadmap, Docs, Flags, Worktrees, Repo Map, Analytics, Scripts. No standalone Skills tab. |
+| Merge gate | `.super-coder/scripts/sprint_cli.py`, required `--merge-grant` and `authorize-merge`; decision #325 | Outside an armed Sprint, explicit operator direction names the PR. Arming records that direction for registered Sprint PRs; the owning Developer needs live authorization before merging. |
+| Private state | `.super-coder/scripts/instance_state.py`, `InstanceState`, `_state_home`, `active_database_path`, `active_snapshot_path`, `active_backup_paths` | Fresh bound installs select private XDG instance state. Legacy and relocation handling are recovery concerns, not the current installation layout. Repo-local renders and configuration are separate. |
+| Ordinary shell boundary | `.super-coder/scripts/execution_view.py`; decision #302 | Downstream ordinary shells use the API; general engine SQL and direct state inspection belong to Admin. Source code visibility does not grant live-state maintenance authority. |
+| Skill ownership | `.super-coder/scripts/skill.py`, API lane; decision #313 | Planner owns fork-local skill operations; Admin owns engine maintenance. |
+| CLI inventory | `.super-coder/scripts/dispatch.sh`; `sc help --all`; decision #326 | Prose is a workflow route map. Exact flags remain in command help. Validate commands without executing destructive verbs. |
+| Effort and reopened chats | `.super-coder/ui/app.js`, `thinkingLevelLabel`, supported-effort selection, `reopenable`, `conversation.reopened` | Explain supported route-specific effort choices and sending a message to reopen eligible closed chats; Sprint-scoped chats are excluded. |
+| Browser capture | `.super-coder/scripts/visual_qa.py`; `.super-coder/templates/fork/visual-qa.example.json` | Existing Playwright capture surface; local dev kit supplies Playwright and Chromium. Engine does not depend on Playwright. |
+| Terminal capture | `docs/demo.tape` | VHS recipe needs current operator command, roster, picker and a real authenticated boot. Existing tape is not current acceptance evidence. |
+
+Feature #28 package-manager distribution stays excluded, as Spec #219 requires.
+The frozen tree has no package recipes or native release artifacts establishing
+that installation path. A roadmap status alone cannot supply that evidence.
+
+## Capture baseline and blocker
+
+The operator-authorized dos-app checkout was clean on `main` at
+`c5851784070ff92e0ae36ed093b80915cd3cf114`, retaining its existing install
+commit. Its installed engine ref was
+`1984c730af24b1c855101be0412d352969995e5d`.
+
+Preparation preserved its refs in a Git bundle and created an independent
+disposable clone from that exact dos-app commit. The clone's
+`docs/capture-baseline` branch received `.super-coder` and `sc` from the frozen
+source ref above. No reset, update, restart, or state mutation was performed
+against the original dos-app checkout or runtime.
+
+The disposable installation attempt was:
+
+```sh
+python3 .super-coder/scripts/install.py --force --skip-harness-install --runtime sandbox --username Demo
+```
+
+It exited 1 during installation identity creation because this launched Dev
+seat cannot create a directory beneath the private instance-state root.
+The installer raised `instance_state.InstanceStateError` with permission
+denied. No state-root override or permission change was attempted.
+See [issue #1541](https://github.com/jedbjorn/subfloor/issues/1541).
+
+**Task #795 remains in progress and blocked on Admin provisioning.** The clone
+is a recoverable preparation artifact, not a successfully installed or clean
+capture baseline. Admin must complete the supported install from its authorized
+seat and supply a usable disposable capture environment. Local artifact
+locations are held in the control-plane handoff, not public image assets.
+
+VHS, ttyd, ffmpeg, Docker, Node and Python 3.14.7 are available. Authentication,
+browser capture dependencies, sanitized demonstration state, and a successful
+sandbox launch and harness boot remain unverified. Do not substitute simulated
+terminal output or the existing running fork's private data.
+
+## Remaining delivery gates
+
+Tasks #796–#800 remain pending. Once preparation passes, correct the four core
+surfaces, then refresh workflows, audit all five adapter READMEs and the seven
+top-level engine runbooks, and capture the settled GUI inventory. Preserve the
+immutable checkpoints in `docs/deepseek-harness-removal.md` when labeling it.
+
+The visuals must cover the CLI picker, Roadmap Board and Flow, Worktrees, Chats,
+and Sprints. Review actual assets at rendered size for privacy and legibility.
+Finish with command/link/anchor/fact drift checks, a quick-start sandbox walk,
+themed rendering, configured CI, independent documentation review, and a final
+link/render pass after review fixes. None of those gates is certified here.


### PR DESCRIPTION
Feature #73 / Spec #219 requires an exact-ref disposable capture installation before public documentation implementation. This preparation records the source contract at `706eaa3da0ce2fe5e6a77644e0e520b43e92c374`, preserves the original dos-app install commit, and documents the failed disposable-install prerequisite.

Draft: task #795 is blocked on Admin provisioning (issue #1541; control-plane flag #614). Tasks #796–#800, public copy changes, captures, drift checks, and independent review remain pending. This is the branch for the continuing refresh, not the completed delivery.

Validation: remote HEAD verified; source anchors inspected; `git diff --check` passed; dos-app remains clean at its original SHA; recovery Git bundle verified. Installer exited 1 at the private-state permission boundary. No runtime, capture, or quick-start acceptance is claimed.
