### PR TITLE
Keep PR watcher pending for same-head Actions workflows

### DIFF
--- a/.super-coder/scripts/github_pull_requests.py
+++ b/.super-coder/scripts/github_pull_requests.py
@@ -1,7 +1,7 @@
 """Bounded, read-only GitHub pull-request collection.
 
 This is the shared normalization seam for git hygiene, browser Diff review,
-and later PR-aware engine surfaces.  It invokes only ``gh pr`` read commands;
+and later PR-aware engine surfaces. It invokes bounded ``gh pr`` and ``gh run`` reads;
 callers decide whether branch-name discovery is sufficient or an exact PR
 number is required.
 """
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 LIST_LIMIT = 300
+WORKFLOW_LIMIT = 100
 MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 GITHUB_TIMEOUT_SECONDS = 20.0
 _COMPAT_FIELDS = (
@@ -395,11 +396,56 @@ class GitHubPullRequestReader:
         if not isinstance(payload, dict):
             raise GitHubReadError("GitHub PR read returned an invalid payload")
         pull_request = normalize_pull_request(payload)
+        if (
+            pull_request.state == "OPEN"
+            and pull_request.checks == "SUCCESS"
+            and pull_request.head_sha
+        ):
+            workflows = self._read_workflows(pull_request.head_sha)
+            workflow_checks, workflow_failed = _check_state(workflows)
+            if workflow_failed:
+                pull_request = replace(
+                    pull_request, checks="FAILURE", checks_failed=True
+                )
+            elif workflow_checks == "PENDING" or len(workflows) == WORKFLOW_LIMIT:
+                # A full page cannot prove that every current-head run was seen.
+                pull_request = replace(pull_request, checks="PENDING")
         return (
             replace(pull_request, base_sha=self._read_base_sha(number))
             if restore_base_sha
             else pull_request
         )
+
+    def _read_workflows(self, head_sha: str) -> list[dict[str, Any]]:
+        raw = self._run(
+            [
+                "gh", "run", "list", "--commit", head_sha,
+                "--limit", str(WORKFLOW_LIMIT),
+                "--json", "headSha,status,conclusion,workflowDatabaseId",
+                *self._repo_args(),
+            ]
+        )
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise GitHubReadError("GitHub workflow list returned invalid JSON") from exc
+        if not isinstance(payload, list) or any(
+            not isinstance(item, dict) for item in payload
+        ):
+            raise GitHubReadError("GitHub workflow list returned an invalid payload")
+        if any(item.get("headSha") != head_sha for item in payload):
+            raise GitHubReadError("GitHub workflow list returned a different commit")
+        if any(not _item_state(item) for item in payload):
+            raise GitHubReadError("GitHub workflow list has an incomplete run")
+        return [
+            {
+                **item,
+                "name": str(item.get("workflowDatabaseId") or ""),
+                "conclusion": None if str(item.get("status", "")).upper()
+                in _PENDING_CHECKS else item.get("conclusion"),
+            }
+            for item in payload
+        ]
 
     def patch(self, number: int) -> str:
         if not isinstance(number, int) or number < 1:

--- a/tests/test_git_review.py
+++ b/tests/test_git_review.py
@@ -161,6 +161,7 @@ class GitHubReaderTest(unittest.TestCase):
                 stderr=b'Unknown JSON field: "baseRefOid"\n',
             ),
             SimpleNamespace(returncode=0, stdout=payload, stderr=b""),
+            SimpleNamespace(returncode=0, stdout=b"[]", stderr=b""),
             SimpleNamespace(returncode=0, stdout=base_sha, stderr=b""),
         ]
         calls = []
@@ -187,7 +188,7 @@ class GitHubReaderTest(unittest.TestCase):
                 "--jq",
                 ".base.sha",
             ],
-            calls[2],
+            calls[3],
         )
 
     def test_explicit_repository_scopes_every_read(self) -> None:
@@ -196,7 +197,11 @@ class GitHubReaderTest(unittest.TestCase):
 
         def runner(args, **kwargs):
             calls.append(args)
-            return SimpleNamespace(returncode=0, stdout=payload, stderr=b"")
+            return SimpleNamespace(
+                returncode=0,
+                stdout=payload if args[1] == "pr" else b"[]",
+                stderr=b"",
+            )
 
         reader = GitHubPullRequestReader(
             "/tmp/repo", repository="acme/project", runner=runner
@@ -206,6 +211,86 @@ class GitHubReaderTest(unittest.TestCase):
             ["gh", "pr", "view", "821", "--json"], calls[0][:5]
         )
         self.assertEqual(["--repo", "acme/project"], calls[0][-2:])
