### PR TITLE
feat(bench): frozen campaigns and disposable host gate (WU155)

### DIFF
--- a/.super-coder/scripts/model_bench.py
+++ b/.super-coder/scripts/model_bench.py
@@ -719,8 +719,14 @@ print(json.dumps({'db_verified': True, 'developer_verified': True}))
         proof = json.loads(self.command(workspace, [sys.executable, "-c", program]).stdout)
         require(proof == {"db_verified": True, "developer_verified": True}, "DB verification missing")
 
+    def refresh_routes(self, workspace):
+        self.sc(workspace, "models", "refresh", timeout=300)
+
     def route(self, workspace, route):
-        return prove_route(self.runner, workspace, route, env=self.environment(workspace))
+        try:
+            return prove_route(self.runner, workspace, route, env=self.environment(workspace))
+        except BenchError as exc:
+            raise BenchError("copy route proof failed") from exc
 
     def place_style(self, workspace, style):
         destination = confined(workspace, style["path"])
@@ -772,6 +778,9 @@ print(json.dumps({'db_verified': True, 'developer_verified': True}))
             # remains on either assigned port before allowing deletion.
             for port in ledger["ports"].values():
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                    # Closed health connections can leave TIME_WAIT sockets.
+                    # Reuse permits those while still rejecting a live listener.
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                     try:
                         sock.bind(("127.0.0.1", port))
                     except OSError as exc:
@@ -894,6 +903,8 @@ class Controller:
                 self._stage(ledger_path, ledger, "health")
                 self.backend.verify(workspace)
                 self._stage(ledger_path, ledger, "verify")
+                self.backend.refresh_routes(workspace)
+                self._stage(ledger_path, ledger, "refresh_routes")
                 ledger["route_proof"] = self.backend.route(workspace, route)
                 self._stage(ledger_path, ledger, "route")
                 ledger["fixture"] = self.backend.place_style(workspace, config["style"])
@@ -911,6 +922,7 @@ class Controller:
                     operation(workspace, config, card, route, ledger)
             except BaseException as exc:
                 ledger["outcome"] = exc.outcome if isinstance(exc, BenchError) else "invalid"
+                ledger["error"] = str(exc) if isinstance(exc, BenchError) else type(exc).__name__
                 if ledger["stages"][-1:] == ["deps"] and ledger["outcome"] == "invalid":
                     ledger["baseline_invalid"] = True
                 write_json(ledger_path, ledger)

