### PR TITLE
feat(gui): Services panel on the Scripts page — broker and Postgres sidecar toggles

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -101,6 +101,7 @@ import vm as vm_mod  # noqa: E402  (Windows Test VM — config + live checks)
 import ts as ts_mod  # noqa: E402  (tailnet — config + live checks)
 import pm2 as pm2_mod  # noqa: E402  (host pm2 stack — config + live checks)
 import browser as browser_mod
+import services as services_mod  # noqa: E402  (Scripts-page service toggles)
 import web_search as web_search_mod  # noqa: E402  (Tavily — key store + client, doc #215)
 import task_context  # noqa: E402  (six-part task/work-unit projection, doc #187)
 sys.path.insert(0, str(ENGINE / "render"))
@@ -5232,6 +5233,11 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, get_analytics_quota(con))
             if path == "/api/scripts":
                 return self._send(200, {"scripts": script_list()})
+            if path == "/api/services":
+                # The Scripts page's Services panel: configured / running /
+                # persistent per broker + sidecar. Status reads work from the
+                # host and the sandbox alike (bind-mounted sockets).
+                return self._send(200, services_mod.list_services())
             if path == "/api/vm":
                 return self._send(200, {"vm": vm_mod.read()})
             if path == "/api/browser":
@@ -5402,6 +5408,23 @@ class Handler(BaseHTTPRequestHandler):
                     r = run_script(script_key)
                 if r is None:
                     return self._send(404, {"error": "no such script"})
+                return self._send(200 if r["ok"] else 500, r)
+            if path.startswith("/api/services/"):
+                # /api/services/<key>/<up|down|install|uninstall> — one fixed
+                # dispatcher verb per (key, action); the body may carry
+                # {"init": true} for the sidecar's enable-and-start. Refused in
+                # the sandbox with the host command (brokers are host processes).
+                parts = path.split("/")
+                if len(parts) != 5:
+                    return self._send(404, {"error": "not found"})
+                r = services_mod.run(parts[3], parts[4],
+                                     init=bool(self._body().get("init")))
+                if r is None:
+                    return self._send(404, {"error": "no such service or action"})
+                if r["code"] == "host_required":
+                    return self._send(503, r)
+                if r["code"] == "not_configured":
+                    return self._send(409, r)
                 return self._send(200 if r["ok"] else 500, r)
             if path.startswith("/api/vm/validate/"):
                 # Run ONE live check against the candidate config in the body, so

