### PR TITLE
fix: run verify against a disposable engine candidate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,9 +65,9 @@ jobs:
           SC_REQUIRE_OPENCODE_CANARY: '1'
           SC_REQUIRE_BROWSER_PACKAGE_CANARY: '1'
 
-  # The end-to-end proof `./sc verify` runs: rebuild the DB from committed text
-  # (schema + migrations + content.sql), flat-render, then a render-only boot —
-  # proving a fresh clone of this exact tree stands up. Complements
+  # The end-to-end proof `./sc verify` runs in a disposable candidate: rebuild
+  # from committed text, flat-render, then a render-only boot without changing
+  # the canonical database. Complements
   # render-check.yml (drift guard) with the boot half.
   verify:
     runs-on: ubuntu-26.04
@@ -97,7 +97,7 @@ jobs:
         with:
           python-version: '3.14'
       - name: Bootstrap the fresh checkout
-        run: ./sc verify
+        run: ./sc rebuild && ./sc init --username verify
       - name: Build and launch the default sandbox
         run: ./sc launch
       - name: Reach the sandbox health endpoint within 90 seconds

--- a/.super-coder/scripts/dispatch.sh
+++ b/.super-coder/scripts/dispatch.sh
@@ -1664,39 +1664,7 @@ case "$cmd" in
     fi
     exec docker logs -f "$CNAME" ;;
   verify)
-    database="$(sc_engine_db)"
-    sc_refuse_linked verify "$database"
-    # Destructive by design: rebuild.py REPLACES the DB below. Say which DB and
-    # which source before that happens — a footer printed after the fact is a
-    # disclosure a crash can skip, and this is the command that eats unsnapshotted
-    # memory when it is pointed at an instance the caller did not mean.
-    echo "→ verify: about to REBUILD $database"
-    echo "          from engine source $ENGINE"
-    "$PY" "$S/rebuild.py"
-    # The engine source intentionally carries no per-instance snapshot in local
-    # artifact mode. Exercise the real fresh-fork initialization path before
-    # the headless boot when rebuild therefore produced an empty instance.
-    if "$PY" - "$database" <<'PY'
-import sqlite3
-import sys
-
-con = sqlite3.connect(sys.argv[1])
-try:
-    populated = con.execute(
-        "SELECT EXISTS(SELECT 1 FROM users WHERE is_active=1) "
-        "AND EXISTS(SELECT 1 FROM shells WHERE COALESCE(is_deleted,0)=0)"
-    ).fetchone()[0]
-finally:
-    con.close()
-raise SystemExit(0 if populated else 1)
-PY
-    then
-      :
-    else
-      "$PY" "$S/init_fork.py" --username verify
-    fi
-    SC_ADMIN=1 "$PY" "$S/render.py" flat
-    RENDER_ONLY=1 exec "$PY" "$S/run.py" --first ;;
+    exec "$PY" -B "$S/verify.py" ;;
   health)       curl -s "http://127.0.0.1:$(port)/api/health" && echo "" ;;
   clean-db)     database="$(sc_engine_db)"
                 sc_refuse_linked clean-db "$database"
