### PR TITLE
fix(codex): launch every seat with a runnable sandbox policy

### DIFF
--- a/.super-coder/adapters/codex/README.md
+++ b/.super-coder/adapters/codex/README.md
@@ -25,7 +25,7 @@ billing are provider-owned; they are not part of the adapter contract.
 | `env` | extra env merged into the launch environment |
 | `model` | `{ "flag": "--model" }` — run.py appends `--model <id>` for the flavor's codex model |
 | `headless.effort` | maps requested effort to `-c model_reasoning_effort="<level>"` |
-| `host_admin.launch_flags` | grants the direct-host Admin the unrestricted filesystem policy its maintenance mandate requires |
+| `launch_flags` / `headless_flags` | always-on argv appended to the interactive / headless launch — `--sandbox danger-full-access` (plus `--ask-for-approval never` interactively; `codex exec` has no approval flag and never prompts) |
 | `sandbox.launch_flags` | flags appended ONLY inside the docker sandbox (`SC_SANDBOX`) |
 
 ## Branch-guard hook
@@ -58,18 +58,53 @@ the cwd-branch check.
    the edit proceeds. So **in-sandbox, codex's edit-time branch-guard cannot block**;
    the git **pre-commit backstop** is the real guard there (it blocks
    protected-branch *commits* regardless of harness flags). On the no-docker host
-   path (`./sc boot`), the flag is absent, approvals are normal, and the exit-2 deny
-   IS honored — so the host edit-time guard blocks.
+   path (`./sc boot`), that flag is absent — the host set is `--sandbox
+   danger-full-access --ask-for-approval never`, which elevates the *sandbox
+   policy* without taking the bypass branch — and the exit-2 deny IS honored, so
+   the host edit-time guard blocks. Never swap the host set for the YOLO flag as
+   a shortcut; it is the bypass branch that loses the guard, not the policy.
 
 **Host setup (one-time):** the binary is baked into the sandbox image, but auth is
 mounted from the host — so `codex` must be installed + logged in on the host once:
 `curl -fsSL https://chatgpt.com/codex/install.sh | sh` then `codex` and sign in
 with ChatGPT. That writes `~/.codex/auth.json`, which `./sc launch` mounts in.
 
-The direct-host Admin launch adds `--sandbox danger-full-access` and
-`--ask-for-approval never`. This is scoped to `subfloor admin`: ordinary host
-shells retain Codex's default filesystem sandbox, while the Admin can update the
-owner-private engine state required by its maintenance mandate.
+## Permission stance
+
+Every launched shell runs with `--sandbox danger-full-access` (interactive
+launches add `--ask-for-approval never`), on the host as well as in the
+sandbox — the same policy the browser-chat lane has always sent through the
+app-server (`approvalPolicy=never`, `sandbox=danger-full-access`). It is an
+always-on launch flag rather than an Admin-only grant because:
+
+1. **Subfloor's host seat already grants host authority.** The rendered
+   EXECUTION CONTEXT tells every host shell that "the host toolchain, network,
+   creds, services, and files available to your user are in reach". Codex was
+   the only harness whose terminal launch contradicted that — Claude shells
+   have carried `--dangerously-skip-permissions` on the host since the
+   permission stance was set.
+2. **Codex's own Linux sandbox is not a portable safety boundary.** Since
+   codex-cli started shelling out to a bundled **bubblewrap** for
+   `read-only`/`workspace-write`, a host that denies unprivileged mount
+   propagation changes fails every single command before it starts:
+
+   ```
+   $ codex exec -s workspace-write 'run pwd'
+   bwrap: Failed to make / slave: Operation not permitted
+   ```
+
+   That is not a degraded seat, it is a dead one: `pwd` fails, so the shell can
+   read no file, run no `sc` command, and load no skill — and the subagents it
+   spawns inherit the same dead policy, which reads from inside the session as
+   "agents are broken". Verified on CachyOS (kernel 7.2.2) with codex-cli
+   0.153.4: `-s workspace-write` fails as above, `-s danger-full-access`
+   succeeds.
+
+The safety boundary is unchanged and is the same one every other harness
+relies on: the branch-guard `PreToolUse` hook at edit time on the host path,
+and the git **pre-commit** hook, which refuses protected-branch commits
+regardless of harness flags. Outside the container, elevating the sandbox
+policy does not elevate a shell past either guard.
 
 ## Conversation capability
 

