### PR TITLE
Fix local file links in browser chat

### DIFF
--- a/.super-coder/api/conversation_routes.py
+++ b/.super-coder/api/conversation_routes.py
@@ -18,6 +18,7 @@ import math
 import os
 import re
 import signal
+import stat
 import sys
 import time
 import uuid
@@ -60,6 +61,7 @@ _MESSAGES_PATH = re.compile(r"^/api/conversations/(cv_[0-9a-f]{32})/messages$")
 _TRANSCRIPT_PATH = re.compile(
     r"^/api/conversations/(cv_[0-9a-f]{32})/transcript$"
 )
+_SOURCE_PATH = re.compile(r"^/api/conversations/(cv_[0-9a-f]{32})/source$")
 _EVENTS_PATH = re.compile(r"^/api/conversations/(cv_[0-9a-f]{32})/events$")
 _INTERRUPTIONS_PATH = re.compile(
     r"^/api/conversations/(cv_[0-9a-f]{32})/interruptions$"
@@ -96,6 +98,7 @@ TRANSCRIPT_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
 TRANSCRIPT_PROJECTION_VERSION = 3
 TRANSCRIPT_MAX_WARNINGS = 20
 TRANSCRIPT_MAX_ACTIVITY_LABEL_BYTES = 1024
+SOURCE_MAX_BYTES = 512 * 1024
 
 
 @dataclass(frozen=True)
@@ -431,7 +434,7 @@ def _conversation_row(con, conversation_id: str, owner_user_id: int):
     return con.execute(
         "SELECT c.conversation_id,c.shell_id,c.owner_user_id,c.harness,"
         "c.provider,c.model,c.effort,c.route_contract_version,c.route_binding,"
-        "c.state,c.title,c.starred,"
+        "c.worktree,c.state,c.title,c.starred,"
         "c.conversation_scope,c.created_at,"
         "c.last_activity_at,c.closed_at,c.version,c.harness_session_ref,"
         "s.display_name,s.shortname,"
@@ -575,6 +578,81 @@ def _require_conversation(con, conversation_id: str, owner_user_id: int):
     if row is None:
         raise ApiError(404, "CONVERSATION_NOT_FOUND", "conversation does not exist")
     return row
+
+
+def _source_projection(con, conversation_id: str, owner_user_id: int, query) -> dict:
+    conversation = _require_conversation(con, conversation_id, owner_user_id)
+    values = query.get("path")
+    if values is None or len(values) != 1 or not values[0]:
+        raise ApiError(422, "SOURCE_PATH_INVALID", "path must be provided once")
+
+    requested = Path(values[0])
+    if not requested.is_absolute():
+        raise ApiError(422, "SOURCE_PATH_INVALID", "path must be absolute")
+    worktree = Path(conversation["worktree"]).resolve(strict=False)
+    try:
+        requested.resolve(strict=False).relative_to(worktree)
+    except ValueError as exc:
+        raise ApiError(
+            403,
+            "SOURCE_OUTSIDE_WORKTREE",
+            "source path is outside this conversation's worktree",
+        ) from exc
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(requested, flags)
+    except OSError as exc:
+        raise ApiError(404, "SOURCE_UNAVAILABLE", "source file is unavailable") from exc
+    try:
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            raise ApiError(404, "SOURCE_UNAVAILABLE", "source file is unavailable")
+        try:
+            opened = Path(os.readlink(f"/proc/self/fd/{descriptor}")).resolve(strict=True)
+            relative = opened.relative_to(worktree)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ApiError(
+                403,
+                "SOURCE_OUTSIDE_WORKTREE",
+                "source path is outside this conversation's worktree",
+            ) from exc
+        if info.st_size > SOURCE_MAX_BYTES:
+            raise ApiError(
+                413,
+                "SOURCE_TOO_LARGE",
+                f"source file exceeds {SOURCE_MAX_BYTES} bytes",
+                {"bytes": info.st_size, "maximum_bytes": SOURCE_MAX_BYTES},
+            )
+        chunks: list[bytes] = []
+        remaining = SOURCE_MAX_BYTES + 1
+        while remaining > 0:
+            chunk = os.read(descriptor, min(64 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+    finally:
+        os.close(descriptor)
+    if len(raw) > SOURCE_MAX_BYTES:
+        raise ApiError(
+            413,
+            "SOURCE_TOO_LARGE",
+            f"source file exceeds {SOURCE_MAX_BYTES} bytes",
+            {"bytes": len(raw), "maximum_bytes": SOURCE_MAX_BYTES},
+        )
+    try:
+        content = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ApiError(415, "SOURCE_NOT_TEXT", "source file is not UTF-8 text") from exc
+    if "\0" in content:
+        raise ApiError(415, "SOURCE_NOT_TEXT", "source file is not text")
+    return {
+        "relative_path": relative.as_posix(),
+        "bytes": len(raw),
+        "content": content,
+    }
 
 
 def _close_requested(con, conversation_id: str) -> bool:
@@ -2598,6 +2676,17 @@ def handle(method: str, path: str, headers_raw: str, raw_body: bytes) -> tuple:
                         transcript.group(1),
                         owner_user_id=operator["user_id"],
                         cursor=_single_cursor(query, "transcript"),
+                    ),
+                )
+            source = _SOURCE_PATH.fullmatch(parsed.path)
+            if source and method == "GET":
+                return _json(
+                    200,
+                    _source_projection(
+                        con,
+                        source.group(1),
+                        owner_user_id=operator["user_id"],
+                        query=query,
                     ),
                 )
             interruptions = _INTERRUPTIONS_PATH.fullmatch(parsed.path)

--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3483,6 +3483,73 @@ function chatCollapseOtherReasoning(disclosure) {
   }
 }
 
+function chatLocalFileTarget(anchor) {
+  const href = anchor.getAttribute("href") || "";
+  if (!href.startsWith("/") || href.startsWith("//") || /[?#]/.test(href))
+    return null;
+  let decoded;
+  try { decoded = decodeURIComponent(href); } catch { return null; }
+  const cited = decoded.match(/^(.*?):([1-9]\d*)(?::([1-9]\d*))?$/);
+  const path = cited ? cited[1] : decoded;
+  return {
+    path,
+    line: cited ? Number(cited[2]) : null,
+    column: cited?.[3] ? Number(cited[3]) : null,
+  };
+}
+
+async function openChatSourceModal(conversation, target) {
+  try {
+    const source = await chatApi(
+      `/conversations/${conversation.conversation_id}/source?path=${encodeURIComponent(target.path)}`,
+    );
+    const viewer = el("div", { className: "chat-source-viewer" });
+    let selected = null;
+    source.content.split("\n").forEach((text, index) => {
+      const number = index + 1;
+      const row = el("div", {
+        className: "chat-source-line" + (number === target.line ? " selected" : ""),
+      },
+      el("span", { className: "chat-source-number" }, String(number)),
+      el("code", { className: "chat-source-code" }, text));
+      if (number === target.line) selected = row;
+      viewer.append(row);
+    });
+    const closeButton = el("button", {
+      className: "act", type: "button", textContent: "Close",
+    });
+    const location = target.line
+      ? `line ${target.line}${target.column ? `:${target.column}` : ""}`
+      : `${fmt(source.bytes)} bytes`;
+    const close = openModal({
+      title: source.relative_path,
+      headExtra: el("div", { className: "modal-count" }, location),
+      bodyNode: viewer,
+      footerEnd: closeButton,
+      width: 1000,
+      height: 750,
+    });
+    closeButton.onclick = close;
+    if (selected) requestAnimationFrame(() => selected.scrollIntoView({ block: "center" }));
+  } catch (error) {
+    toast(`${error.code}: ${error.message}`);
+  }
+}
+
+function chatWireLocalFileLinks(content, conversation) {
+  if (typeof content.querySelectorAll !== "function") return;
+  for (const anchor of content.querySelectorAll("a[href]")) {
+    const target = chatLocalFileTarget(anchor);
+    if (!target) continue;
+    anchor.classList.add("chat-local-file-link");
+    anchor.title = "Open local file";
+    anchor.onclick = (event) => {
+      event.preventDefault();
+      openChatSourceModal(conversation, target);
+    };
+  }
+}
+
 function chatBubble(
   kind, body, meta = "", conversation = null, createdAt = "", contextTokens = null,
   segment = "answer",
@@ -3503,6 +3570,7 @@ function chatBubble(
   const content = kind === "activity"
     ? el("div", { className: "chat-activity-text" }, body)
     : mdBlock(body);
+  if (kind !== "activity") chatWireLocalFileLinks(content, conversation);
   if (kind === "assistant") content.classList.add("chat-assistant-body");
   if (isReasoning) {
     const disclosure = el("details", { className: "chat-reasoning-disclosure" });
@@ -4687,11 +4755,12 @@ function chatTranscriptItemNode(item, conversation, retry) {
   return node;
 }
 
-function chatUpdateTranscriptNode(node, item, retry) {
+function chatUpdateTranscriptNode(node, item, retry, conversation) {
   if (item.kind === "assistant") {
     const body = node.querySelector(".chat-assistant-body");
     const rendered = mdBlock(item.text || "");
     body.replaceChildren(...rendered.childNodes);
+    chatWireLocalFileLinks(body, conversation);
     chatUpdateContextTokens(node, item.context_tokens);
     return;
   }
@@ -4852,7 +4921,7 @@ function chatFlushTranscript(
         const working = transcript.querySelector(".chat-working-indicator");
         transcript.insertBefore(node, next || working || null);
       } else {
-        chatUpdateTranscriptNode(node, item, retry);
+        chatUpdateTranscriptNode(node, item, retry, conversation);
       }
     }
     state.dirty.clear();

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -512,6 +512,20 @@ body.interface-view main {
 .chat-message-time { font-variant-numeric: tabular-nums; white-space: nowrap; }
 .chat-bubble .md > :first-child { margin-top: 0; }
 .chat-bubble .md > :last-child { margin-bottom: 0; }
+.chat-local-file-link::before { content: "↗ "; font-size: .82em; }
+.chat-source-viewer {
+  flex: 1; min-width: 0; min-height: 0; overflow: auto; padding: .35rem 0;
+  background: var(--panel2); border: 1px solid var(--line); border-radius: 6px;
+  font: 12px/1.55 ui-monospace, monospace;
+}
+.chat-source-line { display: flex; min-width: max-content; }
+.chat-source-line.selected { background: rgba(110,168,254,.18); }
+.chat-source-number {
+  position: sticky; left: 0; flex: none; width: 4.5rem; padding-right: .8rem;
+  color: var(--dim); background: var(--panel2); text-align: right; user-select: none;
+}
+.chat-source-line.selected .chat-source-number { background: #263246; color: var(--accent); }
+.chat-source-code { padding: 0 1rem; white-space: pre; color: rgba(255,255,255,.82); }
 .chat-meta { color: var(--dim); font-size: .64rem; margin-top: .35rem; }
 .chat-context-tokens {
   color: var(--dim); font-size: .64rem; margin-top: .35rem; text-align: right;

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
+from urllib.parse import quote
 
 ROOT = Path(__file__).resolve().parents[1]
 ENGINE = ROOT / ".super-coder"
@@ -1429,6 +1430,75 @@ class ConversationResourceTest(ConversationApiCase):
         con.close()
         self.assertEqual(count, 1)
         self.assertEqual(tuple(event), (1, "conversation.created"))
+
+    def test_source_reads_only_regular_utf8_files_inside_conversation_worktree(
+        self,
+    ) -> None:
+        conversation_id = self.create(key="source-reader")["conversation_id"]
+        worktree = self.root / ".sc-worktrees" / "dev"
+        source = worktree / "src" / "example.py"
+        source.parent.mkdir()
+        source.write_text("first\nsecond\n")
+
+        status, _, payload = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/source?path="
+            f"{quote(str(source), safe='')}",
+        )
+        self.assertEqual(status, 200, payload)
+        self.assertEqual(payload["relative_path"], "src/example.py")
+        self.assertEqual(payload["content"], "first\nsecond\n")
+        self.assertEqual(payload["bytes"], len(b"first\nsecond\n"))
+
+        outside = self.root / "outside.txt"
+        outside.write_text("secret")
+        status, _, error = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/source?path="
+            f"{quote(str(outside), safe='')}",
+        )
+        self.assertEqual(status, 403, error)
+        self.assertEqual(error["error"]["code"], "SOURCE_OUTSIDE_WORKTREE")
+
+        link = worktree / "outside-link"
+        link.symlink_to(outside)
+        status, _, error = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/source?path="
+            f"{quote(str(link), safe='')}",
+        )
+        self.assertEqual(status, 403, error)
+        self.assertEqual(error["error"]["code"], "SOURCE_OUTSIDE_WORKTREE")
+
+    def test_source_rejects_invalid_binary_and_oversized_inputs(self) -> None:
+        conversation_id = self.create(key="source-validation")["conversation_id"]
+        worktree = self.root / ".sc-worktrees" / "dev"
+
+        status, _, error = self.request(
+            "GET", f"/api/conversations/{conversation_id}/source?path=relative.py"
+        )
+        self.assertEqual(status, 422, error)
+        self.assertEqual(error["error"]["code"], "SOURCE_PATH_INVALID")
+
+        binary = worktree / "binary.dat"
+        binary.write_bytes(b"text\0data")
+        status, _, error = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/source?path="
+            f"{quote(str(binary), safe='')}",
+        )
+        self.assertEqual(status, 415, error)
+        self.assertEqual(error["error"]["code"], "SOURCE_NOT_TEXT")
+
+        large = worktree / "large.txt"
+        large.write_bytes(b"x" * (conversation_routes.SOURCE_MAX_BYTES + 1))
+        status, _, error = self.request(
+            "GET",
+            f"/api/conversations/{conversation_id}/source?path="
+            f"{quote(str(large), safe='')}",
+        )
+        self.assertEqual(status, 413, error)
+        self.assertEqual(error["error"]["code"], "SOURCE_TOO_LARGE")
 
     def test_controlled_replay_uses_stored_binding_after_catalogue_drift(self) -> None:
         first = self.create(key="controlled-replay")

--- a/tests/test_conversation_ui.py
+++ b/tests/test_conversation_ui.py
@@ -50,6 +50,35 @@ def test_interface_is_a_first_class_reload_safe_view():
     assert "chatRouteConversation = decodeURIComponent(conversation)" in APP
 
 
+def test_chat_local_file_links_open_the_scoped_source_viewer():
+    parser = APP[
+        APP.index("function chatLocalFileTarget"):
+        APP.index("async function openChatSourceModal")
+    ]
+    script = parser + r"""
+const anchor = (href) => ({ getAttribute: () => href });
+console.log(JSON.stringify({
+  line: chatLocalFileTarget(anchor("/tmp/work/app.py:42")),
+  column: chatLocalFileTarget(anchor("/tmp/work/app.py:42:7")),
+  encoded: chatLocalFileTarget(anchor("/tmp/my%20work/app.py:9")),
+  external: chatLocalFileTarget(anchor("https://example.com/file.py:2")),
+  network: chatLocalFileTarget(anchor("//example.com/file.py:2")),
+}));
+"""
+    result = run_js(script)
+    assert result == {
+        "line": {"path": "/tmp/work/app.py", "line": 42, "column": None},
+        "column": {"path": "/tmp/work/app.py", "line": 42, "column": 7},
+        "encoded": {"path": "/tmp/my work/app.py", "line": 9, "column": None},
+        "external": None,
+        "network": None,
+    }
+    assert "/source?path=${encodeURIComponent(target.path)}" in APP
+    assert "event.preventDefault()" in APP
+    assert "chatWireLocalFileLinks(body, conversation)" in APP
+    assert ".chat-source-line.selected" in STYLE
+
+
 def test_admin_shells_stay_on_the_rail_but_chat_is_cli_only():
     interface = APP[APP.index("async function renderInterface"):
                     APP.index("// ── Tabs + boot")]
@@ -655,7 +684,7 @@ def test_transcript_installs_snapshot_then_coalesces_keyed_live_updates():
     assert "nodes: new Map()" in keyed
     assert "dirty: new Set(items.keys())" in keyed
     assert "transcript.replaceChildren(...nodes)" in keyed
-    assert "chatUpdateTranscriptNode(node, item, retry)" in keyed
+    assert "chatUpdateTranscriptNode(node, item, retry, conversation)" in keyed
     assert 'node.querySelector(".chat-assistant-body")' in keyed
     assert "body.replaceChildren(...rendered.childNodes)" in keyed
     assert "if (transcriptState.frame !== null) return" in keyed

--- a/tests/test_modal_ui_contract.py
+++ b/tests/test_modal_ui_contract.py
@@ -145,5 +145,5 @@ def test_all_modal_callers_use_semantic_action_or_named_viewer_slots():
     assert "footNodes" not in APP
     assert APP.count("const close = openActionModal({") == 8
     assert APP.count("footerStart:") == 5  # helper + four viewer callers
-    assert APP.count("footerEnd:") == 5
+    assert APP.count("footerEnd:") == 6  # helper + five viewer callers
     assert "if (overlay?.closeModal) overlay.closeModal();" in APP


### PR DESCRIPTION
Closes #1567

## Summary
- intercept absolute local-file Markdown links in browser chat instead of navigating to an HTTP 404
- open UTF-8 files in a source modal and center the cited `:line[:column]`
- restrict reads to regular files inside the conversation worktree, with symlink/race containment and a 512 KiB limit
- rewire links after streamed assistant updates

## Verification
- `./sc test tests/test_conversation_api.py tests/test_conversation_ui.py` — 134 passed
- `node --check .super-coder/ui/app.js`
- `python -m py_compile .super-coder/api/conversation_routes.py`
- `git diff --check`

## Known baseline/tooling limits
- repository-wide lint remains red on generated state/baseline errors (#1466)
- repository-wide typecheck remains red on module-path baseline errors (#1467)
- optional browser-only target skipped on this seat and the wrapper surfaced pytest exit 5 (#1569)