@@ -1768,10 +1736,10 @@ Subfloor — forkable shell substrate — full command reference (./sc help for 
   ./sc migration new <slug>
                            allocate the next free migration number, write the standard skeleton, and update the source removal-test allowlist
   ./sc snapshot            Admin-only serialization of private instance content
-                             live-state commands (rebuild · migrate · verify · snapshot · render · clean-db) act on the SHARED live
+                             live-state commands (rebuild · migrate · snapshot · render · clean-db) act on the SHARED live
                              instance at the main checkout, so they REFUSE from a linked worktree rather than substitute it, naming
-                             the target declined (decision #81); -h/--help still answers from any checkout. render-check is the
-                             source-pure one: it verifies the CALLER's engine sources and local artifacts, and names the checkout it read.
+                             the target declined (decision #81); -h/--help still answers from any checkout. verify checks the
+                             installed engine source in a disposable candidate; render-check checks the CALLER's source and artifacts.
   ./sc mem <cmd> [args]    a shell's own memory, over the engine API (get/state/seed/lns/decision/flag/roadmap/doc/narrative);
                              already wired to this launched shell, identity resolved by the engine — no DB path, no direct-DB fallback. `./sc mem which` to orient
   ./sc pr subscribe --repository <owner/name> --pr <number>
@@ -1956,7 +1924,7 @@ Subfloor — forkable shell substrate — full command reference (./sc help for 
   ./sc pg-down             stop + remove the container (data volume retained)
                              (recreate via pg-down→pg-up to change --shm-size / SC_PG_SHM)
 
-  ./sc verify              rebuild + flat render + render-only boot (headless proof)
+  ./sc verify              candidate-only rebuild + flat render + render-only boot; live memory untouched
   ./sc health              curl the review layer's /api/health
   ./sc ports               show this fork's derived port
   ./sc url                 print this fork's review GUI + dev-server URLs (derived, never a fixed 8800)

--- a/.super-coder/scripts/instance_state.py
+++ b/.super-coder/scripts/instance_state.py
@@ -136,6 +136,7 @@ PRODUCTION_CONSUMERS = (
             ".super-coder/scripts/artifact_policy.py",
             ".super-coder/scripts/snapshot.py",
             ".super-coder/scripts/render.py",
+            ".super-coder/scripts/verify.py",
             ".super-coder/render/compose.py",
         ),
         "private snapshot and render inputs",

--- a/.super-coder/scripts/verify.py
+++ b/.super-coder/scripts/verify.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Exercise rebuild and render-only boot in an isolated disposable checkout."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import instance_state
+
+ENGINE = Path(__file__).resolve().parents[1]
+ROOT = ENGINE.parent
+
+
+def _copy_engine(source: str, names: list[str]) -> set[str]:
+    # Copy authored engine code, never private instance identity or runtime data.
+    return {
+        name for name in names
+        if name in {"instance.json", "run", "node_modules", "__pycache__",
+                    ".sc-state", "cache", "tmp"}
+        or name.endswith((".pyc", ".db", ".db-wal", ".db-shm", ".sock"))
+    }
+
+
+def main() -> int:
+    # Snapshot is the only per-instance input; verify must not open the live DB.
+    snapshot = instance_state.active_snapshot_path(ROOT)
+    if not snapshot.exists():
+        snapshot = ROOT / ".sc-state" / "content.sql"
+    with tempfile.TemporaryDirectory(prefix="sc-verify-") as directory:
+        env = {key: value for key, value in os.environ.items()
+               if not key.startswith(("SC_", "GIT_", "PYTHON", "XDG_",
+                                      "CODEX_", "CLAUDE_", "OPENCODE_", "KIMI_"))
+               and key not in {"RENDER_ONLY", "HARNESS", "HARNESS_BIN"}}
+        env.update({
+            "HOME": str(Path(directory) / "home"),
+            "XDG_STATE_HOME": str(Path(directory) / "state"),
+            "XDG_CACHE_HOME": str(Path(directory) / "cache"),
+            "XDG_CONFIG_HOME": str(Path(directory) / "config"),
+            "XDG_DATA_HOME": str(Path(directory) / "data"),
+            "PYTHONDONTWRITEBYTECODE": "1",
+        })
+        candidate = Path(directory) / "checkout"
+        candidate.mkdir()
+        for parent, dirs, files in os.walk(ENGINE, followlinks=False):
+            omitted = _copy_engine(parent, dirs + files)
+            for name in dirs + files:
+                if name not in omitted and (Path(parent) / name).is_symlink():
+                    raise SystemExit(f"verify: refusing linked engine path {Path(parent) / name}")
+            dirs[:] = [name for name in dirs if name not in omitted]
+        shutil.copytree(ENGINE, candidate / ".super-coder", ignore=_copy_engine)
+        shutil.copy2(ROOT / "sc", candidate / "sc")
+        if snapshot.exists():
+            content = candidate / ".sc-state" / "local" / "content.sql"
+            content.parent.mkdir(parents=True)
+            shutil.copy2(snapshot, content)
+        retired = ROOT / ".sc-state" / "local" / "skills_retired.json"
+        if not retired.exists():
+            retired = ROOT / ".sc-state" / "skills_retired.json"
+        if retired.is_file() and not retired.is_symlink():
+            target = candidate / ".sc-state" / "local" / "skills_retired.json"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(retired, target)
+        # Preserve only the boot harness choice. Private instance identity and
+        # work-repo paths must never be carried into a disposable checkout.
+        config = ENGINE / "instance.json"
+        if config.is_file() and not config.is_symlink():
+            settings = json.loads(config.read_text())
+            harness = settings.get("harness") if isinstance(settings, dict) else None
+            if isinstance(harness, str):
+                (candidate / ".super-coder" / "instance.json").write_text(
+                    json.dumps({"harness": harness}) + "\n"
+                )
+        # The render-only boot checks source-repository provenance. A fresh,
+        # local git identity makes that check exercise the copied candidate.
+        origin = subprocess.run(
+            ["git", "-C", str(ROOT), "config", "--get", "remote.origin.url"],
+            capture_output=True, text=True, check=False, env=env,
+        ).stdout.strip() or "https://example.invalid/verify-fork.git"
+        remote_name = origin.rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+        if not remote_name.endswith(".git"):
+            remote_name += ".git"
+        remote_name = Path(remote_name).name
+        bare = Path(directory) / remote_name
+        subprocess.run(["git", "init", "-q", "-b", "main", str(candidate)],
+                       env=env, check=True)
+        git_env = {**env, "GIT_AUTHOR_NAME": "Verify", "GIT_AUTHOR_EMAIL": "verify@invalid",
+                   "GIT_COMMITTER_NAME": "Verify", "GIT_COMMITTER_EMAIL": "verify@invalid"}
+        subprocess.run(["git", "-C", str(candidate), "add", "sc", ".super-coder"],
+                       env=git_env, check=True)
+        subprocess.run(["git", "-C", str(candidate), "commit", "-qm", "candidate source"],
+                       env=git_env, check=True)
+        subprocess.run(["git", "clone", "-q", "--bare", str(candidate), str(bare)],
+                       env=git_env, check=True)
+        subprocess.run(["git", "-C", str(candidate), "remote", "add", "origin", str(bare)],
+                       env=git_env, check=True)
+        subprocess.run(["git", "-C", str(candidate), "fetch", "-q", "origin", "main"],
+                       env=git_env, check=True)
+        subprocess.run(["git", "-C", str(candidate), "branch", "--set-upstream-to",
+                        "origin/main", "main"], env=git_env, check=False)
+        python = sys.executable
+        scripts = candidate / ".super-coder" / "scripts"
+        resolved = subprocess.run(
+            [python, str(scripts / "instance_state.py"), "active-database",
+             str(candidate / ".super-coder")], cwd=candidate, env=env,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        if Path(resolved).resolve() != (candidate / ".super-coder" / "shell_db.db").resolve():
+            raise SystemExit(f"verify: candidate database escaped disposable checkout: {resolved}")
+        steps = [
+            [python, str(scripts / "rebuild.py")],
+            [python, str(scripts / "init_fork.py"), "--username", "verify"],
+            [python, str(scripts / "render.py"), "flat"],
+            [python, str(scripts / "run.py"), "--first"],
+        ]
+        # init_fork is needed only when the authored snapshot has no shell.
+        for index, command in enumerate(steps):
+            if index == 1:
+                import sqlite3
+                db = candidate / ".super-coder" / "shell_db.db"
+                with sqlite3.connect(db) as con:
+                    populated = con.execute(
+                        "SELECT EXISTS(SELECT 1 FROM users WHERE is_active=1) "
+                        "AND EXISTS(SELECT 1 FROM shells WHERE COALESCE(is_deleted,0)=0)"
+                    ).fetchone()[0]
+                if populated:
+                    continue
+            step_env = dict(env)
+            if index == 2:
+                step_env["SC_ADMIN"] = "1"
+            if index == 3:
+                step_env["RENDER_ONLY"] = "1"
+                import sqlite3
+                db = candidate / ".super-coder" / "shell_db.db"
+                with sqlite3.connect(db) as con:
+                    selected = con.execute(
+                        "SELECT shortname FROM shells WHERE flavor!='admin' "
+                        "AND COALESCE(is_deleted,0)=0 ORDER BY shell_id LIMIT 1"
+                    ).fetchone()
+                if selected:
+                    command = [*command, selected[0]]
+            result = subprocess.run(command, cwd=candidate, env=step_env, check=False)
+            if result.returncode:
+                return result.returncode
+    print("verify: candidate passed; live engine memory and artifacts were unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.super-coder/scripts/verify.py
+++ b/.super-coder/scripts/verify.py
@@ -26,7 +26,9 @@ def _copy_engine(source: str, names: list[str]) -> set[str]:
     }
 
 
-def main() -> int:
+def main(argv: list[str]) -> int:
+    if argv:
+        raise SystemExit("usage: ./sc verify")
     # Snapshot is the only per-instance input; verify must not open the live DB.
     snapshot = instance_state.active_snapshot_path(ROOT)
     if not snapshot.exists():
@@ -109,7 +111,8 @@ def main() -> int:
              str(candidate / ".super-coder")], cwd=candidate, env=env,
             capture_output=True, text=True, check=True,
         ).stdout.strip()
-        if Path(resolved).resolve() != (candidate / ".super-coder" / "shell_db.db").resolve():
+        candidate_db = instance_state.legacy_database_path(candidate / ".super-coder")
+        if Path(resolved).resolve() != candidate_db.resolve():
             raise SystemExit(f"verify: candidate database escaped disposable checkout: {resolved}")
         steps = [
             [python, str(scripts / "rebuild.py")],
@@ -121,7 +124,7 @@ def main() -> int:
         for index, command in enumerate(steps):
             if index == 1:
                 import sqlite3
-                db = candidate / ".super-coder" / "shell_db.db"
+                db = candidate_db
                 with sqlite3.connect(db) as con:
                     populated = con.execute(
                         "SELECT EXISTS(SELECT 1 FROM users WHERE is_active=1) "
@@ -135,7 +138,7 @@ def main() -> int:
             if index == 3:
                 step_env["RENDER_ONLY"] = "1"
                 import sqlite3
-                db = candidate / ".super-coder" / "shell_db.db"
+                db = candidate_db
                 with sqlite3.connect(db) as con:
                     selected = con.execute(
                         "SELECT shortname FROM shells WHERE flavor!='admin' "
@@ -151,4 +154,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    from cli_entry import run_cli
+
+    raise SystemExit(run_cli(main, sys.argv[1:]))

--- a/tests/test_docker_lifecycle_workflow.py
+++ b/tests/test_docker_lifecycle_workflow.py
@@ -35,7 +35,7 @@ class DockerLifecycleWorkflowTest(unittest.TestCase):
         self.assertIn("SC_CI_SIDECAR: sc-pg-${{ github.event.repository.name }}", self.job)
 
     def test_job_uses_supported_bootstrap_and_real_launch(self) -> None:
-        bootstrap = self.job.index("run: ./sc verify")
+        bootstrap = self.job.index("run: ./sc rebuild && ./sc init --username verify")
         launch = self.job.index("run: ./sc launch")
 
         self.assertLess(bootstrap, launch)

--- a/tests/test_verify_clean_clone.py
+++ b/tests/test_verify_clean_clone.py
@@ -15,7 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class VerifyCleanCloneTest(unittest.TestCase):
-    def test_verify_boots_an_empty_candidate_without_initializing_the_source(self):
+    def test_verify_initializes_an_empty_source_instance(self):
         with tempfile.TemporaryDirectory() as td:
             checkout = Path(td) / "checkout"
             sha = subprocess.run(

--- a/tests/test_verify_clean_clone.py
+++ b/tests/test_verify_clean_clone.py
@@ -15,7 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class VerifyCleanCloneTest(unittest.TestCase):
-    def test_verify_initializes_an_empty_source_instance(self):
+    def test_verify_boots_an_empty_candidate_without_initializing_the_source(self):
         with tempfile.TemporaryDirectory() as td:
             checkout = Path(td) / "checkout"
             sha = subprocess.run(
@@ -32,6 +32,14 @@ class VerifyCleanCloneTest(unittest.TestCase):
             # Include locally edited launch-floor files when this regression
             # test is run before their fixes have been committed.
             shutil.copy2(ROOT / "sc", checkout / "sc")
+            shutil.copy2(
+                ROOT / ".super-coder" / "scripts" / "dispatch.sh",
+                checkout / ".super-coder" / "scripts" / "dispatch.sh",
+            )
+            shutil.copy2(
+                ROOT / ".super-coder" / "scripts" / "verify.py",
+                checkout / ".super-coder" / "scripts" / "verify.py",
+            )
             shutil.copy2(
                 ROOT / ".super-coder" / "scripts" / "pr_cli.py",
                 checkout / ".super-coder" / "scripts" / "pr_cli.py",
@@ -86,6 +94,8 @@ class VerifyCleanCloneTest(unittest.TestCase):
                 f"stdout:\n{stdout}\n\nstderr:\n{stderr}",
             )
             self.assertNotIn("Username:", stdout)
+            self.assertFalse((checkout / ".super-coder" / "shell_db.db").exists())
+            self.assertIn("candidate passed", stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_preserves_live.py
+++ b/tests/test_verify_preserves_live.py
@@ -1,0 +1,113 @@
+"""Candidate verify must leave a newer live memory DB and artifacts untouched."""
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class VerifyPreservesLiveTest(unittest.TestCase):
+    def test_stale_snapshot_does_not_replace_live_db_or_sidecars(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            checkout = base / "source"
+            checkout.mkdir()
+            shutil.copytree(ROOT / ".super-coder", checkout / ".super-coder",
+                            ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.db*"))
+            shutil.copy2(ROOT / "sc", checkout / "sc")
+            env = {k: v for k, v in os.environ.items() if not k.startswith("SC_")}
+            env.update({"HOME": str(base / "home"),
+                        "XDG_STATE_HOME": str(base / "state"),
+                        "TMPDIR": str(base / "tmp"), "SC_ADMIN": "1"})
+            (base / "tmp").mkdir()
+            subprocess.run(["git", "init", "-q", str(checkout)], check=True)
+            subprocess.run(["git", "-C", str(checkout), "remote", "add", "origin",
+                            "https://github.com/jedbjorn/subfloor.git"], check=True)
+            scripts = checkout / ".super-coder" / "scripts"
+
+            def run(script: str, *args: str,
+                    overrides: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+                process_env = {**env, **(overrides or {})}
+                return subprocess.run([sys.executable, str(scripts / script), *args],
+                                      cwd=checkout, env=process_env, capture_output=True,
+                                      text=True, timeout=120, check=False)
+
+            for script, args in (("rebuild.py", ()),
+                                 ("init_fork.py", ("--username", "verify")),
+                                 ("snapshot.py", ())):
+                result = run(script, *args)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+            # A source identity planted by an installed fork must never reach
+            # the copied candidate, where it could redirect maintenance.
+            (checkout / ".super-coder" / "instance.json").write_text(
+                '{"instance_id":"0123456789abcdef0123456789abcdef"}\n'
+            )
+            (checkout / ".sc-state" / "local" / "skills_retired.json").write_text(
+                '["dev_kit"]\n'
+            )
+            subprocess.run(["git", "-C", str(checkout), "remote", "set-url", "origin",
+                            "https://example.invalid/no-network-fork.git"], check=True)
+
+            db = checkout / ".super-coder" / "shell_db.db"
+            with sqlite3.connect(db) as con:
+                con.execute("UPDATE shells SET bootstrapped=1, current_state='newer live write' "
+                            "WHERE shell_id=1")
+            live = sqlite3.connect(db)
+            try:
+                live.execute("PRAGMA journal_mode=WAL")
+                live.execute("PRAGMA wal_autocheckpoint=0")
+                live.execute("UPDATE shells SET current_state='uncheckpointed newer write' "
+                             "WHERE shell_id=1")
+                live.commit()
+                paths = [db, Path(str(db) + "-wal"), Path(str(db) + "-shm")]
+                before = {p: (p.stat().st_ino, p.read_bytes()) for p in paths if p.exists()}
+                artifacts = checkout / ".sc-state" / "local"
+                artifact_before = {p.relative_to(artifacts): p.read_bytes()
+                                   for p in artifacts.rglob("*") if p.is_file()}
+
+                external_git = base / "external-git"
+                subprocess.run(["git", "init", "-q", str(external_git)], check=True)
+                external_index = base / "external-index"
+                external_index.write_bytes(b"untouched external index")
+                result = run("verify.py", overrides={
+                    "GIT_DIR": str(external_git / ".git"),
+                    "GIT_INDEX_FILE": str(external_index),
+                    "GIT_WORK_TREE": str(external_git),
+                })
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertEqual(external_index.read_bytes(), b"untouched external index")
+                self.assertIn("booted Planner", result.stdout)
+                self.assertEqual(before,
+                                 {p: (p.stat().st_ino, p.read_bytes()) for p in before})
+                self.assertEqual(artifact_before,
+                                 {p.relative_to(artifacts): p.read_bytes()
+                                  for p in artifacts.rglob("*") if p.is_file()})
+                self.assertEqual(live.execute(
+                    "SELECT current_state FROM shells WHERE shell_id=1"
+                ).fetchone()[0], "uncheckpointed newer write")
+                self.assertEqual(list((base / "tmp").glob("sc-verify-*")), [])
+                self.assertFalse((checkout / "AGENTS.md").exists())
+                self.assertFalse((checkout / "CLAUDE.md").exists())
+
+                before = {p: (p.stat().st_ino, p.read_bytes()) for p in paths if p.exists()}
+                snapshot = artifacts / "content.sql"
+                snapshot.write_text("THIS IS NOT SQL\n")
+                failed = run("verify.py")
+                self.assertNotEqual(failed.returncode, 0)
+                self.assertEqual(before,
+                                 {p: (p.stat().st_ino, p.read_bytes()) for p in before})
+                self.assertEqual(list((base / "tmp").glob("sc-verify-*")), [])
+            finally:
+                live.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_worktree_targets.py
+++ b/tests/test_worktree_targets.py
@@ -261,8 +261,15 @@ class LinkedWorktreeRefusalTest(WorktreeFixture):
     """Requirements 2 and 3: the live-state commands refuse from a linked
     worktree, before they open or delete anything."""
 
-    LIVE_STATE_COMMANDS = ("rebuild", "migrate", "verify", "snapshot",
+    LIVE_STATE_COMMANDS = ("rebuild", "migrate", "snapshot",
                            "render", "clean-db")
+
+    def test_linked_verify_uses_disposable_candidate(self):
+        before = state_digest(self.main)
+        done = run_sc(self.wt, "verify")
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+        self.assertIn("candidate passed", done.stdout)
+        self.assertEqual(state_digest(self.main), before)
 
     def test_live_state_commands_refuse_and_leave_the_instance_untouched(self):
         for cmd in self.LIVE_STATE_COMMANDS:
@@ -423,9 +430,9 @@ class RootCheckoutUnchangedTest(WorktreeFixture):
             done.stdout,
         )
 
-    def test_root_verify_discloses_its_target_before_the_rebuild_runs(self):
-        """The ordering IS the requirement, so both events are captured in ONE
-        stream: a disclosure printed after the destruction is no disclosure."""
+    def test_root_verify_runs_rebuild_only_in_disposable_candidate(self):
+        """A failing candidate rebuild leaves the canonical DB untouched."""
+        before = state_digest(self.main)
         script = self.main / ".super-coder" / "scripts" / "rebuild.py"
         original = script.read_bytes()
         script.write_text(
@@ -437,12 +444,8 @@ class RootCheckoutUnchangedTest(WorktreeFixture):
         finally:
             script.write_bytes(original)
         self.assertNotEqual(done.returncode, 0)
-        merged = done.stdout
-        self.assertIn(str(self.live_db), merged)
-        self.assertIn("REBUILD-RAN", merged)
-        self.assertLess(
-            merged.index(str(self.live_db)), merged.index("REBUILD-RAN"),
-            "verify disclosed its target only after rebuild had already run")
+        self.assertIn("REBUILD-RAN", done.stdout)
+        self.assertEqual(state_digest(self.main), before)
 
 
 class MigrationScaffoldRunsCallerSourceTest(WorktreeFixture):


### PR DESCRIPTION
`./sc verify` previously rebuilt the canonical engine database from the last snapshot, silently losing newer live memory writes. It now copies the installed engine source and active snapshot into a disposable checkout, runs the existing rebuild, initialization, flat render, and render-only boot there, then removes the candidate. The live database and artifacts remain untouched even when the snapshot is stale. The candidate uses an isolated Git commit and local-only remote so non-Admin worktree boot remains a meaningful check without fetching the real origin.

The Docker lifecycle CI job now explicitly rebuilds and initializes its fresh checkout before launch; candidate-only verify no longer bootstraps canonical state. This PR addresses the narrow verification behavior in #1273, without changing other maintenance commands.

Validation: 38 focused unit tests passed, including a stale snapshot with an open SQLite WAL connection and byte/inode/sidecar assertions, a corrupt snapshot cleanup path, a bogus external origin, and a fresh content-free clone. Ruff passed for the new Python files; shell syntax and `git diff --check` passed. The fixture tests an open SQLite handle, not a full running API process. The disposable source copy and temp Git repository add startup work to keep the existing boot proof while isolating all writable paths.

Fixes #1273
