### PR TITLE
fix(snapshot): never serialize through another installation's runtime

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -2142,6 +2142,12 @@ def health_payload() -> dict:
     return {
         "ok": True,
         "repo": cfg.get("repo"),
+        # Exact identity: a caller that resolved this port from its own repo
+        # must be able to tell "this runtime is mine" from "a stranger holds my
+        # port" before handing over a write command (snapshot.py). The name
+        # alone is ambiguous between same-named checkouts; /api/shells already
+        # publishes the root on this same loopback surface.
+        "repo_root": str(REPO_ROOT),
         "port": cfg.get("port"),
         "artifact_mode": artifact_policy.mode(),
         "git_publication": False,

--- a/.super-coder/scripts/snapshot.py
+++ b/.super-coder/scripts/snapshot.py
@@ -23,7 +23,6 @@ Usage:
 from __future__ import annotations
 
 import json
-import os
 import sqlite3  # kept for map.db (which stays SQLite)
 import sys
 import urllib.error
@@ -630,14 +629,56 @@ def _main_runtime_owned() -> int:
     return 0
 
 
+def _runtime_health(base: str) -> dict | None:
+    """Read the identity a runtime publishes, or None when none answers."""
+    try:
+        with urllib.request.urlopen(base + "/api/health", timeout=10) as response:
+            payload = json.loads(response.read())
+    except (urllib.error.URLError, OSError, ValueError, TypeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _owns_this_checkout(health: dict) -> bool:
+    """True unless the runtime answering our port names a different repo.
+
+    An engine older than this field cannot be checked, so it is accepted: that
+    is exactly the pre-existing behaviour, and `./sc update` serializes through
+    the live runtime it is about to replace. Refusing there would break the
+    update it is meant to protect.
+    """
+    root = health.get("repo_root")
+    if not isinstance(root, str) or not root:
+        return True
+    return Path(root) == REPO_ROOT
+
+
 def _snapshot_via_runtime_api() -> str | None:
-    """Ask a healthy runtime to serialize; return None only when it is absent."""
-    base = os.environ.get("SC_API_BASE", "").rstrip("/")
-    if not base:
-        port = ports.resolve(persist=False).get("port")
-        if not isinstance(port, int):
-            return None
-        base = f"http://127.0.0.1:{port}"
+    """Ask this repo's healthy runtime to serialize; None when it is absent.
+
+    The target is always the port THIS repo resolves — never the ambient
+    ``SC_API_BASE``. Inside a launched shell that variable names the runtime of
+    the installation that booted the seat, so an install or update run from
+    such a seat handed its serialize command to a foreign instance: that
+    instance re-dumped its own DB and the new checkout was left with no
+    content.sql. The port is checked too, because a non-sibling fork with the
+    same derived offset is invisible to the sibling registry and can already be
+    answering on it.
+    """
+    port = ports.resolve(persist=False).get("port")
+    if not isinstance(port, int):
+        return None
+    base = f"http://127.0.0.1:{port}"
+    health = _runtime_health(base)
+    if health is None:
+        return None
+    if not _owns_this_checkout(health):
+        served = health.get("repo_root") or health.get("repo") or "unknown"
+        print(
+            f"snapshot: {base} is serving {served}, not {REPO_ROOT} — "
+            "serializing this checkout offline instead"
+        )
+        return None
     request = urllib.request.Request(
         base + "/api/scripts/snapshot", data=b"", method="POST"
     )

--- a/tests/test_snapshot_live_runtime.py
+++ b/tests/test_snapshot_live_runtime.py
@@ -78,5 +78,86 @@ class SnapshotLiveRuntimeTest(unittest.TestCase):
         self.assertEqual(server._SCRIPTS["snapshot"][2][-1], "--runtime-owned")
 
 
+class SnapshotRuntimeTargetTest(unittest.TestCase):
+    """The serialize command may only ever reach THIS checkout's runtime."""
+
+    def test_ambient_api_base_never_redirects_the_serialize_command(self) -> None:
+        """An install/update run from a launched seat inherits SC_API_BASE
+        pointing at the runtime that booted the seat — a different
+        installation. Honouring it made that instance re-dump its own DB and
+        left this checkout with no content.sql."""
+        posted: list[str] = []
+
+        def urlopen(request, timeout=None):
+            posted.append(request.full_url)
+            response = mock.MagicMock()
+            response.__enter__.return_value.read.return_value = (
+                b'{"ok": true, "output": "snapshot: wrote live"}'
+            )
+            return response
+
+        with mock.patch.dict(
+            os.environ,
+            {"SC_API_BASE": "http://127.0.0.1:8801", "SC_API_TOKEN": "foreign"},
+            clear=False,
+        ), mock.patch.object(
+            snapshot.ports, "resolve", return_value={"port": 8842}
+        ), mock.patch.object(
+            snapshot,
+            "_runtime_health",
+            return_value={"ok": True, "repo_root": str(snapshot.REPO_ROOT)},
+        ), mock.patch.object(snapshot.urllib.request, "urlopen", urlopen):
+            self.assertEqual(
+                snapshot._snapshot_via_runtime_api(), "snapshot: wrote live"
+            )
+
+        self.assertEqual(posted, ["http://127.0.0.1:8842/api/scripts/snapshot"])
+
+    def test_health_probe_targets_this_repo_port(self) -> None:
+        with mock.patch.dict(
+            os.environ, {"SC_API_BASE": "http://127.0.0.1:8801"}, clear=False
+        ), mock.patch.object(
+            snapshot.ports, "resolve", return_value={"port": 8842}
+        ), mock.patch.object(
+            snapshot, "_runtime_health", return_value=None
+        ) as health:
+            self.assertIsNone(snapshot._snapshot_via_runtime_api())
+
+        health.assert_called_once_with("http://127.0.0.1:8842")
+
+    def test_foreign_runtime_on_our_port_falls_back_to_offline(self) -> None:
+        with mock.patch.object(
+            snapshot.ports, "resolve", return_value={"port": 8842}
+        ), mock.patch.object(
+            snapshot,
+            "_runtime_health",
+            return_value={"ok": True, "repo": "stranger", "repo_root": "/tmp/stranger"},
+        ), mock.patch.object(
+            snapshot.urllib.request,
+            "urlopen",
+            side_effect=AssertionError("wrote through a foreign runtime"),
+        ), contextlib.redirect_stdout(io.StringIO()) as output:
+            self.assertIsNone(snapshot._snapshot_via_runtime_api())
+
+        self.assertIn("/tmp/stranger", output.getvalue())
+
+    def test_ownership_accepts_an_engine_that_predates_repo_root(self) -> None:
+        """`./sc update` serializes through the live runtime it replaces; an
+        engine too old to publish its root must still be usable."""
+        self.assertTrue(snapshot._owns_this_checkout({"ok": True, "repo": "old"}))
+        self.assertTrue(
+            snapshot._owns_this_checkout({"repo_root": str(snapshot.REPO_ROOT)})
+        )
+        self.assertFalse(snapshot._owns_this_checkout({"repo_root": "/tmp/stranger"}))
+
+    def test_health_publishes_the_exact_repo_root(self) -> None:
+        with mock.patch.object(
+            server.ports_mod, "resolve", return_value={"repo": "fork", "port": 8842}
+        ):
+            payload = server.health_payload()
+
+        self.assertEqual(payload["repo_root"], str(server.REPO_ROOT))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes flag #615 (SC-615, High), reported by Admin.

## The defect

`snapshot.py::_snapshot_via_runtime_api` preferred the ambient `SC_API_BASE`
before falling back to this repo's derived port. Inside a launched shell that
variable names the runtime of the installation that *booted the seat*. So
`./sc install` for a second checkout, run from a launched shell, POSTed
`/api/scripts/snapshot` to a foreign engine: that engine serialized its own DB
over its own `content.sql`, and the new install finished with no `content.sql`
at all. Silent cross-instance write, and an incomplete install.

## The fix

- `snapshot.py` targets only the port **this** repo resolves. The ambient base
  is never read.
- Before handing that runtime a write command, it asks `/api/health` who the
  runtime serves. A mismatch prints one line and falls through to the ordinary
  offline lease path, which serializes this checkout correctly.
- `health_payload()` gains `repo_root`. The directory name alone (`repo`) is
  ambiguous between same-named checkouts; `/api/shells` already publishes the
  root on this same unauthenticated loopback surface, so this discloses nothing
  new.

## Trade-off

An engine too old to publish `repo_root` is **accepted**, not refused. `./sc
update` serializes through the live runtime it is about to replace, and that
runtime is by definition the pre-update build; refusing there would break the
update this change exists to protect. Falling back to a `repo`-name comparison
was the alternative and I rejected it: `instance.json`'s `repo` is written once
at derive time and goes stale when a checkout is renamed or moved, so it would
fail-stop a legitimate in-place update on a renamed fork.

Dropping the ambient base is the whole fix for #615. The identity probe is
narrower: it closes the case where a non-sibling fork with the same derived
offset is already answering on our port — invisible to `ports._sibling_ports`,
and `resolve()` keeps handing out a persisted port without re-checking that it
is free. `dispatch.sh:208` already names that situation.

## Verification

`tests/test_snapshot_live_runtime.py` — 5 new cases: ambient `SC_API_BASE` does
not redirect the POST (asserts the exact URL reached), the health probe targets
our own port, a foreign runtime on our port falls back offline without writing,
old-engine compatibility, and health publishing the root.

Local: 96 passed across the snapshot + update targets
(`test_snapshot_live_runtime`, `test_snapshot_secrets`,
`test_quota_snapshot_exclusion`, `test_sprint_snapshot_rebuild`,
`test_update_legacy_compat`, `test_update_service_cutover`,
`test_update_materialize`), plus 113 passed across `test_api_endpoints`,
`test_install_fresh_fork`, `test_host_runtime`, `test_vendor_assets`. Ruff on
the three touched files: 99 findings before, 99 after — line shifts only, no
new ones. Repo-wide lint/typecheck baselines are unchanged noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)