--- a/.super-coder/scripts/model_bench.py
+++ b/.super-coder/scripts/model_bench.py
@@ -50,22 +50,22 @@ REDLINES = frozenset((
 COMMON = ["tests_green", "scope_bounded", "commit_on_branch"]
 PRESETS: dict[str, dict[str, Any]] = {
     "T1": {
-        "text": "Move the {button_a} in {view_a} from {position_from} to {position_to}, and add a {button_b} beside it that {button_b_action}. Follow the house style. Run the tests and commit on a branch.",
+        "text": "Move the {button_a} in {view_a} from {position_from} to {position_to}, and add a {button_b} beside it that {button_b_action}. Follow the house style at {style_path}. Run the tests and commit on a branch.",
         "kinds": {"view_a": "ref", "button_a": "ref", "button_b": "new", "position_from": "text", "position_to": "text", "button_b_action": "text"},
         "redlines": ["style_trap", *COMMON],
     },
     "T2": {
-        "text": "Add a filter to {list_view} so a user can narrow the list by {filter_field}. The API must support the filter; the UI must use it. Follow the house style. Run the tests and commit on a branch.",
+        "text": "Add a filter to {list_view} so a user can narrow the list by {filter_field}. The API must support the filter; the UI must use it. Follow the house style at {style_path}. Run the tests and commit on a branch.",
         "kinds": {"list_view": "ref", "filter_field": "ref"},
         "redlines": ["endpoint_param", "endpoint_test_added", "ui_wired", "style_trap", *COMMON],
     },
     "T3": {
-        "text": "Add a {table_name} table with columns {columns}, the migration that creates it, and a read endpoint at {endpoint_path} that lists its rows. Add tests. Run the tests and commit on a branch.",
+        "text": "Add a {table_name} table with columns {columns}, the migration that creates it, and a read endpoint at {endpoint_path} that lists its rows. Follow the house style at {style_path}. Add tests. Run the tests and commit on a branch.",
         "kinds": {"table_name": "new", "endpoint_path": "new", "columns": "text"},
         "redlines": ["migration_present", "migration_applies", "endpoint_present", "endpoint_test_added", *COMMON],
     },
     "T4": {
-        "text": "Add a {table_name} table with columns {columns} and its migration, a read endpoint at {endpoint_path}, and a {view_b} view that lists the rows with a filter by {filter_field} and a {button_c} that {button_c_action}. Follow the house style. Add tests. Run the tests and commit on a branch.",
+        "text": "Add a {table_name} table with columns {columns} and its migration, a read endpoint at {endpoint_path}, and a {view_b} view that lists the rows with a filter by {filter_field} and a {button_c} that {button_c_action}. Follow the house style at {style_path}. Add tests. Run the tests and commit on a branch.",
         "kinds": {"table_name": "new", "endpoint_path": "new", "view_b": "new", "button_c": "new", "columns": "text", "filter_field": "text", "button_c_action": "text"},
         "redlines": sorted(REDLINES),
     },
@@ -324,36 +324,32 @@ def validate_recipes(config):
         argv(migrations["table_check_argv"])
 
 
-def freeze_style(config, base, runner, target):
-    style = object_keys(config["style"], ("kind", "source", "destination", "trap"), ("kind", "source"))
-    require(style["kind"] in ("skill", "doc", "file"), "unknown style kind")
-    source = style["source"]
-    if type(source) is int:
-        require(style["kind"] in ("doc", "skill") and source > 0, "numeric style source must be a document or skill id")
-        if style["kind"] == "doc":
-            payload = json.loads(runner.run([str(ROOT / "sc"), "mem", "get", "documents", "--doc", str(source), "--json"], cwd=ROOT).stdout)
-            content = payload["document"]["body"]
-        else:
-            # Admin's public read-only surface; never open the host DB here.
-            query = f"SELECT name,description,content FROM skills WHERE skill_id={source} AND is_deleted=0"
-            rows = json.loads(runner.run([str(ROOT / "sc"), "sql", "-json", query], cwd=ROOT).stdout)
-            require(isinstance(rows, list) and len(rows) == 1, "style skill id is unavailable")
-            row = rows[0]
-            content = f"---\nname: {row['name']}\ndescription: {row['description']}\n---\n\n{row['content']}\n"
+def freeze_style(config, base, snapshot, target):
+    style = object_keys(config["style"], ("kind", "source", "place_at", "trap"), ("kind", "source"))
+    require(style["kind"] in ("file", "repo"), "style kind must be file or repo")
+    source = line(style["source"], "style.source")
+    if style["kind"] == "repo":
+        require("place_at" not in style, "repo style does not accept place_at")
+        relative(source, "style.source")
+        style["source"] = str(PurePosixPath(source))
+        mode = snapshot.runner.git(snapshot.repo, "ls-tree", snapshot.sha, "--", style["source"]).stdout.split()
+        require(mode and mode[0] in ("100644", "100755"), "repo style must be a regular file at target.ref")
+        content = snapshot.read(style["source"])
+        style["path"] = style["source"]
     else:
-        path = Path(line(source, "style.source"))
+        require("place_at" in style, "file style needs place_at")
+        relative(style["place_at"], "style.place_at")
+        style["place_at"] = str(PurePosixPath(style["place_at"]))
+        require(style["place_at"] != ".", "style.place_at must name a file")
+        path = Path(source)
         if not path.is_absolute():
             path = (base / path).resolve()
             require(target is None or not inside(path, target), "relative style source is inside target")
             require(not inside(path, Path(config["copy"]["root"])), "relative style source is inside copy")
         content = path.read_text()
         style["source"] = str(path.resolve())
+        style["path"] = style["place_at"]
     require(isinstance(content, str) and 0 < len(content) <= 200000, "invalid style artifact")
-    if style["kind"] == "file":
-        require("destination" in style, "file style needs a declared destination")
-        relative(style["destination"], "style.destination")
-    else:
-        require("destination" not in style, "destination applies only to file style")
     if "trap" in style:
         trap = object_keys(style["trap"], ("forbidden", "required"), ("forbidden", "required"))
         for patterns in trap.values():
@@ -365,12 +361,11 @@ def freeze_style(config, base, runner, target):
                     raise BenchError("invalid trap regex") from exc
     style["content"] = content
     style["digest"] = digest(content)
-    if style["kind"] == "skill":
-        # Reuse the serving CLI's parser, not a second frontmatter grammar.
-        from skill import parse_local_skill_spec
-        style["name"] = parse_local_skill_spec(content)["name"]
-    else:
-        style["name"] = "bench_house_style"
+
+
+def path_allowed(path, patterns):
+    """Repo-root-relative glob matching, including zero-directory ** matches."""
+    return any(PurePosixPath(path).full_match(pattern) for pattern in patterns)
 
 
 def freeze_cards(config, snapshot):
@@ -397,8 +392,10 @@ def freeze_cards(config, snapshot):
                 fields.append(field)
         except ValueError as exc:
             raise BenchError("invalid slot syntax") from exc
-        require(isinstance(card["slots"], dict) and set(card["slots"]) == set(fields), "missing or unused slots")
-        values = {}
+        require(isinstance(card["slots"], dict), "slots must be an object")
+        require("style_path" not in card["slots"], "style_path is runner-filled")
+        require(set(card["slots"]) == set(fields) - {"style_path"}, "missing or unused slots")
+        values = {"style_path": config["style"]["path"]}
         for name, slot in card["slots"].items():
             object_keys(slot, ("value", "kind"), ("value", "kind"))
             kind, value = slot["kind"], line(slot["value"], "slot value")
@@ -427,12 +424,15 @@ def freeze_cards(config, snapshot):
         require(isinstance(card["allowed_paths"], list) and card["allowed_paths"], "allowed_paths required")
         for pattern in card["allowed_paths"]:
             relative(pattern, "allowed_paths", glob=True)
+        if config["style"]["kind"] == "file":
+            require(not path_allowed(config["style"]["place_at"], card["allowed_paths"]), "style.place_at overlaps card allowed_paths")
         if any(x.startswith("endpoint_") or x == "ui_wired" for x in checks):
             require("serve" in config, "endpoint redline requires serve")
         if any(x.startswith("migration_") for x in checks) or card.get("preset") in ("T3", "T4"):
             require("migrations" in config, "migration redline requires migrations")
         if "style_trap" in checks:
             require("trap" in config["style"], "style_trap requires trap")
+            require("style_path" in fields, "style_trap card must contain {style_path}")
 
 
 def freeze(config_path, runner=None):
@@ -495,7 +495,7 @@ def freeze(config_path, runner=None):
             require("dev_kit" in config, "target has no dev-kit or override")
             config["dev_kit_digest"] = digest(config["dev_kit"])
             config["dev_kit_declaration"] = None
-        freeze_style(config, config_path.parent, runner, target)
+        freeze_style(config, config_path.parent, snapshot, target)
         freeze_cards(config, snapshot)
     for route in [*config["routes"], config["judge"]]:
         prove_route(runner, ROOT, route)
@@ -613,7 +613,7 @@ class HostBackend:
         # Controller files/state are never offered to the Developer as changes.
         exclude = workspace / ".git/info/exclude"
         with exclude.open("a") as stream:
-            stream.write("\n/.bench-state/\n/.bench-style.md\n/.bench-engine.tar\n")
+            stream.write("\n/.bench-state/\n/.bench-engine.tar\n")
 
     def materialize(self, config, workspace):
         source, ref = Path(config["engine"]["source"]), config["engine"]["ref"]
@@ -692,7 +692,11 @@ class HostBackend:
         raise BenchError("copy health failed", "infra_failed")
 
     def verify(self, workspace):
-        self.sc(workspace, "render", "all", "DEV1")
+        # Install has already rendered the fresh instance. Compare that mirror
+        # against its sources; render/all needs SC_ADMIN and would mutate it.
+        mirror = confined(workspace, ".sc-state/local/renders/skills_sc/README.md")
+        require(mirror.is_file() and mirror.stat().st_size > 0, "installed render is missing")
+        self.sc(workspace, "render-check")
         # sc verify rebuilds the DB; use a read-only integrity proof instead.
         # This executes only in the disposable copy with its private XDG root.
         program = """import json, sqlite3, sys
@@ -719,20 +723,19 @@ print(json.dumps({'db_verified': True, 'developer_verified': True}))
         return prove_route(self.runner, workspace, route, env=self.environment(workspace))
 
     def place_style(self, workspace, style):
-        content = style["content"]
+        destination = confined(workspace, style["path"])
         if style["kind"] == "file":
-            destination = confined(workspace, style["destination"])
-            require(not destination.is_dir(), "style destination is a directory")
+            require(not destination.is_dir(), "style.place_at is a directory")
             destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_text(content)
-            content = f"Read and follow the house style in `{style['destination']}` before editing."
-        if style["kind"] != "skill":
-            content = f"---\nname: {style['name']}\ndescription: Project house style to follow when editing this project.\n---\n\n{content}\n"
-        draft = confined(workspace, ".bench-style.md")
-        draft.write_text(content)
-        self.sc(workspace, "skill", "put", "--file", str(draft))
-        self.sc(workspace, "skill", "grant", style["name"], "DEV1")
-        self.sc(workspace, "render", "skills", "DEV1")
+            destination.write_text(style["content"])
+            # Even an ignored projected skill becomes a tracked fixture file.
+            self.runner.git(workspace, "add", "--force", "--", style["place_at"])
+        require(destination.is_file() and digest(destination.read_text()) == style["digest"], "copy style differs from frozen artifact")
+        self.runner.git(workspace, "add", "-A")
+        self.runner.git(workspace, "-c", "core.hooksPath=/dev/null", "-c", "user.name=Subfloor Bench",
+                        "-c", "user.email=noreply@subfloor.invalid", "-c", "commit.gpgsign=false",
+                        "commit", "--allow-empty", "-m", "chore: prepare frozen project fixture")
+        return {"base_sha": resolve_sha(self.runner, workspace, "HEAD"), "style_digest": style["digest"]}
 
     def hook(self, config, workspace, name):
         declaration = config["dev_kit_declaration"]
@@ -747,13 +750,10 @@ print(json.dumps({'db_verified': True, 'developer_verified': True}))
         return {"exit_status": result.returncode, "hook": declared or {"argv": config["dev_kit"][name], "cwd": "."}}
 
     def preamble(self, config, workspace, route):
-        # Installer/style/deps can legitimately change managed fixture files.
-        # Commit the fixture locally; model diffs start at this clean base and
-        # the original target SHA remains a separate immutable receipt field.
-        self.runner.git(workspace, "add", "-A")
-        self.runner.git(workspace, "-c", "core.hooksPath=/dev/null", "-c", "user.name=Subfloor Bench",
-                        "-c", "user.email=noreply@subfloor.invalid", "-c", "commit.gpgsign=false",
-                        "commit", "--allow-empty", "-m", "chore: prepare frozen project fixture")
+        # The fixture was committed before hooks; hooks must leave it intact.
+        style_path = confined(workspace, config["style"]["path"])
+        require(style_path.is_file() and digest(style_path.read_text()) == config["style"]["digest"], "baseline hook changed style")
+        require(self.runner.git(workspace, "branch", "--show-current").stdout.strip() == "bench-base", "baseline hook changed branch")
         status = self.runner.git(workspace, "status", "--porcelain").stdout.strip()
         require(not status, "baseline Git status is not clean")
         version = self.command(workspace, [route["harness"], "--version"]).stdout.strip()
@@ -896,13 +896,14 @@ class Controller:
                 self._stage(ledger_path, ledger, "verify")
                 ledger["route_proof"] = self.backend.route(workspace, route)
                 self._stage(ledger_path, ledger, "route")
-                self.backend.place_style(workspace, config["style"])
+                ledger["fixture"] = self.backend.place_style(workspace, config["style"])
                 self._stage(ledger_path, ledger, "style")
                 ledger["deps"] = self.backend.hook(config, workspace, "deps")
                 self._stage(ledger_path, ledger, "deps")
                 ledger["baseline_test"] = self.backend.hook(config, workspace, "test")
                 self._stage(ledger_path, ledger, "test")
                 ledger["preamble"] = self.backend.preamble(config, workspace, route)
+                require(ledger["preamble"]["base_sha"] == ledger["fixture"]["base_sha"], "baseline hook advanced fixture SHA")
                 self._stage(ledger_path, ledger, "preamble")
                 ledger["outcome"] = "gate_passed"
                 write_json(ledger_path, ledger)
@@ -955,4 +956,6 @@ def main(args=None):
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/.super-coder/scripts/model_bench.py
+++ b/.super-coder/scripts/model_bench.py
@@ -1,0 +1,958 @@
+#!/usr/bin/env python3
+"""Frozen project benchmark configuration and disposable host gate (spec #222).
+
+freeze --config FILE writes <evidence.root>/<digest>/campaign.json.
+run --campaign FILE --card ID --route-index N proves one fresh-copy gate and
+tears it down. The controller's operation callback is the subsequent cell
+execution seam; this core does not dispatch a provider or evaluate a result.
+cleanup --campaign FILE --cell ID retries a retained cleanup ledger.
+
+Only CommandRunner executes subprocesses. It removes every SC_* binding and
+Git context override, closes stdin, bounds commands, and never uses a shell.
+Copies own their XDG state so removing a copy also removes its engine DB.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import copy
+import getpass
+import hashlib
+import json
+import os
+import re
+import shutil
+import socket
+import stat
+import string
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.error import URLError
+from urllib.parse import unquote, urlsplit
+from urllib.request import ProxyHandler, build_opener
+
+RUNNER_VERSION = "1"
+ROOT = Path(__file__).resolve().parents[2]
+SHA = re.compile(r"[0-9a-f]{40}")
+IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+SAFE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,79}")
+RESERVED = re.compile(r"\b(?:benchmark|evaluate|rubric|judge|score)\b", re.IGNORECASE)
+PUSH_DISABLED = "disabled://bench/no-push"
+REDLINES = frozenset((
+    "tests_green", "style_trap", "scope_bounded", "commit_on_branch",
+    "endpoint_present", "endpoint_param", "endpoint_test_added", "ui_wired",
+    "migration_present", "migration_applies",
+))
+COMMON = ["tests_green", "scope_bounded", "commit_on_branch"]
+PRESETS: dict[str, dict[str, Any]] = {
+    "T1": {
+        "text": "Move the {button_a} in {view_a} from {position_from} to {position_to}, and add a {button_b} beside it that {button_b_action}. Follow the house style. Run the tests and commit on a branch.",
+        "kinds": {"view_a": "ref", "button_a": "ref", "button_b": "new", "position_from": "text", "position_to": "text", "button_b_action": "text"},
+        "redlines": ["style_trap", *COMMON],
+    },
+    "T2": {
+        "text": "Add a filter to {list_view} so a user can narrow the list by {filter_field}. The API must support the filter; the UI must use it. Follow the house style. Run the tests and commit on a branch.",
+        "kinds": {"list_view": "ref", "filter_field": "ref"},
+        "redlines": ["endpoint_param", "endpoint_test_added", "ui_wired", "style_trap", *COMMON],
+    },
+    "T3": {
+        "text": "Add a {table_name} table with columns {columns}, the migration that creates it, and a read endpoint at {endpoint_path} that lists its rows. Add tests. Run the tests and commit on a branch.",
+        "kinds": {"table_name": "new", "endpoint_path": "new", "columns": "text"},
+        "redlines": ["migration_present", "migration_applies", "endpoint_present", "endpoint_test_added", *COMMON],
+    },
+    "T4": {
+        "text": "Add a {table_name} table with columns {columns} and its migration, a read endpoint at {endpoint_path}, and a {view_b} view that lists the rows with a filter by {filter_field} and a {button_c} that {button_c_action}. Follow the house style. Add tests. Run the tests and commit on a branch.",
+        "kinds": {"table_name": "new", "endpoint_path": "new", "view_b": "new", "button_c": "new", "columns": "text", "filter_field": "text", "button_c_action": "text"},
+        "redlines": sorted(REDLINES),
+    },
+}
+
+
+class BenchError(RuntimeError):
+    def __init__(self, message, outcome="invalid"):
+        super().__init__(message)
+        self.outcome = outcome
+
+
+class CleanupError(BenchError):
+    """A retained copy blocks the campaign until explicit cleanup succeeds."""
+
+
+def require(condition, message):
+    if not condition:
+        raise BenchError(message)
+
+
+def object_keys(value, allowed, required=()):
+    require(isinstance(value, dict), "expected an object")
+    require(not value.keys() - set(allowed), f"unknown keys: {sorted(value.keys() - set(allowed))}")
+    require(not set(required) - value.keys(), f"missing keys: {sorted(set(required) - value.keys())}")
+    return value
+
+
+def line(value, label, limit=1024):
+    require(isinstance(value, str) and 0 < len(value) <= limit, f"invalid {label}")
+    require(value == value.strip() and not any(ord(c) < 32 or ord(c) == 127 for c in value), f"{label} must be one bounded line")
+    return value
+
+
+def argv(value):
+    require(isinstance(value, list) and value, "argv must be a nonempty array")
+    return [line(arg, "argv item", 8192) for arg in value]
+
+
+def relative(value, label, *, glob=False):
+    value = line(value, label)
+    p = PurePosixPath(value)
+    require(not p.is_absolute() and ".." not in p.parts and "\\" not in value, f"{label} must stay inside the copy")
+    require(not p.parts or p.parts[0] != ".git", f"{label} may not address .git")
+    if not glob:
+        require(not any(c in value for c in "*?[]"), f"invalid {label}")
+    return value
+
+
+def inside(path, root):
+    return path == root or root in path.parents
+
+
+def digest(value):
+    data = value.encode() if isinstance(value, str) else canonical(value).encode()
+    return hashlib.sha256(data).hexdigest()
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, indent=2, ensure_ascii=False) + "\n"
+
+
+def clean_environment(extra=None):
+    result = {k: v for k, v in os.environ.items() if not k.startswith(("SC_", "GIT_"))}
+    result.update(extra or {})
+    require(not any(k.startswith("SC_") for k in result), "SC_* environment contamination")
+    return result
+
+
+class CommandRunner:
+    def run(self, args, *, cwd=None, env=None, check=True, timeout=300, input=None):
+        try:
+            result = subprocess.run(
+                [str(a) for a in args], cwd=cwd, env=clean_environment(env),
+                input=input, stdin=subprocess.DEVNULL if input is None else None,
+                capture_output=True, text=True, timeout=timeout, check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise BenchError(f"command unavailable or timed out: {args[0]}", "infra_failed") from exc
+        if check and result.returncode:
+            # Do not copy arbitrary command output (credentials, source, prompts)
+            # into errors that an operator might paste into a shared surface.
+            raise BenchError(f"command failed ({result.returncode}): {args[0]}", "infra_failed")
+        return result
+
+    def git(self, repo, *args, **kwargs):
+        return self.run(["git", "-C", str(repo), *args], **kwargs)
+
+
+def resolve_sha(runner, repo, ref):
+    result = runner.git(repo, "rev-parse", "--verify", "--end-of-options", f"{ref}^{{commit}}", check=False)
+    require(result.returncode == 0 and SHA.fullmatch(result.stdout.strip()), "unresolvable Git ref")
+    return result.stdout.strip()
+
+
+def private_dir(path):
+    # A preexisting public evidence directory is refused, never silently trusted.
+    if path.exists():
+        require(path.is_dir() and not path.is_symlink(), "private directory is not a real directory")
+        info = path.stat()
+        require(info.st_uid == os.getuid() and not stat.S_IMODE(info.st_mode) & 0o077, "evidence directory must be owner-only")
+        return
+    path.mkdir(parents=True, mode=0o700)
+    path.chmod(0o700)
+
+
+def write_json(path, value):
+    private_dir(path.parent)
+    require(not path.is_symlink(), "refusing symlink output")
+    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=".bench-")
+    try:
+        with os.fdopen(fd, "w") as stream:
+            stream.write(canonical(value))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def validate_route(route):
+    object_keys(route, ("harness", "model", "effort"), ("harness", "model"))
+    for key, value in route.items():
+        line(value, f"route {key}")
+        require(not value.startswith("-"), "route may not contain an option")
+    require(SAFE_ID.fullmatch(route["harness"]), "invalid harness")
+
+
+def prove_route(runner, repo, route, *, env=None):
+    args = [str(repo / "sc"), "models", "resolve", route["harness"], route["model"], "--json"]
+    if route.get("effort"):
+        args.extend(["--effort", route["effort"]])
+    try:
+        proof = json.loads(runner.run(args, cwd=repo, env=env).stdout)
+        binding = proof["binding"]
+        require(proof.get("ok") is True and proof.get("stale") is False, "route is unavailable or stale")
+        require(binding["harness"] == route["harness"] and binding["requested_model"] == route["model"]
+                and binding["provider_model"] == route["model"] and binding["native_variant_id"] is None,
+                "route mismatch or fallback")
+        require(binding["requested_effort"] == route.get("effort")
+                and binding["effective_effort"] == route.get("effort"), "route effort mismatch")
+    except (ValueError, KeyError, TypeError) as exc:
+        raise BenchError("unusable route proof") from exc
+    return {"harness": route["harness"], "requested": route["model"], "observed": binding["provider_model"],
+            "variant": None, "effort": route.get("effort")}
+
+
+class Snapshot:
+    """Read a commit, never the target working tree; remote scratch is temporary."""
+    def __init__(self, runner, repo, ref):
+        self.runner, self.repo, self.ref = runner, Path(repo), ref
+        self.temporary = None
+        self.sha = None
+
+    def __enter__(self):
+        if not self.repo.is_absolute():
+            self.temporary = tempfile.TemporaryDirectory(prefix="subfloor-bench-freeze-")
+            self.repo = Path(self.temporary.name)
+            try:
+                self.runner.run(["git", "init", "--bare", str(self.repo)])
+                self.runner.git(self.repo, "fetch", "--no-tags", "--", self.ref[0], self.ref[1])
+                self.ref = "FETCH_HEAD"
+            except BaseException:
+                self.temporary.cleanup()
+                raise
+        try:
+            self.sha = resolve_sha(self.runner, self.repo, self.ref)
+        except BaseException:
+            if self.temporary:
+                self.temporary.cleanup()
+            raise
+        return self
+
+    def __exit__(self, *args):
+        if self.temporary:
+            self.temporary.cleanup()
+
+    def read(self, path, required=True):
+        result = self.runner.git(self.repo, "show", f"{self.sha}:{path}", check=False)
+        require(not required or result.returncode == 0, f"missing frozen file: {path}")
+        return result.stdout if result.returncode == 0 else None
+
+    def contains(self, value):
+        path = value.lstrip("/")
+        exists = self.runner.git(self.repo, "cat-file", "-e", f"{self.sha}:{path}", check=False)
+        if exists.returncode == 0:
+            return True
+        found = self.runner.git(self.repo, "grep", "-F", "-q", "-e", value, self.sha, "--", check=False)
+        require(found.returncode in (0, 1), "cannot verify slot against frozen source")
+        return found.returncode == 0
+
+
+def roots(config, base, runner):
+    target = config["target"]["repo"]
+    local = Path(target).is_absolute()
+    target_path = Path(target).resolve() if local else None
+    source = Path(config["engine"]["source"])
+    require(source.is_absolute() and source.is_dir(), "engine.source must be an absolute checkout")
+    source = source.resolve()
+    # Resolve roots before any scratch clone; a root cannot contain a protected
+    # checkout either, since cleanup deletes descendants of the root.
+    protected = {source}
+    if target_path:
+        protected.add(target_path)
+    for repo in tuple(protected):
+        out = runner.git(repo, "worktree", "list", "--porcelain").stdout
+        protected.update(Path(x[9:]).resolve() for x in out.splitlines() if x.startswith("worktree "))
+    resolved = []
+    for key, default in (("copy", ".subfloor-bench"), ("evidence", ".subfloor-bench-runs")):
+        entry = config.get(key, {})
+        object_keys(entry, ("root",))
+        require("root" in entry or target_path is not None, f"{key}.root required for clone URL")
+        if "root" in entry:
+            path = Path(entry["root"])
+        elif target_path is not None:
+            path = target_path.parent / default
+        else:
+            raise BenchError(f"{key}.root required for clone URL")
+        if not path.is_absolute():
+            path = base / path
+        path = path.resolve()
+        require(path != Path("/") and ".sc-worktrees" not in path.parts, "unsafe root")
+        require(not any(inside(path, p) or inside(p, path) for p in protected), "root overlaps target, source, or worktree")
+        for parent in (path, *path.parents):
+            require(not (parent / ".git").exists(), "root is inside a Git worktree")
+        config[key] = {"root": str(path)}
+        resolved.append(path)
+    require(not inside(resolved[0], resolved[1]) and not inside(resolved[1], resolved[0]), "copy and evidence roots overlap")
+    config["engine"]["source"] = str(source)
+    if target_path:
+        config["target"]["repo"] = str(target_path)
+    return target_path
+
+
+def validate_recipes(config):
+    if "dev_kit" in config:
+        object_keys(config["dev_kit"], ("deps", "test"), ("deps", "test"))
+        for value in config["dev_kit"].values():
+            argv(value)
+    if "serve" in config:
+        serve = object_keys(config["serve"], ("argv", "cwd", "port_env", "health_path", "ready_timeout_s"),
+                            ("argv", "cwd", "port_env", "health_path", "ready_timeout_s"))
+        argv(serve["argv"])
+        relative(serve["cwd"], "serve.cwd")
+        require(IDENTIFIER.fullmatch(line(serve["port_env"], "port_env"))
+                and not serve["port_env"].startswith("SC_"), "invalid serve port_env")
+        require(line(serve["health_path"], "health_path").startswith("/")
+                and not serve["health_path"].startswith("//"), "health_path must be local")
+        require(type(serve["ready_timeout_s"]) in (int, float) and 0 < serve["ready_timeout_s"] <= 3600, "invalid serve timeout")
+    if "migrations" in config:
+        migrations = object_keys(config["migrations"], ("path", "apply_argv", "table_check_argv"),
+                                 ("path", "apply_argv", "table_check_argv"))
+        relative(migrations["path"], "migrations.path")
+        argv(migrations["apply_argv"])
+        argv(migrations["table_check_argv"])
+
+
+def freeze_style(config, base, runner, target):
+    style = object_keys(config["style"], ("kind", "source", "destination", "trap"), ("kind", "source"))
+    require(style["kind"] in ("skill", "doc", "file"), "unknown style kind")
+    source = style["source"]
+    if type(source) is int:
+        require(style["kind"] in ("doc", "skill") and source > 0, "numeric style source must be a document or skill id")
+        if style["kind"] == "doc":
+            payload = json.loads(runner.run([str(ROOT / "sc"), "mem", "get", "documents", "--doc", str(source), "--json"], cwd=ROOT).stdout)
+            content = payload["document"]["body"]
+        else:
+            # Admin's public read-only surface; never open the host DB here.
+            query = f"SELECT name,description,content FROM skills WHERE skill_id={source} AND is_deleted=0"
+            rows = json.loads(runner.run([str(ROOT / "sc"), "sql", "-json", query], cwd=ROOT).stdout)
+            require(isinstance(rows, list) and len(rows) == 1, "style skill id is unavailable")
+            row = rows[0]
+            content = f"---\nname: {row['name']}\ndescription: {row['description']}\n---\n\n{row['content']}\n"
+    else:
+        path = Path(line(source, "style.source"))
+        if not path.is_absolute():
+            path = (base / path).resolve()
+            require(target is None or not inside(path, target), "relative style source is inside target")
+            require(not inside(path, Path(config["copy"]["root"])), "relative style source is inside copy")
+        content = path.read_text()
+        style["source"] = str(path.resolve())
+    require(isinstance(content, str) and 0 < len(content) <= 200000, "invalid style artifact")
+    if style["kind"] == "file":
+        require("destination" in style, "file style needs a declared destination")
+        relative(style["destination"], "style.destination")
+    else:
+        require("destination" not in style, "destination applies only to file style")
+    if "trap" in style:
+        trap = object_keys(style["trap"], ("forbidden", "required"), ("forbidden", "required"))
+        for patterns in trap.values():
+            require(isinstance(patterns, list) and patterns, "trap patterns must be nonempty arrays")
+            for pattern in patterns:
+                try:
+                    re.compile(line(pattern, "trap regex", 4096))
+                except re.error as exc:
+                    raise BenchError("invalid trap regex") from exc
+    style["content"] = content
+    style["digest"] = digest(content)
+    if style["kind"] == "skill":
+        # Reuse the serving CLI's parser, not a second frontmatter grammar.
+        from skill import parse_local_skill_spec
+        style["name"] = parse_local_skill_spec(content)["name"]
+    else:
+        style["name"] = "bench_house_style"
+
+
+def freeze_cards(config, snapshot):
+    cards = config["cards"]
+    require(isinstance(cards, list) and cards, "cards must be a nonempty array")
+    ids = set()
+    for card in cards:
+        object_keys(card, ("id", "preset", "text", "slots", "redlines", "allowed_paths"), ("id", "slots", "allowed_paths"))
+        require(SAFE_ID.fullmatch(line(card["id"], "card id")), "invalid card id")
+        require(card["id"] not in ids, "duplicate card id")
+        ids.add(card["id"])
+        require(("preset" in card) != ("text" in card), "exactly one of preset or text is required")
+        preset = PRESETS.get(card.get("preset"))
+        require("preset" not in card or preset is not None, "unknown preset")
+        template = preset["text"] if preset else card["text"]
+        line(template, "card text", 16000)
+        require(not RESERVED.search(template), "reserved word in card text")
+        fields = []
+        try:
+            for _, field, spec, conversion in string.Formatter().parse(template):
+                if field is None:
+                    continue
+                require(IDENTIFIER.fullmatch(field) and not spec and not conversion, "invalid slot substitution")
+                fields.append(field)
+        except ValueError as exc:
+            raise BenchError("invalid slot syntax") from exc
+        require(isinstance(card["slots"], dict) and set(card["slots"]) == set(fields), "missing or unused slots")
+        values = {}
+        for name, slot in card["slots"].items():
+            object_keys(slot, ("value", "kind"), ("value", "kind"))
+            kind, value = slot["kind"], line(slot["value"], "slot value")
+            require(kind in ("ref", "new", "text"), "undeclared slot kind")
+            require(not preset or preset["kinds"][name] == kind, "preset slot kind mismatch")
+            require(not RESERVED.search(value), "reserved word in slot")
+            if kind == "ref":
+                require(snapshot.contains(value), "ref slot absent at target.ref")
+            if kind == "new":
+                is_path = bool(re.fullmatch(r"/?[A-Za-z0-9_][A-Za-z0-9_./-]*", value)) and ".." not in PurePosixPath(value).parts
+                require(IDENTIFIER.fullmatch(value) or is_path, "new slot is not an identifier or path")
+                if preset and name in ("table_name", "button_b", "button_c"):
+                    require(IDENTIFIER.fullmatch(value), "new table/button must be an identifier")
+                require(not snapshot.contains(value), "new slot already exists at target.ref")
+            values[name] = value
+        card["text"] = template.format_map(values)
+        require(not RESERVED.search(card["text"]), "reserved word after slot substitution")
+        card["digest"] = digest(card["text"])
+        if "redlines" not in card:
+            if preset is None:
+                raise BenchError("text cards must declare redlines")
+            card["redlines"] = list(preset["redlines"])
+        checks = card["redlines"]
+        require(isinstance(checks, list) and checks and all(isinstance(x, str) and x in REDLINES for x in checks), "unknown or empty redlines")
+        require(len(checks) == len(set(checks)), "duplicate redline")
+        require(isinstance(card["allowed_paths"], list) and card["allowed_paths"], "allowed_paths required")
+        for pattern in card["allowed_paths"]:
+            relative(pattern, "allowed_paths", glob=True)
+        if any(x.startswith("endpoint_") or x == "ui_wired" for x in checks):
+            require("serve" in config, "endpoint redline requires serve")
+        if any(x.startswith("migration_") for x in checks) or card.get("preset") in ("T3", "T4"):
+            require("migrations" in config, "migration redline requires migrations")
+        if "style_trap" in checks:
+            require("trap" in config["style"], "style_trap requires trap")
+
+
+def freeze(config_path, runner=None):
+    runner = runner or CommandRunner()
+    config_path = Path(config_path).resolve()
+    config = json.loads(config_path.read_text())
+    object_keys(config, ("target", "engine", "copy", "evidence", "style", "dev_kit", "serve", "migrations", "routes", "judge", "cards", "wall_cap_minutes", "shell"),
+                ("target", "engine", "style", "routes", "judge", "cards"))
+    object_keys(config["target"], ("repo", "ref"), ("repo", "ref"))
+    object_keys(config["engine"], ("source", "ref"), ("source",))
+    target_repo = line(config["target"]["repo"], "target.repo")
+    target_ref = line(config["target"]["ref"], "target.ref")
+    require(not target_ref.startswith("-"), "invalid target ref")
+    require(Path(target_repo).is_absolute() or re.match(r"(?:https://|ssh://|git://|file://|git@)", target_repo), "target.repo must be absolute or a clone URL")
+    if target_repo.startswith("file://"):
+        locator = urlsplit(target_repo)
+        require(locator.netloc in ("", "localhost") and not locator.query and not locator.fragment, "invalid local clone URL")
+        config["target"]["repo"] = unquote(locator.path)
+        require(Path(config["target"]["repo"]).is_absolute(), "local clone URL needs an absolute path")
+    target = roots(config, config_path.parent, runner)
+    config["shell"] = config.get("shell", "DEV1")
+    require(config["shell"] == "DEV1", "shell is fixed to DEV1")
+    config["wall_cap_minutes"] = config.get("wall_cap_minutes", 60)
+    require(type(config["wall_cap_minutes"]) in (int, float) and 0 < config["wall_cap_minutes"] <= 1440, "invalid wall cap")
+    validate_recipes(config)
+    require(isinstance(config["routes"], list) and config["routes"], "routes must be nonempty")
+    for route in [*config["routes"], config["judge"]]:
+        validate_route(route)
+    route_ids = [(x["harness"], x["model"]) for x in config["routes"]]
+    require(len(set(route_ids)) == len(route_ids), "duplicate model route")
+    require((config["judge"]["harness"], config["judge"]["model"]) not in route_ids, "judge appears in routes")
+    if target:
+        require(not runner.git(target, "status", "--porcelain").stdout.strip(), "target checkout is dirty")
+    engine_source = Path(config["engine"]["source"])
+    engine_ref = config["engine"].get("ref")
+    if engine_ref is None and target and (target / ".sc-state/engine.ref").exists():
+        engine_ref = (target / ".sc-state/engine.ref").read_text().strip()
+    require(engine_ref is None or isinstance(engine_ref, str) and SHA.fullmatch(engine_ref), "engine.ref must be a full SHA")
+    engine_sha = resolve_sha(runner, engine_source, engine_ref or "origin/main")
+    require(runner.git(engine_source, "merge-base", "--is-ancestor", engine_sha, "origin/main", check=False).returncode == 0, "engine.ref is outside engine.source origin/main")
+    config["engine"]["ref"] = engine_sha
+    snapshot_ref = target_ref if target else (target_repo, target_ref)
+    with Snapshot(runner, str(target) if target else "remote", snapshot_ref) as snapshot:
+        config["target"]["ref"] = snapshot.sha
+        declaration = snapshot.read(".subfloor/dev-kit.json", required=False)
+        if declaration is not None:
+            kit = json.loads(declaration)
+            require(isinstance(kit, dict) and kit.get("version") == 1 and isinstance(kit.get("hooks"), dict), "invalid target dev-kit")
+            for name in ("deps", "test"):
+                hook = kit["hooks"].get(name)
+                if hook is None:
+                    require("dev_kit" in config, f"target has no {name} hook or override")
+                    continue
+                object_keys(hook, ("argv", "cwd"), ("argv",))
+                argv(hook["argv"])
+                relative(hook.get("cwd", "."), "hook cwd")
+            config["dev_kit_digest"] = digest(declaration)
+            config["dev_kit_declaration"] = kit
+        else:
+            require("dev_kit" in config, "target has no dev-kit or override")
+            config["dev_kit_digest"] = digest(config["dev_kit"])
+            config["dev_kit_declaration"] = None
+        freeze_style(config, config_path.parent, runner, target)
+        freeze_cards(config, snapshot)
+    for route in [*config["routes"], config["judge"]]:
+        prove_route(runner, ROOT, route)
+    config["runner_version"] = RUNNER_VERSION
+    config["runner_digest"] = digest(Path(__file__).read_text())
+    campaign_id = digest(config)
+    frozen = {"campaign_version": 1, "campaign_id": campaign_id, "config": config}
+    root = Path(config["evidence"]["root"])
+    private_dir(root)
+    path = root / campaign_id / "campaign.json"
+    if path.exists():
+        require(path.read_text() == canonical(frozen), "campaign digest collision or drift")
+    else:
+        write_json(path, frozen)
+    return path
+
+
+def load_campaign(path, *, cleanup=False):
+    path = Path(path).resolve()
+    frozen = json.loads(path.read_text())
+    object_keys(frozen, ("campaign_version", "campaign_id", "config"), ("campaign_version", "campaign_id", "config"))
+    require(frozen["campaign_version"] == 1 and digest(frozen["config"]) == frozen["campaign_id"], "campaign digest mismatch")
+    config = frozen["config"]
+    require(cleanup or config["runner_version"] == RUNNER_VERSION and config["runner_digest"] == digest(Path(__file__).read_text()), "runner changed since freeze")
+    require(path == Path(config["evidence"]["root"]) / frozen["campaign_id"] / "campaign.json", "campaign moved outside frozen evidence root")
+    require(digest(config["style"]["content"]) == config["style"]["digest"], "style digest mismatch")
+    for card in config["cards"]:
+        require(digest(card["text"]) == card["digest"], "card digest mismatch")
+    return frozen
+
+
+def copy_path(config, campaign_id, cell_id):
+    require(SHA.fullmatch(campaign_id[:40]) and re.fullmatch(r"[0-9a-f]{64}", campaign_id), "invalid campaign id")
+    require(isinstance(cell_id, str) and SAFE_ID.fullmatch(cell_id), "invalid cell id")
+    root = Path(config["copy"]["root"])
+    path = root / campaign_id / cell_id
+    require(path.resolve() == path and inside(path, root), "copy path traverses a symlink")
+    return path
+
+
+def validate_cleanup_roots(config):
+    """Cleanup needs path safety, not an available source repo or model route."""
+    copy_root = Path(config["copy"]["root"])
+    evidence = Path(config["evidence"]["root"])
+    protected = [Path(config["engine"]["source"])]
+    target = Path(config["target"]["repo"])
+    if target.is_absolute():
+        protected.append(target)
+    for root in (copy_root, evidence):
+        require(root.is_absolute() and root.resolve() == root and root != Path("/"), "cleanup root changed")
+        require(".sc-worktrees" not in root.parts, "cleanup root is in a Subfloor worktree")
+        require(not any(inside(root, p) or inside(p, root) for p in protected), "cleanup root overlaps a protected checkout")
+        require(not any((p / ".git").exists() for p in (root, *root.parents)), "cleanup root is inside a Git worktree")
+    require(not inside(copy_root, evidence) and not inside(evidence, copy_root), "cleanup roots overlap")
+
+
+def confined(workspace, name):
+    relative(name, "copy artifact")
+    path = workspace / name
+    require(inside(path.resolve(), workspace), "copy artifact escapes through a symlink")
+    return path
+
+
+def engine_paths(runner, source, ref):
+    """Read the pinned engine's manifest as data, without importing its code."""
+    raw = runner.git(source, "show", f"{ref}:.super-coder/scripts/engine_manifest.py").stdout
+    for node in ast.parse(raw).body:
+        if isinstance(node, ast.Assign) and any(isinstance(x, ast.Name) and x.id == "ENGINE_PATHS" for x in node.targets):
+            paths = ast.literal_eval(node.value)
+            require(isinstance(paths, list) and paths, "invalid engine manifest")
+            for path in paths:
+                relative(path, "engine path")
+                require(path == "sc" or path.startswith(".super-coder/"), "unexpected engine manifest path")
+            require("sc" in paths and ".super-coder/scripts" in paths, "engine manifest lacks runner/dispatcher")
+            return paths
+    raise BenchError("pinned engine has no literal ENGINE_PATHS")
+
+
+class HostBackend:
+    """Serving lifecycle implementation, injectable at its command boundary."""
+    def __init__(self, runner=None):
+        self.runner = runner or CommandRunner()
+        self.port_sockets = []
+
+    def environment(self, workspace):
+        # No live engine DB or session state escapes cleanup. Provider auth
+        # remains at the harness's normal credential location (HOME unchanged).
+        return {"XDG_STATE_HOME": str(workspace / ".bench-state")}
+
+    def command(self, workspace, args, **kwargs):
+        return self.runner.run(args, cwd=workspace, env=self.environment(workspace), **kwargs)
+
+    def sc(self, workspace, *args, **kwargs):
+        return self.command(workspace, [str(workspace / "sc"), *args], **kwargs)
+
+    def preflight(self, config):
+        checked = copy.deepcopy(config)
+        roots(checked, Path.cwd(), self.runner)
+        require(checked["copy"] == config["copy"] and checked["evidence"] == config["evidence"], "frozen roots changed")
+        source = Path(config["engine"]["source"])
+        ref = config["engine"]["ref"]
+        require(resolve_sha(self.runner, source, ref) == ref, "engine ref drift")
+        require(self.runner.git(source, "merge-base", "--is-ancestor", ref, "origin/main", check=False).returncode == 0, "engine ref left origin/main")
+        target = Path(config["target"]["repo"])
+        if target.is_absolute():
+            require(resolve_sha(self.runner, target, config["target"]["ref"]) == config["target"]["ref"], "target ref unavailable")
+        clean_environment(self.environment(Path(config["copy"]["root"])))
+
+    def clone(self, config, workspace):
+        self.runner.run(["git", "clone", "--no-local", "--no-checkout", "--", config["target"]["repo"], str(workspace)])
+        self.runner.git(workspace, "remote", "set-url", "--push", "origin", PUSH_DISABLED)
+        require(self.runner.git(workspace, "remote", "get-url", "--push", "--all", "origin").stdout.strip() == PUSH_DISABLED, "push URL remains enabled")
+        self.runner.git(workspace, "-c", "core.hooksPath=/dev/null", "checkout", "--detach", config["target"]["ref"])
+        require(resolve_sha(self.runner, workspace, "HEAD") == config["target"]["ref"], "clone SHA mismatch")
+        # Controller files/state are never offered to the Developer as changes.
+        exclude = workspace / ".git/info/exclude"
+        with exclude.open("a") as stream:
+            stream.write("\n/.bench-state/\n/.bench-style.md\n/.bench-engine.tar\n")
+
+    def materialize(self, config, workspace):
+        source, ref = Path(config["engine"]["source"]), config["engine"]["ref"]
+        paths = engine_paths(self.runner, source, ref)
+        # Never inherit an instance id, DB, or retired engine file from a
+        # tracked target engine. Only the frozen source manifest is executable.
+        for name in (".super-coder", ".sc-state"):
+            path = workspace / name
+            if path.is_symlink() or path.is_file():
+                path.unlink()
+            elif path.exists():
+                shutil.rmtree(path)
+        remotes = self.runner.git(workspace, "remote").stdout.splitlines()
+        if "super-coder" in remotes:
+            self.runner.git(workspace, "remote", "remove", "super-coder")
+        self.runner.git(workspace, "remote", "add", "super-coder", source.as_uri())
+        self.runner.git(workspace, "remote", "set-url", "--push", "super-coder", PUSH_DISABLED)
+        self.runner.git(workspace, "fetch", "--no-tags", "super-coder", f"{ref}:refs/remotes/super-coder/main")
+        archive = workspace / ".bench-engine.tar"
+        self.runner.git(workspace, "archive", "--format=tar", f"--output={archive}", ref, "--", *paths)
+        self.command(workspace, ["tar", "-xf", str(archive), "-C", str(workspace)])
+        archive.unlink()
+        # A source checkout can track its private snapshot; install must still
+        # be a fresh fork. Its own parser and reset path own fresh initialization.
+        self.runner.git(workspace, "-c", "core.hooksPath=/dev/null", "checkout", "-B", "bench-base")
+
+    def install(self, config, workspace):
+        # install.sc_remote() recognizes source-looking URLs before names. Hide
+        # the target URL during bootstrap so a Subfloor target cannot be mistaken
+        # for the explicit engine source; restore it before any model turn.
+        self.runner.git(workspace, "remote", "set-url", "origin", "disabled://bench-target")
+        self.command(workspace, [sys.executable, ".super-coder/scripts/install.py", "--force", "--skip-harness-install",
+                                 "--runtime", "host", "--username", getpass.getuser()], timeout=900)
+        self.runner.git(workspace, "remote", "set-url", "origin", config["target"]["repo"])
+        pin = confined(workspace, ".sc-state/engine.ref").read_text().strip()
+        require(pin == config["engine"]["ref"], "installed engine pin mismatch")
+        require(self.sc(workspace, "engine-ref").stdout.strip() == pin, "callable engine mismatch")
+        instance_path = confined(workspace, ".super-coder/instance.json")
+        instance = json.loads(instance_path.read_text())
+        require(instance.get("runtime") == "host", "installer did not select host runtime")
+        ports = []
+        for _ in range(2):
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.port_sockets.append(sock)
+            sock.bind(("127.0.0.1", 0))
+            ports.append(sock.getsockname()[1])
+        instance.update(port=ports[0], dev_port=ports[1], repo=workspace.name)
+        instance_path.write_text(canonical(instance))
+        return {"api_port": ports[0], "dev_port": ports[1]}
+
+    def release_ports(self):
+        for sock in self.port_sockets:
+            sock.close()
+        self.port_sockets.clear()
+
+    def launch(self, workspace):
+        self.release_ports()
+        self.sc(workspace, "launch", timeout=300)
+
+    def health(self, workspace, ports):
+        # Disable proxies even when the invoking Admin has HTTP_PROXY set.
+        opener = build_opener(ProxyHandler({}))
+        deadline = time.monotonic() + 30
+        url = f"http://127.0.0.1:{ports['api_port']}/api/health"
+        while time.monotonic() < deadline:
+            try:
+                with opener.open(url, timeout=2) as response:
+                    require(response.geturl() == url, "health redirected outside copy")
+                    payload = json.load(response)
+                    if response.status == 200 and payload.get("ok") is True:
+                        require(payload.get("repo_root") == str(workspace) and payload.get("port") == ports["api_port"], "health belongs to another instance")
+                        return
+            except (URLError, TimeoutError, ValueError):
+                pass
+            time.sleep(0.2)
+        raise BenchError("copy health failed", "infra_failed")
+
+    def verify(self, workspace):
+        self.sc(workspace, "render", "all", "DEV1")
+        # sc verify rebuilds the DB; use a read-only integrity proof instead.
+        # This executes only in the disposable copy with its private XDG root.
+        program = """import json, sqlite3, sys
+from pathlib import Path
+sys.path.insert(0, '.super-coder/scripts')
+import instance_state
+path = instance_state.active_database_path(Path('.super-coder').resolve())
+if not Path(path).resolve().is_relative_to(Path('.bench-state').resolve()):
+    raise SystemExit('DB escaped copy state')
+con = sqlite3.connect(Path(path).as_uri() + '?mode=ro', uri=True)
+if con.execute('PRAGMA integrity_check').fetchall() != [('ok',)]:
+    raise SystemExit('DB integrity failed')
+if con.execute('PRAGMA foreign_key_check').fetchall():
+    raise SystemExit('DB foreign keys failed')
+if con.execute(\"SELECT COUNT(*) FROM shells WHERE shortname='DEV1' AND flavor='dev' AND COALESCE(is_deleted,0)=0\").fetchone()[0] != 1:
+    raise SystemExit('DEV1 flavor failed')
+con.close()
+print(json.dumps({'db_verified': True, 'developer_verified': True}))
+"""
+        proof = json.loads(self.command(workspace, [sys.executable, "-c", program]).stdout)
+        require(proof == {"db_verified": True, "developer_verified": True}, "DB verification missing")
+
+    def route(self, workspace, route):
+        return prove_route(self.runner, workspace, route, env=self.environment(workspace))
+
+    def place_style(self, workspace, style):
+        content = style["content"]
+        if style["kind"] == "file":
+            destination = confined(workspace, style["destination"])
+            require(not destination.is_dir(), "style destination is a directory")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(content)
+            content = f"Read and follow the house style in `{style['destination']}` before editing."
+        if style["kind"] != "skill":
+            content = f"---\nname: {style['name']}\ndescription: Project house style to follow when editing this project.\n---\n\n{content}\n"
+        draft = confined(workspace, ".bench-style.md")
+        draft.write_text(content)
+        self.sc(workspace, "skill", "put", "--file", str(draft))
+        self.sc(workspace, "skill", "grant", style["name"], "DEV1")
+        self.sc(workspace, "render", "skills", "DEV1")
+
+    def hook(self, config, workspace, name):
+        declaration = config["dev_kit_declaration"]
+        declared = declaration and declaration["hooks"].get(name)
+        if declared:
+            # The original declaration stays byte-for-byte in the target copy.
+            result = self.sc(workspace, name, check=False, timeout=900)
+        else:
+            result = self.command(workspace, config["dev_kit"][name], check=False, timeout=900)
+        if result.returncode:
+            raise BenchError(f"baseline {name} hook failed", "invalid" if name == "test" else "infra_failed")
+        return {"exit_status": result.returncode, "hook": declared or {"argv": config["dev_kit"][name], "cwd": "."}}
+
+    def preamble(self, config, workspace, route):
+        # Installer/style/deps can legitimately change managed fixture files.
+        # Commit the fixture locally; model diffs start at this clean base and
+        # the original target SHA remains a separate immutable receipt field.
+        self.runner.git(workspace, "add", "-A")
+        self.runner.git(workspace, "-c", "core.hooksPath=/dev/null", "-c", "user.name=Subfloor Bench",
+                        "-c", "user.email=noreply@subfloor.invalid", "-c", "commit.gpgsign=false",
+                        "commit", "--allow-empty", "-m", "chore: prepare frozen project fixture")
+        status = self.runner.git(workspace, "status", "--porcelain").stdout.strip()
+        require(not status, "baseline Git status is not clean")
+        version = self.command(workspace, [route["harness"], "--version"]).stdout.strip()
+        line(version, "harness version", 200)
+        require(self.runner.git(workspace, "remote", "get-url", "--push", "--all", "origin").stdout.strip() == PUSH_DISABLED, "push URL changed during gate")
+        return {"git_status": status, "base_sha": resolve_sha(self.runner, workspace, "HEAD"),
+                "target_base_sha": config["target"]["ref"], "default_branch": "bench-base",
+                "harness_version": version, "style_digest": config["style"]["digest"],
+                "dev_kit_digest": config["dev_kit_digest"], "sc_environment_stripped": True}
+
+    def stop(self, workspace, ledger):
+        self.release_ports()
+        if ledger.get("launch_attempted"):
+            self.sc(workspace, "down", timeout=60)
+            # down may report success after a partial launch. Prove no listener
+            # remains on either assigned port before allowing deletion.
+            for port in ledger["ports"].values():
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                    try:
+                        sock.bind(("127.0.0.1", port))
+                    except OSError as exc:
+                        raise CleanupError("copy service port remains bound") from exc
+
+    def remove(self, workspace):
+        if workspace.exists():
+            require(not workspace.is_symlink(), "refusing symlink copy cleanup")
+            shutil.rmtree(workspace)
+        require(not workspace.exists(), "copy deletion unconfirmed")
+
+
+class Controller:
+    def __init__(self, backend=None):
+        self.backend = backend or HostBackend()
+
+    def _cleanup(self, config, campaign_id, cell_id, ledger_path, ledger):
+        workspace = copy_path(config, campaign_id, cell_id)
+        require(ledger.get("campaign_id") == campaign_id and ledger.get("cell_id") == cell_id
+                and ledger.get("workspace") == str(workspace), "cleanup ledger identity mismatch")
+        try:
+            if not ledger["cleanup"]["services_stopped"]:
+                self.backend.stop(workspace, ledger)
+                ledger["cleanup"]["services_stopped"] = True
+                write_json(ledger_path, ledger)
+            if ledger.get("clone_attempted"):
+                self.backend.remove(workspace)
+            ledger["cleanup"]["copy_deleted"] = not workspace.exists()
+            require(ledger["cleanup"]["copy_deleted"], "copy deletion unconfirmed")
+            write_json(ledger_path, ledger)
+        except (BenchError, OSError) as exc:
+            ledger["cleanup"]["fatal"] = True
+            write_json(ledger_path, ledger)
+            raise CleanupError("fatal teardown failure; run cleanup before another cell") from exc
+        ledger["cleanup"]["fatal"] = False
+        write_json(ledger_path, ledger)
+
+    def _locked(self, frozen):
+        import fcntl
+        from contextlib import contextmanager
+
+        @contextmanager
+        def lock():
+            directory = Path(frozen["config"]["evidence"]["root"])
+            private_dir(directory)
+            path = Path(tempfile.gettempdir()) / f"subfloor-bench-{os.getuid()}.lock"
+            fd = os.open(path, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+            try:
+                info = os.fstat(fd)
+                require(info.st_uid == os.getuid() and stat.S_ISREG(info.st_mode), "unsafe host campaign lock")
+                os.fchmod(fd, 0o600)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError as exc:
+                    raise BenchError("another campaign operation is active") from exc
+                yield
+            finally:
+                os.close(fd)
+        return lock()
+
+    def cleanup(self, campaign_path, cell_id):
+        frozen = load_campaign(campaign_path, cleanup=True)
+        config, campaign_id = frozen["config"], frozen["campaign_id"]
+        with self._locked(frozen):
+            validate_cleanup_roots(config)
+            copy_path(config, campaign_id, cell_id)
+            ledger_path = Path(campaign_path).parent / cell_id / "gate.json"
+            ledger = json.loads(ledger_path.read_text())
+            self._cleanup(config, campaign_id, cell_id, ledger_path, ledger)
+            return ledger
+
+    def run(self, campaign_path, card_id, route_index=0, cell_id=None, operation=None):
+        frozen = load_campaign(campaign_path)
+        config, campaign_id = frozen["config"], frozen["campaign_id"]
+        require(type(route_index) is int and 0 <= route_index < len(config["routes"]), "invalid route index")
+        cards = [card for card in config["cards"] if card["id"] == card_id]
+        require(len(cards) == 1, "unknown card id")
+        route, card = config["routes"][route_index], cards[0]
+        if cell_id is None:
+            cell_id = f"route-{route_index}-{card_id}"
+            if len(cell_id) > 80:
+                cell_id = f"route-{route_index}-{card_id[:48]}-{card['digest'][:8]}"
+        workspace = copy_path(config, campaign_id, cell_id)
+        campaign_dir = Path(campaign_path).resolve().parent
+        ledger_path = campaign_dir / cell_id / "gate.json"
+        with self._locked(frozen):
+            self.backend.preflight(config)
+            # Scan the evidence root, not just this campaign: a prior campaign's
+            # failed teardown also blocks the next cell on the same host seat.
+            for prior_path in Path(config["evidence"]["root"]).glob("*/*/gate.json"):
+                prior = json.loads(prior_path.read_text())
+                require(prior.get("campaign_id") != campaign_id or not prior.get("baseline_invalid"), "campaign baseline is invalid; freeze a new campaign")
+                cleanup = prior.get("cleanup", {})
+                require(cleanup.get("services_stopped") is True and cleanup.get("copy_deleted") is True
+                        and not cleanup.get("fatal"), "prior teardown incomplete; run cleanup")
+            require(not ledger_path.exists(), "cell already recorded; use a new cell id for a repeat")
+            require(not workspace.exists(), "unowned prior copy; refusing deletion")
+            workspace.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            ledger = {"gate_version": 1, "campaign_id": campaign_id, "cell_id": cell_id,
+                      "workspace": str(workspace), "card_id": card_id, "card_digest": card["digest"],
+                      "route": route, "engine_sha": config["engine"]["ref"], "runner_version": RUNNER_VERSION,
+                      "stages": [], "outcome": "invalid", "clone_attempted": False, "launch_attempted": False,
+                      "cleanup": {"services_stopped": False, "copy_deleted": False, "push_url_disabled": False, "fatal": False}}
+            write_json(ledger_path, ledger)
+            try:
+                ledger["clone_attempted"] = True
+                write_json(ledger_path, ledger)
+                self.backend.clone(config, workspace)
+                ledger["cleanup"]["push_url_disabled"] = True
+                self._stage(ledger_path, ledger, "clone")
+                self.backend.materialize(config, workspace)
+                self._stage(ledger_path, ledger, "materialize")
+                ledger["ports"] = self.backend.install(config, workspace)
+                self._stage(ledger_path, ledger, "install")
+                ledger["launch_attempted"] = True
+                write_json(ledger_path, ledger)
+                self.backend.launch(workspace)
+                self._stage(ledger_path, ledger, "launch")
+                self.backend.health(workspace, ledger["ports"])
+                self._stage(ledger_path, ledger, "health")
+                self.backend.verify(workspace)
+                self._stage(ledger_path, ledger, "verify")
+                ledger["route_proof"] = self.backend.route(workspace, route)
+                self._stage(ledger_path, ledger, "route")
+                self.backend.place_style(workspace, config["style"])
+                self._stage(ledger_path, ledger, "style")
+                ledger["deps"] = self.backend.hook(config, workspace, "deps")
+                self._stage(ledger_path, ledger, "deps")
+                ledger["baseline_test"] = self.backend.hook(config, workspace, "test")
+                self._stage(ledger_path, ledger, "test")
+                ledger["preamble"] = self.backend.preamble(config, workspace, route)
+                self._stage(ledger_path, ledger, "preamble")
+                ledger["outcome"] = "gate_passed"
+                write_json(ledger_path, ledger)
+                if operation is not None:
+                    operation(workspace, config, card, route, ledger)
+            except BaseException as exc:
+                ledger["outcome"] = exc.outcome if isinstance(exc, BenchError) else "invalid"
+                if ledger["stages"][-1:] == ["deps"] and ledger["outcome"] == "invalid":
+                    ledger["baseline_invalid"] = True
+                write_json(ledger_path, ledger)
+                raise
+            finally:
+                self._cleanup(config, campaign_id, cell_id, ledger_path, ledger)
+            return ledger
+
+    @staticmethod
+    def _stage(path, ledger, name):
+        ledger["stages"].append(name)
+        write_json(path, ledger)
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    freeze_parser = commands.add_parser("freeze", help="validate and freeze a configuration")
+    freeze_parser.add_argument("--config", required=True, type=Path)
+    run_parser = commands.add_parser("run", help="prove a fresh-copy gate and tear it down")
+    run_parser.add_argument("--campaign", required=True, type=Path)
+    run_parser.add_argument("--card", required=True)
+    run_parser.add_argument("--route-index", type=int, default=0)
+    run_parser.add_argument("--cell", help="unique cell id for an explicit repeat")
+    cleanup_parser = commands.add_parser("cleanup", help="retry a retained teardown")
+    cleanup_parser.add_argument("--campaign", required=True, type=Path)
+    cleanup_parser.add_argument("--cell", required=True)
+    opts = parser.parse_args(args)
+    try:
+        if opts.command == "freeze":
+            print(freeze(opts.config))
+        elif opts.command == "run":
+            result = Controller().run(opts.campaign, opts.card, opts.route_index, opts.cell)
+            print(canonical({"cell_id": result["cell_id"], "outcome": result["outcome"], "cleanup": result["cleanup"]}), end="")
+        else:
+            result = Controller().cleanup(opts.campaign, opts.cell)
+            print(canonical({"cell_id": result["cell_id"], "cleanup": result["cleanup"]}), end="")
+    except (BenchError, OSError, ValueError, TypeError, KeyError) as exc:
+        # Never print arbitrary config content or subprocess stderr.
+        print(f"model_bench: {exc}" if isinstance(exc, BenchError) else f"model_bench: invalid input or unavailable artifact ({type(exc).__name__})", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_model_bench.py
+++ b/tests/test_model_bench.py
@@ -294,7 +294,7 @@ class FreezeTests(BenchFixture):
         self.assertEqual((destination / path).read_bytes(), (ROOT / path).read_bytes())
 
 
-STAGES = ["clone", "materialize", "install", "launch", "health", "verify", "route", "style", "deps", "test", "preamble"]
+STAGES = ["clone", "materialize", "install", "launch", "health", "verify", "refresh_routes", "route", "style", "deps", "test", "preamble"]
 
 
 class FakeBackend:
@@ -331,6 +331,9 @@ class FakeBackend:
 
     def verify(self, workspace):
         self.stage("verify")
+
+    def refresh_routes(self, workspace):
+        self.stage("refresh_routes")
 
     def route(self, workspace, route):
         self.stage("route")
@@ -406,6 +409,7 @@ class GateTests(BenchFixture):
                 result = json.loads((path.parent / failure / "gate.json").read_text())
                 self.assertTrue(result["cleanup"]["copy_deleted"])
                 self.assertEqual(result["outcome"], "invalid" if failure in ("route", "test") else "infra_failed")
+                self.assertEqual(result["error"], "deliberate gate failure")
 
     def test_cleanup_failure_fatal_retains_copy_and_blocks_next_cell_until_retry(self):
         path = self.freeze()
@@ -627,6 +631,7 @@ class HostBoundaryTests(BenchFixture):
         backend = bench.HostBackend()
         with socket.socket() as sock:
             sock.bind(("127.0.0.1", 0))
+            sock.listen()
             ledger = {"launch_attempted": True, "ports": {"api_port": sock.getsockname()[1]}}
             with mock.patch.object(backend, "sc") as sc:
                 with self.assertRaises(bench.CleanupError):
@@ -634,6 +639,74 @@ class HostBoundaryTests(BenchFixture):
                 sc.assert_called_once_with(workspace, "down", timeout=60)
         with mock.patch.object(backend, "sc"):
             backend.stop(workspace, ledger)
+
+    def test_cleanup_allows_http_time_wait_after_server_stops(self):
+        import http.client
+        import socket
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        port = server.server_port
+        worker = threading.Thread(target=server.handle_request, daemon=True)
+        worker.start()
+        connection = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        try:
+            connection.request("GET", "/")
+            response = connection.getresponse()
+            self.assertEqual(response.status, 200)
+            # Wait for the server to close first, leaving its end in TIME_WAIT.
+            worker.join(timeout=5)
+            self.assertFalse(worker.is_alive())
+            response.read()
+        finally:
+            connection.close()
+            server.server_close()
+        with socket.socket() as probe, self.assertRaises(OSError):
+            probe.bind(("127.0.0.1", port))
+        backend = bench.HostBackend()
+        with mock.patch.object(backend, "sc") as sc:
+            backend.stop(self.root / "copy", {"launch_attempted": True, "ports": {"api_port": port}})
+            sc.assert_called_once_with(self.root / "copy", "down", timeout=60)
+
+    def test_host_refresh_precedes_resolve_with_copy_environment(self):
+        path = self.freeze()
+        backend = FakeBackend()
+        host = bench.HostBackend()
+        backend.refresh_routes = host.refresh_routes
+        backend.route = host.route
+        route = self.config["routes"][0]
+        with mock.patch.object(host.runner, "run", side_effect=[
+            subprocess.CompletedProcess([], 0, "refreshed", ""),
+            subprocess.CompletedProcess([], 0, json.dumps(route_proof(route)), ""),
+        ]) as run:
+            result = bench.Controller(backend).run(path, "custom")
+        workspace = Path(result["workspace"])
+        self.assertEqual(result["stages"], STAGES)
+        self.assertEqual(run.call_args_list, [
+            mock.call([str(workspace / "sc"), "models", "refresh"], cwd=workspace,
+                      env=host.environment(workspace), timeout=300),
+            mock.call([str(workspace / "sc"), "models", "resolve", "codex", "test-model", "--json", "--effort", "medium"],
+                      cwd=workspace, env=host.environment(workspace)),
+        ])
+
+    def test_host_route_command_failure_is_invalid_route(self):
+        backend = bench.HostBackend()
+        with (
+            mock.patch.object(backend.runner, "run", side_effect=bench.BenchError("command failed (2): sc", "infra_failed")),
+            self.assertRaisesRegex(bench.BenchError, "copy route proof failed") as failure,
+        ):
+            backend.route(self.root / "copy", self.config["routes"][0])
+        self.assertEqual(failure.exception.outcome, "invalid")
 
     def test_health_requires_own_identity_and_never_uses_host_proxy(self):
         workspace = self.root / "copy"

--- a/tests/test_model_bench.py
+++ b/tests/test_model_bench.py
@@ -77,7 +77,7 @@ class BenchFixture(unittest.TestCase):
         self.config = {
             "target": {"repo": str(self.target), "ref": "main"},
             "engine": {"source": str(self.engine)},
-            "style": {"kind": "file", "source": str(self.style), "destination": ".subfloor/house-style.md",
+            "style": {"kind": "file", "source": str(self.style), "place_at": ".subfloor/house-style.md",
                       "trap": {"forbidden": ["<button"], "required": ["Button"]}},
             "dev_kit": {"deps": ["true"], "test": ["true"]},
             "routes": [{"harness": "codex", "model": "test-model", "effort": "medium"}],
@@ -215,7 +215,7 @@ class FreezeTests(BenchFixture):
             with self.subTest(preset=preset):
                 slots = {name: {"kind": kind, "value": "existing_view" if kind == "ref" else "fresh_name" if kind == "new" else "a description"}
                          for name, kind in data["kinds"].items()}
-                config["cards"] = [{"id": preset, "preset": preset, "slots": slots, "allowed_paths": ["**"]}]
+                config["cards"] = [{"id": preset, "preset": preset, "slots": slots, "allowed_paths": ["src/**", "app.txt"]}]
                 frozen = bench.load_campaign(self.freeze(config))
                 self.assertNotIn("{", frozen["config"]["cards"][0]["text"])
                 first = next(iter(slots))
@@ -312,6 +312,7 @@ class FakeBackend:
         self.stage("preflight")
 
     def clone(self, config, workspace):
+        self.base_sha = config["target"]["ref"]
         workspace.mkdir(parents=True)
         self.stage("clone")
 
@@ -337,6 +338,7 @@ class FakeBackend:
 
     def place_style(self, workspace, style):
         self.stage("style")
+        return {"base_sha": self.base_sha, "style_digest": style["digest"]}
 
     def hook(self, config, workspace, name):
         self.stage(name)
@@ -563,27 +565,36 @@ class HostBoundaryTests(BenchFixture):
         install_kwargs = next(kwargs for args, kwargs in calls if ".super-coder/scripts/install.py" in args)
         self.assertEqual(install_kwargs["env"]["XDG_STATE_HOME"], str(workspace / ".bench-state"))
 
-    def test_style_uses_serving_parser_and_public_grant_for_all_kinds(self):
-        from skill import parse_local_skill_spec
-        frozen = bench.load_campaign(self.freeze())
-        for kind in ("file", "doc", "skill"):
+    def test_style_is_committed_before_turn_without_any_skill_command(self):
+        for kind in ("file", "repo"):
             with self.subTest(kind=kind):
-                workspace = self.root / f"copy-{kind}"
-                workspace.mkdir()
-                style = copy.deepcopy(frozen["config"]["style"])
-                style["kind"] = kind
-                if kind == "skill":
-                    style["content"] = "---\nname: project_style\ndescription: Follow the project house style.\n---\nUse the Button component.\n"
-                    style["name"] = "project_style"
-                backend = bench.HostBackend()
-                with mock.patch.object(backend, "sc") as sc:
-                    backend.place_style(workspace, style)
-                parsed = parse_local_skill_spec((workspace / ".bench-style.md").read_text())
-                self.assertEqual(parsed["name"], style["name"])
-                self.assertIn(mock.call(workspace, "skill", "grant", style["name"], "DEV1"), sc.call_args_list)
-                self.assertIn(mock.call(workspace, "render", "skills", "DEV1"), sc.call_args_list)
+                config = copy.deepcopy(self.config)
                 if kind == "file":
-                    self.assertEqual((workspace / style["destination"]).read_text(), style["content"])
+                    (self.target / ".gitignore").write_text(".subfloor/\n")
+                    git(self.target, "add", ".")
+                    git(self.target, "commit", "-m", "ignored style destination")
+                if kind == "repo":
+                    (self.target / "house-style.md").write_text(self.style.read_text())
+                    git(self.target, "add", ".")
+                    git(self.target, "commit", "-m", "existing style")
+                    config["style"] = {"kind": "repo", "source": "house-style.md"}
+                frozen = bench.load_campaign(self.freeze(config))
+                style = frozen["config"]["style"]
+                workspace = self.root / f"copy-{kind}"
+                backend = bench.HostBackend()
+                backend.clone(frozen["config"], workspace)
+                git(workspace, "checkout", "-B", "bench-base")
+                with mock.patch.object(backend, "sc") as sc:
+                    fixture = backend.place_style(workspace, style)
+                sc.assert_not_called()
+                self.assertEqual(git(workspace, "show", f"HEAD:{style['path']}"), style["content"].strip())
+                self.assertEqual(git(workspace, "rev-parse", "HEAD"), fixture["base_sha"])
+                self.assertNotEqual(fixture["base_sha"], frozen["config"]["target"]["ref"])
+                self.assertEqual(git(workspace, "status", "--porcelain"), "")
+                self.assertEqual(git(workspace, "diff", "--name-only", fixture["base_sha"]), "")
+                (workspace / "app.txt").write_text("model change")
+                self.assertEqual(git(workspace, "diff", "--name-only", fixture["base_sha"]), "app.txt")
+                self.assertEqual(fixture["style_digest"], style["digest"])
 
     def test_style_symlink_escape_is_refused(self):
         config = bench.load_campaign(self.freeze())["config"]
@@ -678,7 +689,7 @@ class RegressionTests(BenchFixture):
             {"serve": {"argv": ["app"], "cwd": "../target", "port_env": "PORT", "health_path": "/health", "ready_timeout_s": 10}},
             {"serve": {"argv": ["app"], "cwd": ".", "port_env": "SC_API_TOKEN", "health_path": "/health", "ready_timeout_s": 10}},
             {"migrations": {"path": "../target", "apply_argv": ["true"], "table_check_argv": ["true"]}},
-            {"style": {**self.config["style"], "destination": "../target/style.md"}},
+            {"style": {**self.config["style"], "place_at": "../target/style.md"}},
             {"style": {**self.config["style"], "trap": {"required": ["["], "forbidden": ["Button"]}}},
         ]
         for overrides in variants:
@@ -731,10 +742,13 @@ class RegressionTests(BenchFixture):
         con.execute("CREATE TABLE shells(shortname TEXT, flavor TEXT, is_deleted INTEGER)")
         con.execute("INSERT INTO shells VALUES ('DEV1', 'dev', 0)")
         con.commit()
+        mirror = workspace / ".sc-state/local/renders/skills_sc/README.md"
+        mirror.parent.mkdir(parents=True)
+        mirror.write_text("installed rendered catalogue")
         backend = bench.HostBackend()
         with mock.patch.object(backend, "sc") as sc, mock.patch.dict(os.environ, {"PYTHONOPTIMIZE": "1"}):
             backend.verify(workspace)
-            sc.assert_called_once_with(workspace, "render", "all", "DEV1")
+            sc.assert_called_once_with(workspace, "render-check")
             con.execute("UPDATE shells SET flavor='reviewer'")
             con.commit()
             with self.assertRaises(bench.BenchError):
@@ -760,23 +774,102 @@ class RegressionTests(BenchFixture):
             result = bench.Controller(FakeBackend()).cleanup(path, "route-0-custom")
             self.assertTrue(result["cleanup"]["copy_deleted"])
 
-    def test_style_document_and_skill_ids_freeze_through_public_read_surfaces(self):
+    def test_db_style_kinds_and_ids_are_out_of_scope(self):
+        for kind, source in (("skill", 42), ("doc", 42), ("file", 42)):
+            with self.subTest(kind=kind), self.assertRaises(bench.BenchError):
+                self.freeze({**self.config, "style": {"kind": kind, "source": source}})
+
+    def test_file_style_is_outside_every_cards_scope(self):
+        for pattern in ("**", ".subfloor/**", "**/*.md", ".subfloor/**/house-style.md", "./.subfloor/house-style.md"):
+            with self.subTest(pattern=pattern):
+                config = copy.deepcopy(self.config)
+                config["cards"].append({**copy.deepcopy(config["cards"][0]), "id": "second", "allowed_paths": [pattern]})
+                with self.assertRaisesRegex(bench.BenchError, "style.place_at overlaps"):
+                    self.freeze(config)
+
+    def test_style_path_is_runner_filled_and_required_for_custom_style_trap(self):
         config = copy.deepcopy(self.config)
-        original_run = self.runner.run
+        card = config["cards"][0]
+        card["redlines"] = ["style_trap"]
+        with self.assertRaisesRegex(bench.BenchError, "must contain"):
+            self.freeze(config)
+        card["text"] += " Follow the house style at {style_path}."
+        frozen = bench.load_campaign(self.freeze(config))
+        self.assertIn(config["style"]["place_at"], frozen["config"]["cards"][0]["text"])
+        card["slots"]["style_path"] = {"kind": "text", "value": "fake-style.md"}
+        with self.assertRaisesRegex(bench.BenchError, "runner-filled"):
+            self.freeze(config)
 
-        def read_artifact(args, **kwargs):
-            if "mem" in args:
-                return subprocess.CompletedProcess(args, 0, json.dumps({"document": {"body": "Use the Button component."}}), "")
-            if "sql" in args:
-                return subprocess.CompletedProcess(args, 0, json.dumps([{"name": "project_style", "description": "Project house style", "content": "Use the Button component."}]), "")
-            return original_run(args, **kwargs)
+    def test_repo_style_reads_the_frozen_file_and_rejects_absence_or_symlink(self):
+        (self.target / "house-style.md").write_text("frozen style")
+        git(self.target, "add", ".")
+        git(self.target, "commit", "-m", "style")
+        ref = git(self.target, "rev-parse", "HEAD")
+        (self.target / "house-style.md").write_text("later style")
+        git(self.target, "add", ".")
+        git(self.target, "commit", "-m", "later")
+        config = copy.deepcopy(self.config)
+        config["target"]["ref"] = ref
+        config["style"] = {"kind": "repo", "source": "house-style.md"}
+        frozen = bench.load_campaign(self.freeze(config))
+        self.assertEqual(frozen["config"]["style"]["content"], "frozen style")
+        self.assertEqual(frozen["config"]["style"]["digest"], bench.digest("frozen style"))
+        for source in ("absent.md", "../house-style.md", str(self.style)):
+            config["style"]["source"] = source
+            with self.assertRaises(bench.BenchError):
+                self.freeze(config)
+        (self.target / "alias.md").symlink_to("house-style.md")
+        git(self.target, "add", ".")
+        git(self.target, "commit", "-m", "alias")
+        config["target"]["ref"] = "main"
+        config["style"]["source"] = "alias.md"
+        with self.assertRaisesRegex(bench.BenchError, "regular file"):
+            self.freeze(config)
 
-        for kind in ("doc", "skill"):
-            with self.subTest(kind=kind), mock.patch.object(self.runner, "run", side_effect=read_artifact):
-                config["style"] = {"kind": kind, "source": 42}
-                frozen = bench.load_campaign(self.freeze(config))
-                self.assertIn("Use the Button component.", frozen["config"]["style"]["content"])
-                self.assertEqual(frozen["config"]["style"]["source"], 42)
+    def test_fixture_preamble_proves_clean_style_and_branch_after_hooks(self):
+        config = bench.load_campaign(self.freeze())["config"]
+        workspace = self.root / "copy"
+
+        class VersionRunner(bench.CommandRunner):
+            def run(self, args, **kwargs):
+                if args == ["codex", "--version"]:
+                    return subprocess.CompletedProcess(args, 0, "codex-cli fixture-version", "")
+                return super().run(args, **kwargs)
+
+        backend = bench.HostBackend(VersionRunner())
+        backend.clone(config, workspace)
+        git(workspace, "checkout", "-B", "bench-base")
+        fixture = backend.place_style(workspace, config["style"])
+        preamble = backend.preamble(config, workspace, config["routes"][0])
+        self.assertEqual(preamble["base_sha"], fixture["base_sha"])
+        self.assertEqual(preamble["target_base_sha"], config["target"]["ref"])
+        (workspace / "app.txt").write_text("hook mutation")
+        with self.assertRaisesRegex(bench.BenchError, "not clean"):
+            backend.preamble(config, workspace, config["routes"][0])
+        git(workspace, "checkout", "--", "app.txt")
+        (workspace / config["style"]["path"]).write_text("hook changed style")
+        with self.assertRaisesRegex(bench.BenchError, "changed style"):
+            backend.preamble(config, workspace, config["routes"][0])
+
+    def test_missing_installer_render_cannot_pass_render_check_skip(self):
+        workspace = self.root / "copy"
+        workspace.mkdir()
+        backend = bench.HostBackend()
+        with mock.patch.object(backend, "sc") as sc, self.assertRaisesRegex(bench.BenchError, "render is missing"):
+            backend.verify(workspace)
+        sc.assert_not_called()
+
+    def test_hook_commit_cannot_advance_the_receipt_base(self):
+        path = self.freeze()
+        backend = FakeBackend()
+        original = backend.preamble
+
+        def changed_base(config, workspace, route):
+            return {**original(config, workspace, route), "base_sha": "f" * 40}
+
+        with mock.patch.object(backend, "preamble", side_effect=changed_base), self.assertRaisesRegex(bench.BenchError, "advanced fixture SHA"):
+            bench.Controller(backend).run(path, "custom")
+        self.assertEqual(backend.calls[-2:], ["stop", "remove"])
 
 
 if __name__ == "__main__":

--- a/tests/test_model_bench.py
+++ b/tests/test_model_bench.py
@@ -1,0 +1,783 @@
+"""Hermetic benchmark controller tests: temporary Git repos, no provider calls."""
+import copy
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / ".super-coder/scripts"
+sys.path.insert(0, str(SCRIPTS))
+spec = importlib.util.spec_from_file_location("model_bench", SCRIPTS / "model_bench.py")
+bench = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bench)
+
+
+def git(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args], env=bench.clean_environment(),
+                          capture_output=True, text=True, check=True).stdout.strip()
+
+
+def repository(path):
+    path.mkdir()
+    git(path, "init", "-b", "main")
+    git(path, "config", "user.name", "Bench Test")
+    git(path, "config", "user.email", "bench@example.invalid")
+    git(path, "config", "commit.gpgsign", "false")
+    (path / "app.txt").write_text("existing_button existing_view filter_field\n")
+    git(path, "add", ".")
+    git(path, "commit", "-m", "fixture")
+    git(path, "update-ref", "refs/remotes/origin/main", "HEAD")
+    return git(path, "rev-parse", "HEAD")
+
+
+def route_proof(route):
+    return {"ok": True, "stale": False, "binding": {
+        "harness": route["harness"], "requested_model": route["model"],
+        "provider_model": route["model"], "native_variant_id": None,
+        "requested_effort": route.get("effort"), "effective_effort": route.get("effort"),
+    }}
+
+
+class FreezeRunner(bench.CommandRunner):
+    def __init__(self):
+        self.calls = []
+        self.bad_route = None
+
+    def run(self, args, **kwargs):
+        self.calls.append([str(x) for x in args])
+        if "models" in args:
+            route = {"harness": args[3], "model": args[4]}
+            if "--effort" in args:
+                route["effort"] = args[args.index("--effort") + 1]
+            result = route_proof(route)
+            if self.bad_route:
+                result["binding"].update(self.bad_route)
+            return subprocess.CompletedProcess(args, 0, json.dumps(result), "")
+        return super().run(args, **kwargs)
+
+
+class BenchFixture(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.target = self.root / "target"
+        self.engine = self.root / "engine"
+        self.target_sha = repository(self.target)
+        self.engine_sha = repository(self.engine)
+        self.style = self.root / "style.md"
+        self.style.write_text("Every button uses the shared Button component.\n")
+        self.config_path = self.root / "config.json"
+        self.config = {
+            "target": {"repo": str(self.target), "ref": "main"},
+            "engine": {"source": str(self.engine)},
+            "style": {"kind": "file", "source": str(self.style), "destination": ".subfloor/house-style.md",
+                      "trap": {"forbidden": ["<button"], "required": ["Button"]}},
+            "dev_kit": {"deps": ["true"], "test": ["true"]},
+            "routes": [{"harness": "codex", "model": "test-model", "effort": "medium"}],
+            "judge": {"harness": "claude", "model": "test-judge"},
+            "cards": [{"id": "custom", "text": "Change {view}. Run the tests and commit on a branch.",
+                       "slots": {"view": {"value": "existing_view", "kind": "ref"}},
+                       "redlines": ["tests_green", "scope_bounded"], "allowed_paths": ["app.txt"]}],
+        }
+        self.runner = FreezeRunner()
+
+    def freeze(self, config=None):
+        self.config_path.write_text(json.dumps(config or self.config))
+        return bench.freeze(self.config_path, self.runner)
+
+
+
+class FreezeTests(BenchFixture):
+    def test_deterministic_complete_freeze_and_no_target_mutation(self):
+        before = git(self.target, "rev-parse", "HEAD")
+        path = self.freeze()
+        raw = path.read_bytes()
+        self.assertEqual(self.freeze(), path)
+        self.assertEqual(path.read_bytes(), raw)
+        frozen = bench.load_campaign(path)
+        config = frozen["config"]
+        self.assertEqual(config["target"]["ref"], self.target_sha)
+        self.assertEqual(config["engine"]["ref"], self.engine_sha)
+        self.assertEqual(config["cards"][0]["digest"], bench.digest(config["cards"][0]["text"]))
+        self.assertEqual(config["style"]["digest"], bench.digest(self.style.read_text()))
+        self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+        self.assertEqual(path.parent.stat().st_mode & 0o777, 0o700)
+        self.assertEqual(git(self.target, "rev-parse", "HEAD"), before)
+        self.assertEqual(git(self.target, "status", "--porcelain"), "")
+        self.assertFalse(any("clone" in x for x in self.runner.calls))
+
+    def test_unknown_keys_at_every_config_object(self):
+        paths = [(), ("target",), ("engine",), ("style",), ("style", "trap"),
+                 ("dev_kit",), ("routes", 0), ("judge",), ("cards", 0), ("cards", 0, "slots", "view")]
+        for path in paths:
+            with self.subTest(path=path):
+                config = copy.deepcopy(self.config)
+                item = config
+                for name in path:
+                    item = item[name]
+                item["unexpected"] = True
+                with self.assertRaisesRegex(bench.BenchError, "unknown keys"):
+                    self.freeze(config)
+
+    def test_root_overlap_symlinks_and_worktrees_fail_before_clone(self):
+        linked = self.root / "linked"
+        git(self.target, "worktree", "add", "--detach", str(linked))
+        alias = self.root / "alias"
+        alias.symlink_to(self.target, target_is_directory=True)
+        for key, path in [("copy", self.target / "copies"), ("evidence", self.target / "runs"),
+                          ("copy", self.root), ("copy", alias / "copies"),
+                          ("copy", linked / "copies"), ("evidence", self.engine / "runs"),
+                          ("copy", self.root / ".sc-worktrees" / "outside")]:
+            with self.subTest(key=key, path=path):
+                config = copy.deepcopy(self.config)
+                config[key] = {"root": str(path)}
+                with self.assertRaises(bench.BenchError):
+                    self.freeze(config)
+        config = copy.deepcopy(self.config)
+        config["copy"] = {"root": str(self.root / "copies")}
+        config["evidence"] = {"root": str(self.root / "copies" / "evidence")}
+        with self.assertRaisesRegex(bench.BenchError, "overlap"):
+            self.freeze(config)
+        self.assertFalse(any("clone" in x for x in self.runner.calls))
+
+    def test_unresolvable_refs_dirty_target_and_uncontained_engine(self):
+        for section, ref in [("target", "absent"), ("engine", "f" * 40), ("engine", "main")]:
+            with self.subTest(section=section):
+                config = copy.deepcopy(self.config)
+                config[section]["ref"] = ref
+                with self.assertRaises(bench.BenchError):
+                    self.freeze(config)
+        (self.engine / "second").write_text("new")
+        git(self.engine, "add", ".")
+        git(self.engine, "commit", "-m", "not upstream")
+        config = copy.deepcopy(self.config)
+        config["engine"]["ref"] = git(self.engine, "rev-parse", "HEAD")
+        with self.assertRaisesRegex(bench.BenchError, "outside"):
+            self.freeze(config)
+        (self.target / "dirty").write_text("dirty")
+        with self.assertRaisesRegex(bench.BenchError, "dirty"):
+            self.freeze()
+
+    def test_route_judge_variant_fallback_and_effort_rejected(self):
+        config = copy.deepcopy(self.config)
+        config["judge"] = {**config["routes"][0], "effort": "high"}
+        with self.assertRaisesRegex(bench.BenchError, "judge appears"):
+            self.freeze(config)
+        for mismatch in ({"provider_model": "fallback"}, {"native_variant_id": "medium"},
+                         {"harness": "other"}, {"requested_model": "alias"}, {"effective_effort": "high"}):
+            with self.subTest(mismatch=mismatch):
+                self.runner.bad_route = mismatch
+                with self.assertRaises(bench.BenchError):
+                    self.freeze()
+
+    def test_redline_prerequisites_and_menu(self):
+        for redline, missing in [("style_trap", "trap"), ("endpoint_present", "serve"),
+                                 ("endpoint_param", "serve"), ("endpoint_test_added", "serve"),
+                                 ("ui_wired", "serve"), ("migration_present", "migrations"),
+                                 ("migration_applies", "migrations"), ("other", "other")]:
+            with self.subTest(redline=redline):
+                config = copy.deepcopy(self.config)
+                config["cards"][0]["redlines"] = [redline]
+                if missing == "trap":
+                    del config["style"]["trap"]
+                with self.assertRaises(bench.BenchError):
+                    self.freeze(config)
+
+    def test_reserved_words_and_slot_validation(self):
+        for value in ("benchmark", "EVALUATE", "rubric", "judge", "score"):
+            with self.subTest(value=value):
+                config = copy.deepcopy(self.config)
+                config["cards"][0]["text"] = value
+                config["cards"][0]["slots"] = {}
+                with self.assertRaisesRegex(bench.BenchError, "reserved"):
+                    self.freeze(config)
+        for slot in ({"value": "missing", "kind": "ref"}, {"value": "existing_button", "kind": "new"},
+                     {"value": "../escape", "kind": "new"}, {"value": "two\nlines", "kind": "text"},
+                     {"value": "judge", "kind": "text"}, {"value": "existing_view"}):
+            with self.subTest(slot=slot):
+                config = copy.deepcopy(self.config)
+                config["cards"][0]["slots"]["view"] = slot
+                with self.assertRaises(bench.BenchError):
+                    self.freeze(config)
+
+    def test_presets_fix_kinds_and_new_slots_are_absent(self):
+        config = copy.deepcopy(self.config)
+        config["serve"] = {"argv": ["app"], "cwd": ".", "port_env": "PORT", "health_path": "/health", "ready_timeout_s": 10}
+        config["migrations"] = {"path": "migrations", "apply_argv": ["apply"], "table_check_argv": ["table"]}
+        for preset, data in bench.PRESETS.items():
+            with self.subTest(preset=preset):
+                slots = {name: {"kind": kind, "value": "existing_view" if kind == "ref" else "fresh_name" if kind == "new" else "a description"}
+                         for name, kind in data["kinds"].items()}
+                config["cards"] = [{"id": preset, "preset": preset, "slots": slots, "allowed_paths": ["**"]}]
+                frozen = bench.load_campaign(self.freeze(config))
+                self.assertNotIn("{", frozen["config"]["cards"][0]["text"])
+                first = next(iter(slots))
+                slots[first]["kind"] = "text" if slots[first]["kind"] != "text" else "ref"
+                with self.assertRaisesRegex(bench.BenchError, "preset slot kind"):
+                    self.freeze(config)
+
+    def test_declaration_is_frozen_and_override_only_fills_missing_hooks(self):
+        (self.target / ".subfloor").mkdir()
+        kit = {"version": 1, "hooks": {"deps": {"argv": ["echo", "declared"], "cwd": "."}, "test": {"argv": ["true"]}}}
+        (self.target / ".subfloor/dev-kit.json").write_text(json.dumps(kit))
+        git(self.target, "add", ".")
+        git(self.target, "commit", "-m", "dev kit")
+        frozen = bench.load_campaign(self.freeze())
+        self.assertEqual(frozen["config"]["dev_kit_declaration"], kit)
+        config = copy.deepcopy(self.config)
+        del config["dev_kit"]
+        self.freeze(config)
+
+    def test_file_url_target_has_the_same_local_containment_checks(self):
+        config = copy.deepcopy(self.config)
+        config["target"]["repo"] = self.target.as_uri()
+        config["copy"] = {"root": str(self.target / "copies")}
+        with self.assertRaisesRegex(bench.BenchError, "overlap"):
+            self.freeze(config)
+        config["copy"] = {"root": str(self.root / "copies")}
+        config["evidence"] = {"root": str(self.root / "runs")}
+        frozen = bench.load_campaign(self.freeze(config))
+        self.assertEqual(frozen["config"]["target"]["ref"], self.target_sha)
+
+    def test_frozen_inputs_do_not_advance_and_tampering_fails(self):
+        path = self.freeze()
+        frozen = bench.load_campaign(path)
+        self.style.write_text("changed style")
+        (self.target / "new").write_text("new target")
+        git(self.target, "add", ".")
+        git(self.target, "commit", "-m", "advance")
+        self.assertEqual(bench.load_campaign(path), frozen)
+        frozen["config"]["cards"][0]["text"] = "changed card"
+        path.write_text(json.dumps(frozen))
+        with self.assertRaisesRegex(bench.BenchError, "digest mismatch"):
+            bench.load_campaign(path)
+
+    def test_public_evidence_root_is_refused(self):
+        evidence = self.root / "public"
+        evidence.mkdir(mode=0o755)
+        config = copy.deepcopy(self.config)
+        config["evidence"] = {"root": str(evidence)}
+        with self.assertRaisesRegex(bench.BenchError, "owner-only"):
+            self.freeze(config)
+
+    def test_all_subprocesses_strip_host_sc_and_git_context(self):
+        with mock.patch.dict(os.environ, {"SC_API_TOKEN": "secret", "SC_API_URL": "http://host", "SC_EXTRA": "x", "GIT_DIR": "/wrong"}):
+            out = bench.CommandRunner().run([sys.executable, "-c", "import os,json; print(json.dumps(dict(os.environ)))"])
+            env = json.loads(out.stdout)
+            self.assertFalse(any(k.startswith(("SC_", "GIT_")) for k in env))
+            with self.assertRaisesRegex(bench.BenchError, "contamination"):
+                bench.CommandRunner().run(["true"], env={"SC_INJECTED": "bad"})
+
+    def test_engine_manifest_materializes_runner_for_forks(self):
+        import engine_manifest
+        import update
+        path = ".super-coder/scripts/model_bench.py"
+        self.assertTrue(any(path == p or path.startswith(p + "/") for p in engine_manifest.ENGINE_PATHS))
+        # Exercise the serving update materializer without installing a runtime.
+        (self.engine / ".super-coder/scripts").mkdir(parents=True)
+        (self.engine / path).write_bytes((ROOT / path).read_bytes())
+        git(self.engine, "add", ".")
+        git(self.engine, "commit", "-m", "runner")
+        destination = self.root / "fork"
+        destination.mkdir()
+        git(destination, "init", "-b", "main")
+        git(destination, "fetch", str(self.engine), "main")
+        with mock.patch.object(update, "REPO_ROOT", destination):
+            update.materialize_engine("FETCH_HEAD", engine_paths=[".super-coder/scripts"])
+        self.assertEqual((destination / path).read_bytes(), (ROOT / path).read_bytes())
+
+
+STAGES = ["clone", "materialize", "install", "launch", "health", "verify", "route", "style", "deps", "test", "preamble"]
+
+
+class FakeBackend:
+    def __init__(self, fail_at=None, cleanup_failure=None):
+        self.calls = []
+        self.fail_at = fail_at
+        self.cleanup_failure = cleanup_failure
+
+    def stage(self, stage):
+        self.calls.append(stage)
+        if self.fail_at == stage:
+            raise bench.BenchError("deliberate gate failure", "invalid" if stage in ("route", "test") else "infra_failed")
+
+    def preflight(self, config):
+        self.stage("preflight")
+
+    def clone(self, config, workspace):
+        workspace.mkdir(parents=True)
+        self.stage("clone")
+
+    def materialize(self, config, workspace):
+        self.stage("materialize")
+
+    def install(self, config, workspace):
+        self.stage("install")
+        return {"api_port": 11111, "dev_port": 11112}
+
+    def launch(self, workspace):
+        self.stage("launch")
+
+    def health(self, workspace, ports):
+        self.stage("health")
+
+    def verify(self, workspace):
+        self.stage("verify")
+
+    def route(self, workspace, route):
+        self.stage("route")
+        return {"requested": route["model"], "observed": route["model"], "variant": None}
+
+    def place_style(self, workspace, style):
+        self.stage("style")
+
+    def hook(self, config, workspace, name):
+        self.stage(name)
+        return {"exit_status": 0}
+
+    def preamble(self, config, workspace, route):
+        self.stage("preamble")
+        return {"base_sha": config["target"]["ref"], "sc_environment_stripped": True, "git_status": ""}
+
+    def stop(self, workspace, ledger):
+        self.calls.append("stop")
+        if self.cleanup_failure == "stop":
+            raise bench.BenchError("deliberate stop failure")
+
+    def remove(self, workspace):
+        self.calls.append("remove")
+        if self.cleanup_failure == "remove":
+            raise OSError("deliberate delete failure")
+        bench.HostBackend().remove(workspace)
+
+
+class GateTests(BenchFixture):
+
+    def test_success_gate_order_callback_preamble_and_teardown(self):
+        path = self.freeze()
+        backend = FakeBackend()
+        observed = []
+
+        def operation(workspace, config, card, route, ledger):
+            backend.calls.append("operation")
+            self.assertTrue(workspace.is_dir())
+            self.assertEqual(ledger["outcome"], "gate_passed")
+            observed.append(card["text"])
+
+        result = bench.Controller(backend).run(path, "custom", operation=operation)
+        self.assertEqual(backend.calls, ["preflight", *STAGES, "operation", "stop", "remove"])
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(result["stages"], STAGES)
+        self.assertEqual(result["route_proof"], {"requested": "test-model", "observed": "test-model", "variant": None})
+        self.assertTrue(result["cleanup"]["services_stopped"])
+        self.assertTrue(result["cleanup"]["copy_deleted"])
+        self.assertTrue(result["cleanup"]["push_url_disabled"])
+        self.assertFalse(Path(result["workspace"]).exists())
+        self.assertEqual(git(self.target, "status", "--porcelain"), "")
+        ledger = path.parent / "route-0-custom/gate.json"
+        self.assertEqual(json.loads(ledger.read_text()), result)
+        self.assertEqual(ledger.stat().st_mode & 0o777, 0o600)
+
+    def test_every_gate_stop_condition_prevents_operation_and_cleans_partial_copy(self):
+        path = self.freeze()
+        for failure in ["preflight", *STAGES]:
+            with self.subTest(failure=failure):
+                self.config["wall_cap_minutes"] = 60 + ["preflight", *STAGES].index(failure)
+                path = self.freeze()
+                backend = FakeBackend(fail_at=failure)
+                callback = mock.Mock()
+                with self.assertRaises(bench.BenchError):
+                    bench.Controller(backend).run(path, "custom", cell_id=failure, operation=callback)
+                callback.assert_not_called()
+                if failure == "preflight":
+                    self.assertEqual(backend.calls, ["preflight"])
+                    self.assertFalse((path.parent / failure / "gate.json").exists())
+                    continue
+                self.assertEqual(backend.calls, ["preflight", *STAGES[:STAGES.index(failure) + 1], "stop", "remove"])
+                result = json.loads((path.parent / failure / "gate.json").read_text())
+                self.assertTrue(result["cleanup"]["copy_deleted"])
+                self.assertEqual(result["outcome"], "invalid" if failure in ("route", "test") else "infra_failed")
+
+    def test_cleanup_failure_fatal_retains_copy_and_blocks_next_cell_until_retry(self):
+        path = self.freeze()
+        for failure in ("stop", "remove"):
+            with self.subTest(failure=failure):
+                backend = FakeBackend(fail_at="health", cleanup_failure=failure)
+                with self.assertRaises(bench.CleanupError):
+                    bench.Controller(backend).run(path, "custom", cell_id=failure)
+                ledger = json.loads((path.parent / failure / "gate.json").read_text())
+                self.assertTrue(ledger["cleanup"]["fatal"])
+                self.assertTrue(Path(ledger["workspace"]).exists())
+                self.assertEqual(ledger["outcome"], "infra_failed")
+                if failure == "stop":
+                    self.assertNotIn("remove", backend.calls)
+                next_backend = FakeBackend()
+                with self.assertRaisesRegex(bench.BenchError, "prior teardown"):
+                    bench.Controller(next_backend).run(path, "custom", cell_id="next")
+                self.assertEqual(next_backend.calls, ["preflight"])
+                repaired = bench.Controller(next_backend).cleanup(path, failure)
+                self.assertTrue(repaired["cleanup"]["copy_deleted"])
+                self.assertFalse(repaired["cleanup"]["fatal"])
+                # Cleanup is idempotent and no longer needs model/source access.
+                bench.Controller(next_backend).cleanup(path, failure)
+                bench.Controller(next_backend).run(path, "custom", cell_id=f"after-{failure}")
+
+    def test_operation_failure_also_cleans_without_losing_primary_failure(self):
+        path = self.freeze()
+        backend = FakeBackend()
+        with self.assertRaisesRegex(RuntimeError, "operation broke"):
+            bench.Controller(backend).run(path, "custom", operation=mock.Mock(side_effect=RuntimeError("operation broke")))
+        self.assertEqual(backend.calls[-2:], ["stop", "remove"])
+        ledger = json.loads((path.parent / "route-0-custom/gate.json").read_text())
+        self.assertTrue(ledger["cleanup"]["copy_deleted"])
+
+    def test_unowned_prior_copy_and_path_traversal_are_not_deleted(self):
+        path = self.freeze()
+        frozen = bench.load_campaign(path)
+        workspace = bench.copy_path(frozen["config"], frozen["campaign_id"], "prior")
+        workspace.mkdir(parents=True)
+        valuable = workspace / "keep"
+        valuable.write_text("unowned")
+        backend = FakeBackend()
+        with self.assertRaisesRegex(bench.BenchError, "unowned"):
+            bench.Controller(backend).run(path, "custom", cell_id="prior")
+        self.assertEqual(valuable.read_text(), "unowned")
+        for cell in ("../target", "/target", "a/b"):
+            with self.assertRaisesRegex(bench.BenchError, "cell id"):
+                bench.Controller(backend).run(path, "custom", cell_id=cell)
+
+    def test_recorded_cell_is_not_overwritten_and_repeats_use_new_id(self):
+        path = self.freeze()
+        controller = bench.Controller(FakeBackend())
+        controller.run(path, "custom")
+        ledger = path.parent / "route-0-custom/gate.json"
+        before = ledger.read_bytes()
+        with self.assertRaisesRegex(bench.BenchError, "already recorded"):
+            controller.run(path, "custom")
+        self.assertEqual(ledger.read_bytes(), before)
+        controller.run(path, "custom", cell_id="repeat-2")
+
+    def test_cleanup_works_after_source_removed_but_refuses_ledger_escape(self):
+        path = self.freeze()
+        controller = bench.Controller(FakeBackend(cleanup_failure="remove"))
+        with self.assertRaises(bench.CleanupError):
+            controller.run(path, "custom")
+        self.engine.rename(self.root / "engine-unavailable")
+        ledger_path = path.parent / "route-0-custom/gate.json"
+        original = json.loads(ledger_path.read_text())
+        poisoned = copy.deepcopy(original)
+        poisoned["workspace"] = str(self.target)
+        ledger_path.write_text(json.dumps(poisoned))
+        with self.assertRaisesRegex(bench.BenchError, "identity mismatch"):
+            bench.Controller(FakeBackend()).cleanup(path, "route-0-custom")
+        ledger_path.write_text(json.dumps(original))
+        bench.Controller(FakeBackend()).cleanup(path, "route-0-custom")
+        self.assertTrue(self.target.exists())
+
+    def test_campaign_lock_refuses_parallel_cells(self):
+        path = self.freeze()
+        controller = bench.Controller(FakeBackend())
+        with controller._locked(bench.load_campaign(path)), self.assertRaisesRegex(bench.BenchError, "another campaign"):
+            controller.run(path, "custom")
+
+
+class HostBoundaryTests(BenchFixture):
+    def test_real_clone_disables_push_and_pins_sha_even_after_target_advances(self):
+        frozen = bench.load_campaign(self.freeze())
+        (self.target / "advance").write_text("later")
+        git(self.target, "add", ".")
+        git(self.target, "commit", "-m", "later")
+        workspace = self.root / "copy"
+        backend = bench.HostBackend()
+        backend.clone(frozen["config"], workspace)
+        self.assertEqual(git(workspace, "rev-parse", "HEAD"), self.target_sha)
+        self.assertEqual(git(workspace, "remote", "get-url", "--push", "origin"), bench.PUSH_DISABLED)
+        pushed = subprocess.run(["git", "-C", str(workspace), "push", "origin", "HEAD:main"], capture_output=True, check=False)
+        self.assertNotEqual(pushed.returncode, 0)
+        self.assertEqual(git(self.target, "rev-parse", "HEAD"), git(self.target, "rev-parse", "main"))
+
+    def test_real_engine_materialization_uses_its_manifest_and_removes_stale_state(self):
+        scripts = self.engine / ".super-coder/scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "engine_manifest.py").write_text("ENGINE_PATHS = ['sc', '.super-coder/scripts']\n")
+        (scripts / "model_bench.py").write_text("pinned runner")
+        (self.engine / "sc").write_text("#!/bin/sh\n")
+        git(self.engine, "add", ".")
+        git(self.engine, "commit", "-m", "engine")
+        git(self.engine, "update-ref", "refs/remotes/origin/main", "HEAD")
+        config = bench.load_campaign(self.freeze())["config"]
+        workspace = self.root / "copy"
+        backend = bench.HostBackend()
+        backend.clone(config, workspace)
+        (workspace / ".super-coder").mkdir()
+        (workspace / ".super-coder/retired").write_text("retired")
+        (workspace / ".sc-state").mkdir()
+        (workspace / ".sc-state/engine.ref").write_text("stale")
+        backend.materialize(config, workspace)
+        self.assertEqual((workspace / ".super-coder/scripts/model_bench.py").read_text(), "pinned runner")
+        self.assertFalse((workspace / ".super-coder/retired").exists())
+        self.assertFalse((workspace / ".sc-state").exists())
+        self.assertEqual(git(workspace, "rev-parse", "super-coder/main"), config["engine"]["ref"])
+        self.assertEqual(git(workspace, "remote", "get-url", "--push", "super-coder"), bench.PUSH_DISABLED)
+
+    def test_install_uses_host_detect_only_operator_and_exact_callable_pin(self):
+        config = bench.load_campaign(self.freeze())["config"]
+        workspace = self.root / "copy"
+        workspace.mkdir()
+        (workspace / ".super-coder").mkdir()
+        (workspace / ".sc-state").mkdir()
+        calls = []
+
+        class InstallRunner(bench.CommandRunner):
+            def run(self, args, **kwargs):
+                calls.append((args, kwargs))
+                self_env = bench.clean_environment(kwargs.get("env"))
+                assert not any(k.startswith("SC_") for k in self_env)
+                if ".super-coder/scripts/install.py" in args:
+                    (workspace / ".super-coder/instance.json").write_text('{"runtime":"host"}')
+                    (workspace / ".sc-state/engine.ref").write_text(config["engine"]["ref"])
+                out = config["engine"]["ref"] if "engine-ref" in args else ""
+                return subprocess.CompletedProcess(args, 0, out, "")
+
+        backend = bench.HostBackend(InstallRunner())
+        self.addCleanup(backend.release_ports)
+        with mock.patch.dict(os.environ, {"SC_API_TOKEN": "secret", "SC_ADMIN": "1"}):
+            ports = backend.install(config, workspace)
+        install = next(args for args, _ in calls if ".super-coder/scripts/install.py" in args)
+        self.assertIn("--skip-harness-install", install)
+        self.assertEqual(install[install.index("--runtime") + 1], "host")
+        self.assertIn("--username", install)
+        self.assertNotIn("docker", " ".join(str(x) for args, _ in calls for x in args).lower())
+        self.assertNotEqual(ports["api_port"], ports["dev_port"])
+        for sock in backend.port_sockets:
+            self.assertEqual(sock.getsockname()[0], "127.0.0.1")
+        instance = json.loads((workspace / ".super-coder/instance.json").read_text())
+        self.assertEqual(instance["port"], ports["api_port"])
+        install_kwargs = next(kwargs for args, kwargs in calls if ".super-coder/scripts/install.py" in args)
+        self.assertEqual(install_kwargs["env"]["XDG_STATE_HOME"], str(workspace / ".bench-state"))
+
+    def test_style_uses_serving_parser_and_public_grant_for_all_kinds(self):
+        from skill import parse_local_skill_spec
+        frozen = bench.load_campaign(self.freeze())
+        for kind in ("file", "doc", "skill"):
+            with self.subTest(kind=kind):
+                workspace = self.root / f"copy-{kind}"
+                workspace.mkdir()
+                style = copy.deepcopy(frozen["config"]["style"])
+                style["kind"] = kind
+                if kind == "skill":
+                    style["content"] = "---\nname: project_style\ndescription: Follow the project house style.\n---\nUse the Button component.\n"
+                    style["name"] = "project_style"
+                backend = bench.HostBackend()
+                with mock.patch.object(backend, "sc") as sc:
+                    backend.place_style(workspace, style)
+                parsed = parse_local_skill_spec((workspace / ".bench-style.md").read_text())
+                self.assertEqual(parsed["name"], style["name"])
+                self.assertIn(mock.call(workspace, "skill", "grant", style["name"], "DEV1"), sc.call_args_list)
+                self.assertIn(mock.call(workspace, "render", "skills", "DEV1"), sc.call_args_list)
+                if kind == "file":
+                    self.assertEqual((workspace / style["destination"]).read_text(), style["content"])
+
+    def test_style_symlink_escape_is_refused(self):
+        config = bench.load_campaign(self.freeze())["config"]
+        workspace = self.root / "copy"
+        workspace.mkdir()
+        (workspace / ".subfloor").symlink_to(self.target, target_is_directory=True)
+        with self.assertRaisesRegex(bench.BenchError, "symlink"):
+            bench.HostBackend().place_style(workspace, config["style"])
+        self.assertFalse((self.target / "house-style.md").exists())
+
+    def test_hook_selects_declared_recipe_and_baseline_red_is_invalid(self):
+        config = bench.load_campaign(self.freeze())["config"]
+        backend = bench.HostBackend()
+        workspace = self.root / "copy"
+        config["dev_kit_declaration"] = {"hooks": {"test": {"argv": ["declared-test"]}}}
+        ok = subprocess.CompletedProcess([], 0, "", "")
+        with mock.patch.object(backend, "sc", return_value=ok) as sc, mock.patch.object(backend, "command", return_value=ok) as command:
+            backend.hook(config, workspace, "test")
+            sc.assert_called_once_with(workspace, "test", check=False, timeout=900)
+            backend.hook(config, workspace, "deps")
+            command.assert_called_once_with(workspace, ["true"], check=False, timeout=900)
+        with mock.patch.object(backend, "sc", return_value=subprocess.CompletedProcess([], 1, "", "")):
+            with self.assertRaises(bench.BenchError) as failure:
+                backend.hook(config, workspace, "test")
+            self.assertEqual(failure.exception.outcome, "invalid")
+
+    def test_cleanup_uses_lifecycle_and_refuses_bound_port(self):
+        import socket
+        workspace = self.root / "copy"
+        backend = bench.HostBackend()
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            ledger = {"launch_attempted": True, "ports": {"api_port": sock.getsockname()[1]}}
+            with mock.patch.object(backend, "sc") as sc:
+                with self.assertRaises(bench.CleanupError):
+                    backend.stop(workspace, ledger)
+                sc.assert_called_once_with(workspace, "down", timeout=60)
+        with mock.patch.object(backend, "sc"):
+            backend.stop(workspace, ledger)
+
+    def test_health_requires_own_identity_and_never_uses_host_proxy(self):
+        workspace = self.root / "copy"
+        response = mock.MagicMock()
+        response.status = 200
+        response.geturl.return_value = "http://127.0.0.1:1234/api/health"
+        response.__enter__.return_value = response
+        opener = mock.Mock()
+        opener.open.return_value = response
+        with mock.patch.object(bench, "build_opener", return_value=opener), mock.patch.object(bench.json, "load", return_value={"ok": True, "repo_root": str(self.target), "port": 1234}), self.assertRaisesRegex(bench.BenchError, "another instance"):
+            bench.HostBackend().health(workspace, {"api_port": 1234})
+        with mock.patch.object(bench, "build_opener", return_value=opener), mock.patch.object(bench.json, "load", return_value={"ok": True, "repo_root": str(workspace), "port": 1234}):
+            bench.HostBackend().health(workspace, {"api_port": 1234})
+
+
+class RegressionTests(BenchFixture):
+    def test_installer_source_resolution_ignores_the_disabled_origin(self):
+        import install
+        workspace = self.root / "copy"
+        bench.HostBackend().clone(bench.load_campaign(self.freeze())["config"], workspace)
+        git(workspace, "remote", "add", "super-coder", self.engine.as_uri())
+        git(workspace, "fetch", "super-coder", "main:refs/remotes/super-coder/main")
+        git(workspace, "remote", "set-url", "origin", "disabled://bench-target")
+        with mock.patch.object(install, "REPO_ROOT", workspace):
+            self.assertEqual(install.sc_remote(), "super-coder")
+            self.assertEqual(install.resolve_engine_ref(), self.engine_sha)
+
+    def test_baseline_red_invalidates_campaign_after_successful_cleanup(self):
+        path = self.freeze()
+        with self.assertRaises(bench.BenchError):
+            bench.Controller(FakeBackend(fail_at="test")).run(path, "custom")
+        with self.assertRaisesRegex(bench.BenchError, "campaign baseline is invalid"):
+            bench.Controller(FakeBackend()).run(path, "custom", cell_id="another-route")
+
+    def test_remote_snapshot_is_pinned_and_scratch_removed_on_resolution_failure(self):
+        runner = bench.CommandRunner()
+        with bench.Snapshot(runner, "remote", (self.target.as_uri(), "main")) as snapshot:
+            scratch = snapshot.repo
+            self.assertEqual(snapshot.sha, self.target_sha)
+            self.assertTrue(snapshot.contains("existing_view"))
+        self.assertFalse(scratch.exists())
+        snapshot = bench.Snapshot(runner, "remote", (self.target.as_uri(), "main"))
+        with mock.patch.object(bench, "resolve_sha", side_effect=bench.BenchError("bad ref")), self.assertRaises(bench.BenchError):
+            snapshot.__enter__()
+        self.assertFalse(snapshot.repo.exists())
+
+    def test_serve_migrations_roots_and_file_destination_reject_unknown_or_escaping_fields(self):
+        variants = [
+            {"copy": {"root": str(self.root / "copies"), "extra": True}},
+            {"evidence": {"root": str(self.root / "runs"), "extra": True}},
+            {"serve": {"argv": ["app"], "cwd": ".", "port_env": "PORT", "health_path": "/health", "ready_timeout_s": 10, "extra": True}},
+            {"migrations": {"path": "migrations", "apply_argv": ["true"], "table_check_argv": ["true"], "extra": True}},
+            {"serve": {"argv": ["app"], "cwd": "../target", "port_env": "PORT", "health_path": "/health", "ready_timeout_s": 10}},
+            {"serve": {"argv": ["app"], "cwd": ".", "port_env": "SC_API_TOKEN", "health_path": "/health", "ready_timeout_s": 10}},
+            {"migrations": {"path": "../target", "apply_argv": ["true"], "table_check_argv": ["true"]}},
+            {"style": {**self.config["style"], "destination": "../target/style.md"}},
+            {"style": {**self.config["style"], "trap": {"required": ["["], "forbidden": ["Button"]}}},
+        ]
+        for overrides in variants:
+            with self.subTest(overrides=overrides), self.assertRaises(bench.BenchError):
+                self.freeze({**copy.deepcopy(self.config), **overrides})
+
+    def test_cleanup_refuses_copy_replaced_by_symlink(self):
+        path = self.freeze()
+        with self.assertRaises(bench.CleanupError):
+            bench.Controller(FakeBackend(cleanup_failure="remove")).run(path, "custom")
+        ledger_path = path.parent / "route-0-custom/gate.json"
+        workspace = Path(json.loads(ledger_path.read_text())["workspace"])
+        workspace.rmdir()
+        workspace.symlink_to(self.target, target_is_directory=True)
+        with self.assertRaisesRegex(bench.BenchError, "symlink"):
+            bench.Controller(FakeBackend()).cleanup(path, "route-0-custom")
+        self.assertTrue(self.target.is_dir())
+
+    def test_runner_subprocess_timeout_never_prints_secret_stderr(self):
+        runner = bench.CommandRunner()
+        with self.assertRaises(bench.BenchError) as failure:
+            runner.run([sys.executable, "-c", "import sys; sys.stderr.write('seeded-secret'); sys.exit(1)"])
+        self.assertNotIn("seeded-secret", str(failure.exception))
+        with mock.patch.object(bench.subprocess, "run", side_effect=subprocess.TimeoutExpired(["tool"], 1)), self.assertRaises(bench.BenchError) as failure:
+            runner.run(["tool"])
+        self.assertEqual(failure.exception.outcome, "infra_failed")
+
+    def test_cli_help_and_invalid_config_do_not_launch(self):
+        result = subprocess.run([sys.executable, str(SCRIPTS / "model_bench.py"), "--help"], capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 0)
+        for verb in ("freeze", "run", "cleanup"):
+            self.assertIn(verb, result.stdout)
+        self.config_path.write_text('{"bad": true}')
+        result = subprocess.run([sys.executable, str(SCRIPTS / "model_bench.py"), "freeze", "--config", str(self.config_path)], capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("unknown keys", result.stderr)
+
+    def test_readonly_db_gate_executes_integrity_and_flavor_checks_under_optimization(self):
+        import sqlite3
+        workspace = self.root / "copy"
+        scripts = workspace / ".super-coder/scripts"
+        scripts.mkdir(parents=True)
+        state = workspace / ".bench-state"
+        state.mkdir()
+        database = state / "fixture.db"
+        (scripts / "instance_state.py").write_text(
+            "from pathlib import Path\ndef active_database_path(engine):\n    return Path('.bench-state/fixture.db').resolve()\n"
+        )
+        con = sqlite3.connect(database)
+        con.execute("CREATE TABLE shells(shortname TEXT, flavor TEXT, is_deleted INTEGER)")
+        con.execute("INSERT INTO shells VALUES ('DEV1', 'dev', 0)")
+        con.commit()
+        backend = bench.HostBackend()
+        with mock.patch.object(backend, "sc") as sc, mock.patch.dict(os.environ, {"PYTHONOPTIMIZE": "1"}):
+            backend.verify(workspace)
+            sc.assert_called_once_with(workspace, "render", "all", "DEV1")
+            con.execute("UPDATE shells SET flavor='reviewer'")
+            con.commit()
+            with self.assertRaises(bench.BenchError):
+                backend.verify(workspace)
+        con.close()
+
+    def test_host_lock_serializes_different_evidence_roots(self):
+        first = self.freeze()
+        config = copy.deepcopy(self.config)
+        config["evidence"] = {"root": str(self.root / "other-runs")}
+        second = self.freeze(config)
+        controller = bench.Controller(FakeBackend())
+        with controller._locked(bench.load_campaign(first)), self.assertRaisesRegex(bench.BenchError, "another campaign"):
+            controller.run(second, "custom")
+
+    def test_cleanup_after_runner_update_still_recovers_retained_copy(self):
+        path = self.freeze()
+        with self.assertRaises(bench.CleanupError):
+            bench.Controller(FakeBackend(cleanup_failure="remove")).run(path, "custom")
+        with mock.patch.object(bench, "RUNNER_VERSION", "next-version"):
+            with self.assertRaisesRegex(bench.BenchError, "runner changed"):
+                bench.Controller(FakeBackend()).run(path, "custom", cell_id="new")
+            result = bench.Controller(FakeBackend()).cleanup(path, "route-0-custom")
+            self.assertTrue(result["cleanup"]["copy_deleted"])
+
+    def test_style_document_and_skill_ids_freeze_through_public_read_surfaces(self):
+        config = copy.deepcopy(self.config)
+        original_run = self.runner.run
+
+        def read_artifact(args, **kwargs):
+            if "mem" in args:
+                return subprocess.CompletedProcess(args, 0, json.dumps({"document": {"body": "Use the Button component."}}), "")
+            if "sql" in args:
+                return subprocess.CompletedProcess(args, 0, json.dumps([{"name": "project_style", "description": "Project house style", "content": "Use the Button component."}]), "")
+            return original_run(args, **kwargs)
+
+        for kind in ("doc", "skill"):
+            with self.subTest(kind=kind), mock.patch.object(self.runner, "run", side_effect=read_artifact):
+                config["style"] = {"kind": kind, "source": 42}
+                frozen = bench.load_campaign(self.freeze(config))
+                self.assertIn("Use the Button component.", frozen["config"]["style"]["content"])
+                self.assertEqual(frozen["config"]["style"]["source"], 42)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds frozen benchmark campaigns and a disposable host gate so each cell can begin from a verified Git/engine SHA, explicit model route, committed house style, and green baseline, with teardown after every success or failure.

Sprint 34 work-unit 155, tasks #801–#802. Governing spec #222 revision `0c0ac4a205ab94a7036d897b40985abc872e89b28a7c34002d02b2a10978da7a`.

- Strict config validation rejects unknown keys, unsafe/overlapping roots, unavailable refs, engine refs outside the source's origin/main, route substitutions or variants, judge/route overlap, missing redline prerequisites, reserved card words, and invalid typed slots. `freeze` writes deterministic owner-only campaign.json with resolved SHAs, card/style digests, and runner provenance. The existing ENGINE_PATHS scripts entry distributes the runner.
- Style is file or repo. Host files are copied to place_at outside every card's allowed_paths; repo files are read from target.ref. The runner fills style_path, rejects config-authored replacements, and requires it for custom style_trap cards. All presets name the style path, following the Task Cards rule that this runner-filled slot belongs to every preset. The style and installer preparation are committed before hooks. The resulting fixture SHA is the receipt base; hooks must preserve that SHA, branch, style, and clean status.
- The gate clones at the frozen SHA, disables pushes, materializes the pinned engine manifest, installs noninteractively with --runtime host and without harness updates, launches on free loopback ports, verifies the responding instance, checks the installer's renders and DB integrity, refreshes the copy-local model catalogue in a recorded refresh_routes stage, then proves the exact model/effort with null variant, places the style, and runs deps/test hooks. Every subprocess strips inherited SC_* and Git context. Copy-owned XDG state contains its engine DB.
- A host lock prevents parallel cells. Owner-only gate.json retains the preamble, stage outcomes, failure reasons, and cleanup identities. A red baseline invalidates its campaign. Teardown probes use SO_REUSEADDR so closed health connections in TIME_WAIT do not prevent cleanup, while a live listener still blocks deletion. Teardown failure preserves the copy and blocks further cells; cleanup retries without requiring an available source checkout or unchanged runner. The entrypoint uses the shared run_cli wrapper, including broken-pipe handling.

This lane owns the gate. CLI surfaces are `freeze --config`, `run --campaign --card [--route-index] [--cell]`, and `cleanup --campaign --cell`. `run` reports `gate_passed` and tears down. `Controller.run(..., operation=...)` supplies the copy root, frozen config/card/route, and fixture/preamble ledger to the subsequent dispatch/evaluation lane; this PR does not claim a live campaign, model result, or completed evaluation receipt.

Rationale: compare installer renders with render-check and use a read-only DB proof; sc verify rebuilds the DB and render/all requires SC_ADMIN. File fixtures avoid changing skill ownership or provisioning DB skills. Keep target_base_sha separate from the fixture base so later model diffs exclude setup/style changes. Full-match repo-relative globs give freeze and the later scope redline a shared interpretation of allowed_paths.

Validation: `./sc test tests/test_model_bench.py tests/test_cli_sigpipe.py -q` — 64 passed, 274 subtests passed. Focused Ruff and mypy (`--follow-imports=skip --check-untyped-defs`) passed. Tests exercise temporary Git/SQLite fixtures, the actual update materializer, real clone/push refusal, committed style exclusion from diffs, typed presets/custom cards, command/controller failure boundaries, cleanup recovery, and the shared CLI contract. A real loopback HTTP server regression proves teardown with TIME_WAIT; controller command tests prove refresh-before-resolve using copy-local state and stopping on refresh failure. No provider calls or live Subfloor service launches were used. A live dos-app gate ledger is not included: this Developer worktree uses mocked lifecycle boundaries under its standing host-safety rule; the campaign seat retains the live gate proof. Repository-wide verification belongs to the authoritative CI gate.
