### PR TITLE
fix(browser): refuse setup by seat on a container engine runtime (#1556)

### DIFF
--- a/.super-coder/docs/browser-driving.md
+++ b/.super-coder/docs/browser-driving.md
@@ -19,6 +19,11 @@ extension credential.
    the Chromium binary (on Arch, `/usr/lib/chromium/chromium`), not a shell
    wrapper. Adjust the absolute executable/user-data paths for your installation.
    The engine resolves `Subfloor` to its actual profile directory using Local State.
+   This step requires the host runtime. On the docker runtime the API server
+   itself runs inside `sc-<repo>`, which mounts no Chromium profile and has its
+   own PID namespace; check/link/arm refuse there with `unsupported seat:
+   browser requires bare metal`, and the GUI disables those controls rather than
+   reporting an existing host path as missing.
 4. Open Subfloor, give a shell a directive naming the site and actions, and
    approve that connection in the extension. Shells preflight with
    `sc browser status --json` and work in `Playwright · Subfloor <SHORTNAME>`.

--- a/.super-coder/scripts/browser.py
+++ b/.super-coder/scripts/browser.py
@@ -29,6 +29,7 @@ VERSIONS = {
 }
 EXTENSION_ID = "mmlmfjhmonkocbjadbfplnigmagldckm"
 TIMEOUT = 30
+UNSUPPORTED_SEAT = "unsupported seat: browser requires bare metal"
 SUPPORTED = ("claude", "codex", "opencode")
 FIELDS = {
     "executable",
@@ -42,6 +43,17 @@ FIELDS = {
     "blocked_origins",
     "armed",
 }
+
+
+def require_bare_metal() -> None:
+    """Setup and lifecycle need the host's Chromium profile and process table.
+
+    On the docker runtime the API server itself runs in `sc-<repo>`, which
+    mounts no browser profile and has its own PID namespace, so the profile and
+    window probes would read the container instead of the operator's host.
+    Refuse by seat rather than reporting a host path as missing (issue #1556)."""
+    if os.environ.get("SC_SANDBOX"):
+        raise ValueError(UNSUPPORTED_SEAT)
 
 
 def read() -> dict | None:
@@ -262,6 +274,7 @@ def profile_checks(config: dict) -> dict:
 
 def link(value: dict, *, save: bool = True) -> dict:
     """Resolve the human display name; save only a validated, nonsecret block."""
+    require_bare_metal()
     if set(value) - {"executable", "user_data_dir", "profile_name", "blocked_origins"}:
         raise ValueError("unknown browser link field")
     directory = guard.operator_path(
@@ -468,7 +481,7 @@ def status(*, harness: str | None = None, sandbox: bool = False) -> dict:
         return {
             "state": "failed",
             "supported": False,
-            "detail": "unsupported seat: browser requires bare metal",
+            "detail": UNSUPPORTED_SEAT,
         }
     if harness and harness not in SUPPORTED:
         return {
@@ -511,8 +524,7 @@ def status(*, harness: str | None = None, sandbox: bool = False) -> dict:
 
 
 def operate(action: str) -> dict:
-    if os.environ.get("SC_SANDBOX"):
-        raise ValueError("unsupported seat: browser requires bare metal")
+    require_bare_metal()
     if action == "status":
         return status()
     if action == "doctor":

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -2049,6 +2049,7 @@ function serviceRow(s, hostLifecycle) {
 }
 
 function browserStatusText(st) {
+  if (st.supported === false) return st.detail || "unsupported seat";
   return `${st.state} · server ${st.server ? "up" : "down"} · extension ${st.extension || "not connected"} · active shells: ${(st.active_shells || []).join(", ") || "none"}`;
 }
 
@@ -2059,8 +2060,14 @@ async function openBrowserModal(onChange) {
   const directory = el("input", { value: cfg.user_data_dir });
   const executable = el("input", { value: cfg.executable });
   const result = el("pre", { className: "doc-body" }, browserStatusText(st));
-  const note = el("div", { className: "muted" },
-    "1. Create a Chromium profile named Subfloor. 2. Install the Playwright Extension in it. " +
+  // A container engine seat can reach neither the operator's Chromium profile
+  // nor its process table, so setup is refused there rather than failing on a
+  // host path it cannot see. Say so instead of offering the buttons.
+  const unsupported = st.supported === false;
+  const note = el("div", { className: "muted" }, unsupported
+    ? `${st.detail || "unsupported seat"} — browser driving needs the host runtime; `
+      + "re-run ./sc launch there before linking a profile."
+    : "1. Create a Chromium profile named Subfloor. 2. Install the Playwright Extension in it. " +
     "3. Sign in to the accounts you intend shells to use. 4. Check and link below. " +
     "Keep Subfloor open for browser tasks and approve every new connection yourself.");
   const extension = el("a", { href: "https://chromewebstore.google.com/detail/mmlmfjhmonkocbjadbfplnigmagldckm", target: "_blank", rel: "noopener noreferrer" }, "Playwright Extension");
@@ -2078,23 +2085,23 @@ async function openBrowserModal(onChange) {
       return receipt;
     } catch (e) { result.textContent = e.message; return null; }
   };
-  const check = el("button", { className: "act", textContent: "check setup" });
+  const check = el("button", { className: "act", textContent: "check setup", disabled: unsupported });
   check.onclick = async () => { check.disabled = true; await action("validate", candidate()); check.disabled = false; };
   const arm = el("button", { className: "act", textContent: st.armed ? "disarm" : "arm" });
-  arm.disabled = !st.config;
+  arm.disabled = unsupported || !st.config;
   arm.onclick = async () => {
     arm.disabled = true;
     const receipt = await action(arm.textContent);
     if (receipt) arm.textContent = receipt.armed ? "disarm" : "arm";
     arm.disabled = false;
   };
-  const disable = el("button", { className: "act", textContent: "disable browser" });
+  const disable = el("button", { className: "act", textContent: "disable browser", disabled: unsupported });
   disable.onclick = async () => {
     disable.disabled = true;
     if (await action("disable")) arm.disabled = true;
     disable.disabled = false;
   };
-  const save = el("button", { className: "act primary", textContent: "link profile" });
+  const save = el("button", { className: "act primary", textContent: "link profile", disabled: unsupported });
   const cancel = el("button", { className: "act", textContent: "close" });
   const close = openActionModal({ title: "Browser", width: 680, height: 700,
     bodyNode: el("div", {}, note, extension, form, check, arm, disable, result),

--- a/tests/test_browser_foundation.py
+++ b/tests/test_browser_foundation.py
@@ -105,9 +105,27 @@ def test_link_rejects_invalid_paths_before_filesystem_access(field, value, monke
     def unexpected_read(*args, **kwargs):
         pytest.fail("invalid setup reached the filesystem")
 
+    monkeypatch.delenv("SC_SANDBOX", raising=False)
     monkeypatch.setattr(Path, "read_text", unexpected_read)
     with pytest.raises(ValueError, match="absolute paths"):
         browser.link({field: value}, save=False)
+
+
+@pytest.mark.parametrize("save", [False, True])
+def test_link_refuses_container_seat_before_reading_host_paths(monkeypatch, save):
+    """A sandboxed API server sees neither the profile nor the browser process,
+    so setup names the seat instead of calling a live host path missing."""
+
+    def unexpected_read(*args, **kwargs):
+        pytest.fail("container seat reached the host profile")
+
+    monkeypatch.setenv("SC_SANDBOX", "1")
+    monkeypatch.setattr(Path, "read_text", unexpected_read)
+    with pytest.raises(ValueError, match="unsupported seat"):
+        browser.link(
+            {"executable": "/usr/bin/chromium", "user_data_dir": "/home/op/chromium"},
+            save=save,
+        )
 
 
 def test_profile_probe_rejects_traversal_before_filesystem_access(config, monkeypatch):

--- a/tests/test_browser_surfaces.py
+++ b/tests/test_browser_surfaces.py
@@ -91,6 +91,16 @@ def test_status_requires_shell_auth_and_hides_configuration(api):
         assert body == {"state": "absent"}
 
 
+@pytest.mark.parametrize("action", ["validate", "link", "arm"])
+def test_container_seat_refuses_setup_with_the_seat_reason(api, monkeypatch, action):
+    """The docker runtime serves this GUI from `sc-<repo>`; issue #1556 saw the
+    operator's real profile reported as a missing file instead."""
+    monkeypatch.setenv("SC_SANDBOX", "1")
+    status, body = api(action)
+    assert status == 400
+    assert body == {"state": "failed", "error": browser.UNSUPPORTED_SEAT}
+
+
 def test_feature_grants_survive_reseed_and_reverse(tmp_path, monkeypatch):
     path = tmp_path / "engine.db"
     _build_file_db(path)
@@ -173,6 +183,53 @@ async function api(path, method, body) {
   await button('disable browser').onclick();
   assert.equal(calls.at(-1).body.action, 'disable');
   assert(!nodes.some(n => n.type === 'password'));
+})().catch(e => {console.error(e);process.exit(1)});
+"""
+    )
+    result = subprocess.run(
+        ["node"], input=script, text=True, capture_output=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_browser_gui_offers_no_setup_on_an_unsupported_seat():
+    import subprocess
+
+    source = (ROOT / ".super-coder/ui/app.js").read_text()
+    functions = source[
+        source.index("function browserStatusText(") : source.index(
+            "// Windows Test VM wizard"
+        )
+    ]
+    script = (
+        r"""
+const assert = require('node:assert/strict');
+const calls = [];
+let modal;
+function el(tag, attrs, ...children) { return {tag, ...attrs, children, append(...xs) {this.children.push(...xs);}}; }
+function openActionModal(spec) { modal = spec; return () => {}; }
+async function api(path, method, body) {
+  calls.push({path, method, body});
+  return {state:'failed', supported:false,
+          detail:'unsupported seat: browser requires bare metal',
+          config:null, defaults:{executable:'/usr/lib/chromium/chromium',user_data_dir:'/home/op/.config/chromium'}};
+}
+"""
+        + functions
+        + r"""
+(async () => {
+  assert.equal(browserStatusText({state:'failed', supported:false, detail:'unsupported seat: x'}),
+               'unsupported seat: x');
+  await openBrowserModal(() => {});
+  function walk(node) { return [node, ...(node.children || []).flatMap(x => typeof x === 'object' ? walk(x) : [])]; }
+  const nodes = walk(modal.bodyNode);
+  const buttons = nodes.filter(n => n.tag === 'button');
+  for (const text of ['check setup', 'arm', 'disable browser'])
+    assert.equal(buttons.find(n => n.textContent === text).disabled, true, text);
+  assert.equal(modal.actionNode.disabled, true);
+  assert.equal(calls.length, 1, 'the modal only read status');
+  assert(nodes.some(n => typeof n.children?.[0] === 'string'
+                         && n.children[0].includes('needs the host runtime')));
 })().catch(e => {console.error(e);process.exit(1)});
 """
     )


### PR DESCRIPTION
Closes #1556.

## The defect

On the docker runtime the API server itself runs inside `sc-<repo>` (`update.py:1485`, launched with `SC_SANDBOX=1` at `dispatch.sh:1448`). That container mounts no Chromium profile and has its own PID namespace.

`browser.operate()` and `browser.status()` already refused that seat. `browser.link()` — which backs both GUI actions, **check setup** and **link profile** — did not. It went straight to `Path(user_data_dir) / "Local State"` and the GUI returned `[Errno 2] No such file or directory: '$HOME/snap/chromium/common/chromium/Local State'` for a file that exists on the host and is in use by the running browser. The operator is told their paths are wrong when the runtime is what cannot see them.

The modal made this worse by never reading `supported`, so it offered the whole setup flow on a seat where it can never succeed.

## The trade-off

The issue's "Expected" is that the link works from the sandbox. I did not implement that. Browser driving is documented bare-metal-only ("container seats are unsupported"), and `sc launch` only starts the service under `sc_host_runtime` — so on the docker runtime the feature is unavailable by construction, not by accident. Making link work there means bind-mounting the operator's Chromium profile and process surfaces into the sandbox, which moves the feature's security boundary; the issue says the same. The fix makes the existing boundary legible at every operator surface instead.

## Changes

- `browser.py`: `require_bare_metal()` holds the one seat check and the message constant. `link()` calls it before touching any host path; `operate()` now calls it too instead of repeating the literal.
- `app.js`: `browserStatusText` returns the seat reason when `supported === false`, so the Scripts card says why. The modal disables check / arm / link profile / disable and replaces the setup steps with a note naming the host runtime.
- `browser-driving.md`: the link step states the host-runtime requirement and the exact refusal text.

## Tests

- `test_link_refuses_container_seat_before_reading_host_paths` — for `save` both ways, `link()` raises `unsupported seat` and `Path.read_text` is never reached.
- `test_container_seat_refuses_setup_with_the_seat_reason` — real dispatch through `POST /api/browser` for `validate` / `link` / `arm` returns 400 with the seat reason.
- `test_browser_gui_offers_no_setup_on_an_unsupported_seat` — drives the real `app.js` functions under Node: every setup control is disabled, only the status read fires, and the host-runtime note is present.

All three fail on `main`; the `arm` case is a regression guard for the path that was already correct. `tests/test_browser_{foundation,surfaces,proxy,package}.py`, `test_ui_freshness.py`, `test_vendor_assets.py`: 85 passed, 8 skipped (`test_browser_package` skips are pre-existing — no installed package tree). Ruff clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)