### PR TITLE
fix: render Markdown and wrap chat file modal content

### DIFF
--- a/.super-coder/ui/app.js
+++ b/.super-coder/ui/app.js
@@ -3505,16 +3505,21 @@ async function openChatSourceModal(conversation, target) {
     );
     const viewer = el("div", { className: "chat-source-viewer" });
     let selected = null;
-    source.content.split("\n").forEach((text, index) => {
-      const number = index + 1;
-      const row = el("div", {
-        className: "chat-source-line" + (number === target.line ? " selected" : ""),
-      },
-      el("span", { className: "chat-source-number" }, String(number)),
-      el("code", { className: "chat-source-code" }, text));
-      if (number === target.line) selected = row;
-      viewer.append(row);
-    });
+    if (/\.(md|markdown)$/i.test(source.relative_path)) {
+      viewer.classList.add("chat-source-markdown");
+      viewer.append(mdBlock(source.content));
+    } else {
+      source.content.split("\n").forEach((text, index) => {
+        const number = index + 1;
+        const row = el("div", {
+          className: "chat-source-line" + (number === target.line ? " selected" : ""),
+        },
+        el("span", { className: "chat-source-number" }, String(number)),
+        el("code", { className: "chat-source-code" }, text));
+        if (number === target.line) selected = row;
+        viewer.append(row);
+      });
+    }
     const closeButton = el("button", {
       className: "act", type: "button", textContent: "Close",
     });

--- a/.super-coder/ui/style.css
+++ b/.super-coder/ui/style.css
@@ -518,14 +518,21 @@ body.interface-view main {
   background: var(--panel2); border: 1px solid var(--line); border-radius: 6px;
   font: 12px/1.55 ui-monospace, monospace;
 }
-.chat-source-line { display: flex; min-width: max-content; }
+.chat-source-line { display: flex; }
 .chat-source-line.selected { background: rgba(110,168,254,.18); }
 .chat-source-number {
   position: sticky; left: 0; flex: none; width: 4.5rem; padding-right: .8rem;
   color: var(--dim); background: var(--panel2); text-align: right; user-select: none;
 }
 .chat-source-line.selected .chat-source-number { background: #263246; color: var(--accent); }
-.chat-source-code { padding: 0 1rem; white-space: pre; color: rgba(255,255,255,.82); }
+.chat-source-code {
+  flex: 1; min-width: 0; padding: 0 1rem; white-space: pre-wrap;
+  overflow-wrap: anywhere; color: rgba(255,255,255,.82);
+}
+.chat-source-markdown { padding: .8rem 1rem; font-family: inherit; }
+.chat-source-markdown .md { overflow-wrap: anywhere; }
+.chat-source-markdown .md table { display: table; table-layout: fixed; }
+.chat-source-markdown .md table th, .chat-source-markdown .md table td { white-space: normal; }
 .chat-meta { color: var(--dim); font-size: .64rem; margin-top: .35rem; }
 .chat-context-tokens {
   color: var(--dim); font-size: .64rem; margin-top: .35rem; text-align: right;


### PR DESCRIPTION
Opening a Markdown report from chat displayed raw markup in an unwrapped source viewer. Render `.md` and `.markdown` files through the existing sanitized Markdown renderer, and wrap long lines in other source files while retaining line numbers and citation highlighting. Markdown table cells wrap within the modal.

Validation: `./sc test tests/test_conversation_ui.py -q` (51 passed), `node --check .super-coder/ui/app.js`, and `git diff --check`. No browser visual check was available in this seat.
