### PR TITLE
feat(sprint): resume re-enters interrupted lanes; reporting-only health (F78)

### DIFF
--- a/.super-coder/api/server.py
+++ b/.super-coder/api/server.py
@@ -3704,6 +3704,7 @@ class Handler(BaseHTTPRequestHandler):
                     "conformance_reviewer_shell_id": int(owner[0]),
                     "conformance_owner_generation": int(owner[1]),
                     "dispatched_wake_ids": list(receipt.dispatched_wake_ids),
+                    "reentered_wake_ids": list(receipt.reentered_wake_ids),
                     "requeued_wake_ids": list(receipt.requeued_wake_ids),
                     "projected_work_unit_ids": list(
                         receipt.projected_work_unit_ids

--- a/.super-coder/assets/skills/sprint_protocol/SKILL.md
+++ b/.super-coder/assets/skills/sprint_protocol/SKILL.md
@@ -42,9 +42,17 @@ Three literals name how a Sprint message reaches you:
 | `re-enter` | resumes the existing chat at its next boundary |
 
 Assignments, review requests, and verdicts arrive `force-new`; Planner-bound
-results, decisions, and PR facts arrive `re-enter`. You never choose a type,
-poll, boot a participant, or schedule a watcher; the engine delivers. Stop
-after a successful typed handoff and wait for the next wake.
+results, decisions, and PR facts arrive `re-enter`. One engine wake names its
+moment rather than a sender:
+
+| Wake | Meaning |
+|---|---|
+| resume re-enter | a pause interrupted your live turn; on resume the engine queues this `re-enter` notification into your chat — continue that lane from its current state, do not re-accept the assignment |
+
+You never choose a type, poll, boot a participant, or schedule a watcher; the
+engine delivers. Health is reporting-only: nobody — engine or Planner — pings
+a participant for silence; the board carries that signal. Stop after a
+successful typed handoff and wait for the next wake.
 
 ## Inbox, accept, decline
 

--- a/.super-coder/migrations/0001_seed_skills.sql
+++ b/.super-coder/migrations/0001_seed_skills.sql
@@ -1532,6 +1532,11 @@ artifacts, interrupt intent, judgment, and evidence:
 sc sprint pause --sprint <id> --reason <decision-or-restructure-reason>
 ```
 
+Pause interrupts every live participant turn, and resume re-enters each
+interrupted participant automatically with one re-enter wake into their
+existing chat. Health is reporting-only: never send status-check messages on
+silence — read the board (`sc sprint show --sprint <id>`) instead.
+
 Resume only after recording recovery/restructure and reconciling native runs,
 unread messages, wakes, units, PRs, capacity, and spec drift:
 
@@ -1913,9 +1918,17 @@ Three literals name how a Sprint message reaches you:
 | `re-enter` | resumes the existing chat at its next boundary |
 
 Assignments, review requests, and verdicts arrive `force-new`; Planner-bound
-results, decisions, and PR facts arrive `re-enter`. You never choose a type,
-poll, boot a participant, or schedule a watcher; the engine delivers. Stop
-after a successful typed handoff and wait for the next wake.
+results, decisions, and PR facts arrive `re-enter`. One engine wake names its
+moment rather than a sender:
+
+| Wake | Meaning |
+|---|---|
+| resume re-enter | a pause interrupted your live turn; on resume the engine queues this `re-enter` notification into your chat — continue that lane from its current state, do not re-accept the assignment |
+
+You never choose a type, poll, boot a participant, or schedule a watcher; the
+engine delivers. Health is reporting-only: nobody — engine or Planner — pings
+a participant for silence; the board carries that signal. Stop after a
+successful typed handoff and wait for the next wake.
 
 ## Inbox, accept, decline
 

--- a/.super-coder/migrations/0262_reseed_sprint_resume_reentry.sql
+++ b/.super-coder/migrations/0262_reseed_sprint_resume_reentry.sql
@@ -1,15 +1,24 @@
----
-name: sprint_pln
-description: Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.
-category: workflow
-common: false
----
+-- 0262 — reseed the sprint_pln and sprint_protocol guidance for resume
+-- re-entry. Pause interrupts every live participant turn and resume re-enters
+-- each interrupted participant with one re-enter wake; health stays
+-- reporting-only and nobody is pinged for silence. No schema change: a
+-- full-body UPSERT converges upgraded installations on the same text a fresh
+-- seed produces. Idempotent.
 
-# sprint_pln — govern the armed Sprint
+BEGIN;
+
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_pln',
+  'Run an armed Sprints v2 collaboration loop as Planner — dispatch and restructure lanes, change participant routes, and execute Reviewer decisions through durable pause, resume, and close protocols.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_pln — govern the armed Sprint
 
 Load `sprint_protocol` first; it holds the lifecycle, wake types, inbox
 commands, relay contract, body limits, artifact paths, receipt recovery, and
-authority boundary. This skill holds only the Planner's steps after
+authority boundary. This skill holds only the Planner''s steps after
 `sprint_prep` arms the Sprint.
 
 ## What you can read
@@ -174,11 +183,11 @@ sc sprint resolve-unit --sprint <id> --work-unit <id> \
   --to completed|cancelled --reason <reason>
 ```
 
-Paused-only; retires the lane's open expectations, supersedes its PR links
+Paused-only; retires the lane''s open expectations, supersedes its PR links
 (registration kept for reconcile-pr), and wakes both seats.
 
 To change a future assignment or review route, pause the armed Sprint, take
-each participant's `shell_id` and current route from `sc sprint show`, preview
+each participant''s `shell_id` and current route from `sc sprint show`, preview
 the replacement with `sc models resolve`, then replace the route and resume:
 
 ```text
@@ -225,7 +234,7 @@ peer chats.
 
 The completion receipt is the only success wake: it names the Developer chats
 the engine closed and the artifact directory it deletes. Your chat and every
-Reviewer's persist; no worktree is reset. Do not poll cleanup or reset
+Reviewer''s persist; no worktree is reset. Do not poll cleanup or reset
 participant trees. A second wake arrives only if artifact deletion failed —
 inspect once and retry only after correcting the named condition:
 
@@ -256,4 +265,156 @@ wake is the only normal next-wave dispatch trigger. On it:
 
 On a clean completion receipt, verify the named Sprint is terminal and record
 the closed Developer chats; run no close command. Then stop — a cleanup wake
-arrives only if artifact deletion failed.
+arrives only if artifact deletion failed.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+INSERT INTO skills (name, description, category, command, common, content, is_deleted) VALUES (
+  'sprint_protocol',
+  'The shared Sprints v2 protocol every participant follows — lifecycle, wake types, inbox/accept/decline, the typed relay with stable keys, body limits, artifact paths, receipt recovery, and the authority boundary. Load first in every Sprint turn, then your role skill.',
+  'workflow',
+  NULL,
+  0,
+  '# sprint_protocol — what every Sprint participant does the same way
+
+Load this first in any Sprint turn, then your role skill (`sprint_prep`,
+`sprint_pln`, `sprint_dev`, `sprint_rev`). Use the simplest path the current
+durable state supports; treat authority, lifecycle preconditions, durable
+writes, and typed handoffs as hard boundaries and use judgment inside them.
+Repeat a read only when later activity could have changed it or the next
+command requires live revalidation.
+
+## Lifecycle
+
+One Sprint binds one roadmap feature, exact governing spec revisions, a
+participant set (one Planner, Developers, Reviewers) each on one
+harness/model/effort route, and work units: editing lanes of spec tasks, each
+with one Developer and one Reviewer, ordered by dependencies and waves.
+`prepared` (editable) -> `armed` (ready lanes dispatch to Developers) <->
+`paused` (relay off; restructure and reroute here) -> `completed` or `aborted`
+(terminal; nothing deleted). One Sprint is armed at a time. A lane: dispatched
+-> Developer builds, registers the PR, requests review -> Reviewer records a
+verdict -> Developer merges under the Sprint grant once `authorize-merge`
+returns live green + approved -> the merged handoff wakes the Planner, who
+dispatches what became ready. After the last lane the conformance Reviewer
+records the whole-Sprint report; the engine closes the Sprint, closes the
+Developer chats, and deletes the Sprint artifact directory. Planner and
+Reviewer chats persist; no worktree is reset.
+
+## Wake types
+
+Three literals name how a Sprint message reaches you:
+
+| Type | Delivery |
+|---|---|
+| `new` | a fresh chat when the shell has none or its chat is idle; absorbed at the boundary of a live turn |
+| `force-new` | never absorbed; waits for the live turn to end and a quiet gate, then closes the old chat and opens a fresh one |
+| `re-enter` | resumes the existing chat at its next boundary |
+
+Assignments, review requests, and verdicts arrive `force-new`; Planner-bound
+results, decisions, and PR facts arrive `re-enter`. One engine wake names its
+moment rather than a sender:
+
+| Wake | Meaning |
+|---|---|
+| resume re-enter | a pause interrupted your live turn; on resume the engine queues this `re-enter` notification into your chat — continue that lane from its current state, do not re-accept the assignment |
+
+You never choose a type, poll, boot a participant, or schedule a watcher; the
+engine delivers. Health is reporting-only: nobody — engine or Planner — pings
+a participant for silence; the board carries that signal. Stop after a
+successful typed handoff and wait for the next wake.
+
+## Inbox, accept, decline
+
+```text
+sc sprint show --sprint <id>
+sc sprint inbox --sprint <id>
+sc sprint accept --sprint <id> --message <message-id>
+sc sprint decline --sprint <id> --message <message-id> --reason <reason>
+```
+
+Inspect the inbox once per trigger. Accepting an assignment starts ownership;
+decline only with a concrete reason. After an informational message, `accept`
+marks it read and changes no Sprint or work-unit state. Re-run the inbox once
+immediately before each typed handoff and act on new items; after the handoff
+confirms its durable write, stop without another pass.
+
+## Relay
+
+Every message is one short body file. Unit question or blocker (requires a
+reply):
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent question|blocker --requires-reply --work-unit <work-unit-id> \
+  --key <stable-key>
+```
+
+Cross-unit, closeout, or external-authority rulings are Sprint-level:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent decision --requires-reply --sprint-level --key <stable-key>
+```
+
+Reply through the original message; the reply inherits its scope, so never add
+`--work-unit` or `--sprint-level` to a reply:
+
+```text
+sc sprint send --sprint <id> --to <shortname> --body-file <path> \
+  --intent information --reply-to <message-id> --key <stable-key>
+```
+
+Confirm the durable reply, then `accept` the incoming message. At a decision
+boundary, stop until the required answer arrives; unread recovery re-wakes the
+recipient, so send no duplicate reminder.
+
+**Stable key** = recipient + exact body + intent + reply target + scope. Reuse
+it only to retry the same failed or ambiguous write; when any field changes,
+use a new key. **Body size**: near 6,000 characters and below 8,000 — run
+`wc -m < <path>` before sending. A handoff is complete only when the command
+exits successfully and confirms the durable write and wake. Rejected or
+transport-failed -> correct and retry. Relay itself unavailable -> give the FnB
+the attempted command, evidence, impact, and recommendation; invent no
+alternate protocol.
+
+## Receipt recovery
+
+An unusable success receipt from idempotent bookkeeping does not stall the
+Sprint: retry the exact command once, then use its normal read surface once to
+prove the postcondition (for an informational `accept`: the message was in the
+inbox and is now absent). Continue under that proof and name the receipt
+defect in your next handoff. Never use this to infer assignment ownership,
+review outcome, merge authorization, a lifecycle or work-unit transition, the
+governing revision, PR head or green state, or cleanup authority; an unproved
+postcondition stops.
+
+## Artifacts
+
+Working material — review notes, raw diffs, evidence packets, report drafts,
+scratch proof — goes under the gitignored `shared/sprints/sprint-<n>/`; never
+commit, branch, or PR it (a review-notes commit is a finding). Durable records
+are DB rows: judgments via `record-review`, reports via `record-conformance`,
+decisions in the relay.
+
+## Authority
+
+Reviewers own judgments: verdicts, conformance, re-enter and abort decisions.
+The Planner owns plan structure — lanes, dependencies, waves, assignment,
+routes, pause, resume, dispatch — and executes Reviewer decisions without
+re-adjudicating them. A Developer owns one lane and its PR. The FnB may
+override any of it from the GUI Sprints tab; name that authority in the
+durable evidence when acting under it. A command that rejects a transition
+returns the durable state to the deciding role; substitute nothing.',
+  0
+)
+ON CONFLICT(name) DO UPDATE SET
+  description=excluded.description, category=excluded.category,
+  command=excluded.command, common=excluded.common,
+  content=excluded.content, is_deleted=0;
+
+COMMIT;

--- a/.super-coder/scripts/sprint_board.py
+++ b/.super-coder/scripts/sprint_board.py
@@ -99,6 +99,7 @@ _EVENT_FIELDS = {
             "initial_wake_ids",
             "reconciled",
             "dispatched_wake_ids",
+            "reentered_wake_ids",
         }
     ),
     "lifecycle.paused": frozenset(

--- a/.super-coder/scripts/sprint_domain.py
+++ b/.super-coder/scripts/sprint_domain.py
@@ -134,6 +134,7 @@ class PauseReceipt:
 class ResumeReceipt:
     changed: bool
     dispatched_wake_ids: tuple[int, ...]
+    reentered_wake_ids: tuple[int, ...]
     requeued_wake_ids: tuple[int, ...]
     projected_work_unit_ids: tuple[int, ...]
     resolved_review_message_ids: tuple[int, ...]
@@ -1247,6 +1248,7 @@ class SprintLifecycleStore:
         )
         all_anomalies = anomalies
         notice_conversations: tuple[str, ...] = ()
+        reentered: tuple[int, ...] = ()
         pause_receipt: PauseReceipt | None = None
         with db_driver.write_transaction(self.con, "sprint.resume"):
             sprint = self._sprint(sprint_id)
@@ -1261,7 +1263,7 @@ class SprintLifecycleStore:
                         "conformance ownership changes require a paused Sprint",
                         {"code": "conformance_owner_change_requires_pause"},
                     )
-                return ResumeReceipt(False, (), (), (), (), (), anomalies)
+                return ResumeReceipt(False, (), (), (), (), (), (), anomalies)
             if current == "prepared":
                 raise SprintInvariantError(
                     "prepared Sprints must use arm() so plan release is atomic"
@@ -1358,6 +1360,11 @@ class SprintLifecycleStore:
                             planner_participant_id=planner,
                         )
                     )
+                    reentered = (
+                        self._reenter_interrupted_participants_in_transaction(
+                            sprint_id
+                        )
+                    )
                     self._event(
                         sprint_id,
                         "lifecycle.armed",
@@ -1367,6 +1374,7 @@ class SprintLifecycleStore:
                             "reason": reason,
                             "reconciled": True,
                             "dispatched_wake_ids": list(dispatched),
+                            "reentered_wake_ids": list(reentered),
                         },
                     )
         if pause_receipt is not None:
@@ -1376,6 +1384,7 @@ class SprintLifecycleStore:
         return ResumeReceipt(
             pause_receipt is None,
             dispatched,
+            reentered,
             requeued,
             tuple(projected),
             tuple(resolved),
@@ -2091,6 +2100,90 @@ class SprintLifecycleStore:
                         )
                     )
         return tuple(sorted(set(projected))), tuple(sorted(set(resolved)))
+
+    def _reenter_interrupted_participants_in_transaction(
+        self,
+        sprint_id: int,
+    ) -> tuple[int, ...]:
+        """Queue one re-enter wake per participant the latest pause interrupted.
+
+        The pause report's active_turns name every run the pause interrupted.
+        Each distinct roster participant behind those runs receives one
+        notification wake keyed on its interrupted run, unless its lane is
+        already terminal or a wake is already pending or delivering.
+        """
+        if not self.con.in_transaction:
+            raise RuntimeError("resume re-entry requires an active transaction")
+        report = self.con.execute(
+            "SELECT body,created_at FROM sprint_reports WHERE sprint_id=? "
+            "AND report_kind='pause' ORDER BY report_id DESC LIMIT 1",
+            (sprint_id,),
+        ).fetchone()
+        if report is None:
+            return ()
+        active_turns = (
+            json.loads(str(report["body"]))
+            .get("deterministic", {})
+            .get("active_turns", [])
+        )
+        paused_at = str(report["created_at"])
+        from sprint_message_delivery import SprintMessageStore
+
+        messages = SprintMessageStore(self.con)
+        wake_ids: list[int] = []
+        seen_participants: set[int] = set()
+        for turn in active_turns:
+            participant = self.con.execute(
+                "SELECT p.participant_id,p.shell_id "
+                "FROM sprint_participant_conversations pc "
+                "JOIN sprint_participants p "
+                "ON p.participant_id=pc.sprint_participant_id "
+                "WHERE pc.conversation_id=? AND p.sprint_id=?",
+                (str(turn["conversation_id"]), sprint_id),
+            ).fetchone()
+            if participant is None:
+                continue
+            participant_id = int(participant["participant_id"])
+            if participant_id in seen_participants:
+                continue
+            seen_participants.add(participant_id)
+            shell_id = int(participant["shell_id"])
+            unit = self.con.execute(
+                "SELECT work_unit_id FROM sprint_work_units WHERE sprint_id=? "
+                "AND (assigned_shell_id=? OR reviewer_shell_id=?) "
+                "AND disposition NOT IN ('completed','cancelled') "
+                "ORDER BY work_unit_id LIMIT 1",
+                (sprint_id, shell_id, shell_id),
+            ).fetchone()
+            if unit is None:
+                continue
+            busy = self.con.execute(
+                "SELECT 1 FROM sprint_wake_outbox WHERE receiver_shell_id=? "
+                "AND state IN ('pending','delivering') LIMIT 1",
+                (shell_id,),
+            ).fetchone()
+            if busy is not None:
+                continue
+            work_unit_id = int(unit["work_unit_id"])
+            receipt = messages.send_in_transaction(
+                sprint_id,
+                to_participant_id=participant_id,
+                message_kind="notification",
+                body=(
+                    f"Sprint {sprint_id} resumed. Your turn on work unit "
+                    f"{work_unit_id} was interrupted by the pause at "
+                    f"{paused_at}. Continue that lane from its current state; "
+                    "do not re-accept the assignment."
+                ),
+                idempotency_key=(
+                    f"sprint-resume:{sprint_id}:reentered:{int(turn['run_id'])}"
+                ),
+                work_unit_id=work_unit_id,
+                declared_type="re-enter",
+            )
+            if receipt.wake_id is not None:
+                wake_ids.append(int(receipt.wake_id))
+        return tuple(sorted(wake_ids))
 
     def _reconcile_unread_wakes_in_transaction(
         self,

--- a/tests/fixtures/sprint_removal/manifest.json
+++ b/tests/fixtures/sprint_removal/manifest.json
@@ -102,6 +102,7 @@
     ".super-coder/migrations/0259_seed_drive_browser.sql",
     ".super-coder/migrations/0260_reseed_sprint_closeout_scope.sql",
     ".super-coder/migrations/0261_dev_long_job_guidance.sql",
+    ".super-coder/migrations/0262_reseed_sprint_resume_reentry.sql",
     ".super-coder/scripts/activity_monitor.py",
     ".super-coder/scripts/harness_surfaces.py",
     ".super-coder/scripts/instance_state.py",

--- a/tests/test_focused_dev_verification.py
+++ b/tests/test_focused_dev_verification.py
@@ -25,6 +25,7 @@ MIGRATIONS = (
     ENGINE / "migrations" / "0258_reseed_non_sprint_green_wake.sql",
     ENGINE / "migrations" / "0260_reseed_sprint_closeout_scope.sql",
     ENGINE / "migrations" / "0261_dev_long_job_guidance.sql",
+    ENGINE / "migrations" / "0262_reseed_sprint_resume_reentry.sql",
 )
 sys.path.insert(0, str(ENGINE / "scripts"))
 

--- a/tests/test_sprint_recovery.py
+++ b/tests/test_sprint_recovery.py
@@ -2818,7 +2818,14 @@ class SprintRecoveryCase(SprintPRWatcherCase):
             1,
             self.con.execute(
                 "SELECT COUNT(*) FROM wake_message "
-                "WHERE idempotency_key LIKE 'sprint-resume:%'",
+                "WHERE idempotency_key LIKE 'sprint-resume:%:v%'",
+            ).fetchone()[0],
+        )
+        self.assertEqual(
+            1,
+            self.con.execute(
+                "SELECT COUNT(*) FROM wake_message "
+                "WHERE idempotency_key LIKE 'sprint-resume:%:reentered:%'",
             ).fetchone()[0],
         )
 

--- a/tests/test_sprint_skills.py
+++ b/tests/test_sprint_skills.py
@@ -38,6 +38,7 @@ RECONCILIATION = (
     ENGINE / "migrations" / "0257_guidance_reconciliation.sql",
     ENGINE / "migrations" / "0258_reseed_non_sprint_green_wake.sql",
     ENGINE / "migrations" / "0260_reseed_sprint_closeout_scope.sql",
+    ENGINE / "migrations" / "0262_reseed_sprint_resume_reentry.sql",
 )
 RETIRED = (
     "memory", "db_map", "bootstrap", "surface_catalogue", "messaging", "flags",

--- a/tests/test_sprint_v2_domain.py
+++ b/tests/test_sprint_v2_domain.py
@@ -1255,6 +1255,266 @@ class LiveReplanningTest(SprintDomainCase):
         self.assertEqual(5, fresh["receiver_shell_id"])
         self.assertTrue(str(fresh["idempotency_key"]).endswith(":assignment:2"))
 
+    def _live_turn(self, sprint_id: int, shell_id: int, label: str) -> int:
+        """Seed one running participant turn the next pause will interrupt."""
+        participant_id = int(
+            self.con.execute(
+                "SELECT participant_id FROM sprint_participants "
+                "WHERE sprint_id=? AND shell_id=?",
+                (sprint_id, shell_id),
+            ).fetchone()[0]
+        )
+        conversation_id = f"cv_{label}"
+        self.con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id,shell_id,owner_user_id,harness,worktree,state,"
+            "title,creation_idempotency_key,creation_request_hash,"
+            "conversation_scope) "
+            "VALUES (?,?,1,'codex','/work','running',?,?,?,'sprint')",
+            (
+                conversation_id,
+                shell_id,
+                f"Lane {label}",
+                f"create-{label}",
+                f"hash-{label}",
+            ),
+        )
+        message_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_messages "
+                "(conversation_id,sender_kind,sender_ref,message_kind,body,"
+                "idempotency_key,request_hash,state) "
+                "VALUES (?,'engine','sprint','prompt',?,?,?,'running')",
+                (
+                    conversation_id,
+                    f"work on lane {label}",
+                    f"prompt-{label}",
+                    f"request-{label}",
+                ),
+            ).lastrowid
+        )
+        run_id = int(
+            self.con.execute(
+                "INSERT INTO conversation_runs "
+                "(conversation_id,shell_id,trigger_message_id,lease_owner,"
+                "lease_expires_at,state,started_at) "
+                "VALUES (?,?,?,'fixture',datetime('now','+1 hour'),'running',"
+                "datetime('now'))",
+                (conversation_id, shell_id, message_id),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_participant_conversations "
+            "(sprint_participant_id,conversation_id) VALUES (?,?)",
+            (participant_id, conversation_id),
+        )
+        return run_id
+
+    def test_resume_reenters_participants_whose_runs_the_pause_interrupted(
+        self,
+    ) -> None:
+        self.con.executemany(
+            "INSERT INTO shells "
+            "(shell_id,display_name,shortname,flavor,system_prompt,user_id) "
+            "VALUES (?,?,?,?,?,1)",
+            (
+                (5, "Developer 2", "DEV2", "dev", "prompt"),
+                (6, "Developer 3", "DEV3", "dev", "prompt"),
+                (7, "Developer 4", "DEV4", "dev", "prompt"),
+            ),
+        )
+        sprint_id, first_unit = self.create_sprint()
+        self.con.executemany(
+            "INSERT INTO sprint_participants "
+            "(sprint_id,shell_id,role,harness,model,effort) "
+            "VALUES (?,?,'developer','codex','dev-model','high')",
+            ((sprint_id, 5), (sprint_id, 6), (sprint_id, 7)),
+        )
+        second_unit = int(
+            self.con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output) VALUES (?,5,2,'Second','Ship the second lane')",
+                (sprint_id,),
+            ).lastrowid
+        )
+        self.con.execute(
+            "INSERT INTO sprint_work_units "
+            "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+            "expected_output) VALUES (?,6,2,'Third','Ship the third lane')",
+            (sprint_id,),
+        )
+        terminal_unit = int(
+            self.con.execute(
+                "INSERT INTO sprint_work_units "
+                "(sprint_id,assigned_shell_id,reviewer_shell_id,title,"
+                "expected_output) VALUES (?,7,2,'Fourth','Ship the fourth lane')",
+                (sprint_id,),
+            ).lastrowid
+        )
+        self.con.commit()
+        store = sprint_domain.SprintLifecycleStore(
+            self.con,
+            probe_harness=lambda _harness: None,
+            interrupt_run=lambda _run_id: True,
+        )
+        store.arm(sprint_id, 3)
+        messages = sprint_message_delivery.SprintMessageStore(self.con)
+        assignments = self.con.execute(
+            "SELECT m.message_id,m.receiver_shell_id,wm.wake_id "
+            "FROM wake_message m JOIN sprint_wake_messages wm USING (message_id) "
+            "WHERE m.sprint_id=? AND m.message_kind='work_assignment'",
+            (sprint_id,),
+        ).fetchall()
+        self.assertEqual(4, len(assignments))
+        for assignment in assignments:
+            self.con.execute(
+                "UPDATE wake_message SET delivered_at=datetime('now') "
+                "WHERE message_id=?",
+                (assignment["message_id"],),
+            )
+            self.con.execute(
+                "UPDATE sprint_wake_outbox SET state='delivered',"
+                "delivered_at=datetime('now') WHERE wake_id=?",
+                (assignment["wake_id"],),
+            )
+            self.con.commit()
+            messages.mark_read(
+                int(assignment["message_id"]),
+                int(assignment["receiver_shell_id"]),
+                sprint_id=sprint_id,
+            )
+        # The first lane sits in review with the reviewer; the fourth is done.
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='in_review' "
+            "WHERE work_unit_id=?",
+            (first_unit,),
+        )
+        self.con.execute(
+            "UPDATE sprint_work_units SET disposition='completed' "
+            "WHERE work_unit_id=?",
+            (terminal_unit,),
+        )
+        self.con.commit()
+        # The third developer already has a wake on the way.
+        messages.send(
+            sprint_id,
+            to_participant_id=int(
+                self.con.execute(
+                    "SELECT participant_id FROM sprint_participants "
+                    "WHERE sprint_id=? AND shell_id=6",
+                    (sprint_id,),
+                ).fetchone()[0]
+            ),
+            message_kind="notification",
+            body="A notice still waiting on delivery",
+            idempotency_key=f"test:{sprint_id}:pending-notice:6",
+        )
+        run_ids = {
+            shell_id: self._live_turn(sprint_id, shell_id, f"lane{shell_id}")
+            for shell_id in (1, 2, 5, 6, 7)
+        }
+        self.con.commit()
+
+        store.pause(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="rebind the governing spec",
+        )
+        paused_at = str(
+            self.con.execute(
+                "SELECT created_at FROM sprint_reports WHERE sprint_id=? "
+                "AND report_kind='pause' ORDER BY report_id DESC LIMIT 1",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+
+        receipt = store.resume(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="rebind complete",
+        )
+
+        self.assertTrue(receipt.changed)
+        self.assertEqual(3, len(receipt.reentered_wake_ids))
+        reentered = self.con.execute(
+            "SELECT receiver_shell_id,work_unit_id,message_kind,declared_type,"
+            "actionable,idempotency_key,body FROM wake_message "
+            "WHERE idempotency_key LIKE 'sprint-resume:%:reentered:%' "
+            "ORDER BY receiver_shell_id"
+        ).fetchall()
+        self.assertEqual(
+            [1, 2, 5], [int(row["receiver_shell_id"]) for row in reentered]
+        )
+        self.assertEqual(
+            [first_unit, first_unit, second_unit],
+            [int(row["work_unit_id"]) for row in reentered],
+        )
+        self.assertEqual(
+            [run_ids[1], run_ids[2], run_ids[5]],
+            [
+                int(str(row["idempotency_key"]).rsplit(":", 1)[1])
+                for row in reentered
+            ],
+        )
+        for row in reentered:
+            self.assertEqual("notification", row["message_kind"])
+            self.assertEqual("re-enter", row["declared_type"])
+            self.assertEqual(0, row["actionable"])
+        self.assertEqual(
+            f"Sprint {sprint_id} resumed. Your turn on work unit {first_unit} "
+            f"was interrupted by the pause at {paused_at}. Continue that lane "
+            "from its current state; do not re-accept the assignment.",
+            reentered[0]["body"],
+        )
+        wakes = self.con.execute(
+            "SELECT w.wake_id,w.receiver_shell_id,w.state "
+            "FROM sprint_wake_outbox w "
+            "JOIN sprint_wake_messages wm USING (wake_id) "
+            "JOIN wake_message m USING (message_id) "
+            "WHERE m.idempotency_key LIKE 'sprint-resume:%:reentered:%' "
+            "ORDER BY w.wake_id"
+        ).fetchall()
+        self.assertEqual(
+            list(receipt.reentered_wake_ids),
+            [int(wake["wake_id"]) for wake in wakes],
+        )
+        self.assertTrue(all(wake["state"] == "pending" for wake in wakes))
+        event = json.loads(
+            self.con.execute(
+                "SELECT payload FROM sprint_events WHERE sprint_id=? "
+                "AND event_type='lifecycle.armed' "
+                "ORDER BY event_id DESC LIMIT 1",
+                (sprint_id,),
+            ).fetchone()[0]
+        )
+        self.assertEqual(
+            sorted(receipt.reentered_wake_ids),
+            sorted(event["reentered_wake_ids"]),
+        )
+
+        # A second pause/resume cycle replays no wake: every interrupted
+        # participant now has a pending wake or a terminal lane.
+        store.pause(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="rebind again",
+        )
+        replay = store.resume(
+            sprint_id,
+            sprint_domain.LifecycleActor("planner", 3),
+            reason="second rebind complete",
+        )
+        self.assertTrue(replay.changed)
+        self.assertEqual((), replay.reentered_wake_ids)
+        self.assertEqual(
+            3,
+            self.con.execute(
+                "SELECT COUNT(*) FROM wake_message "
+                "WHERE idempotency_key LIKE 'sprint-resume:%:reentered:%'"
+            ).fetchone()[0],
+        )
+
     def test_recall_rejects_armed_and_registered_pr_lanes(self) -> None:
         sprint_id, work_unit_id = self.create_sprint()
         self.store.arm(sprint_id, 3)


### PR DESCRIPTION
Spec #227, tasks #819 and #820.

## Engine (task #819)

- `SprintLifecycleStore.resume` reads the latest pause report's `active_turns` and queues one `re-enter` notification wake per distinct interrupted roster participant, inside the resume transaction.
- Keyed `sprint-resume:<sprint>:reentered:<run_id>` on the wake message, so a replayed resume refuses a second row for the same run.
- Skips participants with a `pending`/`delivering` wake and participants whose interrupted lane is now terminal (`completed`/`cancelled`).
- `reentered_wake_ids` added to `ResumeReceipt`, the `lifecycle.armed` event payload (and the board's payload allowlist), and the `/_sc/sprint/resume` API response.
- Wake body: "Sprint <id> resumed. Your turn on work unit <id> was interrupted by the pause at <time>. Continue that lane from its current state; do not re-accept the assignment."

## Skill text (task #820)

- `sprint_pln` Pause-or-resume: pause interrupts every live participant turn, resume re-enters them automatically, and the Planner reads the board instead of sending status-check pings on silence.
- `sprint_protocol` Wake types: one row explaining the resume re-enter wake; both skills state health is reporting-only.
- Two-artifact commit: asset text + trailing reseed migration `0262_reseed_sprint_resume_reentry.sql`, with the regenerated `0001_seed_skills.sql` and the convergence test's RECONCILIATION list extended.

## Verification

- New hermetic test `test_resume_reenters_participants_whose_runs_the_pause_interrupted`: two developers plus a reviewer interrupted mid-turn each get exactly one re-enter wake; a participant with a pending wake and a terminal unit get none; a second pause/resume cycle inserts no duplicate rows; the `lifecycle.armed` payload carries the same ids.
- One existing assertion updated (`test_resume_surfaces_native_and_capacity_anomalies_without_blocking`): its `sprint-resume:%` count now legitimately includes the re-enter wake; split into planner-notice vs reentered counts.
- 393 tests + 159 subtests green across the sprint, skill, migration, and render-freshness suites; ruff shows zero net-new findings over base; mypy errors on `sprint_domain.py` are all pre-existing outside the edited regions.
- Note: the configured `sc lint`/`sc typecheck` dev-kit hooks resolve to the live main checkout from a worktree and fail there on host cache permissions (pre-existing environment limitation); verification ran the same tools directly from this worktree.