--- a/.super-coder/adapters/codex/adapter.json
+++ b/.super-coder/adapters/codex/adapter.json
@@ -1,6 +1,8 @@
 {
   "harness": "codex",
   "launch": ["codex", "--dangerously-bypass-hook-trust"],
+  "launch_flags": ["--sandbox", "danger-full-access", "--ask-for-approval", "never"],
+  "headless_flags": ["--sandbox", "danger-full-access"],
   "surfaces": {
     "terminal": true,
     "one_shot": true,
@@ -42,9 +44,6 @@
     "launch": ["codex", "exec"],
     "model_flag": "-m",
     "effort": { "config_flag": "-c", "config_key": "model_reasoning_effort" }
-  },
-  "host_admin": {
-    "launch_flags": ["--sandbox", "danger-full-access", "--ask-for-approval", "never"]
   },
   "conversation": {
     "contract_version": 1,

--- a/tests/test_codex_permission_flags.py
+++ b/tests/test_codex_permission_flags.py
@@ -1,4 +1,13 @@
-"""Codex host Admin gets its declared direct-host maintenance authority."""
+"""Codex launches carry a working execution policy on every seat.
+
+Codex's own `read-only`/`workspace-write` sandbox shells out to a bundled
+bubblewrap; on a host that denies unprivileged mount-propagation changes it
+fails before the first command runs (`bwrap: Failed to make / slave`), which
+kills the seat outright. Every launch therefore carries
+`--sandbox danger-full-access` — the same policy the browser-chat lane sends
+through the app-server — and never the YOLO bypass flag outside the container,
+so the branch-guard hook keeps its exit-2 deny.
+"""
 from __future__ import annotations
 
 import json
@@ -14,12 +23,13 @@ sys.path.insert(0, str(SCRIPTS))
 
 import run
 
-ADMIN_FLAGS = [
+INTERACTIVE_FLAGS = [
     "--sandbox",
     "danger-full-access",
     "--ask-for-approval",
     "never",
 ]
+HEADLESS_FLAGS = ["--sandbox", "danger-full-access"]
 BYPASS = "--dangerously-bypass-approvals-and-sandbox"
 
 
@@ -28,23 +38,45 @@ def _codex() -> dict:
 
 
 class CodexPermissionFlagsTest(unittest.TestCase):
-    def test_host_admin_gets_unrestricted_filesystem_without_bypass_flag(self) -> None:
+    def test_host_shell_gets_a_runnable_sandbox_policy_without_bypass_flag(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            flags = run.launch_mode_flags(_codex(), headless=False)
+        self.assertEqual(flags, INTERACTIVE_FLAGS)
+        self.assertNotIn(BYPASS, flags)
+
+    def test_host_admin_gets_the_same_policy_and_no_duplicate_flags(self) -> None:
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertEqual(
                 run.launch_mode_flags(_codex(), headless=False, host_admin=True),
-                ADMIN_FLAGS,
+                INTERACTIVE_FLAGS,
             )
 
-    def test_ordinary_host_shell_keeps_codex_defaults(self) -> None:
+    def test_headless_gets_the_policy_without_the_approval_flag(self) -> None:
+        # `codex exec` has no --ask-for-approval; it never prompts.
         with mock.patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(run.launch_mode_flags(_codex(), headless=False), [])
+            self.assertEqual(
+                run.launch_mode_flags(_codex(), headless=True),
+                HEADLESS_FLAGS,
+            )
 
     def test_container_keeps_external_sandbox_bypass(self) -> None:
         with mock.patch.dict(os.environ, {"SC_SANDBOX": "1"}, clear=True):
             self.assertEqual(
                 run.launch_mode_flags(_codex(), headless=False),
-                [BYPASS],
+                INTERACTIVE_FLAGS + [BYPASS],
             )
+
+    def test_no_launch_mode_leaves_the_bwrap_backed_sandbox_selected(self) -> None:
+        # The failure this guards: an empty/`workspace-write` policy makes
+        # codex wrap every command in bundled bwrap, which cannot start on a
+        # host that denies unprivileged mount-propagation changes.
+        for headless in (False, True):
+            for env in ({}, {"SC_SANDBOX": "1"}):
+                with self.subTest(headless=headless, sandbox=bool(env)):
+                    with mock.patch.dict(os.environ, env, clear=True):
+                        flags = run.launch_mode_flags(_codex(), headless=headless)
+                    self.assertIn("danger-full-access", flags)
+                    self.assertNotIn("workspace-write", flags)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

A codex shell on this host cannot run a single command. Every one fails before it starts:

```
bwrap: Failed to make / slave: Operation not permitted
```

Codex's `read-only` / `workspace-write` sandbox shells out to a **bundled bubblewrap**. On a host that denies unprivileged mount-propagation changes, bwrap dies at setup. Reproduced directly (CachyOS 7.2.2, codex-cli 0.153.4):

| policy | result |
|---|---|
| `codex exec -s workspace-write 'run pwd'` | `bwrap: Failed to make / slave: Operation not permitted` |
| `codex exec -s danger-full-access 'run pwd'` | `/tmp` |

Subfloor gave ordinary codex shells no `--sandbox` flag, so they inherited `workspace-write` — a dead seat. `pwd` fails, so the shell reads no file, runs no `sc` command, and loads no skill. Subagents it spawns inherit the same dead policy, which from inside the session reads as *"subagents are broken"* — they are not; the agents start fine and then hit the same wall.

Only the host **Admin** got `--sandbox danger-full-access --ask-for-approval never` (#1525). Browser chats were never affected: the conversation adapter has always sent `approvalPolicy=never` / `sandbox=danger-full-access`.

## The change

Promote that Admin-only set to always-on adapter `launch_flags` / `headless_flags`, matching what the claude adapter already does on the host. `codex exec` has no `--ask-for-approval`, so the headless set is the sandbox flag alone. The `host_admin` block is removed — it is now the same set, and keeping it would emit the flags twice.

## Safety

Unchanged, and it is not codex's sandbox:

- **Host** — the branch-guard `PreToolUse` hook still denies edits on a protected branch. The host set deliberately avoids `--dangerously-bypass-approvals-and-sandbox`, which *is* the flag that defeats the exit-2 deny; that one stays container-only.
- **Everywhere** — the git **pre-commit** hook refuses protected-branch commits regardless of harness flags.
- Subfloor's rendered EXECUTION CONTEXT already tells every host shell it has host toolchain/creds/files in reach. Codex's terminal launch was the only one contradicting that.

## Trade-off

The simpler-looking alternative — probe bwrap at launch and fall back only when broken — was rejected: it adds a second behaviour to reason about for no gain, since codex's own sandbox was never part of Subfloor's safety model (the container is the boundary in the sandbox; the guards above are the boundary on the host).

## Verification

- `tests/test_codex_permission_flags.py` rewritten: host / host-admin / headless / container flag sets, no duplicate flags, no bypass flag outside the container, and a guard that no launch mode can land back on the bwrap-backed policy. 5 tests, green.
- `tests.test_admin_host_launch tests.test_harness_surfaces tests.test_conversation_adapters tests.test_conversation_capabilities tests.test_run_session` — 135 tests, green.
- Broader codex-touching sweep green; `tests.test_branch_guard` has one pre-existing environment error (`PermissionError` on `mkdir ~/sc-bg-test-*`), confirmed identical on a clean tree.

## Out of scope (surfaced, not changed here)

The installed CLI is 0.153.4; `harness_versions.MAINTAINED_OBSERVED_VERSIONS` pins `codex-cli 0.147.0` and the conversation contract caps at `< 0.148.0`. That is a `harness_promotion` question, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ytyN5J8GhD8Vii1qtYiML