### PR TITLE
docs: require feasible planner acceptance criteria

### DIFF
--- a/.super-coder/templates/shells/planner.md
+++ b/.super-coder/templates/shells/planner.md
@@ -34,6 +34,50 @@ Out of Scope with the boundary it leaves behind. The conversation is input;
 the spec is the resolved contract: settled FnB decisions sit beside the clause
 they govern, and an unconfirmed suggestion is never promoted to a requirement.
 
+## ACCEPTANCE FEASIBILITY
+
+Before committing acceptance criteria or handing a spec to implementation,
+walk each criterion through these questions in order. Apply this to new specs,
+substantive revisions, and existing specs entering a Sprint.
+
+1. **Can we meet it with available resources?** Name the environment, tools,
+   access, data, people, and time needed, and establish what is available now.
+   A hoped-for capability is an unresolved prerequisite, not a test plan.
+2. **What evidence is worth obtaining?** Separate directly proven success
+   from inferred success. Weigh the value of direct proof against its cost;
+   assess how accurately success can be inferred from available tests and
+   observations, naming assumptions, blind spots, and residual uncertainty.
+   Choose and justify the evidence level with the FnB when it changes the
+   acceptance promise. Never label inference as proof or demand direct proof
+   merely because it sounds stronger. Evidence choices do not waive the
+   correctness, authorization, or tenancy requirements themselves.
+3. **Is post-implementation verification practical in Dev?** Describe the
+   setup, action, observable result, and cleanup on the actual available seat.
+   Bound the effort and state what that environment can and cannot establish;
+   mocks or a Dev pass do not prove behavior beyond their demonstrated reach.
+4. **Can the FnB supply the missing proof?** Consider concrete privileged
+   console commands run by the FnB in cooperation with shells during or after
+   the Sprint. Specify the target, commands, expected evidence, shell role,
+   cleanup, and timing; confirm FnB participation before depending on it.
+   Distinguish Sprint completion from any pending post-Sprint acceptance, and
+   keep unperformed checks explicitly pending.
+5. **Is a privileged process still justified?** Only if direct proof remains
+   required and the preceding paths are insufficient, consider implementing a
+   narrowly scoped privileged process. State why it is worth building, its
+   exact operations and authority, lifetime, cleanup, and verification path.
+   Resolve that scope with the FnB before adding it to implementation; a
+   verification gap is not authority to build general privileged tooling.
+
+Record the result in `## Acceptance Criteria`: for each criterion, give the
+claim, required evidence level and rationale, verification method and seat,
+owner and timing, prerequisites, and observable pass condition. Keep this
+proportional to the work; a compact table is sufficient. Unavailable required
+proof -> resolve the prerequisite, agree a narrower claim or justified
+inference, or defer the criterion explicitly before releasing dependent work.
+If feasibility breaks during implementation, return to the FnB and the normal
+spec revision/Sprint rebind procedure before expanding verification scope.
+Do not keep adding code to chase an acceptance claim the resources cannot prove.
+
 ## THE SPEC CONTRACT
 
 Every new spec and every substantive revision of an unfrozen spec carries:
@@ -43,6 +87,7 @@ Every new spec and every substantive revision of an unfrozen spec carries:
 | `## Current Posture` | related systems and behavior before the change; documents and decisions consulted; code paths read because documentation was missing, ambiguous, or stale |
 | `## Scope` → `### In Scope` / `### Out of Scope` | what this delivery adds, changes, or removes; what it deliberately excludes and the boundary retained ("not in this delivery", never "never") |
 | design sections | synthesized FnB decisions and rationale beside the requirement they constrain |
+| `## Acceptance Criteria` | per-criterion evidence choice, feasibility, verification method, owner, timing, prerequisites, and observable pass condition from ACCEPTANCE FEASIBILITY |
 | `## Anticipated User Activity` | `### Vocabulary`, `### Expected Activity`, `### Reach`, `### Audience and Assurance`, `### Data Tenancy`, `### Beyond Intention`; about 60 lines at most |
 
 Vocabulary roster: Valid Privileged User, Valid User, Visitor, Future


### PR DESCRIPTION
Specs could require acceptance evidence that available environments and permissions cannot produce, driving implementation growth without a feasible finish. Add a planner boot gate that checks resources, weighs direct proof against justified inference, tests Dev practicality, considers FnB-run privileged console verification, and only then considers a narrowly scoped privileged process.

Require each acceptance criterion to name its evidence level, rationale, method, seat, owner, timing, prerequisites, and observable pass condition. Apply the gate to new/revised specs and existing specs entering a Sprint; revisit the contract when feasibility breaks, and keep post-Sprint checks explicitly pending. This changes planner guidance only; it does not rewrite existing specs or grant privileged access.

Validation: `git diff --check`; `./sc test tests/test_mem.py -k test_feature_move_guidance_is_rendered_for_shells -q` (1 passed, 2 subtests passed). Manually checked the guidance against all five requested considerations. Behavioral compliance by future planners is not established by the existing test.
