### PR TITLE
Resolve engine module roots in source typecheck hook

### DIFF
--- a/.subfloor/dev-kit
+++ b/.subfloor/dev-kit
@@ -126,7 +126,11 @@ PY
       exit 126
     }
     if [ "$#" -eq 0 ]; then set -- .; fi
-    exec "$tool" "$@"
+    # The engine keeps flat import roots while tests import those modules by
+    # name. Give mypy the same roots and a single stable package mapping.
+    MYPYPATH="$root/.super-coder/scripts:$root/.super-coder/api:$root/.super-coder/render${MYPYPATH:+:$MYPYPATH}"
+    export MYPYPATH
+    exec "$tool" --explicit-package-bases "$@"
     ;;
   *)
     echo "usage: .subfloor/dev-kit <deps|test|lint|typecheck> [args...]" >&2

--- a/tests/test_source_typecheck_hook.py
+++ b/tests/test_source_typecheck_hook.py
@@ -1,0 +1,47 @@
+"""Source-owned typecheck hook resolves flat engine modules without hiding errors."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class SourceTypecheckHookTest(unittest.TestCase):
+    def test_engine_roots_and_caller_path_preserve_type_diagnostics(self) -> None:
+        if shutil.which("mypy") is None and not (ROOT / ".venv/bin/mypy").is_file():
+            self.skipTest("declared mypy dependency is unavailable")
+
+        with tempfile.TemporaryDirectory() as td:
+            scratch = Path(td)
+            (scratch / "caller_module.py").write_text("name: str = 'caller'\n")
+            subject = scratch / "subject.py"
+            imports = "import update\nimport server\nimport flat\nimport caller_module\n"
+            env = {**os.environ, "SC_DEVKIT_ROOT": str(ROOT), "MYPYPATH": str(scratch)}
+
+            def check(value: str) -> subprocess.CompletedProcess[str]:
+                subject.write_text(imports + f"answer: int = {value}\n")
+                return subprocess.run(
+                    [str(ROOT / ".subfloor/dev-kit"), "typecheck", "--follow-imports=silent", str(subject)],
+                    cwd=ROOT,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+
+            good = check("1")
+            self.assertEqual(0, good.returncode, good.stdout + good.stderr)
+            bad = check("'wrong'")
+            self.assertEqual(1, bad.returncode, bad.stdout + bad.stderr)
+            self.assertIn("[assignment]", bad.stdout)
+            self.assertNotIn("[import-not-found]", bad.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #1467. The source-owned `typecheck` hook did not give mypy the engine's flat script, API, and render import roots, and module discovery stopped on duplicate names before a complete diagnostic pass.

The hook now supplies those absolute roots, preserves any caller-provided `MYPYPATH` and arguments, and uses explicit package bases. A regression exercises the hook with direct imports from all three engine roots plus a caller module; valid code passes and a real assignment error fails.

This fixes engine module/package discovery, not the repository-wide type baseline. The full hook now checks 209 files and reports 1,065 errors in 120 files, including 30 remaining missing imports (mostly test-local helpers and the optional Playwright stub). The issue remains open for those and the underlying type diagnostics. Focused unittest and Ruff checks passed; independent scoped review passed.