+        self.assertEqual(["--repo", "acme/project"], calls[1][-2:])
+
+    def test_exact_head_workflow_blocks_partial_green_rollup(self) -> None:
+        pr = MockGitHub().pr(821)
+        sha = pr["headRefOid"]
+        workflow = {
+            "headSha": sha, "status": "pending", "conclusion": None,
+            "workflowDatabaseId": 12,
+        }
+        reads = []
+
+        def runner(args, **kwargs):
+            reads.append(args)
+            body = pr if args[1] == "pr" else [workflow]
+            return SimpleNamespace(
+                returncode=0, stdout=json.dumps(body).encode(), stderr=b""
+            )
+
+        reader = GitHubPullRequestReader(
+            "/tmp/repo", repository="acme/project", runner=runner
+        )
+        self.assertEqual("PENDING", reader.get(821).checks)
+        self.assertEqual(["gh", "run", "list", "--commit", sha], reads[1][:5])
+        workflow["conclusion"] = "success"
+        self.assertEqual("PENDING", reader.get(821).checks)
+        workflow.update(status="completed", conclusion="success")
+        self.assertEqual("SUCCESS", reader.get(821).checks)
+        workflow.update(conclusion="failure")
+        self.assertTrue(reader.get(821).checks_failed)
+        workflow.update(conclusion="cancelled")
+        replacement = dict(workflow, conclusion="success")
+
+        def replacement_runner(args, **kwargs):
+            body = pr if args[1] == "pr" else [workflow, replacement]
+            return SimpleNamespace(
+                returncode=0, stdout=json.dumps(body).encode(), stderr=b""
+            )
+
+        replacement_reader = GitHubPullRequestReader(
+            "/tmp/repo", runner=replacement_runner
+        )
+        self.assertEqual("SUCCESS", replacement_reader.get(821).checks)
+
+    def test_workflow_read_failure_does_not_publish_green(self) -> None:
+        pr = MockGitHub().pr(821)
+
+        def runner(args, **kwargs):
+            if args[1] == "run":
+                return SimpleNamespace(returncode=1, stdout=b"", stderr=b"unavailable")
+            return SimpleNamespace(
+                returncode=0, stdout=json.dumps(pr).encode(), stderr=b""
+            )
+
+        reader = GitHubPullRequestReader("/tmp/repo", runner=runner)
+        with self.assertRaises(GitHubReadError):
+            reader.get(821)
+
+    def test_workflow_inventory_must_match_head_and_be_complete(self) -> None:
+        pr = MockGitHub().pr(821)
+        sha = pr["headRefOid"]
+        workflows = []
+
+        def runner(args, **kwargs):
+            body = pr if args[1] == "pr" else workflows
+            return SimpleNamespace(
+                returncode=0, stdout=json.dumps(body).encode(), stderr=b""
+            )
+
+        reader = GitHubPullRequestReader("/tmp/repo", runner=runner)
+        self.assertEqual("SUCCESS", reader.get(821).checks)  # External checks only.
+        workflows[:] = [{"headSha": "b" * 40, "status": "pending"}]
+        with self.assertRaises(GitHubReadError):
+            reader.get(821)
+        workflows[:] = [{"headSha": sha}]
+        with self.assertRaises(GitHubReadError):
+            reader.get(821)
+        workflows[:] = [
+            {"headSha": sha, "status": "completed", "conclusion": "success"}
+        ] * 100
+        self.assertEqual("PENDING", reader.get(821).checks)
 
     def test_response_cap_fails_closed(self) -> None:
         def runner(args, **kwargs):


### PR DESCRIPTION
When a PR's fast check jobs succeed before another same-head Actions workflow registers its jobs, the watcher can read a successful partial check rollup and send a green wake while that workflow is still pending. The exact PR read now checks the workflow-run inventory for the PR head before accepting a successful rollup. Pending runs keep the PR pending; failed runs keep it red; a cancelled duplicate workflow is superseded by its replacement. Workflow reads are bounded and errors do not publish green. External-only successful checks remain valid when no Actions runs exist.

This addresses the observed same-head pending-workflow race in #955. A finite workflow inventory cannot prove that a new workflow will not register later, so this PR does not claim to solve every possible future-registration gap. Refs #955.

Validation: `python -m unittest tests.test_git_review.GitHubReaderTest tests.test_sprint_pr_watcher -q` (67 tests passed); `git diff --check`.
