### PR TITLE
Add Tailscale read-only diagnostics client

### DIFF
--- a/.super-coder/api/ts_broker.py
+++ b/.super-coder/api/ts_broker.py
@@ -17,6 +17,8 @@ Routes (all JSON `{ok, ...}`):
     PUT  /ts        {ts}        write the ts block
     GET  /status               `tailscale status --json` -> self + peers summary
     POST /exec      {host,command,timeout?}  tailscale ssh -> {ok, exit, stdout, stderr}
+                    readonly_hosts are limited to ts.READONLY_COMMANDS and
+                    refuse unsafe input as {error: readonly_refused, token}
     POST /validate/{check}     one live setup check against the body's candidate cfg
 
 Verbs act on the SAVED `ts` block + a caller-named host; `/validate` tests the

--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -1068,7 +1068,7 @@ esac
 # migrate) probes first because it executes host Python. Container entry
 # deliberately remains a Docker handoff rather than a host-runtime gate.
 case "$cmd" in
-  install|ensure-harness|doctor|update|update-harnesses|harness-status|docker-cache-gc|rollback|feature|runtime|artifact-mode|eject|remove|init|rebuild|migrate|migration|snapshot|mem|pr|token|persist|job|visual-qa|sql|sql-rw|map-sql|map-sql-rw|map-schema|map-extractor|context|render|render-check|map|map-setup|analytics|models|seed-skills|skill|search|ports|url|preview|serve|vm|remote|vm-broker|vm-bake|vm-broker-up|vm-broker-down|vm-broker-sock|vm-mcp-relay|vm-broker-install|vm-broker-uninstall|ts-broker|ts-broker-up|ts-broker-down|ts-broker-sock|ts-broker-install|ts-broker-uninstall|pm2-broker|pm2-broker-up|pm2-broker-down|pm2-broker-sock|pm2-broker-install|pm2-broker-uninstall|db-broker|db-broker-up|db-broker-down|db-broker-sock|db-broker-install|db-broker-uninstall|db-init|pg-init|pg-up|pg-down|admin|boot|boot-*|run|deps|test|lint|typecheck|launch|down|restart|build|verify|health|clean-db)
+  install|ensure-harness|doctor|update|update-harnesses|harness-status|docker-cache-gc|rollback|feature|runtime|artifact-mode|eject|remove|init|rebuild|migrate|migration|snapshot|mem|pr|token|persist|job|visual-qa|sql|sql-rw|map-sql|map-sql-rw|map-schema|map-extractor|context|render|render-check|map|map-setup|analytics|models|seed-skills|skill|search|ports|url|preview|serve|vm|remote|vm-broker|vm-bake|vm-broker-up|vm-broker-down|vm-broker-sock|vm-mcp-relay|vm-broker-install|vm-broker-uninstall|ts|ts-broker|ts-broker-up|ts-broker-down|ts-broker-sock|ts-broker-install|ts-broker-uninstall|pm2-broker|pm2-broker-up|pm2-broker-down|pm2-broker-sock|pm2-broker-install|pm2-broker-uninstall|db-broker|db-broker-up|db-broker-down|db-broker-sock|db-broker-install|db-broker-uninstall|db-init|pg-init|pg-up|pg-down|admin|boot|boot-*|run|deps|test|lint|typecheck|launch|down|restart|build|verify|health|clean-db)
     case "$cmd" in
       deps|test|lint|typecheck)
         sc_devkit_help_form "$@" || sc_python_probe ;;
@@ -1250,6 +1250,7 @@ case "$cmd" in
   vm-broker-install)   sc_vm_broker_install ;;
   vm-broker-uninstall) sc_vm_broker_uninstall ;;
   # ── Tailnet broker (HOST-side primitive — runs where the tailnet node lives) ──
+  ts)                exec "$PY" "$S/ts.py" client "$@" ;;
   ts-broker)         exec "$PY" "$ENGINE/api/ts_broker.py" "$@" ;;
   ts-broker-up)      sc_ts_broker_up ;;
   ts-broker-down)    sc_ts_broker_down ;;