--- a/.super-coder/scripts/services.py
+++ b/.super-coder/scripts/services.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Operational services the GUI's Scripts page toggles: the four HOST-side
+brokers (vm / ts / pm2 / db) and the Postgres sidecar.
+
+Status is read in-process — the instance.json block says "configured", the
+broker's unix socket (bind-mounted, so it answers from the host AND the
+sandbox) says "running", `systemctl --user` says "supervised by systemd", and
+`docker inspect` says whether the sidecar container is up. Lifecycle goes
+through the engine dispatcher's FIXED verbs (`ts-broker-up`, `pg-down`, …),
+exactly what `./sc <verb>` runs, so the GUI passes a registry key + an action
+name and nothing arbitrary executes. Brokers start host processes, so lifecycle
+is refused in the sandbox with the host command to run instead — the same
+contract the /api/ts/status and /api/pm2/status proxies keep.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import dbq  # noqa: E402
+import pm2  # noqa: E402
+import ports  # noqa: E402
+import ts  # noqa: E402
+import vm  # noqa: E402
+
+ENGINE = ports.ENGINE
+REPO_ROOT = ports.REPO_ROOT
+DISPATCH = ENGINE / "scripts" / "dispatch.sh"
+
+BROKER_ACTIONS = ("up", "down", "install", "uninstall")
+SIDECAR_ACTIONS = ("up", "down")
+
+# Display order. `block` is the instance.json key that marks the service as
+# configured; `verb` is the dispatcher verb prefix (`<verb>-up`, `<verb>-down`,
+# and for brokers `<verb>-install` / `<verb>-uninstall`); `unit` is the systemd
+# --user unit dispatch.sh writes on install (the fork's repo basename fills in).
+# `onboarding` is what the GUI shows when the operator switches on a service
+# that has no config block yet — the CLI one-time setup, in prose.
+SERVICES: dict[str, dict] = {
+    "ts": {
+        "name": "Tailnet broker",
+        "desc": "Lets sandboxed shells run commands on declared tailnet hosts "
+                "through the host's already-authenticated Tailscale node.",
+        "kind": "broker", "block": "ts", "verb": "ts-broker", "module": ts,
+        "unit": "sc-ts-broker-{repo}.service",
+        "onboarding": (
+            "No tailnet is linked to this fork. On the host: 1. `tailscale up` "
+            "and confirm `tailscale status` shows your node. 2. Add a `ts` block "
+            "to .super-coder/instance.json naming the hosts shells may reach, "
+            "e.g. {\"allowed_hosts\": [\"build-box\"], \"ssh_user\": \"deploy\"} "
+            "(PUT /api/ts writes it; POST /api/ts/validate/{daemon|auth|peer|ssh} "
+            "tests it). 3. Switch the broker on here. "
+            "See .super-coder/docs/tailscale-broker.md."),
+    },
+    "vm": {
+        "name": "Windows VM broker",
+        "desc": "Drives the linked Windows test VM (status, start, reset, push, "
+                "exec) for sandboxed shells.",
+        "kind": "broker", "block": "vm", "verb": "vm-broker", "module": vm,
+        "unit": "sc-vm-broker-{repo}.service",
+        "onboarding": (
+            "No Windows VM is linked. Use the Windows Test VM card's "
+            "\"configure…\" wizard on this page to link one (every field is "
+            "live-tested before it saves), then switch the broker on here."),
+    },
+    "pm2": {
+        "name": "PM2 broker",
+        "desc": "Lets sandboxed shells see and restart the host's declared "
+                "pm2-supervised processes, fail-closed on the allowlist.",
+        "kind": "broker", "block": "pm2", "verb": "pm2-broker", "module": pm2,
+        "unit": "sc-pm2-broker-{repo}.service",
+        "onboarding": (
+            "No pm2 stack is linked. On the host: 1. Confirm `pm2 jlist` lists "
+            "your app processes. 2. Add a `pm2` block to "
+            ".super-coder/instance.json naming the processes shells may manage, "
+            "e.g. {\"processes\": [\"myapp-api\"], \"health_url\": "
+            "\"http://127.0.0.1:8000/health\"} (PUT /api/pm2 writes it; "
+            "POST /api/pm2/validate/{daemon|procs|health} tests it). "
+            "3. Switch the broker on here. See .super-coder/docs/pm2-broker.md."),
+    },
+    "db": {
+        "name": "Read-only DB broker",
+        "desc": "Runs SELECT-only, table-allowlisted reads of the fork's live "
+                "app database for sandboxed shells; the DSN never leaves the host.",
+        "kind": "broker", "block": "db", "verb": "db-broker", "module": dbq,
+        "unit": "sc-db-broker-{repo}.service",
+        "onboarding": (
+            "No live DB is linked. On the host: 1. `./sc db-init` adds the `db` "
+            "block (dsn_env, allow_tables, row_cap) and prints the setup. "
+            "2. Provision a read-only role and GRANT SELECT on the allowlisted "
+            "tables. 3. `export SC_RO_DSN=postgresql://sc_ro:…@host:5432/db` in "
+            "the broker's environment. 4. Switch the broker on here. "
+            "See .super-coder/docs/db-broker.md."),
+    },
+    "pg": {
+        "name": "Postgres sidecar",
+        "desc": "A per-fork postgres:17 container on the sandbox network for "
+                "developing and testing the fork's app; data lives in a named "
+                "volume. The engine DB stays SQLite.",
+        "kind": "sidecar", "block": "pg", "verb": "pg", "module": None,
+        "unit": None,
+        "onboarding": (
+            "The Postgres sidecar is not enabled for this fork. Enabling it adds "
+            "a `pg` key to .super-coder/instance.json (what `./sc pg-init` does) "
+            "and starts the container; `./sc launch` then starts it with every "
+            "launch and forwards DATABASE_URL into the sandbox."),
+    },
+}
+
+
+def _repo_name() -> str:
+    return REPO_ROOT.name
+
+
+def in_sandbox() -> bool:
+    return bool(os.environ.get("SC_SANDBOX"))
+
+
+def _configured(spec: dict, cfg: dict) -> bool:
+    return spec["block"] in cfg
+
+
+def _broker_running(spec: dict) -> bool:
+    try:
+        return bool(spec["module"].broker_call("GET", "/health", timeout=3).get("ok"))
+    except ConnectionError:
+        return False
+
+
+def _sidecar_running() -> bool | None:
+    """True/False from docker; None when docker is not reachable here (the
+    sandbox has no docker socket, and a no-docker host has no sidecar)."""
+    if not shutil.which("docker"):
+        return None
+    try:
+        p = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.Running}}",
+             f"sc-pg-{_repo_name()}"],
+            capture_output=True, text=True, timeout=10, check=False)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return p.returncode == 0 and p.stdout.strip() == "true"
+
+
+def _systemd_state(spec: dict) -> tuple[bool | None, bool]:
+    """(enabled, active) for the broker's systemd --user unit. `enabled` is
+    None when systemctl is not available here (sandbox, or a non-systemd host)."""
+    if not spec["unit"] or not shutil.which("systemctl"):
+        return None, False
+    unit = spec["unit"].format(repo=_repo_name())
+    try:
+        enabled = subprocess.run(["systemctl", "--user", "is-enabled", unit],
+                                 capture_output=True, text=True, timeout=10, check=False)
+        active = subprocess.run(["systemctl", "--user", "is-active", unit],
+                                capture_output=True, text=True, timeout=10, check=False)
+    except (OSError, subprocess.TimeoutExpired):
+        return None, False
+    return enabled.returncode == 0, active.stdout.strip() == "active"
+
+
+def status(key: str, cfg: dict | None = None) -> dict | None:
+    spec = SERVICES.get(key)
+    if spec is None:
+        return None
+    cfg = ports.resolve(persist=False) if cfg is None else cfg
+    configured = _configured(spec, cfg)
+    if spec["kind"] == "broker":
+        running: bool | None = _broker_running(spec)
+        persistent, systemd_active = _systemd_state(spec)
+        actions = BROKER_ACTIONS
+    else:
+        running = _sidecar_running()
+        persistent, systemd_active = None, False
+        actions = SIDECAR_ACTIONS
+    return {
+        "key": key, "name": spec["name"], "desc": spec["desc"],
+        "kind": spec["kind"], "configured": configured, "running": running,
+        # `persistent` = a systemd unit is enabled (survives reboot); None when
+        # that cannot be known here. `supervisor` names who owns the live
+        # process, so the UI can explain why `down` would be refused.
+        "persistent": persistent,
+        "supervisor": ("systemd" if systemd_active else "pidfile") if running else None,
+        "onboarding": spec["onboarding"],
+        "actions": list(actions),
+        "host_command": f"./sc {spec['verb']}-up",
+    }
+
+
+def list_services() -> dict:
+    cfg = ports.resolve(persist=False)
+    return {
+        "services": [status(k, cfg) for k in SERVICES],
+        # Lifecycle needs the host: brokers are host processes and the sidecar
+        # needs the host's docker. The GUI disables the toggles in the sandbox
+        # and shows the host command instead.
+        "host_lifecycle": not in_sandbox(),
+    }
+
+
+def _dispatch(verb: str, timeout: int = 120) -> dict:
+    """Run ONE fixed dispatcher verb the way `./sc <verb>` would, from this
+    fork's root. The dispatcher backgrounds brokers with nohup and redirects
+    their output to the run/ log, so capturing here never blocks on them."""
+    try:
+        p = subprocess.run(["sh", str(DISPATCH), verb], capture_output=True,
+                           text=True, cwd=str(REPO_ROOT), timeout=timeout,
+                           env={**os.environ, "SC_CALLER_ROOT": str(REPO_ROOT)},
+                           check=False)
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "code": -1, "output": f"{verb}: timed out (>{timeout}s)"}
+    return {"ok": p.returncode == 0, "code": p.returncode,
+            "output": (p.stdout + p.stderr).strip() or "(no output)"}
+
+
+def run(key: str, action: str, *, init: bool = False) -> dict | None:
+    """Apply one lifecycle action. Returns None for an unknown key/action, else
+    {ok, code, output, service} where `service` is the fresh status row.
+    `init=True` is the sidecar's "enable and start": `pg-init` before `pg-up`."""
+    spec = SERVICES.get(key)
+    if spec is None:
+        return None
+    actions = BROKER_ACTIONS if spec["kind"] == "broker" else SIDECAR_ACTIONS
+    if action not in actions:
+        return None
+    if in_sandbox():
+        return {"ok": False, "code": "host_required",
+                "output": (f"{spec['name']}: lifecycle runs on the host — run "
+                           f"`./sc {spec['verb']}-{action}` there, then refresh.")}
+    before = status(key)
+    if action in ("up", "install") and not before["configured"] and not (init and key == "pg"):
+        return {"ok": False, "code": "not_configured",
+                "output": spec["onboarding"], "service": before}
+    outputs: list[str] = []
+    if init and key == "pg" and not before["configured"]:
+        r = _dispatch("pg-init")
+        outputs.append(r["output"])
+        if not r["ok"]:
+            return {**r, "output": "\n".join(outputs), "service": status(key)}
+    r = _dispatch(f"{spec['verb']}-{action}")
+    outputs.append(r["output"])
+    return {**r, "output": "\n".join(outputs), "service": status(key)}

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -1860,9 +1860,15 @@ function flagRow(f, features) {
 }
 
 // ── Scripts ─────────────────────────────────────────────────────────────────────
-async function renderScripts(root) {
+async function renderScripts(view) {
   const { scripts } = await api("/scripts");
-  root.replaceChildren();
+  view.replaceChildren();
+  // Two columns: the script + configuration cards, and the Services panel
+  // beside them (host brokers + the Postgres sidecar as toggles).
+  const root = el("div", { className: "scripts-main" });
+  const services = el("aside", { className: "services-panel" });
+  view.append(el("div", { className: "scripts-layout" }, root, services));
+  renderServicesPanel(services);
   root.append(el("div", { className: "muted" },
     "Run a maintenance script. Output appears below it. Per-instance DB edits → Save locally to refresh the ignored snapshot and flat renders."));
 
@@ -1936,6 +1942,110 @@ async function renderScripts(root) {
     c.append(run, out);
     root.append(c);
   }
+}
+
+// ── Services panel ────────────────────────────────────────────────────────────
+// Each row is one host-side service (a broker or the Postgres sidecar) with a
+// running toggle, and for brokers a "survive reboot" toggle (systemd --user
+// unit). Switching ON an unconfigured service shows its onboarding instead of
+// running anything; every action's output lands under the row.
+function serviceStateText(s, hostLifecycle) {
+  if (!s.configured) return "not configured";
+  if (s.running === null) return hostLifecycle ? "state unknown" : "state unknown (host only)";
+  if (!s.running) return s.persistent ? "stopped · systemd unit enabled" : "stopped";
+  return s.supervisor === "systemd" ? "running · systemd" : "running";
+}
+
+function switchEl(checked, onChange, opts = {}) {
+  const input = el("input", { type: "checkbox", checked, disabled: !!opts.disabled });
+  if (opts.title) input.title = opts.title;
+  input.onchange = () => onChange(input);
+  return el("label", { className: "switch" + (opts.small ? " small" : "") }, input, el("span", { className: "slider" }));
+}
+
+async function renderServicesPanel(aside) {
+  aside.replaceChildren(el("h2", {}, "Services"), el("div", { className: "muted" }, "loading…"));
+  let data;
+  try { data = await api("/services"); }
+  catch (e) { aside.replaceChildren(el("h2", {}, "Services"), el("div", { className: "muted" }, e.message)); return; }
+  const hostLifecycle = !!data.host_lifecycle;
+  aside.replaceChildren(el("h2", {}, "Services"));
+  aside.append(el("div", { className: "muted" },
+    hostLifecycle
+      ? "Host-side brokers and the Postgres sidecar. Switch one on to start it; a service with no configuration shows its setup steps instead."
+      : "Status only: this GUI runs in the sandbox, so start and stop each service on the host with the command shown."));
+  for (const s of data.services) aside.append(serviceRow(s, hostLifecycle));
+  const refresh = el("button", { className: "act", textContent: "refresh" });
+  refresh.onclick = () => renderServicesPanel(aside);
+  aside.append(refresh);
+}
+
+function serviceRow(s, hostLifecycle) {
+  const row = el("div", { className: "service-row" });
+  const state = el("div", { className: "service-state muted" });
+  const out = el("pre", { className: "doc-body service-out", hidden: true });
+  const onboarding = el("div", { className: "service-onboarding", hidden: true });
+  let runInput, persistInput;
+
+  // Re-apply a fresh status row in place, so the action's output stays visible.
+  const apply = (fresh) => {
+    s = fresh;
+    state.textContent = serviceStateText(s, hostLifecycle);
+    const systemdOwned = !!s.running && s.supervisor === "systemd";
+    runInput.checked = !!s.running;
+    runInput.disabled = !hostLifecycle || systemdOwned;
+    runInput.title = !hostLifecycle ? `on the host: ${s.host_command}`
+      : systemdOwned ? "managed by systemd — turn off \"survive reboot\" to stop it" : (s.running ? "stop" : "start");
+    if (persistInput) persistInput.checked = !!s.persistent;
+    if (s.configured) onboarding.hidden = true;
+  };
+
+  const act = async (action, body) => {
+    setStatus(`${s.name}: ${action}…`);
+    row.classList.add("busy");
+    try {
+      const r = await fetch(`/api/services/${s.key}/${action}`, {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body || {}) });
+      const data = await r.json();
+      out.hidden = false; out.textContent = data.output || "(done)";
+      setStatus(data.ok ? `${s.name} ${action} ✓` : `${s.name} ${action} failed`);
+      if (data.service) apply(data.service); else apply(s);
+    } catch (e) { out.hidden = false; out.textContent = "error: " + e.message; apply(s); }
+    finally { row.classList.remove("busy"); }
+  };
+
+  const showOnboarding = () => {
+    onboarding.replaceChildren(el("div", {}, s.onboarding));
+    if (s.key === "vm") {
+      const b = el("button", { className: "act primary", textContent: "configure…" });
+      b.onclick = openWinVmModal; onboarding.append(b);
+    }
+    if (s.key === "pg") {
+      const b = el("button", { className: "act primary", textContent: "enable & start" });
+      b.onclick = () => act("up", { init: true }); onboarding.append(b);
+    }
+    onboarding.hidden = false;
+  };
+
+  const runToggle = switchEl(!!s.running, (input) => {
+    if (input.checked && !s.configured) { input.checked = false; showOnboarding(); return; }
+    if (!input.checked && s.key === "pg" && !confirm("Stop the Postgres sidecar? The container is removed; its data volume is kept.")) { input.checked = true; return; }
+    act(input.checked ? "up" : "down");
+  });
+  runInput = runToggle.querySelector("input");
+
+  row.append(el("div", { className: "service-head" }, el("span", { className: "service-name" }, s.name), runToggle));
+  row.append(el("div", { className: "muted service-desc" }, s.desc), state);
+  if (!hostLifecycle) row.append(el("code", { className: "service-cmd" }, s.host_command));
+  if (s.kind === "broker" && s.configured && s.persistent !== null) {
+    const persist = switchEl(!!s.persistent, (input) => act(input.checked ? "install" : "uninstall"),
+      { small: true, disabled: !hostLifecycle, title: "install / remove the systemd --user unit" });
+    persistInput = persist.querySelector("input");
+    row.append(el("label", { className: "service-persist muted" }, persist, " survive reboot"));
+  }
+  row.append(onboarding, out);
+  apply(s);
+  return row;
 }
 
 function browserStatusText(st) {

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -1577,3 +1577,50 @@ textarea, input[type=text], select { transition: border-color .12s, outline-colo
 .an-meter-fill { height: 100%; background: var(--accent); border-radius: 99px; }
 .an-meter-fill.amber { background: var(--warn); }
 .an-meter-fill.red { background: #d45a5a; }
+
+/* ── Scripts page: cards + Services panel ─────────────────────────────────── */
+#view-scripts { max-width: 1240px; }
+.scripts-layout { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 1rem; align-items: start; }
+.scripts-main { display: grid; gap: 1rem; min-width: 0; }
+.services-panel {
+  position: sticky; top: 4.2rem; display: grid; gap: .7rem; min-width: 0;
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--r); padding: 1rem 1.1rem;
+}
+.services-panel h2 { margin: 0; font-size: 1rem; }
+.services-panel > .act { justify-self: start; }
+.service-row { display: grid; gap: .3rem; padding-top: .7rem; border-top: 1px solid var(--line-soft); }
+.service-row.busy { opacity: .6; pointer-events: none; }
+.service-head { display: flex; align-items: center; justify-content: space-between; gap: .6rem; }
+.service-name { font-weight: 600; }
+.service-desc, .service-state { font-size: .78rem; }
+.service-cmd { font-size: .74rem; color: var(--dim); }
+.service-persist { display: inline-flex; align-items: center; gap: .4rem; font-size: .76rem; cursor: pointer; }
+.service-onboarding {
+  display: grid; gap: .5rem; padding: .6rem .7rem; font-size: .8rem; color: var(--warn);
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--line));
+  background: color-mix(in srgb, var(--warn) 8%, var(--panel)); border-radius: 7px;
+}
+.service-onboarding .act { justify-self: start; margin: 0; }
+.service-out { max-height: 200px; font-size: 11.5px; }
+/* Toggle switch: a checkbox styled as a slider; the input stays focusable. */
+.switch { position: relative; display: inline-block; flex: none; width: 34px; height: 18px; }
+.switch.small { width: 26px; height: 14px; }
+.switch input { position: absolute; opacity: 0; width: 0; height: 0; margin: 0; }
+.switch .slider {
+  position: absolute; inset: 0; cursor: pointer; border-radius: 999px;
+  background: var(--panel2); border: 1px solid var(--line); transition: background .15s, border-color .15s;
+}
+.switch .slider::before {
+  content: ""; position: absolute; top: 2px; left: 2px; width: 12px; height: 12px; border-radius: 50%;
+  background: var(--dim); transition: transform .15s, background .15s;
+}
+.switch.small .slider::before { width: 8px; height: 8px; }
+.switch input:checked + .slider { background: color-mix(in srgb, var(--ok) 30%, var(--panel2)); border-color: var(--ok); }
+.switch input:checked + .slider::before { transform: translateX(16px); background: var(--ok); }
+.switch.small input:checked + .slider::before { transform: translateX(12px); }
+.switch input:disabled + .slider { opacity: .5; cursor: not-allowed; }
+.switch input:focus-visible + .slider { outline: 2px solid var(--accent); outline-offset: 1px; }
+@media (max-width: 900px) {
+  .scripts-layout { grid-template-columns: minmax(0, 1fr); }
+  .services-panel { position: static; }
+}