@@ -1893,6 +1894,9 @@ Subfloor — forkable shell substrate — full command reference (./sc help for 
   Tailnet broker (run on the HOST — drives the tailnet for sandboxed forks; holds
   the already-`tailscale up` node so the fork never holds a tailnet credential.
   See .super-coder/docs/tailscale-broker.md). `launch` brings it up when a tailnet is linked:
+  ./sc ts status|exec HOST -- COMMAND
+                           observe the tailnet or run a policy-checked diagnostic command
+  ./sc ts init             write the ts block from flags and show broker health
   ./sc ts-broker           run the broker in the foreground (unix socket)
   ./sc ts-broker-up        start it in the background (nohup + pidfile); self-skips if unlinked/already up
   ./sc ts-broker-down      stop the backgrounded broker

--- a/.super-coder/scripts/ts.py
+++ b/.super-coder/scripts/ts.py
@@ -14,6 +14,7 @@ the host. The block only configures *use*:
 
     ssh_user       remote user for `tailscale ssh` (user@host)
     allowed_hosts  the tailnet hosts this fork may exec against (scoping policy)
+    readonly_hosts implicitly allowed hosts restricted to diagnostic commands
     tailscale_bin  path/name of the tailscale CLI (default "tailscale")
 
 Unlike the Windows VM (one fixed target), a tailnet has N hosts — so the loop
@@ -26,7 +27,9 @@ sandbox names verbs over the broker's unix socket and holds nothing. The broker
 """
 from __future__ import annotations
 
+import argparse
 import json
+import shlex
 import socket
 import subprocess
 import sys
@@ -34,6 +37,46 @@ import sys
 import ports
 
 CHECKS = ("daemon", "auth", "peer", "ssh")
+
+# Read-only commands are prefixes: trailing operands remain available for
+# selecting a service, container, file, or other diagnostic target. Keeping the
+# policy as data makes additions reviewable and lets tests exercise every entry.
+READONLY_COMMANDS = (
+    ("systemctl", "status"),
+    ("systemctl", "is-active"),
+    ("systemctl", "list-units"),
+    ("systemctl", "list-timers"),
+    ("journalctl",),
+    ("pm2", "status"),
+    ("pm2", "list"),
+    ("pm2", "describe"),
+    ("pm2", "logs", "--nostream"),
+    ("docker", "ps"),
+    ("docker", "logs"),
+    ("docker", "inspect"),
+    ("docker", "stats", "--no-stream"),
+    ("docker", "images"),
+    ("df",),
+    ("free",),
+    ("uptime",),
+    ("ps",),
+    ("ss",),
+    ("ip",),
+    ("ls",),
+    ("stat",),
+    ("cat",),
+    ("head",),
+    ("tail",),
+    ("du",),
+    ("nproc",),
+    ("hostname",),
+    ("whoami",),
+    ("id",),
+)
+READONLY_FORBIDDEN_CHARACTERS = (
+    ";", "&", "|", ">", "<", "$", "`", "(", ")", "\n", "\r",
+)
+READONLY_TOKEN_DISPLAY = {"\n": r"\n", "\r": r"\r"}
 
 # The broker listens here — a unix socket inside the bind-mounted engine dir, so
 # the same absolute path resolves on the host (where the broker runs) and in the
@@ -90,17 +133,62 @@ def _ssh_argv(cfg: dict, host: str, remote: str) -> list[str]:
     return [_bin(cfg), "ssh", target, remote]
 
 
+def _declared_hosts(cfg: dict) -> list[str]:
+    """Allowed plus read-only hosts, in declaration order without duplicates."""
+    return list(dict.fromkeys(
+        [*(cfg.get("allowed_hosts") or []), *(cfg.get("readonly_hosts") or [])]
+    ))
+
+
 def _denied(cfg: dict, host: str) -> str | None:
-    """Fail-closed scoping. `allowed_hosts` is the set a fork may exec against;
-    empty/absent denies all, so a devops shell must declare its targets and a
-    compromised sandbox cannot reach arbitrary tailnet nodes."""
+    """Fail closed; readonly_hosts are implicitly allowed and win on overlap."""
     allowed = cfg.get("allowed_hosts") or []
-    if not allowed:
-        return ("no allowed_hosts in the `ts` block — exec is denied until you "
-                "declare the tailnet hosts this fork may reach.")
-    if host not in allowed:
-        return f"host '{host}' is not in allowed_hosts {allowed}"
+    readonly = cfg.get("readonly_hosts") or []
+    if not allowed and not readonly:
+        return ("no allowed_hosts or readonly_hosts in the `ts` block — exec is "
+                "denied until you declare the tailnet hosts this fork may reach.")
+    if host not in allowed and host not in readonly:
+        return f"host '{host}' is not in allowed_hosts or readonly_hosts"
     return None
+
+
+def readonly_refusal(command: str) -> str | None:
+    """Return the token that makes a read-only command unsafe, else None."""
+    for character in READONLY_FORBIDDEN_CHARACTERS:
+        if character in command:
+            return READONLY_TOKEN_DISPLAY.get(character, character)
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return command
+    if "sudo" in tokens:
+        return "sudo"
+    if not tokens:
+        return command
+    for prefix in READONLY_COMMANDS:
+        if tuple(tokens[:len(prefix)]) == prefix:
+            if prefix == ("journalctl",):
+                blocked = next(
+                    (token for token in tokens[1:]
+                     if token.startswith(("--vacuum", "--rotate"))),
+                    None,
+                )
+                if blocked:
+                    return blocked
+            return None
+    known_verbs = {prefix[0] for prefix in READONLY_COMMANDS}
+    return tokens[1] if tokens[0] in known_verbs and len(tokens) > 1 else tokens[0]
+
+
+def _readonly_refused(token: str) -> dict:
+    return {
+        "ok": False,
+        "error": "readonly_refused",
+        "token": token,
+        "exit": -1,
+        "stdout": "",
+        "stderr": f"read-only host refused token: {token}",
+    }
 
 
 def _status_json(cfg: dict, timeout: int = 15) -> tuple[bool, dict | str]:
@@ -148,25 +236,25 @@ def _check_auth(cfg: dict) -> tuple[bool, str]:
 
 
 def _check_peer(cfg: dict) -> tuple[bool, str]:
-    allowed = cfg.get("allowed_hosts") or []
-    if not allowed:
-        return False, "no allowed_hosts configured — nothing to resolve."
+    declared = _declared_hosts(cfg)
+    if not declared:
+        return False, "no allowed_hosts or readonly_hosts configured — nothing to resolve."
     ok, data = _status_json(cfg)
     if not ok:
         return False, str(data)
     names = _peer_names(data)
-    missing = [h for h in allowed if h not in names]
+    missing = [h for h in declared if h not in names]
     if missing:
-        return False, (f"allowed_hosts not found in the tailnet: {missing}. "
+        return False, (f"declared hosts not found in the tailnet: {missing}. "
                        f"Visible peers: {sorted(n for n in names if n)}")
-    return True, f"all allowed_hosts resolve as tailnet peers: {allowed}"
+    return True, f"all declared hosts resolve as tailnet peers: {declared}"
 
 
 def _check_ssh(cfg: dict) -> tuple[bool, str]:
-    allowed = cfg.get("allowed_hosts") or []
-    if not allowed:
-        return False, "no allowed_hosts configured — nothing to probe."
-    host = allowed[0]
+    declared = _declared_hosts(cfg)
+    if not declared:
+        return False, "no allowed_hosts or readonly_hosts configured — nothing to probe."
+    host = declared[0]
     ok, out = _run(_ssh_argv(cfg, host, "echo ok"), timeout=20)
     if ok:
         return True, f"tailscale ssh to '{host}' works: {out or 'ok'}"
@@ -233,6 +321,10 @@ def do_exec(host: str, command: str, timeout: int = 120) -> dict:
         return {"ok": False, "exit": -1, "stdout": "", "stderr": "exec: empty command"}
     if denied := _denied(cfg, host):
         return {"ok": False, "exit": -1, "stdout": "", "stderr": denied}
+    if host in (cfg.get("readonly_hosts") or []) and (
+        token := readonly_refusal(command)
+    ):
+        return _readonly_refused(token)
     try:
         p = subprocess.run(_ssh_argv(cfg, host, command), capture_output=True,
                            text=True, timeout=timeout)
@@ -281,10 +373,76 @@ def broker_call(method: str, path: str, body: dict | None = None,
                 "raw": raw_body[:200].decode("latin1")}
 
 
+# -- socket-backed public client ---------------------------------------------
+
+def _client_error(operation: str, message: str) -> dict:
+    return {"ok": False, "error": "broker_unreachable",
+            "operation": operation, "message": message}
+
+
+def _broker_health() -> dict:
+    try:
+        response = broker_call("GET", "/health")
+    except ConnectionError:
+        return {"ready": False, "start_command": "./sc ts-broker-up"}
+    return {"ready": response.get("ok") is True,
+            "start_command": "./sc ts-broker-up"}
+
+
+def client_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="./sc ts",
+        description="Observe and diagnose declared tailnet hosts through ts-broker.",
+    )
+    commands = parser.add_subparsers(dest="operation", required=True)
+    commands.add_parser("status", help="show tailnet node and peer status")
+    execute = commands.add_parser(
+        "exec", help="execute a permitted command on a declared tailnet host"
+    )
+    execute.add_argument("host")
+    execute.add_argument("command", nargs=argparse.REMAINDER, metavar="COMMAND")
+    init = commands.add_parser("init", help="write the ts block and show broker health")
+    init.add_argument("--ssh-user")
+    init.add_argument("--allowed-host", action="append", dest="allowed_hosts")
+    init.add_argument("--readonly-host", action="append", dest="readonly_hosts")
+    init.add_argument("--tailscale-bin")
+    args = parser.parse_args(argv)
+
+    if args.operation == "init":
+        current = read() or {}
+        block = {
+            "ssh_user": args.ssh_user if args.ssh_user is not None
+            else current.get("ssh_user", ""),
+            "allowed_hosts": args.allowed_hosts if args.allowed_hosts is not None
+            else current.get("allowed_hosts", []),
+            "readonly_hosts": args.readonly_hosts if args.readonly_hosts is not None
+            else current.get("readonly_hosts", []),
+            "tailscale_bin": args.tailscale_bin if args.tailscale_bin is not None
+            else current.get("tailscale_bin", "tailscale"),
+        }
+        write(block)
+        result = {"ok": True, "ts": block, "broker": _broker_health()}
+    else:
+        try:
+            if args.operation == "status":
+                result = broker_call("GET", "/status")
+            else:
+                command = args.command[1:] if args.command[:1] == ["--"] else args.command
+                result = broker_call(
+                    "POST", "/exec", {"host": args.host, "command": " ".join(command)}
+                )
+        except ConnectionError as exc:
+            result = _client_error(args.operation, str(exc))
+    print(json.dumps(result, separators=(",", ":")))
+    return 0 if result.get("ok") else 1
+
+
 # -- host CLI (path lookup for `sc`; verbs for manual no-broker testing) ------
 
 def main(argv: list[str]) -> int:
     mode = argv[0] if argv else "sock"
+    if mode == "client":
+        return client_main(argv[1:])
     if mode == "sock":
         print(SOCKET)
     elif mode == "configured":
@@ -299,7 +457,7 @@ def main(argv: list[str]) -> int:
     elif mode == "validate":
         print(json.dumps(validate(argv[1] if len(argv) > 1 else "", read() or {})))
     else:
-        sys.exit("usage: ts.py [sock|status|exec <host> <cmd>|validate <check>]")
+        sys.exit("usage: ts.py [client <status|exec|init>|sock|status|exec <host> <cmd>|validate <check>]")
     return 0
 
 

--- a/tests/test_ts_broker.py
+++ b/tests/test_ts_broker.py
@@ -14,10 +14,13 @@ Run:
 """
 from __future__ import annotations
 
+import io
 import json
 import sys
+import tempfile
 import threading
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -33,6 +36,8 @@ SAVED = {
     "allowed_hosts": ["build-box", "deploy-target"],
     "tailscale_bin": "tailscale",
 }
+
+READONLY_SAVED = dict(SAVED, readonly_hosts=["production"])
 
 # A minimal `tailscale status --json` payload.
 STATUS_JSON = json.dumps({
@@ -77,6 +82,86 @@ class VerbDispatchTests(unittest.TestCase):
         self.assertFalse(r["ok"])
         self.assertIn("no allowed_hosts", r["stderr"])
         run.assert_not_called()
+
+    def test_every_readonly_command_table_entry_passes(self):
+        fake = mock.Mock(returncode=0, stdout="ok\n", stderr="")
+        with mock.patch.object(ts, "read", return_value=READONLY_SAVED), \
+             mock.patch("subprocess.run", return_value=fake) as run:
+            for prefix in ts.READONLY_COMMANDS:
+                with self.subTest(prefix=prefix):
+                    command = " ".join((*prefix, "target"))
+                    r = ts.do_exec("production", command)
+                    self.assertTrue(r["ok"], r)
+        self.assertEqual(run.call_count, len(ts.READONLY_COMMANDS))
+
+    def test_each_forbidden_character_is_structurally_refused(self):
+        with mock.patch.object(ts, "read", return_value=READONLY_SAVED), \
+             mock.patch("subprocess.run") as run:
+            for character in ts.READONLY_FORBIDDEN_CHARACTERS:
+                with self.subTest(character=character):
+                    r = ts.do_exec("production", f"uptime {character} whoami")
+                    self.assertEqual(r["error"], "readonly_refused")
+                    self.assertEqual(
+                        r["token"], ts.READONLY_TOKEN_DISPLAY.get(character, character)
+                    )
+        run.assert_not_called()
+
+    def test_each_forbidden_character_remains_unrestricted_on_allowed_host(self):
+        fake = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(ts, "read", return_value=SAVED), \
+             mock.patch("subprocess.run", return_value=fake) as run:
+            for character in ts.READONLY_FORBIDDEN_CHARACTERS:
+                with self.subTest(character=character):
+                    command = f"uptime {character} whoami"
+                    r = ts.do_exec("build-box", command)
+                    self.assertTrue(r["ok"])
+                    self.assertEqual(run.call_args[0][0][-1], command)
+        self.assertEqual(run.call_count, len(ts.READONLY_FORBIDDEN_CHARACTERS))
+
+    def test_sudo_and_off_table_verb_are_structurally_refused(self):
+        with mock.patch.object(ts, "read", return_value=READONLY_SAVED), \
+             mock.patch("subprocess.run") as run:
+            for command, token in (("sudo uptime", "sudo"), ("reboot", "reboot")):
+                with self.subTest(command=command):
+                    r = ts.do_exec("production", command)
+                    self.assertEqual(r["error"], "readonly_refused")
+                    self.assertEqual(r["token"], token)
+        run.assert_not_called()
+
+    def test_readonly_subcommand_restrictions_are_enforced(self):
+        cases = (
+            ("systemctl restart app", "restart"),
+            ("journalctl --vacuum-time=1d", "--vacuum-time=1d"),
+            ("journalctl --rotate", "--rotate"),
+            ("pm2 restart app", "restart"),
+            ("pm2 logs app", "logs"),
+            ("docker stats", "stats"),
+            ("docker restart app", "restart"),
+        )
+        with mock.patch.object(ts, "read", return_value=READONLY_SAVED), \
+             mock.patch("subprocess.run") as run:
+            for command, token in cases:
+                with self.subTest(command=command):
+                    r = ts.do_exec("production", command)
+                    self.assertEqual(r["error"], "readonly_refused")
+                    self.assertEqual(r["token"], token)
+        run.assert_not_called()
+
+    def test_allowed_hosts_only_entry_remains_unrestricted(self):
+        fake = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(ts, "read", return_value=SAVED), \
+             mock.patch("subprocess.run", return_value=fake) as run:
+            r = ts.do_exec("build-box", "sudo reboot; now")
+        self.assertTrue(r["ok"])
+        run.assert_called_once()
+
+    def test_readonly_host_is_implicitly_allowed(self):
+        fake = mock.Mock(returncode=0, stdout="", stderr="")
+        cfg = {"readonly_hosts": ["production"]}
+        with mock.patch.object(ts, "read", return_value=cfg), \
+             mock.patch("subprocess.run", return_value=fake):
+            r = ts.do_exec("production", "uptime")
+        self.assertTrue(r["ok"])
 
     def test_exec_empty_command_is_a_clean_error(self):
         with mock.patch.object(ts, "read", return_value=SAVED):
@@ -126,6 +211,16 @@ class CheckTests(unittest.TestCase):
         self.assertFalse(r["ok"])
         self.assertIn("ghost", r["output"])
 
+    def test_peer_and_ssh_checks_include_implicitly_allowed_readonly_hosts(self):
+        cfg = {"readonly_hosts": ["build-box"], "ssh_user": "tester"}
+        with mock.patch.object(ts, "_run", return_value=(True, STATUS_JSON)):
+            peer = ts.validate("peer", cfg)
+        self.assertTrue(peer["ok"])
+        with mock.patch.object(ts, "_run", return_value=(True, "ok")) as run:
+            ssh = ts.validate("ssh", cfg)
+        self.assertTrue(ssh["ok"])
+        self.assertIn("tester@build-box", run.call_args[0][0])
+
     def test_unknown_check_is_none(self):
         self.assertIsNone(ts.validate("nope", SAVED))
 
@@ -172,6 +267,16 @@ class SocketTransportTests(unittest.TestCase):
         self.assertEqual(r["exit"], 2)
         self.assertEqual(r["stdout"], "out")
 
+    def test_readonly_refusal_round_trips_over_the_socket(self):
+        with mock.patch.object(ts, "read", return_value=READONLY_SAVED), \
+             mock.patch("subprocess.run") as run:
+            r = ts.broker_call(
+                "POST", "/exec", {"host": "production", "command": "uptime\nreboot"}
+            )
+        self.assertEqual(r["error"], "readonly_refused")
+        self.assertEqual(r["token"], r"\n")
+        run.assert_not_called()
+
     def test_status_round_trips_over_the_socket(self):
         with mock.patch.object(ts, "read", return_value=SAVED), \
              mock.patch.object(ts, "_run", return_value=(True, STATUS_JSON)):
@@ -183,6 +288,79 @@ class SocketTransportTests(unittest.TestCase):
         ts.SOCKET = self.sock.with_name("_absent.sock")
         with self.assertRaises(ConnectionError):
             ts.broker_call("GET", "/health")
+
+
+class ClientTests(unittest.TestCase):
+    def _run(self, argv):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            code = ts.client_main(argv)
+        return code, json.loads(output.getvalue())
+
+    def test_status_calls_the_broker(self):
+        response = {"ok": True, "backend": "Running", "self": {}, "peers": []}
+        with mock.patch.object(ts, "broker_call", return_value=response) as call:
+            code, result = self._run(["status"])
+        self.assertEqual(code, 0)
+        self.assertEqual(result, response)
+        call.assert_called_once_with("GET", "/status")
+
+    def test_exec_calls_the_broker_with_command_after_separator(self):
+        response = {"ok": True, "exit": 0, "stdout": "up", "stderr": ""}
+        with mock.patch.object(ts, "broker_call", return_value=response) as call:
+            code, result = self._run(["exec", "production", "--", "uptime"])
+        self.assertEqual(code, 0)
+        self.assertEqual(result, response)
+        call.assert_called_once_with(
+            "POST", "/exec", {"host": "production", "command": "uptime"}
+        )
+
+    def test_init_preserves_unspecified_values_and_reports_broker_health(self):
+        current = {"ssh_user": "ops", "allowed_hosts": ["build-box"]}
+        with mock.patch.object(ts, "read", return_value=current), \
+             mock.patch.object(ts, "write") as write, \
+             mock.patch.object(ts, "broker_call", return_value={"ok": True}):
+            code, result = self._run(
+                ["init", "--readonly-host", "production", "--tailscale-bin", "/bin/ts"]
+            )
+        expected = {
+            "ssh_user": "ops",
+            "allowed_hosts": ["build-box"],
+            "readonly_hosts": ["production"],
+            "tailscale_bin": "/bin/ts",
+        }
+        self.assertEqual(code, 0)
+        write.assert_called_once_with(expected)
+        self.assertEqual(result["ts"], expected)
+        self.assertTrue(result["broker"]["ready"])
+        self.assertEqual(result["broker"]["start_command"], "./sc ts-broker-up")
+
+    def test_init_succeeds_and_reports_how_to_start_a_down_broker(self):
+        with mock.patch.object(ts, "read", return_value=None), \
+             mock.patch.object(ts, "write"), \
+             mock.patch.object(ts, "broker_call", side_effect=ConnectionError("down")):
+            code, result = self._run(["init"])
+        self.assertEqual(code, 0)
+        self.assertFalse(result["broker"]["ready"])
+        self.assertEqual(result["broker"]["start_command"], "./sc ts-broker-up")
+
+    def test_init_writes_only_ts_and_preserves_vm_and_ports(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "instance.json"
+            vm_block = {"domain": "dev-vm", "snapshot": "clean"}
+            initial = {"port": 8837, "dev_port": 4173, "vm": vm_block}
+            config.write_text(json.dumps(initial) + "\n")
+            with mock.patch.object(ts.ports, "CONFIG", config), \
+                 mock.patch.object(ts, "broker_call", side_effect=ConnectionError("down")):
+                code, result = self._run(
+                    ["init", "--ssh-user", "ops", "--readonly-host", "production"]
+                )
+            written = json.loads(config.read_text())
+        self.assertEqual(code, 0)
+        self.assertEqual(written["port"], initial["port"])
+        self.assertEqual(written["dev_port"], initial["dev_port"])
+        self.assertEqual(written["vm"], vm_block)
+        self.assertEqual(written["ts"], result["ts"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Sprint scope

Sprint 35 work unit 161 · Spec #230 task #831.

Adds the data-driven Tailscale read-only diagnostics tier, structured refusals, socket-backed `sc ts status|exec|init`, and focused exhaustive coverage while preserving unrestricted behavior for hosts declared only in `allowed_hosts`.

Decision #354 governs the broker allowlist boundary. Read-only hosts are implicitly allowed and remain restricted when also present in `allowed_hosts`.

Ratified judgments: Sprint message #1979 raised the CR/LF and init-contract gaps; assigned Reviewer ruling #1980 ratified printable CR/LF refusals and the four-flag preserve-on-omit JSON init contract.

## Verification

- `./sc test tests/test_ts_broker.py` — 30 passed
- changed-code Ruff gate — passed (legacy file-wide EXE001/RUF100/BLE001/PLW1510 findings excluded; all predate this diff)
- `bash -n .super-coder/scripts/dispatch.sh` — passed
- Python compile check for changed Python files — passed
- direct `ts.py client --help` — exposes status, exec, and init

The repository-wide typecheck remains red on existing `ports.py`, `ts.py`, and `ts_broker.py` findings that predate this lane; no new typecheck diagnostic is introduced by the diff.

## Trade-off

The diagnostic policy is a flat tuple of allowed command prefixes. This keeps the exact Spec #230 table directly enumerable and avoids a parser abstraction that would obscure or widen the fixed policy.