--- a/tests/test_services_panel.py
+++ b/tests/test_services_panel.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""The Scripts page's Services panel (scripts/services.py + /api/services).
+
+Stdlib unittest, no pytest. Probes (sockets, systemctl, docker) and the
+dispatcher are mocked: these tests pin the contract — the five services in
+display order, fail-closed `up` on an unconfigured service, sandbox refusal
+with the host command, the fixed dispatcher verb per (key, action), and the
+sidecar's enable-and-start — never the host's live state.
+
+Run:
+    python3 tests/test_services_panel.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ENGINE = Path(__file__).resolve().parents[1] / ".super-coder"
+sys.path.insert(0, str(ENGINE / "scripts"))
+sys.path.insert(0, str(ENGINE / "api"))
+import server  # noqa: E402
+import services  # noqa: E402
+
+
+class _Done:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
+
+
+class ServicesStatusTest(unittest.TestCase):
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        os.environ.pop("SC_SANDBOX", None)
+        self.addCleanup(self.env.stop)
+
+    def test_five_services_in_display_order_with_contract_fields(self):
+        with mock.patch.object(services.ports, "resolve", return_value={"port": 8800}), \
+             mock.patch.object(services, "_broker_running", return_value=False), \
+             mock.patch.object(services, "_systemd_state", return_value=(False, False)), \
+             mock.patch.object(services, "_sidecar_running", return_value=None):
+            data = services.list_services()
+        self.assertTrue(data["host_lifecycle"])
+        rows = data["services"]
+        self.assertEqual([r["key"] for r in rows], ["ts", "vm", "pm2", "db", "pg"])
+        for r in rows:
+            self.assertFalse(r["configured"])
+            self.assertTrue(r["onboarding"])
+            self.assertTrue(r["host_command"].startswith("./sc "))
+        self.assertEqual(rows[0]["actions"], ["up", "down", "install", "uninstall"])
+        self.assertEqual(rows[4]["actions"], ["up", "down"])
+        self.assertIsNone(rows[4]["running"], "no docker here → unknown, never False")
+        self.assertEqual(rows[0]["host_command"], "./sc ts-broker-up")
+
+    def test_configured_running_and_supervisor_projection(self):
+        cfg = {"ts": {"allowed_hosts": ["a"]}, "pg": {}}
+        with mock.patch.object(services.ports, "resolve", return_value=cfg), \
+             mock.patch.object(services, "_broker_running", return_value=True), \
+             mock.patch.object(services, "_systemd_state", return_value=(True, True)), \
+             mock.patch.object(services, "_sidecar_running", return_value=True):
+            ts = services.status("ts")
+            pg = services.status("pg")
+        self.assertTrue(ts["configured"] and ts["running"] and ts["persistent"])
+        self.assertEqual(ts["supervisor"], "systemd")
+        self.assertTrue(pg["configured"] and pg["running"])
+        self.assertIsNone(pg["persistent"])
+        self.assertEqual(pg["supervisor"], "pidfile")
+
+    def test_broker_probe_treats_unreachable_socket_as_stopped(self):
+        with mock.patch.object(services.ts, "broker_call", side_effect=ConnectionError("no sock")):
+            self.assertFalse(services._broker_running(services.SERVICES["ts"]))
+        with mock.patch.object(services.ts, "broker_call", return_value={"ok": True}):
+            self.assertTrue(services._broker_running(services.SERVICES["ts"]))
+
+    def test_sandbox_reports_status_but_not_lifecycle(self):
+        os.environ["SC_SANDBOX"] = "1"
+        with mock.patch.object(services.ports, "resolve", return_value={}), \
+             mock.patch.object(services, "_broker_running", return_value=False), \
+             mock.patch.object(services, "_systemd_state", return_value=(None, False)), \
+             mock.patch.object(services, "_sidecar_running", return_value=None):
+            self.assertFalse(services.list_services()["host_lifecycle"])
+
+
+class ServicesLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {}, clear=False)
+        self.env.start()
+        os.environ.pop("SC_SANDBOX", None)
+        self.addCleanup(self.env.stop)
+        self.calls: list[list[str]] = []
+
+        def fake_run(argv, **kw):
+            self.calls.append(argv)
+            return _Done(0, f"→ {argv[-1]} ok")
+        self.run_patch = mock.patch.object(services.subprocess, "run", side_effect=fake_run)
+        self.run_patch.start(); self.addCleanup(self.run_patch.stop)
+        self.status_patch = mock.patch.object(services, "_broker_running", return_value=False)
+        self.status_patch.start(); self.addCleanup(self.status_patch.stop)
+        mock.patch.object(services, "_systemd_state", return_value=(False, False)).start()
+        mock.patch.object(services, "_sidecar_running", return_value=False).start()
+        self.addCleanup(mock.patch.stopall)
+
+    def _cfg(self, cfg):
+        p = mock.patch.object(services.ports, "resolve", return_value=cfg)
+        p.start(); self.addCleanup(p.stop)
+
+    def _verbs(self):
+        return [argv[-1] for argv in self.calls if argv[0] == "sh"]
+
+    def test_unknown_key_or_action_is_none(self):
+        self._cfg({"ts": {}})
+        self.assertIsNone(services.run("nope", "up"))
+        self.assertIsNone(services.run("ts", "restart"))
+        self.assertIsNone(services.run("pg", "install"), "sidecar has no systemd unit")
+        self.assertEqual(self.calls, [])
+
+    def test_up_on_unconfigured_broker_returns_onboarding_without_running(self):
+        self._cfg({})
+        r = services.run("ts", "up")
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["code"], "not_configured")
+        self.assertEqual(r["output"], services.SERVICES["ts"]["onboarding"])
+        self.assertFalse(r["service"]["configured"])
+        self.assertEqual(self._verbs(), [])
+
+    def test_actions_map_to_fixed_dispatcher_verbs(self):
+        self._cfg({"ts": {"allowed_hosts": ["a"]}, "pm2": {"processes": ["x"]}})
+        for key, action, verb in [("ts", "up", "ts-broker-up"), ("ts", "down", "ts-broker-down"),
+                                  ("pm2", "install", "pm2-broker-install"),
+                                  ("pm2", "uninstall", "pm2-broker-uninstall")]:
+            self.calls.clear()
+            r = services.run(key, action)
+            self.assertTrue(r["ok"], r)
+            self.assertEqual(self._verbs(), [verb])
+            argv = self.calls[0]
+            self.assertEqual(argv[:2], ["sh", str(services.DISPATCH)])
+            self.assertIn("service", r)
+
+    def test_dispatch_runs_from_repo_root_as_the_caller(self):
+        self._cfg({"ts": {}})
+        captured = {}
+
+        def fake_run(argv, **kw):
+            captured.update(kw); return _Done(0, "ok")
+        with mock.patch.object(services.subprocess, "run", side_effect=fake_run):
+            services.run("ts", "up")
+        self.assertEqual(captured["cwd"], str(services.REPO_ROOT))
+        self.assertEqual(captured["env"]["SC_CALLER_ROOT"], str(services.REPO_ROOT))
+
+    def test_down_is_allowed_even_when_unconfigured(self):
+        # A block removed while the broker still runs must remain stoppable.
+        self._cfg({})
+        r = services.run("ts", "down")
+        self.assertTrue(r["ok"])
+        self.assertEqual(self._verbs(), ["ts-broker-down"])
+
+    def test_sidecar_enable_and_start_runs_init_then_up(self):
+        self._cfg({})
+        self.assertEqual(services.run("pg", "up")["code"], "not_configured")
+        self.calls.clear()
+        r = services.run("pg", "up", init=True)
+        self.assertTrue(r["ok"])
+        self.assertEqual(self._verbs(), ["pg-init", "pg-up"])
+        self.assertIn("pg-init ok", r["output"])
+        self.assertIn("pg-up ok", r["output"])
+
+    def test_sidecar_init_failure_stops_before_up(self):
+        self._cfg({})
+
+        def fail_init(argv, **kw):
+            self.calls.append(argv)
+            return _Done(1, "", "✗ init failed") if argv[-1] == "pg-init" else _Done(0, "up")
+        with mock.patch.object(services.subprocess, "run", side_effect=fail_init):
+            r = services.run("pg", "up", init=True)
+        self.assertFalse(r["ok"])
+        self.assertEqual(self._verbs(), ["pg-init"])
+        self.assertIn("init failed", r["output"])
+
+    def test_configured_sidecar_up_skips_init(self):
+        self._cfg({"pg": {}})
+        services.run("pg", "up", init=True)
+        self.assertEqual(self._verbs(), ["pg-up"])
+
+    def test_sandbox_refuses_lifecycle_with_host_command(self):
+        self._cfg({"ts": {}})
+        os.environ["SC_SANDBOX"] = "1"
+        r = services.run("ts", "up")
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["code"], "host_required")
+        self.assertIn("./sc ts-broker-up", r["output"])
+        self.assertEqual(self.calls, [])
+
+    def test_dispatch_timeout_is_a_failure_result(self):
+        self._cfg({"ts": {}})
+        with mock.patch.object(services.subprocess, "run",
+                               side_effect=services.subprocess.TimeoutExpired("sh", 120)):
+            r = services.run("ts", "up")
+        self.assertFalse(r["ok"])
+        self.assertIn("timed out", r["output"])
+
+
+class ServerWiringTest(unittest.TestCase):
+    def test_server_exposes_services_module_and_routes(self):
+        self.assertIs(server.services_mod, services)
+        src = Path(server.__file__).read_text()
+        self.assertIn('if path == "/api/services":', src)
+        self.assertIn('if path.startswith("/api/services/"):', src)
+        # Status codes the UI keys off: sandbox → 503, unconfigured → 409.
+        self.assertIn('if r["code"] == "host_required":\n                    return self._send(503, r)', src)
+        self.assertIn('if r["code"] == "not_configured":\n                    return self._send(409, r)', src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New **Services** sidebar beside the Scripts cards: one row per host-side service (Tailnet broker, Windows VM broker, PM2 broker, read-only DB broker, Postgres sidecar) with state text and a **running toggle**; brokers also get a **survive reboot** toggle (systemd `--user` unit install/uninstall).
- Switching on an unconfigured service shows its **onboarding steps** instead of running anything. The VM row opens the existing configure wizard; the sidecar row offers **enable & start** (`pg-init` then `pg-up`).
- `scripts/services.py`: status in-process (instance.json block · broker health socket · `systemctl --user is-enabled/is-active` · `docker inspect`); lifecycle through the dispatcher's **fixed verbs** (`ts-broker-up`, `pg-down`, …) with `SC_CALLER_ROOT` set, so the GUI passes a registry key + action and nothing arbitrary executes.
- Routes: `GET /api/services`, `POST /api/services/<key>/<up|down|install|uninstall>` (body may carry `{"init": true}` for the sidecar). `404` unknown key/action · `409` unconfigured (returns onboarding) · `503` in the sandbox (returns the host command) · `200/500` on the verb's exit.

## Trade-off stated
In the sandbox the panel is **status-only**: brokers are host processes and the sidecar needs the host's docker, so lifecycle returns 503 with `./sc <verb>` to run on the host. This mirrors the existing `/api/ts/status` and `/api/pm2/status` proxies rather than adding a host lifecycle daemon (decision #340). A host bridge is a later era if sandbox toggling is wanted.

Browser arm/disarm was left in its configuration modal; Docker cache cleanup and harness status remain candidate script cards for a follow-up.

## Verification
- `python3 tests/test_services_panel.py` — 15 tests: display order + contract fields, fail-closed `up` on unconfigured, sandbox refusal, fixed verb per (key, action), dispatcher cwd/env, sidecar init→up and init-failure stop, timeout as failure, server wiring.
- `python3 tests/test_api_endpoints.py` — 65 tests, OK.
- Scratch server from the worktree (migrated local DB, port 8899): `GET /api/services` 200 with five rows; `POST …/nope/up` 404; `POST …/ts/restart` 404; `POST …/ts/up` 409 with onboarding; `POST …/pg/install` 404; `/api/scripts` and `/app.js` still 200.
- Real dispatcher path exercised (`help`, `ts-broker-down`/`-up` via `sh dispatch.sh` with `SC_CALLER_ROOT`).
- `node --check app.js`; ruff on touched files — remaining findings (RUF100 noqa E402, EXE001) match the repo-wide baseline.
- No browser seat in this shell: the panel's rendering was not viewed in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)